### PR TITLE
fix(docs): playground visuel + lancement dev plus fluide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ Thumbs.db
 .env.*.local
 .claude
 .superpowers/
+.github/hooks/

--- a/apps/docs/scripts/check-manifest.js
+++ b/apps/docs/scripts/check-manifest.js
@@ -1,15 +1,10 @@
 #!/usr/bin/env node
 /**
- * Attend que le Custom Elements Manifest soit disponible avant de lancer Astro.
+ * Vérifie que le Custom Elements Manifest est disponible avant de lancer Astro.
  *
- * Pourquoi "attendre" et pas juste "vérifier l'existence" ?
- * En mode `npm run dev` depuis la racine, Turbo lance les tâches en parallèle.
- * Le core peut être en train de builder (clean + rebuild) au moment où la doc démarre.
- * Le fichier peut donc exister puis disparaître (pendant le clean) puis réapparaître.
- * Un simple existsSync() arriverait potentiellement dans cette fenêtre.
- *
- * On poll donc le fichier jusqu'à ce qu'il soit stable (même contenu sur 2 checks consécutifs),
- * ce qui garantit que le build est terminé et le fichier complet.
+ * Depuis la racine, `npm run dev` garantit que `build:manifest` a tourné avant
+ * de démarrer les watchers — ce script est un filet de sécurité pour les lancements
+ * directs (`npm run dev --workspace=apps/docs`).
  */
 import { existsSync, readFileSync } from 'fs';
 import { resolve, dirname } from 'path';
@@ -18,51 +13,15 @@ import { fileURLToPath } from 'url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const manifestPath = resolve(__dirname, '../../../packages/core/dist/custom-elements.json');
 
