### PR TITLE
test(core): tests a11y axe-core + autoloader browser (issues #2, #30)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,8 @@ Cette approche évoluera naturellement quand le token system sera plus mature (c
 ```bash
 npm run build             # Build all packages/apps
 npm run dev               # Parallel dev mode (watch)
-npm run test              # Run all tests
+npm run test              # Run all Vitest tests (core + docs)
+npm run test:all          # Run all tests including browser (Vitest + WTR/Chromium)
 npm run lint              # Lint all packages
 npm run format            # Prettier (TS, JS, JSON, CSS, Astro, MD)
 npm run create ar-<name>  # Scaffold a new component

--- a/package-lock.json
+++ b/package-lock.json
@@ -4015,6 +4015,13 @@
       "integrity": "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==",
       "license": "MIT"
     },
+    "node_modules/@types/mocha": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
@@ -16576,6 +16583,7 @@
       "devDependencies": {
         "@custom-elements-manifest/analyzer": "^0.10.3",
         "@open-wc/testing": "^4.0.0",
+        "@types/mocha": "^10.0.10",
         "@types/sinon": "^21.0.0",
         "@vitest/coverage-v8": "^3.0.4",
         "@web/dev-server-esbuild": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build": "turbo run build",
     "dev": "turbo run dev --parallel",
     "test": "turbo run test",
+    "test:all": "turbo run test test:browser",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,js,mjs,json,css,astro,md}\" --ignore-path .gitignore",
     "create": "node packages/core/scripts/create-component.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@custom-elements-manifest/analyzer": "^0.10.3",
     "@open-wc/testing": "^4.0.0",
+    "@types/mocha": "^10.0.10",
     "@types/sinon": "^21.0.0",
     "@vitest/coverage-v8": "^3.0.4",
     "@web/dev-server-esbuild": "^1.0.5",

--- a/packages/core/src/autoloader.browser.test.ts
+++ b/packages/core/src/autoloader.browser.test.ts
@@ -1,0 +1,131 @@
+/// <reference types="mocha" />
+/**
+ * autoloader.browser.test.ts
+ *
+ * Teste le comportement de l'autoloader dans un vrai browser (Chromium via @web/test-runner).
+ * Se concentre sur les cas impossibles à couvrir avec happy-dom :
+ *   - Détection de composants dans des shadow DOM imbriqués
+ *   - Upgrade après chargement dynamique dans un shadow root
+ *   - MutationObserver cross-shadow
+ *
+ * Utilise le bundle CDN (Lit bundlé + autoloader + tous les composants).
+ * Le dist/ doit être buildé avant de lancer ces tests (assuré par le job CI).
+ */
+
+import { expect } from '@open-wc/testing';
+
+// Le bundle CDN enregistre tous les composants ET démarre l'autoloader.
+// On l'importe une seule fois — l'autoloader attache son MutationObserver à document.body.
+await import('../cdn/index.js');
+
+const tick = () => new Promise((r) => setTimeout(r, 50));
+
+afterEach(() => {
+    document.body.innerHTML = '';
+});
+
+// ─── Cas de base ──────────────────────────────────────────────────────────────
+
+describe('autoloader — cas de base', () => {
+    it('upgrade un composant ajouté directement dans document.body', async () => {
+        const el = document.createElement('ar-alert');
+        document.body.appendChild(el);
+        await customElements.whenDefined('ar-alert');
+        await tick();
+
+        expect(el.shadowRoot).to.not.equal(null);
+    });
+
+    it('ne charge pas deux fois le même composant (idempotent)', async () => {
+        const a = document.createElement('ar-alert');
+        const b = document.createElement('ar-alert');
+        document.body.appendChild(a);
+        document.body.appendChild(b);
+        await customElements.whenDefined('ar-alert');
+        await tick();
+
+        // Les deux instances sont upgradées sans erreur
+        expect(a.shadowRoot).to.not.equal(null);
+        expect(b.shadowRoot).to.not.equal(null);
+    });
+});
+
+// ─── Shadow DOM imbriqué ──────────────────────────────────────────────────────
+
+describe('autoloader — shadow DOM imbriqué', () => {
+    it("détecte un composant dans le shadow DOM d'un élément hôte custom", async () => {
+        // Simule un hôte non-ariane avec un shadow root contenant un ar-alert
+        const host = document.createElement('div');
+        document.body.appendChild(host);
+        const shadow = host.attachShadow({ mode: 'open' });
+
+        const alertInShadow = document.createElement('ar-alert');
+        shadow.appendChild(alertInShadow);
+
+        await customElements.whenDefined('ar-alert');
+        await tick();
+
+        // L'autoloader doit avoir observé le shadow root et upgradé ar-alert
+        expect(alertInShadow.shadowRoot).to.not.equal(null);
+    });
+
+    it('détecte un composant ajouté après coup dans un shadow root déjà observé', async () => {
+        const host = document.createElement('div');
+        document.body.appendChild(host);
+        const shadow = host.attachShadow({ mode: 'open' });
+
+        // Ajoute un premier composant pour que l'autoloader observe ce shadow root
+        const first = document.createElement('ar-spinner');
+        shadow.appendChild(first);
+        await customElements.whenDefined('ar-spinner');
+        await tick();
+
+        // Puis ajoute un second composant dans le même shadow root
+        const second = document.createElement('ar-alert');
+        shadow.appendChild(second);
+        await customElements.whenDefined('ar-alert');
+        await tick();
+
+        expect(second.shadowRoot).to.not.equal(null);
+    });
+
+    it("détecte un composant dans le shadow DOM d'un autre composant ar-*", async () => {
+        // ar-breadcrumb contient ar-breadcrumb-item dans son light DOM (slot)
+        const breadcrumb = document.createElement('ar-breadcrumb');
+        const item = document.createElement('ar-breadcrumb-item');
+        item.innerHTML = '<a href="/">Accueil</a>';
+        breadcrumb.appendChild(item);
+        document.body.appendChild(breadcrumb);
+
+        await customElements.whenDefined('ar-breadcrumb');
+        await customElements.whenDefined('ar-breadcrumb-item');
+        await tick();
+
+        // ar-breadcrumb a un shadow root (LitElement standard)
+        expect(breadcrumb.shadowRoot).to.not.equal(null);
+        // ar-breadcrumb-item n'a pas de shadow root (createRenderRoot retourne this),
+        // mais doit être upgradé (`:defined`)
+        expect(item.matches(':defined')).to.equal(true);
+    });
+
+    it('détecte des composants à deux niveaux de shadow DOM', async () => {
+        // Niveau 1 : hôte custom → shadow root → ar-breadcrumb
+        // Niveau 2 : ar-breadcrumb-item en light DOM de ar-breadcrumb
+        const outerHost = document.createElement('div');
+        document.body.appendChild(outerHost);
+        const outerShadow = outerHost.attachShadow({ mode: 'open' });
+
+        const breadcrumb = document.createElement('ar-breadcrumb');
+        const item = document.createElement('ar-breadcrumb-item');
+        item.innerHTML = '<a href="/">Accueil</a>';
+        breadcrumb.appendChild(item);
+        outerShadow.appendChild(breadcrumb);
+
+        await customElements.whenDefined('ar-breadcrumb');
+        await customElements.whenDefined('ar-breadcrumb-item');
+        await tick();
+
+        expect(breadcrumb.shadowRoot).to.not.equal(null);
+        expect(item.matches(':defined')).to.equal(true);
+    });
+});

--- a/packages/core/src/components/alert/alert.a11y.test.ts
+++ b/packages/core/src/components/alert/alert.a11y.test.ts
@@ -1,0 +1,66 @@
+/// <reference types="mocha" />
+/**
+ * alert.a11y.test.ts
+ *
+ * Tests d'accessibilité axe-core pour ar-alert, via @web/test-runner (Chromium).
+ * fixture() de @open-wc/testing attend déjà updateComplete — aucun délai supplémentaire requis.
+ */
+import { fixture, html, expect } from '@open-wc/testing';
+import './alert.js';
+
+describe('ar-alert — accessibilité', () => {
+    it('version "info" est accessible', async () => {
+        const el = await fixture(html`
+            <ar-alert version="info">
+                <span slot="title">Information importante</span>
+                <span slot="content">Voici un message informatif.</span>
+            </ar-alert>
+        `);
+        await expect(el).to.be.accessible();
+    });
+
+    it('version "success" est accessible', async () => {
+        const el = await fixture(html`
+            <ar-alert version="success">
+                <span slot="title">Succès</span>
+                <span slot="content">L'opération a réussi.</span>
+            </ar-alert>
+        `);
+        await expect(el).to.be.accessible();
+    });
+
+    it('version "warning" est accessible', async () => {
+        const el = await fixture(html`
+            <ar-alert version="warning">
+                <span slot="title">Attention</span>
+                <span slot="content">Vérifiez vos informations.</span>
+            </ar-alert>
+        `);
+        await expect(el).to.be.accessible();
+    });
+
+    it('version "error" est accessible', async () => {
+        const el = await fixture(html`
+            <ar-alert version="error">
+                <span slot="title">Erreur</span>
+                <span slot="content">Une erreur s'est produite.</span>
+            </ar-alert>
+        `);
+        await expect(el).to.be.accessible();
+    });
+
+    it('avec bouton de fermeture (next-focus) est accessible', async () => {
+        const container = await fixture(html`
+            <div>
+                <button id="focus-target">Retour</button>
+                <ar-alert version="warning" next-focus="focus-target">
+                    <span slot="title">Attention</span>
+                    <span slot="content">Vérifiez vos informations.</span>
+                </ar-alert>
+            </div>
+        `);
+        const el = container.querySelector('ar-alert');
+        if (!el) throw new Error('ar-alert not found in fixture');
+        await expect(el).to.be.accessible();
+    });
+});

--- a/packages/core/src/components/breadcrumb/breadcrumb.a11y.test.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.a11y.test.ts
@@ -1,0 +1,36 @@
+/// <reference types="mocha" />
+/**
+ * breadcrumb.a11y.test.ts
+ *
+ * Tests d'accessibilité axe-core pour ar-breadcrumb, via @web/test-runner (Chromium).
+ * aTimeout(0) laisse les queueMicrotask internes (collecte des items) se vider
+ * avant le contrôle axe.
+ */
+import { fixture, html, expect, aTimeout } from '@open-wc/testing';
+import './breadcrumb.js';
+import '../breadcrumb-item/breadcrumb-item.js';
+
+describe('ar-breadcrumb — accessibilité', () => {
+    it("fil d'ariane avec plusieurs items est accessible", async () => {
+        const el = await fixture(html`
+            <ar-breadcrumb>
+                <ar-breadcrumb-item label="Accueil" href="/"></ar-breadcrumb-item>
+                <ar-breadcrumb-item label="Catégorie" href="/cat"></ar-breadcrumb-item>
+                <ar-breadcrumb-item label="Page actuelle"></ar-breadcrumb-item>
+            </ar-breadcrumb>
+        `);
+        await aTimeout(0);
+        await expect(el).to.be.accessible();
+    });
+
+    it("fil d'ariane avec deux items est accessible", async () => {
+        const el = await fixture(html`
+            <ar-breadcrumb>
+                <ar-breadcrumb-item label="Accueil" href="/"></ar-breadcrumb-item>
+                <ar-breadcrumb-item label="Page actuelle"></ar-breadcrumb-item>
+            </ar-breadcrumb>
+        `);
+        await aTimeout(0);
+        await expect(el).to.be.accessible();
+    });
+});

--- a/packages/core/src/components/pagination/pagination.a11y.test.ts
+++ b/packages/core/src/components/pagination/pagination.a11y.test.ts
@@ -1,0 +1,32 @@
+/// <reference types="mocha" />
+/**
+ * pagination.a11y.test.ts
+ *
+ * Tests d'accessibilité axe-core pour ar-pagination, via @web/test-runner (Chromium).
+ */
+import { fixture, html, expect } from '@open-wc/testing';
+import './pagination.js';
+
+describe('ar-pagination — accessibilité', () => {
+    it('premiere page est accessible', async () => {
+        const el = await fixture(html`<ar-pagination current="1" total="5"></ar-pagination>`);
+        await expect(el).to.be.accessible();
+    });
+
+    it('milieu de liste est accessible', async () => {
+        const el = await fixture(html`<ar-pagination current="3" total="10"></ar-pagination>`);
+        await expect(el).to.be.accessible();
+    });
+
+    it('derniere page est accessible', async () => {
+        const el = await fixture(html`<ar-pagination current="5" total="5"></ar-pagination>`);
+        await expect(el).to.be.accessible();
+    });
+
+    it('variante "dark" est accessible', async () => {
+        const el = await fixture(
+            html`<ar-pagination current="2" total="5" variant="dark"></ar-pagination>`,
+        );
+        await expect(el).to.be.accessible();
+    });
+});

--- a/packages/core/src/components/progressbar/progressbar.a11y.test.ts
+++ b/packages/core/src/components/progressbar/progressbar.a11y.test.ts
@@ -1,0 +1,31 @@
+/// <reference types="mocha" />
+/**
+ * progressbar.a11y.test.ts
+ *
+ * Tests d'accessibilité axe-core pour ar-progressbar, via @web/test-runner (Chromium).
+ */
+import { fixture, html, expect } from '@open-wc/testing';
+import './progressbar.js';
+
+describe('ar-progressbar — accessibilité', () => {
+    it('barre de progression a 0% est accessible', async () => {
+        const el = await fixture(html`
+            <ar-progressbar percent="0">Chargement du fichier</ar-progressbar>
+        `);
+        await expect(el).to.be.accessible();
+    });
+
+    it('barre de progression a 50% est accessible', async () => {
+        const el = await fixture(html`
+            <ar-progressbar percent="50">Chargement du fichier</ar-progressbar>
+        `);
+        await expect(el).to.be.accessible();
+    });
+
+    it('barre de progression a 100% est accessible', async () => {
+        const el = await fixture(html`
+            <ar-progressbar percent="100">Chargement termine</ar-progressbar>
+        `);
+        await expect(el).to.be.accessible();
+    });
+});

--- a/packages/core/src/components/progressbar/progressbar.ts
+++ b/packages/core/src/components/progressbar/progressbar.ts
@@ -49,7 +49,7 @@ export class ArProgressbar extends LitElement {
         const percentValue = Math.max(0, Math.min(100, this.percent));
 
         return html` <div part="container" class="progressbar-container">
-            <p part="label" class="progress-label">
+            <p part="label" id="progressbar-label" class="progress-label">
                 <span part="label-text" class="content-label">
                     <slot></slot>
                 </span>
@@ -61,6 +61,7 @@ export class ArProgressbar extends LitElement {
                     class="progress-bar"
                     style=${styleMap({ width: percentValue + '%' })}
                     role="progressbar"
+                    aria-labelledby="progressbar-label"
                     aria-valuenow="${percentValue}"
                     aria-valuemin="0"
                     aria-valuemax="100"

--- a/packages/core/src/components/spinner/spinner.a11y.test.ts
+++ b/packages/core/src/components/spinner/spinner.a11y.test.ts
@@ -1,0 +1,30 @@
+/// <reference types="mocha" />
+/**
+ * spinner.a11y.test.ts
+ *
+ * Tests d'accessibilité axe-core pour ar-spinner, via @web/test-runner (Chromium).
+ */
+import { fixture, html, expect } from '@open-wc/testing';
+import './spinner.js';
+
+describe('ar-spinner — accessibilité', () => {
+    it('en cours de chargement est accessible', async () => {
+        const el = await fixture(html`<ar-spinner></ar-spinner>`);
+        await expect(el).to.be.accessible();
+    });
+
+    it('avec etat termine est accessible', async () => {
+        const el = await fixture(html`<ar-spinner done></ar-spinner>`);
+        await expect(el).to.be.accessible();
+    });
+
+    it('avec labels personnalises est accessible', async () => {
+        const el = await fixture(html`
+            <ar-spinner
+                loading-label="Chargement de l'image en cours"
+                done-label="Image chargee avec succes"
+            ></ar-spinner>
+        `);
+        await expect(el).to.be.accessible();
+    });
+});

--- a/packages/core/src/components/stepper/stepper.a11y.test.ts
+++ b/packages/core/src/components/stepper/stepper.a11y.test.ts
@@ -1,0 +1,37 @@
+/// <reference types="mocha" />
+/**
+ * stepper.a11y.test.ts
+ *
+ * Tests d'accessibilité axe-core pour ar-stepper, via @web/test-runner (Chromium).
+ * aTimeout(0) laisse les queueMicrotask internes (construction de l'arbre) se vider
+ * avant le contrôle axe.
+ */
+import { fixture, html, expect, aTimeout } from '@open-wc/testing';
+import './stepper.js';
+import '../stepper-item/stepper-item.js';
+
+describe('ar-stepper — accessibilité', () => {
+    it('stepper desktop (mode create, etape 1) est accessible', async () => {
+        const el = await fixture(html`
+            <ar-stepper current-path="/step1">
+                <ar-stepper-item path="/step1" label="Informations" href="/step1"></ar-stepper-item>
+                <ar-stepper-item path="/step2" label="Confirmation" href="/step2"></ar-stepper-item>
+                <ar-stepper-item path="/step3" label="Paiement" href="/step3"></ar-stepper-item>
+            </ar-stepper>
+        `);
+        await aTimeout(0);
+        await expect(el).to.be.accessible();
+    });
+
+    it('stepper desktop (mode edit) est accessible', async () => {
+        const el = await fixture(html`
+            <ar-stepper current-path="/step2" mode="edit">
+                <ar-stepper-item path="/step1" label="Informations" href="/step1"></ar-stepper-item>
+                <ar-stepper-item path="/step2" label="Confirmation" href="/step2"></ar-stepper-item>
+                <ar-stepper-item path="/step3" label="Paiement" href="/step3"></ar-stepper-item>
+            </ar-stepper>
+        `);
+        await aTimeout(0);
+        await expect(el).to.be.accessible();
+    });
+});

--- a/packages/core/src/controllers/scroll-follow.controller.browser.test.ts
+++ b/packages/core/src/controllers/scroll-follow.controller.browser.test.ts
@@ -1,3 +1,4 @@
+/// <reference types="mocha" />
 import { expect } from '@open-wc/testing';
 import { ScrollFollowController } from './scroll-follow.controller.js';
 

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,14 +1,9 @@
 {
-    "extends": "../../tsconfig.base.json",
-    "compilerOptions": {
-        "rootDir": "src",
-        "outDir":  "dist"
-    },
-    "include": ["src/**/*.ts"],
-    "exclude": [
-        "src/**/*.test.ts",
-        "node_modules",
-        "dist",
-        "cdn"
-    ]
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "node_modules", "dist", "cdn"]
 }

--- a/packages/core/tsconfig.wtr.json
+++ b/packages/core/tsconfig.wtr.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "experimentalDecorators": true,
+    "useDefineForClassFields": false
+  }
+}

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -7,9 +7,9 @@ export default defineConfig({
         // n'ajoute pas 300MB de browsers Playwright en CI.
         environment: 'happy-dom',
 
-        // *.browser.test.ts sont gérés par @web/test-runner, pas Vitest
+        // *.browser.test.ts et *.a11y.test.ts sont gérés par @web/test-runner, pas Vitest
         include: ['src/**/*.test.ts'],
-        exclude: ['src/**/*.browser.test.ts'],
+        exclude: ['src/**/*.browser.test.ts', 'src/**/*.a11y.test.ts'],
 
         // Rapport de couverture granulaire par fichier
         coverage: {
@@ -19,6 +19,7 @@ export default defineConfig({
             exclude: [
                 'src/**/*.test.ts',
                 'src/**/*.browser.test.ts',
+                'src/**/*.a11y.test.ts',
                 'src/**/*.styles.ts',
                 // ScrollFollowController désormais couvert par les browser tests (issue #30)
                 'src/controllers/scroll-follow.controller.ts',

--- a/packages/core/web-test-runner.config.js
+++ b/packages/core/web-test-runner.config.js
@@ -3,13 +3,19 @@ import { esbuildPlugin } from '@web/dev-server-esbuild';
 
 export default {
     // Fichiers de test browser — séparés des tests Vitest (.test.ts)
-    files: 'src/**/*.browser.test.{js,ts}',
+    // *.browser.test.ts : tests d'intégration (shadow DOM, MutationObserver…)
+    // *.a11y.test.ts    : tests d'accessibilité axe-core par composant
+    files: 'src/**/*.{browser,a11y}.test.{js,ts}',
 
     // Chromium uniquement en CI ; WebKit peut être ajouté plus tard
     browsers: [playwrightLauncher({ product: 'chromium' })],
 
-    // Plugin esbuild pour transpiler TypeScript à la volée
-    plugins: [esbuildPlugin({ ts: true })],
+    // Plugin esbuild pour transpiler TypeScript à la volée.
+    // tsconfig.wtr.json est un fichier plat (sans "extends") qui transmet
+    // experimentalDecorators + useDefineForClassFields, requis par les décorateurs Lit.
+    // Le plugin ne résout pas "extends" quand il lit tsconfigRaw, donc tsconfig.json
+    // (qui étend tsconfig.base.json) ne suffit pas.
+    plugins: [esbuildPlugin({ ts: true, tsconfig: './tsconfig.wtr.json' })],
 
     nodeResolve: true,
 };

--- a/turbo.json
+++ b/turbo.json
@@ -3,81 +3,44 @@
   "ui": "tui",
   "tasks": {
     "build:manifest": {
-      "inputs": [
-        "src/**/*.ts",
-        "cem.config.js"
-      ],
-      "outputs": [
-        "dist/custom-elements.json"
-      ]
+      "inputs": ["src/**/*.ts", "cem.config.js"],
+      "outputs": ["dist/custom-elements.json"]
     },
     "build:bundles": {
-      "dependsOn": [
-        "build:manifest"
-      ],
-      "inputs": [
-        "src/**/*.ts",
-        "scripts/build-bundles.js"
-      ],
-      "outputs": [
-        "dist/**",
-        "cdn/**"
-      ]
+      "dependsOn": ["build:manifest"],
+      "inputs": ["src/**/*.ts", "scripts/build-bundles.js"],
+      "outputs": ["dist/**", "cdn/**"]
     },
     "build:css": {
-      "inputs": [
-        "src/styles/**/*.css"
-      ],
-      "outputs": [
-        "dist/styles/**"
-      ]
+      "inputs": ["src/styles/**/*.css"],
+      "outputs": ["dist/styles/**"]
     },
     "build:types": {
-      "dependsOn": [
-        "build:manifest"
-      ],
-      "inputs": [
-        "src/**/*.ts",
-        "tsconfig.json"
-      ],
-      "outputs": [
-        "dist/**/*.d.ts",
-        "dist/**/*.d.ts.map"
-      ]
+      "dependsOn": ["build:manifest"],
+      "inputs": ["src/**/*.ts", "tsconfig.json"],
+      "outputs": ["dist/**/*.d.ts", "dist/**/*.d.ts.map"]
     },
     "build": {
-      "dependsOn": [
-        "build:manifest",
-        "build:bundles",
-        "build:css",
-        "build:types",
-        "^build"
-      ],
-      "outputs": [
-        "dist/**",
-        "cdn/**"
-      ]
+      "dependsOn": ["build:manifest", "build:bundles", "build:css", "build:types", "^build"],
+      "outputs": ["dist/**", "cdn/**"]
     },
     "dev": {
       "cache": false,
       "persistent": true,
-      "dependsOn": [
-        "^build"
-      ]
+      "dependsOn": ["^build"]
     },
     "test": {
-      "dependsOn": [
-        "^build:bundles"
-      ],
+      "dependsOn": ["^build:bundles"],
       "outputs": []
     },
     "test:coverage": {
-      "dependsOn": [
-        "^build:bundles"
-      ],
-      "outputs": [
-        "coverage/**"
-      ]
+      "dependsOn": ["^build:bundles"],
+      "outputs": ["coverage/**"]
+    },
+    "test:browser": {
+      "dependsOn": ["build:bundles"],
+      "cache": false,
+      "outputs": []
     },
     "lint": {
       "outputs": []


### PR DESCRIPTION
## Résumé

- **Config WTR** : tsconfig.wtr.json plat pour `experimentalDecorators` (esbuild ne résout pas `extends` en tsconfigRaw), glob étendu aux `*.a11y.test.ts`, `@types/mocha` pour le typage IDE
- **Autoloader browser tests** : 6 tests Chromium couvrant la détection de composants dans des shadow DOM imbriqués (issue #2)
- **Tests a11y axe-core** : 19 tests répartis sur 6 composants via `@open-wc/testing` + axe-core (issue #30)
- **Fix a11y progressbar** : `aria-labelledby` ajouté sur `role="progressbar"` — bug détecté par axe (règle `aria-progressbar-name`)

## Plan de test

- [ ] Job "Browser Tests (core)" passe en vert (31 tests)
- [ ] Job "Lint, Test & Build (core)" reste vert (couverture Vitest inchangée)
- [ ] Job "Lint, Test & Build (docs)" reste vert

Closes #2, #30

🤖 Generated with [Claude Code](https://claude.ai/claude-code)