### PR TITLE
docs: met à jour README et CONTRIBUTING avec références à jour

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,13 @@
-# Contributing to mARIAnne
+# Contributing to Ariane
 
-Ce guide couvre le workflow de contribution pour le **package core** (`@marianne/core`).
+Ce guide couvre le workflow de contribution pour le **package core** (`@ariane-ui/core`).
 Pour modifier le site de documentation, voir [apps/docs/CONTRIBUTING.md](apps/docs/CONTRIBUTING.md).
 
 ---
 
 ## Prérequis
 
-- Node ≥ 20, npm ≥ 10
+- Node ≥ 24 (LTS), npm ≥ 11
 - Lire [README.md](README.md) pour comprendre la structure du monorepo
 
 ---
@@ -15,13 +15,14 @@ Pour modifier le site de documentation, voir [apps/docs/CONTRIBUTING.md](apps/do
 ## Workflow général
 
 ```bash
-git clone https://github.com/jonTravens/mARIAnne
-cd mARIAnne
+git clone https://github.com/jogo-labs/ariane
+cd ariane
+nvm use          # active automatiquement Node 24 via .nvmrc
 npm install
 npm run dev          # watch core + docs en parallèle
 ```
 
-Toutes les contributions passent par une **Pull Request** sur `main`.
+Toutes les contributions passent par une **Pull Request** sur `dev`.
 
 ---
 
@@ -236,7 +237,7 @@ Pour les activer dans votre projet consommateur, référencez-les dans `.vscode/
 
 ```json
 {
-    "html.customData": ["./node_modules/@marianne/core/dist/vscode.html-custom-data.json"],
-    "css.customData": ["./node_modules/@marianne/core/dist/vscode.css-custom-data.json"]
+    "html.customData": ["./node_modules/@ariane-ui/core/dist/vscode.html-custom-data.json"],
+    "css.customData": ["./node_modules/@ariane-ui/core/dist/vscode.css-custom-data.json"]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Ariane/
 ├── packages/
 │   └── core/          # @ariane-ui/core — la bibliothèque de composants
 └── apps/
-    └── docs/          # Site de documentation (Astro 5)
+    └── docs/          # Site de documentation (Astro 6)
 ```
 
 Le monorepo est géré par **npm workspaces** et orchestré par **Turborepo**.
@@ -44,7 +44,7 @@ Le monorepo est géré par **npm workspaces** et orchestré par **Turborepo**.
 ### Installation
 
 ```bash
-git clone https://github.com/jonTravens/Ariane
+git clone https://github.com/jogo-labs/ariane
 cd Ariane
 nvm use   # active automatiquement Node 24 via .nvmrc
 npm install
@@ -106,6 +106,10 @@ import '@ariane-ui/core/themes/default.css'; // thème par défaut
 
 // ou import individuel (tree-shaking)
 import '@ariane-ui/core/dist/components/button/button.js';
+
+// attendre que des composants spécifiques soient prêts
+import { whenAllDefined } from '@ariane-ui/core';
+await whenAllDefined('ar-button', 'ar-stepper');
 ```
 
 ### Autoloader CDN
@@ -143,7 +147,7 @@ Consultez la page **Design Tokens** du site de documentation pour la liste compl
 | [esbuild](https://esbuild.github.io/)                                                 | Build rapide — bundles npm et CDN            |
 | [@custom-elements-manifest/analyzer](https://custom-elements-manifest.open-wc.org/)   | Génération du manifest CEM depuis la JSDoc   |
 | [Vitest](https://vitest.dev/) + [happy-dom](https://github.com/capricorn86/happy-dom) | Tests unitaires                              |
-| [Astro 5](https://astro.build/)                                                       | Site de documentation statique               |
+| [Astro 6](https://astro.build/)                                                       | Site de documentation statique               |
 | npm workspaces + [Turborepo](https://turbo.build/)                                    | Monorepo                                     |
 
 ---

--- a/apps/docs/CONTRIBUTING.md
+++ b/apps/docs/CONTRIBUTING.md
@@ -8,7 +8,7 @@ modifier une page ou comprendre l'architecture du site.
 
 ## Vue d'ensemble
 
-Le site est un **Astro 5 statique** sans framework UI côté client.
+Le site est un **Astro 6 statique** sans framework UI côté client.
 Chaque page de composant est générée automatiquement depuis deux sources :
 
 | Source                                   | Rôle                                                 |
@@ -106,7 +106,7 @@ Deux modes d'affichage sont disponibles, configurés via la JSDoc du composant L
  * @display docs
  */
 @customElement('ar-stepper-item')
-export class MrStepperItem extends LitElement { … }
+export class ArStepperItem extends LitElement { … }
 ```
 
 ### Sous-composants (relation parent / enfant)
@@ -120,7 +120,7 @@ et utilisée par la nav et la page d'accueil pour masquer automatiquement le sou
  * @parent ar-stepper
  */
 @customElement('ar-stepper-item')
-export class MrStepperItem extends LitElement { … }
+export class ArStepperItem extends LitElement { … }
 ```
 
 Après avoir ajouté l'annotation, regénérez le CEM :


### PR DESCRIPTION
## Summary

- `mARIAnne` → `Ariane`, `@marianne/core` → `@ariane-ui/core` dans tous les fichiers de contribution
- Node ≥ 20 / npm ≥ 10 → Node ≥ 24 (LTS) / npm ≥ 11
- URL git `jonTravens/mARIAnne` → `jogo-labs/ariane`, `cd mARIAnne` → `cd ariane`
- Ajoute `nvm use` dans le workflow d'installation
- PRs ciblent `dev` (pas `main`)
- Astro 5 → Astro 6 dans `README.md` et `apps/docs/CONTRIBUTING.md`
- `MrStepperItem` → `ArStepperItem` dans `apps/docs/CONTRIBUTING.md`
- Ajoute un exemple `whenAllDefined()` dans la section npm du README

## Test plan

- [ ] Vérifier que tous les liens et noms de packages sont corrects dans les trois fichiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)