-const POLL_INTERVAL_MS = 300;
-const TIMEOUT_MS = 30_000;
-const STABLE_CHECKS = 2; // nb de lectures identiques consécutives pour valider la stabilité
-
-async function waitForManifest() {
-    const start = Date.now();
-    let stableCount = 0;
-    let lastContent = null;
-
-    process.stdout.write('⏳ En attente du Custom Elements Manifest');
-
-    while (Date.now() - start < TIMEOUT_MS) {
-        if (existsSync(manifestPath)) {
-            try {
-                const content = readFileSync(manifestPath, 'utf-8');
-
-                // Vérifier que c'est du JSON valide et non-vide (pas un fichier en cours d'écriture)
-                JSON.parse(content);
-
-                if (content === lastContent) {
-                    stableCount++;
-                    if (stableCount >= STABLE_CHECKS) {
-                        process.stdout.write(' ✓\n');
-                        return;
-                    }
-                } else {
-                    // Contenu différent du check précédent → le fichier est encore en cours de modification
-                    stableCount = 0;
-                    lastContent = content;
-                }
-            } catch {
-                // JSON invalide → écriture en cours, on continue à poller
-                stableCount = 0;
-                lastContent = null;
-            }
-        }
-
-        process.stdout.write('.');
-        await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+if (existsSync(manifestPath)) {
+    try {
+        JSON.parse(readFileSync(manifestPath, 'utf-8'));
+        process.exit(0);
+    } catch {
+        // JSON invalide — probablement une écriture en cours
     }
-
-    process.stdout.write('\n');
-    console.error('\n❌ Timeout : custom-elements.json non disponible après 30s.');
-    console.error('   Lance manuellement : cd packages/core && npm run build:manifest\n');
-    process.exit(1);
 }
 
-await waitForManifest();
+console.error('❌ custom-elements.json introuvable ou invalide.');
+console.error('   Lance : npm run build:manifest --workspace=packages/core\n');
+process.exit(1);

--- a/apps/docs/src/components/Playground.astro
+++ b/apps/docs/src/components/Playground.astro
@@ -87,65 +87,66 @@ const showPlayground = displayMode === 'demo';
 {showPlayground && (
     <section class="playground-section" id="playground" data-playground data-tag-name={tagName}>
         <h4 class="subsection-title">Playground</h4>
-        <div class="preview-wrap">
-            <div class="preview" data-playground-preview>
-                <Fragment set:html={playgroundHtml} />
+        <div class="playground-card">
+            <div class="preview-wrap">
+                <div class="preview" data-playground-preview>
+                    <Fragment set:html={playgroundHtml} />
+                </div>
             </div>
-        </div>
-        <div class="playground-code-block">
-            <button class="copy-btn" data-copy-playground aria-label="Copier le code">Copier</button>
-            {/* Le <pre><code> est mis à jour par playground.js après chaque changement de contrôle */}
-            <pre data-playground-pre><code class="language-html" data-playground-code>{playgroundHtml.trim()}</code></pre>
-        </div>
-
-        {controls.length > 0 && (
-            <div class="controls-panel">
-                {controls.map((ctrl) => (
-                    <label class="control-row">
-                        <span class="control-label">{ctrl.attribute}</span>
-                        {ctrl.controlType === 'select' && (
-                            <select
-                                data-attr={ctrl.attribute}
-                                data-playground-ctrl
-                                data-default={ctrl.default ?? ''}
-                            >
-                                {ctrl.addDefault && (
-                                    <option value="">Par défaut</option>
-                                )}
-                                {ctrl.options.map((opt) => (
-                                    <option value={opt}>{opt}</option>
-                                ))}
-                            </select>
-                        )}
-                        {ctrl.controlType === 'checkbox' && (
-                            <input
-                                type="checkbox"
-                                data-attr={ctrl.attribute}
-                                data-playground-ctrl
-                            />
-                        )}
-                        {ctrl.controlType === 'text' && (
-                            <input
-                                type="text"
-                                data-attr={ctrl.attribute}
-                                data-playground-ctrl
-                                data-default={ctrl.default ?? ''}
-                                placeholder={ctrl.default ?? ''}
-                            />
-                        )}
-                        {ctrl.controlType === 'number' && (
-                            <input
-                                type="number"
-                                data-attr={ctrl.attribute}
-                                data-playground-ctrl
-                                data-default={ctrl.default ?? ''}
-                                placeholder={ctrl.default ?? ''}
-                            />
-                        )}
-                    </label>
-                ))}
+            <div class="playground-code-block">
+                <button class="copy-btn" data-copy-playground aria-label="Copier le code">Copier</button>
+                {/* Le <pre><code> est mis à jour par playground.js après chaque changement de contrôle */}
+                <pre data-playground-pre><code class="language-html" data-playground-code>{playgroundHtml.trim()}</code></pre>
             </div>
-        )}
+            {controls.length > 0 && (
+                <div class="controls-panel">
+                    {controls.map((ctrl) => (
+                        <label class="control-row">
+                            <span class="control-label">{ctrl.attribute}</span>
+                            {ctrl.controlType === 'select' && (
+                                <select
+                                    data-attr={ctrl.attribute}
+                                    data-playground-ctrl
+                                    data-default={ctrl.default ?? ''}
+                                >
+                                    {ctrl.addDefault && (
+                                        <option value="">Par défaut</option>
+                                    )}
+                                    {ctrl.options.map((opt) => (
+                                        <option value={opt}>{opt}</option>
+                                    ))}
+                                </select>
+                            )}
+                            {ctrl.controlType === 'checkbox' && (
+                                <input
+                                    type="checkbox"
+                                    data-attr={ctrl.attribute}
+                                    data-playground-ctrl
+                                />
+                            )}
+                            {ctrl.controlType === 'text' && (
+                                <input
+                                    type="text"
+                                    data-attr={ctrl.attribute}
+                                    data-playground-ctrl
+                                    data-default={ctrl.default ?? ''}
+                                    placeholder={ctrl.default ?? ''}
+                                />
+                            )}
+                            {ctrl.controlType === 'number' && (
+                                <input
+                                    type="number"
+                                    data-attr={ctrl.attribute}
+                                    data-playground-ctrl
+                                    data-default={ctrl.default ?? ''}
+                                    placeholder={ctrl.default ?? ''}
+                                />
+                            )}
+                        </label>
+                    ))}
+                </div>
+            )}
+        </div>
     </section>
 )}
 
@@ -171,6 +172,11 @@ const showPlayground = displayMode === 'demo';
         display:        flex;
         flex-direction: column;
         gap:            1rem;
+    }
+
+    .playground-card {
+        display:        flex;
+        flex-direction: column;
     }
 
     h5 {
@@ -231,12 +237,14 @@ const showPlayground = displayMode === 'demo';
 
     .code-block,
     .playground-code-block {
-        position:      relative;
-        border:        1px solid var(--doc-border, #e5e7eb);
-        border-top:    none;
-        border-radius: 0 0 0.5rem 0.5rem;
-        overflow:      hidden;
+        position:   relative;
+        border:     1px solid var(--doc-border, #e5e7eb);
+        border-top: none;
+        overflow:   hidden;
     }
+
+    .code-block          { border-radius: 0 0 0.5rem 0.5rem; }
+    .playground-code-block { border-radius: 0; }
 
     .copy-btn {
         position:      absolute;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "build": "turbo run build",
-    "dev": "turbo run dev --parallel",
+    "dev": "turbo run build:manifest && turbo run dev --parallel",
     "test": "turbo run test",
     "test:all": "turbo run test test:browser",
     "lint": "turbo run lint",


### PR DESCRIPTION
## Summary

- Regroupe les 3 blocs du playground (preview / code / contrôles) dans `.playground-card` pour supprimer les gaps visuels liés au `flex-column` de `.playground-section`
- Sépare le `border-radius` de la règle commune `.code-block` / `.playground-code-block` (règle partagée pour les propriétés communes, une règle dédiée par classe pour le radius)
- Simplifie `check-manifest.js` : vérification one-shot au lieu d'une boucle de polling
- Dev script racine : pré-build le CEM avant de démarrer les watchers en parallèle (`turbo run build:manifest && turbo run dev --parallel`) — supprime le message "En attente du CEM" au démarrage

## Test plan

- [ ] `npm run dev` depuis la racine → le playground s'affiche sans gaps entre les 3 blocs
- [ ] Les borders du playground forment un rectangle continu (preview haut arrondi, controls bas arrondi, code sans radius au milieu)
- [ ] `npm run dev` depuis la racine → aucun message "En attente du CEM" si le manifest n'existe pas encore (message d'erreur clair à la place)
- [ ] `npm run build` passe sans erreur

🤖 Generated with [Claude Code](https://claude.com/claude-code)