### PR TITLE
fix(core): complète COMPONENT_MAP de l'autoloader

### DIFF
--- a/apps/docs/CONTRIBUTING.md
+++ b/apps/docs/CONTRIBUTING.md
@@ -42,7 +42,7 @@ npm run dev
 
 ### 1. Créer le fichier MDX
 
-Créez `apps/docs/src/content/components/mr-<nom>.mdx` :
+Créez `apps/docs/src/content/components/ar-<nom>.mdx` :
 
 ```yaml
 ---
@@ -209,7 +209,7 @@ apps/docs/
 La page `/foundations/tokens` est **entièrement auto-générée** depuis
 `packages/core/src/styles/themes/default.css`.
 
-Ajouter une variable `--mr-*` dans ce fichier → elle apparaît automatiquement dans la page,
+Ajouter une variable `--ar-*` dans ce fichier → elle apparaît automatiquement dans la page,
 classée par catégorie (Couleurs, Typographie, Espacement, Forme, Focus).
 
 ---
@@ -299,11 +299,16 @@ Lors d'une PR qui modifie l'un des éléments ci-dessous, mettre à jour la sect
 
 ## Checklist pour ajouter un composant
 
-- [ ] Créer `packages/core/src/components/<nom>/<nom>.ts` avec les annotations JSDoc
+> **Utiliser le script de scaffolding** : `npm run create -- <nom>` génère automatiquement
+> les fichiers du composant (`.ts`, `.styles.ts`, `.test.ts`, `.mdx`), met à jour le barrel
+> (`index.ts`) et l'autoloader (`autoloader.ts`). C'est le point d'entrée recommandé.
+
+- [ ] Lancer `npm run create -- <nom>` pour scaffolder le composant
+- [ ] Implémenter le composant avec les annotations JSDoc
 - [ ] Régénérer le CEM : `cd packages/core && npm run build:manifest`
-- [ ] Créer `apps/docs/src/content/components/mr-<nom>.mdx` avec au moins une variante
+- [ ] Compléter les variantes dans `apps/docs/src/content/components/ar-<nom>.mdx`
 - [ ] Lancer `npm run dev` et vérifier la page `/components/<nom>`
-- [ ] Si sous-composant : ajouter uniquement `@parent mr-<parent>` dans la JSDoc (aucun champ MDX supplémentaire)
+- [ ] Si sous-composant : ajouter uniquement `@parent ar-<parent>` dans la JSDoc (aucun champ MDX supplémentaire)
 
 ## Checklist pour modifier l'architecture du site
 

--- a/packages/core/scripts/create-component.js
+++ b/packages/core/scripts/create-component.js
@@ -7,12 +7,12 @@
  *   - src/components/<n>/<tagname>.styles.ts
  *   - src/components/<n>/<tagname>.test.ts
  *   - ../../apps/docs/src/content/components/<tagname>.mdx
- *   Et met à jour src/index.ts (barrel)
+ *   Et met à jour src/index.ts (barrel) et src/autoloader.ts (COMPONENT_MAP)
  *
  * Usage :
- *   npm run create -- button              → mr-button  (prefix par défaut)
- *   npm run create -- my-component        → mr-my-component
- *   npm run create -- mr-button           → mr-button  (prefix déjà présent, pas doublé)
+ *   npm run create -- button              → ar-button  (prefix par défaut)
+ *   npm run create -- my-component        → ar-my-component
+ *   npm run create -- ar-button           → ar-button  (prefix déjà présent, pas doublé)
  *   npm run create -- button --prefix ft  → ft-button
  *   npm run create -- button --prefix ""  → erreur, prefix requis
  */
@@ -50,7 +50,7 @@ if (prefixFlagIndex !== -1) {
 }
 
 const input = args[0];
-const PREFIX = cliPrefix ?? readPackagePrefix() ?? 'mr';
+const PREFIX = cliPrefix ?? readPackagePrefix() ?? 'ar';
 
 // ─── Validation ───────────────────────────────────────────────────────────────
 
@@ -274,6 +274,19 @@ const exportLine = `export { ${className} } from './components/${dirName}/${file
 if (!barrelContent.includes(exportLine)) {
     writeFileSync(barrelPath, barrelContent + exportLine, 'utf-8');
     console.log(`  ✓ src/index.ts mis à jour`);
+}
+
+// ─── Mise à jour de l'autoloader ─────────────────────────────────────────────
+
+const autoloaderPath = join(ROOT, 'src', 'autoloader.ts');
+const autoloaderContent = readFileSync(autoloaderPath, 'utf-8');
+const autoloaderEntry = `    '${tagName}': () => import('./components/${dirName}/${fileName}.js'),`;
+const marker = '    // ⚠ Mis à jour automatiquement par le script create-component.js';
+
+if (!autoloaderContent.includes(`'${tagName}'`)) {
+    const updated = autoloaderContent.replace(marker, `${autoloaderEntry}\n${marker}`);
+    writeFileSync(autoloaderPath, updated, 'utf-8');
+    console.log(`  ✓ src/autoloader.ts mis à jour`);
 }
 
 // ─── Résumé ───────────────────────────────────────────────────────────────────

--- a/packages/core/src/autoloader.ts
+++ b/packages/core/src/autoloader.ts
@@ -16,8 +16,16 @@
  */
 
 const COMPONENT_MAP: Record<string, () => Promise<unknown>> = {
+    'ar-alert': () => import('./components/alert/alert.js'),
+    'ar-breadcrumb': () => import('./components/breadcrumb/breadcrumb.js'),
+    'ar-breadcrumb-item': () => import('./components/breadcrumb-item/breadcrumb-item.js'),
     'ar-button': () => import('./components/button/button.js'),
-    // Ajouter les nouveaux composants ici au fil du développement
+    'ar-pagination': () => import('./components/pagination/pagination.js'),
+    'ar-progressbar': () => import('./components/progressbar/progressbar.js'),
+    'ar-spinner': () => import('./components/spinner/spinner.js'),
+    'ar-stepper': () => import('./components/stepper/stepper.js'),
+    'ar-stepper-item': () => import('./components/stepper-item/stepper-item.js'),
+    // ⚠ Mis à jour automatiquement par le script create-component.js
 };
 
 /** Roots actuellement observés (évite les doublons). */


### PR DESCRIPTION
## Résumé

- Ajoute les 9 composants existants dans `COMPONENT_MAP` (l'autoloader CDN ne chargeait que `ar-button`)
- Le script `create-component.js` met à jour automatiquement `autoloader.ts` lors du scaffolding
- Corrige le fallback prefix (`mr` → `ar`) et les commentaires du script
- Met à jour `CONTRIBUTING.md` : la checklist insiste sur l'utilisation du script de scaffolding

Closes #3

## Test plan

- [x] 199 tests passent
- [ ] Vérifier que `npm run create -- test-component` ajoute bien l'entrée dans `autoloader.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)