### PR TITLE
docs: mise à jour README et CONTRIBUTING

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,161 +4,35 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**Ariane** is an accessible web components library (`@ariane-ui/core`) built with **Lit 3** and **TypeScript**. It's an npm workspaces monorepo orchestrated by Turborepo with a dual distribution strategy (NPM + CDN).
+**Ariane** is an accessible web components library (`@ariane-ui/core`) built with **Lit 3** and **TypeScript**. npm workspaces monorepo orchestrated by Turborepo. Dual distribution: NPM (tree-shakeable ESM) + CDN (self-contained bundle with autoloader).
 
-## Philosophie de la librairie
+Ariane is a **foundation** for building design systems — not a design system itself. It handles patterns where correct accessible implementation is a real obstacle. It does not rewrite native elements that already work well.
 
-### Mission
+## Références
 
-Ariane est une librairie de composants web **accessibles par défaut**, **agnostiques de framework**, **thémables** et **open source**. Elle ne réécrit pas les éléments natifs qui fonctionnent bien — elle prend en charge les patterns dont la complexité d'implémentation correcte est un obstacle à l'accessibilité dans les projets réels.
+- **Philosophie, positionnement et critères d'inclusion** → [CONTRIBUTING.md](CONTRIBUTING.md)
+- **Setup, commandes, architecture, patterns de code** → [DEVELOPMENT.md](DEVELOPMENT.md)
+- **Décisions techniques détaillées** → [`docs/decisions/`](docs/decisions/) — indexées par context-mode, utiliser `ctx_search` pour les retrouver
 
-Ariane est pensée comme un **ensemble de briques logicielles prêtes à l'emploi servant de base stable pour construire un design system**. À ce titre, elle doit être parfaitement conforme aux normes attendues en termes de fonctionnement et de capacité de personnalisation via des design tokens bien réfléchis. L'objectif n'est pas d'être un design system en soi, mais d'être la fondation sur laquelle un design system peut être bâti — avec le moins de friction possible.
+## Règles actives
 
-### Critères d'inclusion d'un composant
+### Naming
 
-Un composant intègre Ariane si au moins l'une de ces conditions est vraie :
+- Tag: `ar-<name>` · Class: `Ar<Name>` · Events: `ar-<event>`
+- CSS custom properties: `--ar-<component>-<property>` (e.g. `--ar-button-bg`)
+- CSS parts: `part="base"`, `part="label"`, `part="prefix"`, `part="suffix"`
 
-1. **Complexité a11y non triviale** — implémenter correctement le comportement accessible est difficile et souvent mal fait (stepper, datepicker, dialog, tabs, dropdown).
-2. **Absent des projets non par manque de besoin, mais par difficulté d'implémentation** — si un composant est rare alors qu'il améliorerait l'UX, c'est un signal positif d'inclusion (datepicker en est l'exemple typique).
-3. **Extension d'un natif insuffisant** — quand un élément natif existe mais ne couvre pas les usages réels (`<dialog>` → `<ar-dialog>` qui l'étend).
+### Properties — always `reflect: true`
 
-Un composant est **exclu** si :
+Without `reflect: true`, the HTML attribute won't sync with the JS property — the playground's `outerHTML` will show missing attributes.
 
-- Il réplique un natif qui fait déjà bien le job (`<button>`, `<input>`, `<select>` de base).
-- Sa valeur ajoutée est purement graphique sans apport a11y ou comportemental.
+### Custom events — always `{ bubbles: true, composed: true }`
 
-### Ergonomie de l'API
+Without `composed: true`, events don't cross Shadow DOM boundary. Without `bubbles: true`, they don't bubble up through the light DOM either.
 
-L'API des composants doit être **intuitive par rapport aux natifs** : un breadcrumb se compose comme un `<ul>/<li>`, pas comme un JSON stringifié. Utiliser des éléments enfants slottés plutôt que des props de données complexes.
+### Global type declaration
 
-### Thémabilité encadrée par l'accessibilité
-
-- Les aspects visuels personnalisables sont exposés via CSS custom properties (`--ar-*`).
-- Les aspects qui garantissent l'accessibilité (présence du bouton de fermeture d'une modale, focus management, etc.) sont **non négociables** — ils ne peuvent pas être désactivés, seulement restyled.
-- Le thème par défaut (`default.css`) doit satisfaire les ratios de contraste **WCAG 2.2 AA sans configuration supplémentaire** — c'est la promesse "out of the box".
-
-### Gestion du contexte d'affichage (`variant`)
-
-Deux dimensions orthogonales coexistent :
-
-1. **Mode système** (`light`/`dark`) — géré via `prefers-color-scheme` et `data-theme`, les tokens sémantiques suivent automatiquement.
-2. **Contexte de fond** — certains composants s'affichent sur des fonds de couleur contrôlée par l'intégrateur (header coloré, overlay sombre). Ces composants exposent un attribut `variant="on-light"` / `variant="on-dark"` pour garantir la lisibilité.
-
-Règle : **si `variant` est défini explicitement, il prime sur le mode système** — le fond du conteneur ne change pas quand l'utilisateur bascule en dark mode. Si `variant` n'est pas défini, le composant suit le mode système via les tokens sémantiques.
-
-### Architecture des composants
-
-Trois catégories :
-
-| Catégorie                           | Description                                                                    | Exemple                               |
-| ----------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------- |
-| **Custom elements avec Shadow DOM** | Composants visuels complets, hermétiques                                       | `ar-alert`, `ar-stepper`, `ar-dialog` |
-| **Custom elements sans Shadow DOM** | Conteneurs de données / comportement pur, `createRenderRoot() { return this }` | `ar-stepper-item`, `ar-collapse`      |
-| **Extension de natif**              | Wraps un élément natif pour l'enrichir                                         | `ar-dialog` wraps `<dialog>`          |
-
-Le CEM (`custom-elements.json`) est la source de vérité pour toute l'API publique — préférer les custom elements aux directives/attributs custom pour bénéficier de la documentation automatique.
-
-### Relation entre tokens de la librairie et styles de la doc
-
-Les variables `--doc-*` (dans `apps/docs/`) peuvent référencer des tokens `--ar-*` **qui existent déjà pour les besoins des composants**. Elles ne doivent jamais forcer l'ajout d'un token dans `packages/core` pour un besoin purement documentaire.
-
-Règle : **un token n'entre dans `packages/core` que si un composant en a besoin**. La doc bénéficie des tokens existants, elle ne les pilote pas.
-
-En pratique :
-
-- Couleurs sémantiques (`--ar-color-bg`, `--ar-color-text`, `--ar-color-border`, `--ar-color-interactive`) → référencées directement dans les `--doc-*`
-- Besoins propres à la doc (fond des blocs de code, largeur sidebar, etc.) → valeurs fixes dans les `--doc-*`, pas de token `--ar-*` créé pour ça
-
-Cette approche évoluera naturellement quand le token system sera plus mature (cf. Web Awesome qui n'a plus besoin de couche intermédiaire).
-
-### Distribution
-
-- **CDN recommandé** pour l'intégration simple (bundle autoportant avec autoloader).
-- **npm** disponible pour les projets qui veulent contrôler l'hébergement ou intégrer dans un bundler.
-- Les composants sont **hermétiques** (Shadow DOM) et cohabitent avec d'autres systèmes de design sans pollution CSS mutuelle.
-
-### Accessibilité
-
-- Cible : **WCAG 2.2 niveau AA**.
-- Compatibilité maximale avec tous les lecteurs d'écran (pas de dépendance à NVDA/JAWS/VoiceOver spécifiquement).
-- Compatibilité navigateurs : **navigateurs modernes avec support des Custom Elements** uniquement.
-
-## Commands
-
-### Monorepo (root)
-
-```bash
-npm run build             # Build all packages/apps
-npm run dev               # Parallel dev mode (watch)
-npm run test              # Run all Vitest tests (core + docs)
-npm run test:all          # Run all tests including browser (Vitest + WTR/Chromium)
-npm run lint              # Lint all packages
-npm run format            # Prettier (TS, JS, JSON, CSS, Astro, MD)
-npm run create ar-<name>  # Scaffold a new component
-```
-
-### Core package (`packages/core/`)
-
-```bash
-npm run build:manifest  # Generate custom-elements.json (CEM)
-npm run build:bundles   # esbuild → dist/ (NPM) + cdn/
-npm run build:css       # Process CSS themes
-npm run build:types     # tsc --emitDeclarationOnly
-npm run test            # vitest run (single pass)
-npm run test:watch      # vitest (interactive)
-npm run test:coverage   # vitest --coverage
-npm run lint            # eslint src
-```
-
-### Docs app (`apps/docs/`)
-
-```bash
-npm run dev    # Astro dev server (requires custom-elements.json to exist first)
-npm run build  # Astro static build
-```
-
-## Architecture
-
-### Structure
-
-```
-packages/core/src/
-  components/   # One directory per component (e.g., button/, stepper/)
-  controllers/  # Reusable Lit ReactiveControllers
-  context/      # @lit/context providers for parent-child communication
-  state/        # Pure state computation engines
-  styles/       # Shared CSS (reset, utilities, animations, themes/)
-  types/        # TypeScript interfaces
-  index.ts      # Barrel export
-apps/docs/      # Astro 5 + MDX documentation site
-```
-
-### Component file conventions
-
-Each component lives in `components/<name>/` with:
-
-- `<name>.ts` — LitElement class, decorated with `@customElement('ar-<name>')`
-- `<name>.styles.ts` — Lit `css` tagged template styles
-- `<name>.test.ts` — Vitest tests
-
-Complex components add:
-
-- `<name>.renderer.ts` — Separate render helpers (e.g., `renderDesktop` / `renderMobile`)
-- `<name>.utils.ts` — Helper functions
-
-### Naming conventions
-
-- **Tag names**: `ar-<name>` (prefix defined in `packages/core/package.json` → `config.componentPrefix`)
-- **Class names**: `Ar<Name>` (PascalCase)
-- **Custom events**: prefixed `ar-` (e.g., `ar-alert-close`, `ar-stepper-step-changed`)
-- **CSS custom properties**: `--ar-<component>-<property>` (e.g., `--ar-button-bg`)
-- **CSS parts**: `part="base"`, `part="label"`, `part="prefix"`, `part="suffix"`
-
-### Key patterns
-
-**Properties**: Always use `reflect: true` for attributes that should sync to HTML.
-
-**Global type declaration**: Every component file ends with:
+Every component file ends with:
 
 ```typescript
 declare global {
@@ -168,57 +42,19 @@ declare global {
 }
 ```
 
-**Custom events**: Always `{ bubbles: true, composed: true }` to traverse Shadow DOM.
+### Tokens: doc vs. library
 
-**Parent-child composition**: Use `@lit/context` — parent exposes a `ContextProvider`, child subscribes via `ContextConsumer`. See `stepper/` for reference.
+`--doc-*` variables (in `apps/docs/`) may reference existing `--ar-*` tokens but must never force adding a token to `packages/core` for a documentation-only need. **A token only enters `packages/core` if a component needs it.**
 
-**No Shadow DOM components**: Data-container components (e.g., `ar-stepper-item`) override `createRenderRoot()` to return `this`.
+### Component variant
 
-### Build outputs
+If `variant` is set explicitly on a component, it overrides the system theme. If unset, the component follows the system theme via semantic tokens.
 
-- `dist/` — Tree-shakeable ESM, Lit as external peer dep
-- `cdn/` — Self-contained bundle (Lit bundled in), includes an autoloader
-- `custom-elements.json` — Source of truth for all component metadata; consumed by the docs app
+---
 
-### Testing pattern
+## Docs site architecture (`apps/docs/`)
 
-```typescript
-async function fixture(html: string): Promise<MrComponent> {
-    const template = document.createElement('template');
-    template.innerHTML = html.trim();
-    const el = template.content.firstElementChild as MrComponent;
-    document.body.appendChild(el);
-    await (el as any).updateComplete;
-    return el;
-}
-```
-
-### Docs generation
-
-`packages/core/cem.config.js` configures `@custom-elements-manifest/analyzer` to generate:
-
-- `custom-elements.json` — component API (props, events, slots, CSS parts/props)
-- `vscode.html-custom-data.json` / `vscode.css-custom-data.json` — IDE completions
-
-JSDoc tags used in component files:
-
-| Tag                | Effect                                                |
-| ------------------ | ----------------------------------------------------- |
-| `@display demo`    | Page shows variants + playground + API ref (default)  |
-| `@display docs`    | Page shows only API ref (no playground)               |
-| `@parent ar-<tag>` | Marks as sub-component; adds back-link to parent page |
-| `@ignore`          | Hides a member from the playground controls           |
-
-### Docs site architecture (`apps/docs/`)
-
-The docs site is a custom Astro 5 + MDX static site. **No Starlight, no api-viewer.**
-
-**Page structure per component** (`/components/[slug]`):
-
-1. **Exemples** — variants stacked vertically, all server-side rendered via `<Fragment set:html>`
-2. **Playground** — server-side initial render + live controls generated from CEM members
-3. **Référence API** — static tables (attributes, events, slots, CSS parts/props)
-4. **Sticky TOC** — right column, `IntersectionObserver`-driven active highlighting
+Custom Astro + MDX static site. No Starlight, no api-viewer.
 
 **Key files:**
 
@@ -252,10 +88,9 @@ variants:
       html: '<ar-button>Label</ar-button>'
 ```
 
-> **Sub-components**: use only `@parent ar-<tag>` JSDoc in the Lit class. No MDX field needed —
-> the CEM `x-parent` field is read directly by the nav and home page to filter and nest the component.
+> **Sub-components**: use only `@parent ar-<tag>` JSDoc in the Lit class. No MDX field needed — the CEM `x-parent` field is read directly by the nav and home page.
 
-**Playground control type detection** (in `src/utils/cem-types.ts` → `buildControls()`):
+**Playground control type detection** (`src/utils/cem-types.ts` → `buildControls()`):
 
 | CEM type                         | Control                                              |
 | -------------------------------- | ---------------------------------------------------- |
@@ -265,61 +100,29 @@ variants:
 | `number` / `number \| undefined` | `<input type="number">`                              |
 | anything else                    | `<input type="text">`                                |
 
+---
+
 ## Tooling Notes
 
 - **Commits**: Conventional Commits enforced by commitlint + Husky
 - **Pre-commit**: lint-staged runs ESLint + Prettier on staged files
 - **TypeScript**: strict mode; use inline type imports (`import type`)
 - **Prettier config**: 100 char width, 4 spaces, single quotes
-- **Node requirement**: >=20, npm >=10
+- **Node requirement**: >=24, npm >=11
+
+---
 
 ## Méthode de travail
 
 **Remettre en cause la demande après 3 essais infructueux**
-Si un correctif échoue 3 fois de suite, ne pas insister. S'arrêter et questionner la logique de la demande elle-même : est-ce rationnel ? Est-ce que ça va à l'encontre des conventions du domaine ? Est-ce que le problème vient du _quoi_ plutôt que du _comment_ ? Exposer le doute clairement à l'utilisateur et proposer une alternative avant de continuer. Exemple : tenter de simuler un layout mobile dans une preview desktop via CSS/JS alors que les DevTools sont l'outil fait pour ça.
+Si un correctif échoue 3 fois de suite, ne pas insister. S'arrêter et questionner la logique de la demande elle-même : est-ce rationnel ? Est-ce que ça va à l'encontre des conventions du domaine ? Est-ce que le problème vient du _quoi_ plutôt que du _comment_ ? Exposer le doute clairement à l'utilisateur et proposer une alternative avant de continuer.
 
 ---
 
-## Lessons — décisions techniques et erreurs à ne pas reproduire
-
-### Docs site
-
-**Highlight.js plutôt que Shiki pour la coloration syntaxique**
-Shiki est 100% serveur — impossible de re-coloriser côté client après que le playground ait réécrit le DOM. Utiliser uniquement highlight.js (CDN cdnjs, thème `github-dark`) : `hljs.highlightAll()` au chargement, `hljs.highlightElement(el)` après chaque mise à jour (après avoir réinitialisé l'attribut `data-highlighted`). Ne pas mélanger les deux outils — leurs palettes divergent même avec le même thème.
-
-**Overlay nav mobile — `pointer-events`**
-Un overlay avec `opacity: 0` bloque quand même les clics. Toujours ajouter `pointer-events: none` par défaut sur `.nav-overlay`, et `pointer-events: auto` uniquement avec la classe `.open`.
-
-**IntersectionObserver double-init (TableOfContents)**
-`TableOfContents.astro` est monté deux fois (desktop sticky + mobile inline). Utiliser un guard `window.__tocObserverInit` — seule la première instance crée l'observer. Les deux partagent les mêmes classes CSS `.toc-link`, un seul observer suffit.
-
-**Sous-composants : `@parent` JSDoc seul suffit**
-`index.astro` et `SiteNav.astro` lisent tous les deux `c['x-parent']` depuis le CEM. Le champ MDX `parent` a été supprimé du schéma Zod. L'annotation `@parent ar-<tag>` dans le composant Lit est la seule source de vérité — ne pas ajouter de champ MDX.
-
-**Types CEM : ne pas dupliquer, utiliser `cem-types.ts`**
-Toutes les interfaces CEM et helpers (`getCustomElements`, `buildControls`) sont dans `src/utils/cem-types.ts`. Avant d'écrire une interface CEM dans un fichier Astro, vérifier si elle existe déjà.
-
-**Astro scoped styles et imports CSS partagés**
-Pour partager du CSS entre composants, utiliser `@import` au début d'un bloc `<style>`. Astro résout les imports relatifs et applique quand même le scoping.
-
-**`<script is:inline src="...">` plutôt que `defer`**
-`defer` charge le script après le DOM, ce qui posait un problème pour `hljs.highlightAll()`. Utiliser `is:inline` explicitement pour un chargement synchrone — highlight.js est assez petit pour ça.
-
-**Scripts `is:inline src="..."` dans `<head>` — envelopper dans `DOMContentLoaded`**
-Un script `is:inline src="..."` dans `<head>` s'exécute avant le parsing du `<body>`. Tout `document.querySelectorAll(...)` retourne zéro éléments. Envelopper le code dans `document.addEventListener('DOMContentLoaded', function() { ... })`. C'était la cause du dysfonctionnement complet du playground interactif (contrôles sans effet).
-
-**Preview de composants indépendante du thème global**
-Les éléments `.preview` ont leur propre attribut `data-theme="light|dark"` et redéfinissent les tokens `--ar-color-*` pour un contexte CSS isolé. Un bouton toggle local permet de basculer indépendamment du thème global.
-
-**Variables CSS `--doc-*` pour les couleurs de la doc**
-Ne jamais mettre de couleurs hex hardcodées dans `apps/docs/`. Le site supporte les thèmes light/dark via les variables `--doc-*` (ex : `--doc-text`, `--doc-border`, `--doc-text-muted`). Toujours vérifier si une variable existe avant d'écrire une valeur fixe.
-
-### Package core
+## Lessons — package core
 
 **Convention de dépréciation**
-Utiliser `warnDeprecated(tag, member, message)` depuis `src/utils/deprecated.ts` pour signaler une propriété ou un attribut obsolète. Le warning ne s'affiche qu'une fois par session (garde en `Set`). Toujours annoter avec `@deprecated` en JSDoc pour que l'IDE le signale. Annoncer la suppression cible dans le message (ex: `Sera supprimé en v1.0.0.`).
-
-Exemple d'usage dans un composant :
+Utiliser `warnDeprecated(tag, member, message)` depuis `src/utils/deprecated.ts`. Le warning ne s'affiche qu'une fois par session (garde en `Set`). Toujours annoter avec `@deprecated` en JSDoc. Annoncer la suppression cible dans le message.
 
 ```typescript
 import { warnDeprecated } from '../../utils/deprecated.js';
@@ -334,23 +137,17 @@ if (this.links !== undefined) {
 }
 ```
 
-**`reflect: true` obligatoire**
-Sans `reflect: true`, l'attribut n'est pas synchronisé dans le DOM — le `outerHTML` du playground affichera des attributs absents même si la propriété a changé côté JS.
-
-**`{ bubbles: true, composed: true }` sur tous les événements custom**
-Sans `composed: true`, les événements ne traversent pas la frontière Shadow DOM. Sans `bubbles: true`, ils ne remontent pas non plus dans le DOM shadow.
-
 **Tests : `textContent` des Text nodes Lit interpolés dans happy-dom**
-happy-dom ne sérialise pas correctement les Text nodes dynamiques générés par Lit (`${this.prop}` dans un template html`...`). `element.textContent` retourne `''` même si le rendu est correct visuellement. Pour tester le contenu textuel, vérifier la propriété JS directement (`el.myProp`) plutôt que `element.textContent`. Les attributs, `hasAttribute`, `getAttribute` et la structure DOM (présence d'éléments, `hidden`) fonctionnent correctement.
+`element.textContent` retourne `''` même si le rendu est correct. Tester la propriété JS directement (`el.myProp`). Les attributs, `hasAttribute`, `getAttribute` et la structure DOM fonctionnent correctement.
 
-**Tests : helpers `fixture()`, `waitForUpdate()`, `getPart()` pour les composants Lit**
-Extraire ces trois helpers dans chaque fichier de test pour éviter les non-null assertions (`!`) bloquées par `lint-staged --max-warnings=0`. `getPart(el, 'name')` cible les éléments par `part="…"` — l'API publique stable du composant.
+**Tests : helpers `fixture()`, `waitForUpdate()`, `getPart()`**
+Extraire ces trois helpers dans chaque fichier de test pour éviter les non-null assertions (`!`) bloquées par `lint-staged --max-warnings=0`. `getPart(el, 'name')` cible les éléments par `part="…"`.
 
 **Tests : `.ariaCurrent` (et autres propriétés ARIA Lit) ne reflètent pas en attribut dans happy-dom**
-Quand Lit assigne une propriété ARIA via `.ariaCurrent`, `.ariaExpanded`, etc. (liaison de propriété DOM), `getAttribute('aria-current')` retourne `null` dans happy-dom. Tester la propriété JS directement : `(el as unknown as { ariaCurrent: string }).ariaCurrent`.
+Tester la propriété JS directement : `(el as unknown as { ariaCurrent: string }).ariaCurrent`.
 
-**Tests : `MrBreadcrumb.mobileQuery` — mock minimal avec `addEventListener`/`removeEventListener`**
-Remplacer `MrBreadcrumb.mobileQuery` par `{ matches: true/false, addEventListener: vi.fn(), removeEventListener: vi.fn() } as unknown as MediaQueryList`. Un objet sans ces méthodes plante dans `connectedCallback`/`disconnectedCallback`. Créer un helper `mockMediaQuery(matches)` en tête de fichier.
+**Tests : `MediaQueryList` mock**
+Toujours inclure `addEventListener` et `removeEventListener` : `{ matches: true, addEventListener: vi.fn(), removeEventListener: vi.fn() } as unknown as MediaQueryList`.
 
-**Tests : composants avec `queueMicrotask` (ex: `_scheduleRebuild`) nécessitent deux `updateComplete`**
-Quand le rendu est déclenché depuis un `queueMicrotask` (pattern de debounce), `await updateComplete` une seule fois ne suffit pas. Dans `fixture()` et `waitForUpdate()`, `await updateComplete` deux fois de suite pour absorber le cycle initial + le cycle déclenché par le microtask.
+**Tests : `queueMicrotask` — double `updateComplete`**
+Quand le rendu est déclenché depuis un `queueMicrotask`, `await updateComplete` deux fois de suite pour absorber le cycle initial + le cycle du microtask.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,263 +1,89 @@
-# Contributing to Ariane
+# Contribuer à Ariane
 
-Ce guide couvre le workflow de contribution pour le **package core** (`@ariane-ui/core`).
-Pour modifier le site de documentation, voir [apps/docs/CONTRIBUTING.md](apps/docs/CONTRIBUTING.md).
+Ce guide s'adresse aux contributeurs externes qui souhaitent proposer une amélioration,
+signaler un bug ou soumettre un nouveau composant.
 
----
-
-## Prérequis
-
-- Node ≥ 24 (LTS), npm ≥ 11
-- Lire [README.md](README.md) pour comprendre la structure du monorepo
+Pour le setup technique et les commandes de développement : voir [DEVELOPMENT.md](DEVELOPMENT.md).
 
 ---
 
-## Workflow général
+## Qu'est-ce qu'Ariane ?
+
+Ariane se positionne entre deux extrêmes du marché des composants web :
+
+- **Web Awesome / Shoelace** — design system complet et opiniaté : l'intégrateur adopte le look de la librairie.
+- **Radix UI / Headless UI** — composants sans style : l'intégrateur apporte tout le CSS.
+
+**Ariane** : comportement accessible + tokens thémables, aucune opinion visuelle forte.
+C'est la **fondation** sur laquelle construire son propre design system — pas un design system en soi.
+
+---
+
+## Philosophie
+
+### Mission
+
+Ariane prend en charge les patterns dont la complexité d'implémentation correcte est un obstacle
+à l'accessibilité dans les projets réels. Elle ne réécrit pas les éléments natifs qui fonctionnent bien.
+
+### Critères d'inclusion d'un composant
+
+Un composant intègre Ariane si au moins l'une de ces conditions est vraie :
+
+1. **Complexité a11y non triviale** — implémenter correctement le comportement accessible est difficile (stepper, datepicker, dialog, tabs).
+2. **Absent des projets par difficulté d'implémentation** — le composant améliorerait l'UX mais est rarement bien fait (datepicker).
+3. **Extension d'un natif insuffisant** — `<dialog>` → `<ar-dialog>` qui l'étend.
+
+Un composant est **exclu** si :
+
+- Il réplique un natif qui fait déjà bien le job (`<button>`, `<input>`, `<select>` de base).
+- Sa valeur ajoutée est purement graphique sans apport a11y ou comportemental.
+
+### Ergonomie de l'API
+
+Intuitive par rapport aux natifs : un breadcrumb se compose comme un `<ul>/<li>`,
+pas comme un JSON stringifié. Préférer des éléments enfants slottés aux props complexes.
+
+### Thémabilité et accessibilité
+
+- Les aspects visuels sont exposés via CSS custom properties (`--ar-*`).
+- Les aspects qui garantissent l'accessibilité (focus management, bouton de fermeture) sont non négociables.
+- Le thème par défaut satisfait les ratios de contraste **WCAG 2.2 AA** sans configuration supplémentaire.
+
+---
+
+## Proposer un nouveau composant
+
+1. **Ouvrir une issue** en expliquant le besoin, les critères d'inclusion satisfaits, et une esquisse d'API.
+2. **Discussion** — attendre un retour avant de commencer l'implémentation.
+3. **PR sur `dev`** une fois l'issue validée.
+
+---
+
+## Workflow PR
+
+Toutes les contributions passent par une Pull Request sur la branche `dev`.
 
 ```bash
 git clone https://github.com/jogo-labs/ariane
 cd ariane
-nvm use          # active automatiquement Node 24 via .nvmrc
+nvm use
 npm install
-npm run dev          # watch core + docs en parallèle
+git checkout -b feat/mon-composant
 ```
-
-Toutes les contributions passent par une **Pull Request** sur `dev`.
 
 ---
 
 ## Conventions de commit
 
-Les commits suivent la spécification **Conventional Commits**, vérifiée automatiquement
-par commitlint + Husky au moment du `git commit`.
+Les commits suivent **Conventional Commits**, vérifiés automatiquement par commitlint + Husky.
 
 ```
-<type>(<scope>): <description courte>
-
 feat(button): ajoute la prop `loading`
 fix(stepper): corrige la navigation au clavier
-docs(alert): met à jour les exemples MDX
-refactor(core): extrait les types CEM dans cem-types.ts
+docs(alert): met à jour les exemples
 test(button): ajoute les cas disabled
+chore(deps): met à jour esbuild
 ```
 
 Types autorisés : `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `perf`, `ci`.
-
----
-
-## Créer un nouveau composant
-
-### Via le scaffolder
-
-```bash
-npm run create ar-mon-composant
-```
-
-Le script génère automatiquement la structure dans `packages/core/src/components/mon-composant/` :
-
-```
-mon-composant/
-├── mon-composant.ts           ← Classe LitElement
-├── mon-composant.styles.ts    ← Styles Lit CSS
-└── mon-composant.test.ts      ← Tests Vitest
-```
-
-### Conventions à respecter dans le fichier `.ts`
-
-**JSDoc obligatoire** — le CEM et la documentation sont générés depuis ces annotations :
-
-```typescript
-/**
- * @summary Description courte (une phrase).
- * @display demo
- *
- * @slot             - Slot par défaut.
- * @slot prefix      - Icône avant le contenu.
- *
- * @csspart base     - L'élément racine du composant.
- *
- * @cssprop --ar-mon-composant-bg - Couleur de fond.
- *
- * @event {CustomEvent} ar-change - Émis lors d'un changement.
- */
-@customElement('ar-mon-composant')
-export class ArMonComposant extends LitElement { … }
-```
-
-**Annotations JSDoc spéciales :**
-
-| Annotation         | Effet                                           |
-| ------------------ | ----------------------------------------------- |
-| `@display demo`    | Page doc : exemples + playground + API (défaut) |
-| `@display docs`    | Page doc : API uniquement, pas de playground    |
-| `@parent ar-<tag>` | Marque comme sous-composant de `<tag>`          |
-| `@ignore`          | Exclut un membre des contrôles du playground    |
-
-**Propriétés :**
-
-```typescript
-// Toujours reflect: true pour que l'attribut HTML reste synchronisé
-@property({ reflect: true })
-variant: 'filled' | 'outlined' = 'filled';
-
-// Boolean
-@property({ type: Boolean, reflect: true })
-disabled = false;
-```
-
-**Événements custom :**
-
-```typescript
-// Toujours bubbles: true + composed: true pour traverser le Shadow DOM
-this.dispatchEvent(new CustomEvent('ar-change', { bubbles: true, composed: true }));
-```
-
-**Global type declaration** (à la fin de chaque fichier) :
-
-```typescript
-declare global {
-    interface HTMLElementTagNameMap {
-        'ar-mon-composant': ArMonComposant;
-    }
-}
-```
-
-### Sous-composants (parent / enfant)
-
-Utilisez `@parent` dans la JSDoc du composant enfant — c'est la seule déclaration nécessaire :
-
-```typescript
-/**
- * @parent ar-stepper
- * @display docs
- */
-@customElement('ar-stepper-item')
-export class ArStepperItem extends LitElement { … }
-```
-
-Cela suffit pour que le sous-composant soit :
-
-- masqué de la liste principale de la doc
-- imbriqué sous son parent dans la navigation
-
----
-
-## Tests
-
-### Tests unitaires (Vitest + happy-dom)
-
-```bash
-cd packages/core
-npm run test           # passe unique
-npm run test:watch     # mode interactif
-npm run test:coverage  # rapport de couverture
-```
-
-### Tests browser (web-test-runner + Playwright + axe-core)
-
-Les tests browser vérifient le comportement réel dans Chromium et l'accessibilité via axe-core.
-Ils sont séparés des tests unitaires car ils nécessitent un vrai navigateur.
-
-```bash
-cd packages/core
-npm run test:browser   # lance WTR + Chromium (Playwright)
-```
-
-Pour lancer l'ensemble des tests depuis la racine :
-
-```bash
-npm run test:all       # tests unitaires + tests browser
-```
-
-Les fichiers de tests browser sont nommés `*.browser.test.ts` ou `*.a11y.test.ts`.
-
-### Pattern de test
-
-```typescript
-import { describe, it, expect, beforeEach } from 'vitest';
-import { ArAlert } from './alert.js';
-
-async function fixture(html: string): Promise<ArAlert> {
-    const template = document.createElement('template');
-    template.innerHTML = html.trim();
-    const el = template.content.firstElementChild as ArAlert;
-    document.body.appendChild(el);
-    await (el as any).updateComplete;
-    return el;
-}
-
-describe('ArAlert', () => {
-    beforeEach(() => {
-        document.body.innerHTML = '';
-    });
-
-    it("est dismissible quand l'attribut next-focus est présent", async () => {
-        const el = await fixture('<ar-alert next-focus="btn">Alerte</ar-alert>');
-        expect(el.getAttribute('next-focus')).toBe('btn');
-    });
-});
-```
-
----
-
-## Mise à jour du Custom Elements Manifest
-
-Après avoir modifié les annotations JSDoc ou la structure d'un composant :
-
-```bash
-cd packages/core
-npm run build:manifest    # regénère custom-elements.json
-```
-
-Le CEM est la source de vérité pour la documentation et les intégrations IDE.
-Il est regénéré automatiquement lors d'un `npm run dev` ou `npm run build`.
-
----
-
-## Build
-
-```bash
-cd packages/core
-npm run build             # tout : manifest + bundles + CSS + types
-
-npm run build:manifest    # custom-elements.json uniquement
-npm run build:bundles     # dist/ (npm) + cdn/ (CDN auto-contenu)
-npm run build:css         # thèmes CSS
-npm run build:types       # déclarations TypeScript (.d.ts)
-```
-
-### Outputs
-
-| Répertoire                  | Usage                                                  |
-| --------------------------- | ------------------------------------------------------ |
-| `dist/`                     | Bundle npm — Lit en peer dependency, tree-shakeable    |
-| `cdn/`                      | Bundle CDN — Lit bundlé, auto-contenu, avec autoloader |
-| `dist/custom-elements.json` | Manifest CEM — consommé par la documentation           |
-| `dist/styles/themes/`       | Fichiers CSS de thème                                  |
-
----
-
-## Lint et formatage
-
-```bash
-npm run lint      # ESLint (depuis la racine ou packages/core)
-npm run format    # Prettier — s'applique à tout le monorepo
-```
-
-Le pre-commit hook (lint-staged) lance automatiquement ESLint + Prettier sur les fichiers stagés.
-
----
-
-## Intégration IDE (VS Code)
-
-Le build génère `dist/vscode.html-custom-data.json` et `dist/vscode.css-custom-data.json`.
-Ces fichiers permettent l'autocomplétion des composants et propriétés CSS dans VS Code.
-
-Pour les activer dans votre projet consommateur, référencez-les dans `.vscode/settings.json` :
-
-```json
-{
-    "html.customData": ["./node_modules/@ariane-ui/core/dist/vscode.html-custom-data.json"],
-    "css.customData": ["./node_modules/@ariane-ui/core/dist/vscode.css-custom-data.json"]
-}
-```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,12 +144,32 @@ Cela suffit pour que le sous-composant soit :
 
 ## Tests
 
+### Tests unitaires (Vitest + happy-dom)
+
 ```bash
 cd packages/core
 npm run test           # passe unique
 npm run test:watch     # mode interactif
 npm run test:coverage  # rapport de couverture
 ```
+
+### Tests browser (web-test-runner + Playwright + axe-core)
+
+Les tests browser vérifient le comportement réel dans Chromium et l'accessibilité via axe-core.
+Ils sont séparés des tests unitaires car ils nécessitent un vrai navigateur.
+
+```bash
+cd packages/core
+npm run test:browser   # lance WTR + Chromium (Playwright)
+```
+
+Pour lancer l'ensemble des tests depuis la racine :
+
+```bash
+npm run test:all       # tests unitaires + tests browser
+```
+
+Les fichiers de tests browser sont nommés `*.browser.test.ts` ou `*.a11y.test.ts`.
 
 ### Pattern de test
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,264 @@
+# Guide de développement
+
+> **Philosophie et positionnement du projet → [CONTRIBUTING.md](CONTRIBUTING.md)**
+> Lis-le avant de démarrer si ce n'est pas déjà fait.
+
+---
+
+## Prérequis
+
+- Node ≥ 24 (LTS)
+- npm ≥ 11
+- [nvm](https://github.com/nvm-sh/nvm) recommandé
+
+## Setup
+
+```bash
+git clone https://github.com/jogo-labs/ariane
+cd ariane
+nvm use          # active Node 24 via .nvmrc
+npm install
+```
+
+## Commandes racine
+
+| Commande                  | Description                                       |
+| ------------------------- | ------------------------------------------------- |
+| `npm run dev`             | Watch core + docs en parallèle (pré-build le CEM) |
+| `npm run build`           | Build complet (core + docs)                       |
+| `npm run test`            | Tests unitaires Vitest                            |
+| `npm run test:all`        | Tests unitaires + tests browser (Vitest + WTR)    |
+| `npm run lint`            | ESLint sur tous les packages                      |
+| `npm run format`          | Prettier sur tous les fichiers                    |
+| `npm run create ar-<nom>` | Scaffold un nouveau composant                     |
+
+## Commandes par workspace
+
+### `packages/core`
+
+| Commande                 | Description                       |
+| ------------------------ | --------------------------------- |
+| `npm run build:manifest` | Génère `custom-elements.json`     |
+| `npm run build:bundles`  | esbuild → `dist/` (npm) + `cdn/`  |
+| `npm run build:css`      | Thèmes CSS                        |
+| `npm run build:types`    | Déclarations TypeScript           |
+| `npm run test`           | Vitest, passe unique              |
+| `npm run test:watch`     | Vitest interactif                 |
+| `npm run test:coverage`  | Vitest avec rapport de couverture |
+| `npm run test:browser`   | @web/test-runner + Chromium       |
+| `npm run lint`           | ESLint                            |
+
+---
+
+## Architecture du monorepo
+
+```text
+packages/core/src/
+  components/   # Un répertoire par composant (ex: button/, stepper/)
+  controllers/  # Lit ReactiveControllers réutilisables
+  context/      # @lit/context providers (communication parent-enfant)
+  state/        # Moteurs de calcul d'état purs
+  styles/       # CSS partagé (reset, utilitaires, animations, thèmes)
+  types/        # Interfaces TypeScript
+  index.ts      # Export barrel
+apps/docs/      # Site de documentation Astro
+```
+
+## Conventions fichiers composant
+
+Chaque composant dans `components/<name>/` :
+
+- `<name>.ts` — classe LitElement, `@customElement('ar-<name>')`
+- `<name>.styles.ts` — styles Lit `css` tagged template
+- `<name>.test.ts` — tests Vitest
+
+Composants complexes ajoutent :
+
+- `<name>.renderer.ts` — helpers de rendu (desktop/mobile)
+- `<name>.utils.ts` — fonctions utilitaires
+
+## Conventions de nommage
+
+| Élément               | Convention                | Exemple          |
+| --------------------- | ------------------------- | ---------------- |
+| Tag HTML              | `ar-<name>`               | `ar-button`      |
+| Classe                | `Ar<Name>`                | `ArButton`       |
+| Événements custom     | `ar-<event>`              | `ar-alert-close` |
+| CSS custom properties | `--ar-<component>-<prop>` | `--ar-button-bg` |
+| CSS parts             | `part="base"`             | `part="label"`   |
+
+---
+
+## Patterns de code
+
+### Propriétés — toujours `reflect: true`
+
+Sans `reflect: true`, l'attribut HTML n'est pas synchronisé avec la propriété JS.
+Le `outerHTML` du playground afficherait des attributs absents.
+
+```typescript
+@property({ reflect: true })
+variant: 'filled' | 'outlined' = 'filled';
+
+@property({ type: Boolean, reflect: true })
+disabled = false;
+```
+
+### Événements custom — toujours `bubbles + composed`
+
+Sans `composed: true`, l'événement ne traverse pas le Shadow DOM.
+Sans `bubbles: true`, il ne remonte pas dans le DOM light.
+
+```typescript
+this.dispatchEvent(
+    new CustomEvent('ar-change', {
+        bubbles: true,
+        composed: true,
+        detail: { value: this.value },
+    }),
+);
+```
+
+### Global type declaration (fin de chaque fichier composant)
+
+```typescript
+declare global {
+    interface HTMLElementTagNameMap {
+        'ar-<name>': Ar<Name>;
+    }
+}
+```
+
+### Composition parent-enfant
+
+Utiliser `@lit/context` — le parent expose un `ContextProvider`, l'enfant s'abonne via `ContextConsumer`. Voir `stepper/` pour référence.
+
+### Composants sans Shadow DOM
+
+Les composants conteneurs de données overrident `createRenderRoot()` :
+
+```typescript
+override createRenderRoot() {
+    return this;
+}
+```
+
+---
+
+## JSDoc CEM — annotations obligatoires
+
+Le CEM (`custom-elements.json`) est généré depuis la JSDoc. Toujours documenter :
+
+```typescript
+/**
+ * @summary Description courte (une phrase).
+ * @display demo
+ *
+ * @slot              - Slot par défaut.
+ * @slot prefix       - Icône avant le contenu.
+ *
+ * @csspart base      - L'élément racine du composant.
+ *
+ * @cssprop --ar-mon-composant-bg - Couleur de fond.
+ *
+ * @event {CustomEvent} ar-change - Émis lors d'un changement.
+ */
+```
+
+| Annotation         | Effet                                           |
+| ------------------ | ----------------------------------------------- |
+| `@display demo`    | Page doc : exemples + playground + API (défaut) |
+| `@display docs`    | Page doc : API uniquement                       |
+| `@parent ar-<tag>` | Marque comme sous-composant                     |
+| `@ignore`          | Exclut un membre des contrôles playground       |
+
+---
+
+## Tests unitaires (Vitest + happy-dom)
+
+### Pattern standard
+
+```typescript
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { ArAlert } from './alert.js';
+
+async function fixture<T extends HTMLElement>(html: string): Promise<T> {
+    const template = document.createElement('template');
+    template.innerHTML = html.trim();
+    const el = template.content.firstElementChild as T;
+    document.body.appendChild(el);
+    await (el as any).updateComplete;
+    await (el as any).updateComplete; // double await pour les queueMicrotask
+    return el;
+}
+
+async function waitForUpdate(el: HTMLElement): Promise<void> {
+    await (el as any).updateComplete;
+    await (el as any).updateComplete;
+}
+
+function getPart(el: Element, name: string): Element | null {
+    return el.shadowRoot?.querySelector(`[part="${name}"]`) ?? null;
+}
+
+describe('ArAlert', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    it('affiche le message', async () => {
+        const el = await fixture<ArAlert>('<ar-alert>Texte</ar-alert>');
+        expect(el.getAttribute('role')).toBe('alert');
+    });
+});
+```
+
+### Pièges courants happy-dom
+
+- **`textContent` des interpolations Lit** : retourne `''`. Tester la propriété JS directement (`el.myProp`) plutôt que `el.textContent`.
+- **Propriétés ARIA via liaison Lit** (`.ariaCurrent`, `.ariaExpanded`) : `getAttribute('aria-current')` retourne `null`. Tester `(el as any).ariaCurrent` directement.
+- **`MediaQueryList` mock** : toujours inclure `addEventListener` et `removeEventListener` :
+    ```typescript
+    { matches: true, addEventListener: vi.fn(), removeEventListener: vi.fn() } as unknown as MediaQueryList
+    ```
+- **`queueMicrotask` dans le rendu** : `await updateComplete` deux fois pour absorber le cycle initial + le cycle du microtask.
+
+## Tests browser (web-test-runner + Playwright + axe-core)
+
+Fichiers nommés `*.browser.test.ts` ou `*.a11y.test.ts`.
+
+```typescript
+import { expect, fixture, html } from '@open-wc/testing';
+import { checkAccessibility } from '../../test-utils.js';
+
+describe('ArAlert a11y', () => {
+    it('passe axe-core', async () => {
+        const el = await fixture(html`<ar-alert>Message</ar-alert>`);
+        await checkAccessibility(el);
+    });
+});
+```
+
+---
+
+## Build outputs
+
+| Répertoire                  | Usage                                        |
+| --------------------------- | -------------------------------------------- |
+| `dist/`                     | Bundle npm — Lit en peer dep, tree-shakeable |
+| `cdn/`                      | Bundle CDN — Lit bundlé, avec autoloader     |
+| `dist/custom-elements.json` | Manifest CEM — consommé par la doc           |
+| `dist/styles/themes/`       | Fichiers CSS de thème                        |
+
+---
+
+## Intégration IDE (VS Code)
+
+Référencer dans `.vscode/settings.json` du projet consommateur :
+
+```json
+{
+    "html.customData": ["./node_modules/@ariane-ui/core/dist/vscode.html-custom-data.json"],
+    "css.customData": ["./node_modules/@ariane-ui/core/dist/vscode.css-custom-data.json"]
+}
+```

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Bibliothèque de composants web accessibles, construite avec **Lit 3** et **Type
 
 ## Ce que c'est
 
-Ariane est un **Design System** : un ensemble de composants UI réutilisables, autonomes et accessibles.
-Les composants sont des **Custom Elements** natifs — ils fonctionnent dans n'importe quel framework
-(React, Vue, Angular, Svelte) ou sans framework du tout.
+Ariane est une **librairie de composants web accessibles** — une fondation sur laquelle construire un design system,
+pas un design system en soi. Les composants sont des **Custom Elements** natifs : ils fonctionnent dans n'importe
+quel framework (React, Vue, Angular, Svelte) ou sans framework du tout.
 
 Composants disponibles : `ar-alert`, `ar-breadcrumb`, `ar-button`, `ar-pagination`,
 `ar-progressbar`, `ar-spinner`, `ar-stepper` / `ar-stepper-item`.
@@ -22,7 +22,7 @@ Composants disponibles : `ar-alert`, `ar-breadcrumb`, `ar-button`, `ar-paginatio
 
 ## Structure du monorepo
 
-```
+```text
 Ariane/
 ├── packages/
 │   └── core/          # @ariane-ui/core — la bibliothèque de composants
@@ -58,10 +58,6 @@ npm run dev        # Lance le watch du package core + le serveur Astro en parall
 
 Le site de documentation est disponible sur `http://localhost:4321`.
 
-> Au premier lancement, le CEM (`custom-elements.json`) doit exister.
-> Il est généré automatiquement par `npm run dev`. Si vous partez de zéro,
-> lancez d'abord : `cd packages/core && npm run build:manifest`
-
 ### Build complet
 
 ```bash
@@ -76,7 +72,8 @@ npm run build      # Build tous les packages et le site de doc
 | ------------------------- | ---------------------------------------------------- |
 | `npm run dev`             | Mode développement parallèle (core watch + docs dev) |
 | `npm run build`           | Build complet (core + docs)                          |
-| `npm run test`            | Lance tous les tests                                 |
+| `npm run test`            | Tests unitaires (Vitest)                             |
+| `npm run test:all`        | Tests unitaires + tests browser (Vitest + WTR)       |
 | `npm run lint`            | ESLint sur tous les packages                         |
 | `npm run format`          | Prettier sur tous les fichiers                       |
 | `npm run create ar-<nom>` | Scaffold un nouveau composant                        |
@@ -140,15 +137,16 @@ Consultez la page **Design Tokens** du site de documentation pour la liste compl
 
 ## Stack technique
 
-| Outil                                                                                 | Rôle                                         |
-| ------------------------------------------------------------------------------------- | -------------------------------------------- |
-| [Lit 3](https://lit.dev/)                                                             | Base des composants (Shadow DOM, réactivité) |
-| [TypeScript 5](https://www.typescriptlang.org/)                                       | Typage strict                                |
-| [esbuild](https://esbuild.github.io/)                                                 | Build rapide — bundles npm et CDN            |
-| [@custom-elements-manifest/analyzer](https://custom-elements-manifest.open-wc.org/)   | Génération du manifest CEM depuis la JSDoc   |
-| [Vitest](https://vitest.dev/) + [happy-dom](https://github.com/capricorn86/happy-dom) | Tests unitaires                              |
-| [Astro 6](https://astro.build/)                                                       | Site de documentation statique               |
-| npm workspaces + [Turborepo](https://turbo.build/)                                    | Monorepo                                     |
+| Outil                                                                                                                                                             | Rôle                                         |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| [Lit 3](https://lit.dev/)                                                                                                                                         | Base des composants (Shadow DOM, réactivité) |
+| [TypeScript 6](https://www.typescriptlang.org/)                                                                                                                   | Typage strict                                |
+| [esbuild](https://esbuild.github.io/)                                                                                                                             | Build rapide — bundles npm et CDN            |
+| [@custom-elements-manifest/analyzer](https://custom-elements-manifest.open-wc.org/)                                                                               | Génération du manifest CEM depuis la JSDoc   |
+| [Vitest](https://vitest.dev/) + [happy-dom](https://github.com/capricorn86/happy-dom)                                                                             | Tests unitaires                              |
+| [@web/test-runner](https://modern-web.dev/docs/test-runner/overview/) + [Playwright](https://playwright.dev/) + [axe-core](https://github.com/dequelabs/axe-core) | Tests browser et a11y                        |
+| [Astro 6](https://astro.build/)                                                                                                                                   | Site de documentation statique               |
+| npm workspaces + [Turborepo](https://turbo.build/)                                                                                                                | Monorepo                                     |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -20,67 +20,7 @@ Composants disponibles : `ar-alert`, `ar-breadcrumb`, `ar-button`, `ar-paginatio
 
 ---
 
-## Structure du monorepo
-
-```text
-Ariane/
-├── packages/
-│   └── core/          # @ariane-ui/core — la bibliothèque de composants
-└── apps/
-    └── docs/          # Site de documentation (Astro 6)
-```
-
-Le monorepo est géré par **npm workspaces** et orchestré par **Turborepo**.
-
----
-
-## Démarrage rapide
-
-### Prérequis
-
-- Node ≥ 24 (LTS)
-- npm ≥ 11
-
-### Installation
-
-```bash
-git clone https://github.com/jogo-labs/ariane
-cd Ariane
-nvm use   # active automatiquement Node 24 via .nvmrc
-npm install
-```
-
-### Développement
-
-```bash
-npm run dev        # Lance le watch du package core + le serveur Astro en parallèle
-```
-
-Le site de documentation est disponible sur `http://localhost:4321`.
-
-### Build complet
-
-```bash
-npm run build      # Build tous les packages et le site de doc
-```
-
----
-
-## Commandes racine
-
-| Commande                  | Description                                          |
-| ------------------------- | ---------------------------------------------------- |
-| `npm run dev`             | Mode développement parallèle (core watch + docs dev) |
-| `npm run build`           | Build complet (core + docs)                          |
-| `npm run test`            | Tests unitaires (Vitest)                             |
-| `npm run test:all`        | Tests unitaires + tests browser (Vitest + WTR)       |
-| `npm run lint`            | ESLint sur tous les packages                         |
-| `npm run format`          | Prettier sur tous les fichiers                       |
-| `npm run create ar-<nom>` | Scaffold un nouveau composant                        |
-
----
-
-## Utilisation
+## Installation
 
 ### Via CDN (sans bundler)
 
@@ -91,15 +31,15 @@ npm run build      # Build tous les packages et le site de doc
 <ar-button>Cliquez-moi</ar-button>
 ```
 
-### Via npm (avec bundler)
+### Via npm
 
 ```bash
 npm install @ariane-ui/core
 ```
 
 ```typescript
-import '@ariane-ui/core'; // enregistre tous les composants
-import '@ariane-ui/core/themes/default.css'; // thème par défaut
+import '@ariane-ui/core';
+import '@ariane-ui/core/themes/default.css';
 
 // ou import individuel (tree-shaking)
 import '@ariane-ui/core/dist/components/button/button.js';
@@ -110,8 +50,6 @@ await whenAllDefined('ar-button', 'ar-stepper');
 ```
 
 ### Autoloader CDN
-
-Le bundle CDN inclut un autoloader qui ne charge chaque composant que quand il est utilisé :
 
 ```html
 <script type="module" src="/cdn/autoloader.js"></script>
@@ -152,8 +90,8 @@ Consultez la page **Design Tokens** du site de documentation pour la liste compl
 
 ## Contribution
 
-Voir [CONTRIBUTING.md](CONTRIBUTING.md) pour les conventions et le workflow.
-Pour modifier le site de documentation, voir [apps/docs/CONTRIBUTING.md](apps/docs/CONTRIBUTING.md).
+Voir [CONTRIBUTING.md](CONTRIBUTING.md) pour la philosophie et le workflow de contribution.
+Pour le setup et les commandes de développement, voir [DEVELOPMENT.md](DEVELOPMENT.md).
 
 ---
 

--- a/docs/decisions/ADR-001-highlight-js-vs-shiki.md
+++ b/docs/decisions/ADR-001-highlight-js-vs-shiki.md
@@ -1,0 +1,31 @@
+# ADR-001 : Highlight.js plutôt que Shiki pour la coloration syntaxique
+
+**Statut :** Adopté
+**Date :** 2026-01-15
+
+## Contexte
+
+Le site de documentation affiche des blocs de code avec coloration syntaxique.
+Le playground interactif régénère le HTML de ces blocs côté client après chaque
+changement de contrôle — il faut donc pouvoir re-coloriser à la demande.
+
+## Décision
+
+Utiliser **highlight.js** via CDN (thème `github-dark`, chargé via `is:inline`).
+Appeler `hljs.highlightAll()` au chargement initial, et `hljs.highlightElement(el)`
+après chaque mise à jour du playground (après avoir réinitialisé `data-highlighted`).
+
+Le script highlight.js est chargé dans `<head>` avec `is:inline` et le code
+enveloppé dans `DOMContentLoaded` pour éviter que les `querySelectorAll` retournent
+zéro éléments (le script s'exécute avant le parsing du `<body>`).
+
+## Alternatives rejetées
+
+- **Shiki** — 100% serveur. Impossible de re-coloriser côté client après que le
+  playground ait réécrit le DOM. Éliminé d'emblée.
+
+## Conséquences
+
+- La coloration syntaxique est uniforme sur toute la doc (même outil, même thème).
+- Ne pas mélanger Shiki et highlight.js — leurs palettes divergent même avec le
+  même nom de thème.

--- a/docs/decisions/ADR-002-ci-workflows-separes.md
+++ b/docs/decisions/ADR-002-ci-workflows-separes.md
@@ -1,0 +1,35 @@
+# ADR-002 : Deux workflows CI séparés (core / docs)
+
+**Statut :** Adopté
+**Date :** 2026-03-20
+
+## Contexte
+
+Le projet a un monorepo avec deux packages distincts : `packages/core` et `apps/docs`.
+Un seul workflow CI lançait tous les jobs à chaque PR, même celles ne touchant qu'un seul package.
+
+## Décision
+
+Deux fichiers de workflow séparés avec filtres `on.pull_request.paths` natifs GitHub :
+
+- `.github/workflows/ci-core.yml` — déclenché uniquement si `packages/core/**` ou les fichiers
+  de config racine sont modifiés.
+- `.github/workflows/ci-docs.yml` — déclenché uniquement si `apps/docs/**` ou `packages/core/**`
+  sont modifiés (la doc dépend du core).
+
+Le lint core est isolé : `npm run lint --workspace=packages/core` (pas `turbo run lint` global).
+
+## Alternatives rejetées
+
+- **`dorny/paths-filter` action** — filtre par job dans un seul workflow. Plus complexe,
+  génère des warnings de dépréciation Node 20, et ne réduit pas vraiment les runs CI.
+- **`on.pull_request.paths` dans un seul fichier avec jobs conditionnels** — les conditions
+  `if:` sur les jobs ne permettent pas de filtrer le déclenchement du workflow lui-même.
+
+## Conséquences
+
+- Les paths filters s'appliquent au niveau `pull_request` seulement — pas sur les `push`
+  directs sur les branches protégées.
+- GitHub évalue les paths sur l'ensemble du diff PR (pas seulement le dernier commit) :
+  si `package.json` est modifié dans un commit antérieur de la PR, les deux workflows
+  se déclenchent sur chaque push ultérieur.

--- a/docs/decisions/ADR-003-stack-tests-vitest-wtr.md
+++ b/docs/decisions/ADR-003-stack-tests-vitest-wtr.md
@@ -1,0 +1,41 @@
+# ADR-003 : Stack de tests dual — Vitest + @web/test-runner
+
+**Statut :** Adopté
+**Date :** 2026-02-10
+
+## Contexte
+
+Les composants Lit ont deux types de besoins de test distincts :
+
+1. Tests unitaires rapides (logique, état, attributs) — pas besoin d'un vrai navigateur.
+2. Tests d'accessibilité et de comportement Shadow DOM — nécessitent un vrai navigateur
+   car happy-dom ne supporte pas correctement certains comportements Shadow DOM.
+
+## Décision
+
+Stack dual :
+
+- **Vitest + happy-dom** pour les tests unitaires (`*.test.ts`). Rapide, pas de navigateur,
+  couverture de code native.
+- **@web/test-runner + Playwright (Chromium) + @open-wc/testing + axe-core** pour les tests
+  browser (`*.browser.test.ts`, `*.a11y.test.ts`). Vrai navigateur, Shadow DOM réel,
+  axe-core pour les audits d'accessibilité automatisés.
+
+Les deux sont orchestrés depuis la racine via Turborepo (`test` et `test:browser`).
+
+## Alternatives rejetées
+
+- **Vitest browser mode** — en beta au moment du choix, API instable, support Shadow DOM
+  limité pour les tests axe-core.
+- **Jest + jsdom** — jsdom supporte encore moins bien le Shadow DOM que happy-dom.
+  Moins adapté à l'écosystème ESM/Lit.
+- **Migration complète vers WTR** — WTR ne produit pas de rapport de couverture de code
+  natif, nécessiterait une consolidation manuelle. Objectif long terme possible.
+
+## Conséquences
+
+- Deux commandes séparées : `npm run test` (Vitest) et `npm run test:browser` (WTR).
+- `npm run test:all` depuis la racine lance les deux.
+- Les tests browser nécessitent Playwright Chromium installé (géré automatiquement en CI).
+- En local, Playwright Chromium doit être installé au premier setup :
+  `npx playwright install chromium`.

--- a/docs/superpowers/plans/2026-03-27-information-architecture.md
+++ b/docs/superpowers/plans/2026-03-27-information-architecture.md
@@ -1,0 +1,826 @@
+# Information Architecture Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restructurer la documentation du projet en cinq couches à audience unique pour éliminer la duplication et clarifier où mettre chaque nouvelle information.
+
+**Architecture:** Chaque fichier a une seule audience (intégrateur / contributeur externe / développeur interne / décisions techniques / Claude). La philosophie vit dans `CONTRIBUTING.md` — les autres fichiers pointent vers elle sans la dupliquer. Les Lessons de `CLAUDE.md` sont triées : vrais choix → ADRs, gotchas framework → `DEVELOPMENT.md`, règles actives courtes → restent dans `CLAUDE.md`.
+
+**Tech Stack:** Markdown, Prettier (lint), Astro build (vérification liens), Git (PR par étape)
+
+---
+
+## Fichiers créés / modifiés
+
+| Fichier                                            | Action                                |
+| -------------------------------------------------- | ------------------------------------- |
+| `DEVELOPMENT.md`                                   | Créer                                 |
+| `CONTRIBUTING.md`                                  | Modifier (alléger)                    |
+| `README.md`                                        | Modifier (alléger)                    |
+| `docs/decisions/ADR-001-highlight-js-vs-shiki.md`  | Créer                                 |
+| `docs/decisions/ADR-002-ci-workflows-separes.md`   | Créer                                 |
+| `docs/decisions/ADR-003-stack-tests-vitest-wtr.md` | Créer                                 |
+| `CLAUDE.md`                                        | Modifier (alléger + pointeurs)        |
+| `.claude/settings.json`                            | Créer ou modifier (hook SessionStart) |
+
+---
+
+## Tâche 1 — Créer `DEVELOPMENT.md`
+
+Contenu extrait de `CONTRIBUTING.md` (sections techniques) et `CLAUDE.md` (architecture, patterns, commandes).
+
+**Fichiers :**
+
+- Créer : `DEVELOPMENT.md`
+
+- [ ] **Étape 1 : Créer `DEVELOPMENT.md`**
+
+Contenu complet :
+
+````markdown
+# Guide de développement
+
+> **Philosophie et positionnement du projet → [CONTRIBUTING.md](CONTRIBUTING.md)**
+> Lis-le avant de démarrer si ce n'est pas déjà fait.
+
+---
+
+## Prérequis
+
+- Node ≥ 24 (LTS)
+- npm ≥ 11
+- [nvm](https://github.com/nvm-sh/nvm) recommandé
+
+## Setup
+
+```bash
+git clone https://github.com/jogo-labs/ariane
+cd ariane
+nvm use          # active Node 24 via .nvmrc
+npm install
+```
+````
+
+## Commandes racine
+
+| Commande                  | Description                                       |
+| ------------------------- | ------------------------------------------------- |
+| `npm run dev`             | Watch core + docs en parallèle (pré-build le CEM) |
+| `npm run build`           | Build complet (core + docs)                       |
+| `npm run test`            | Tests unitaires Vitest                            |
+| `npm run test:all`        | Tests unitaires + tests browser (Vitest + WTR)    |
+| `npm run lint`            | ESLint sur tous les packages                      |
+| `npm run format`          | Prettier sur tous les fichiers                    |
+| `npm run create ar-<nom>` | Scaffold un nouveau composant                     |
+
+## Commandes par workspace
+
+### `packages/core`
+
+| Commande                 | Description                       |
+| ------------------------ | --------------------------------- |
+| `npm run build:manifest` | Génère `custom-elements.json`     |
+| `npm run build:bundles`  | esbuild → `dist/` (npm) + `cdn/`  |
+| `npm run build:css`      | Thèmes CSS                        |
+| `npm run build:types`    | Déclarations TypeScript           |
+| `npm run test`           | Vitest, passe unique              |
+| `npm run test:watch`     | Vitest interactif                 |
+| `npm run test:coverage`  | Vitest avec rapport de couverture |
+| `npm run test:browser`   | @web/test-runner + Chromium       |
+| `npm run lint`           | ESLint                            |
+
+---
+
+## Architecture du monorepo
+
+```text
+packages/core/src/
+  components/   # Un répertoire par composant (ex: button/, stepper/)
+  controllers/  # Lit ReactiveControllers réutilisables
+  context/      # @lit/context providers (communication parent-enfant)
+  state/        # Moteurs de calcul d'état purs
+  styles/       # CSS partagé (reset, utilitaires, animations, thèmes)
+  types/        # Interfaces TypeScript
+  index.ts      # Export barrel
+apps/docs/      # Site de documentation Astro
+```
+
+## Conventions fichiers composant
+
+Chaque composant dans `components/<name>/` :
+
+- `<name>.ts` — classe LitElement, `@customElement('ar-<name>')`
+- `<name>.styles.ts` — styles Lit `css` tagged template
+- `<name>.test.ts` — tests Vitest
+
+Composants complexes ajoutent :
+
+- `<name>.renderer.ts` — helpers de rendu (desktop/mobile)
+- `<name>.utils.ts` — fonctions utilitaires
+
+## Conventions de nommage
+
+| Élément               | Convention                | Exemple          |
+| --------------------- | ------------------------- | ---------------- |
+| Tag HTML              | `ar-<name>`               | `ar-button`      |
+| Classe                | `Ar<Name>`                | `ArButton`       |
+| Événements custom     | `ar-<event>`              | `ar-alert-close` |
+| CSS custom properties | `--ar-<component>-<prop>` | `--ar-button-bg` |
+| CSS parts             | `part="base"`             | `part="label"`   |
+
+---
+
+## Patterns de code
+
+### Propriétés — toujours `reflect: true`
+
+Sans `reflect: true`, l'attribut HTML n'est pas synchronisé avec la propriété JS.
+Le `outerHTML` du playground afficherait des attributs absents.
+
+```typescript
+@property({ reflect: true })
+variant: 'filled' | 'outlined' = 'filled';
+
+@property({ type: Boolean, reflect: true })
+disabled = false;
+```
+
+### Événements custom — toujours `bubbles + composed`
+
+Sans `composed: true`, l'événement ne traverse pas le Shadow DOM.
+Sans `bubbles: true`, il ne remonte pas dans le DOM light.
+
+```typescript
+this.dispatchEvent(
+    new CustomEvent('ar-change', {
+        bubbles: true,
+        composed: true,
+        detail: { value: this.value },
+    }),
+);
+```
+
+### Global type declaration (fin de chaque fichier composant)
+
+```typescript
+declare global {
+    interface HTMLElementTagNameMap {
+        'ar-<name>': Ar<Name>;
+    }
+}
+```
+
+### Composition parent-enfant
+
+Utiliser `@lit/context` — le parent expose un `ContextProvider`, l'enfant s'abonne via `ContextConsumer`. Voir `stepper/` pour référence.
+
+### Composants sans Shadow DOM
+
+Les composants conteneurs de données overrident `createRenderRoot()` :
+
+```typescript
+override createRenderRoot() {
+    return this;
+}
+```
+
+---
+
+## JSDoc CEM — annotations obligatoires
+
+Le CEM (`custom-elements.json`) est généré depuis la JSDoc. Toujours documenter :
+
+```typescript
+/**
+ * @summary Description courte (une phrase).
+ * @display demo
+ *
+ * @slot              - Slot par défaut.
+ * @slot prefix       - Icône avant le contenu.
+ *
+ * @csspart base      - L'élément racine du composant.
+ *
+ * @cssprop --ar-mon-composant-bg - Couleur de fond.
+ *
+ * @event {CustomEvent} ar-change - Émis lors d'un changement.
+ */
+```
+
+| Annotation         | Effet                                           |
+| ------------------ | ----------------------------------------------- |
+| `@display demo`    | Page doc : exemples + playground + API (défaut) |
+| `@display docs`    | Page doc : API uniquement                       |
+| `@parent ar-<tag>` | Marque comme sous-composant                     |
+| `@ignore`          | Exclut un membre des contrôles playground       |
+
+---
+
+## Tests unitaires (Vitest + happy-dom)
+
+### Pattern standard
+
+```typescript
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ArAlert } from './alert.js';
+
+async function fixture(html: string): Promise<ArAlert> {
+    const template = document.createElement('template');
+    template.innerHTML = html.trim();
+    const el = template.content.firstElementChild as ArAlert;
+    document.body.appendChild(el);
+    await (el as any).updateComplete;
+    await (el as any).updateComplete; // double await pour les queueMicrotask
+    return el;
+}
+
+async function waitForUpdate(el: LitElement): Promise<void> {
+    await (el as any).updateComplete;
+    await (el as any).updateComplete;
+}
+
+function getPart(el: Element, name: string): Element | null {
+    return el.shadowRoot?.querySelector(`[part="${name}"]`) ?? null;
+}
+
+describe('ArAlert', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    it('affiche le message', async () => {
+        const el = await fixture('<ar-alert>Texte</ar-alert>');
+        expect(el.getAttribute('role')).toBe('alert');
+    });
+});
+```
+
+### Pièges courants happy-dom
+
+- **`textContent` des interpolations Lit** : retourne `''`. Tester la propriété JS directement (`el.myProp`) plutôt que `el.textContent`.
+- **Propriétés ARIA via liaison Lit** (`.ariaCurrent`, `.ariaExpanded`) : `getAttribute('aria-current')` retourne `null`. Tester `(el as any).ariaCurrent` directement.
+- **`MediaQueryList` mock** : toujours inclure `addEventListener` et `removeEventListener` : `{ matches: true, addEventListener: vi.fn(), removeEventListener: vi.fn() } as unknown as MediaQueryList`.
+- **`queueMicrotask` dans le rendu** : `await updateComplete` deux fois pour absorber le cycle initial + le cycle du microtask.
+
+## Tests browser (web-test-runner + Playwright + axe-core)
+
+Fichiers nommés `*.browser.test.ts` ou `*.a11y.test.ts`.
+
+```typescript
+import { expect, fixture, html } from '@open-wc/testing';
+import { checkAccessibility } from '../../test-utils.js';
+
+describe('ArAlert a11y', () => {
+    it('passe axe-core', async () => {
+        const el = await fixture(html`<ar-alert>Message</ar-alert>`);
+        await checkAccessibility(el);
+    });
+});
+```
+
+---
+
+## Build outputs
+
+| Répertoire                  | Usage                                        |
+| --------------------------- | -------------------------------------------- |
+| `dist/`                     | Bundle npm — Lit en peer dep, tree-shakeable |
+| `cdn/`                      | Bundle CDN — Lit bundlé, avec autoloader     |
+| `dist/custom-elements.json` | Manifest CEM — consommé par la doc           |
+| `dist/styles/themes/`       | Fichiers CSS de thème                        |
+
+---
+
+## Intégration IDE (VS Code)
+
+Référencer dans `.vscode/settings.json` du projet consommateur :
+
+```json
+{
+    "html.customData": ["./node_modules/@ariane-ui/core/dist/vscode.html-custom-data.json"],
+    "css.customData": ["./node_modules/@ariane-ui/core/dist/vscode.css-custom-data.json"]
+}
+```
+
+````
+
+- [ ] **Étape 2 : Vérifier le lint**
+
+```bash
+npm run format
+npm run lint
+````
+
+Résultat attendu : pas d'erreur.
+
+- [ ] **Étape 3 : Commit**
+
+```bash
+git add DEVELOPMENT.md
+git commit -m "docs: crée DEVELOPMENT.md — guide développeur interne"
+```
+
+---
+
+## Tâche 2 — Alléger `CONTRIBUTING.md`
+
+Remplacer le contenu technique par la philosophie, le positionnement et le workflow de contribution.
+
+**Fichiers :**
+
+- Modifier : `CONTRIBUTING.md`
+
+- [ ] **Étape 1 : Réécrire `CONTRIBUTING.md`**
+
+````markdown
+# Contribuer à Ariane
+
+Ce guide s'adresse aux contributeurs externes qui souhaitent proposer une amélioration,
+signaler un bug ou soumettre un nouveau composant.
+
+Pour le setup technique et les commandes : voir [DEVELOPMENT.md](DEVELOPMENT.md).
+
+---
+
+## Qu'est-ce qu'Ariane ?
+
+Ariane se positionne entre deux extrêmes :
+
+- **Web Awesome / Shoelace** — design system complet et opiniaté : l'intégrateur adopte le look de la librairie.
+- **Radix UI / Headless UI** — composants sans style : l'intégrateur apporte tout le CSS.
+
+**Ariane** : comportement accessible + tokens thémables, aucune opinion visuelle forte.
+C'est la **fondation** sur laquelle construire son propre design system — pas un design system en soi.
+
+---
+
+## Philosophie
+
+### Mission
+
+Ariane prend en charge les patterns dont la complexité d'implémentation correcte est un obstacle
+à l'accessibilité dans les projets réels. Elle ne réécrit pas les éléments natifs qui fonctionnent bien.
+
+### Critères d'inclusion d'un composant
+
+Un composant intègre Ariane si au moins l'une de ces conditions est vraie :
+
+1. **Complexité a11y non triviale** — implémenter correctement le comportement accessible est difficile (stepper, datepicker, dialog, tabs).
+2. **Absent des projets par difficulté d'implémentation** — le composant améliorerait l'UX mais est rarement bien fait (datepicker).
+3. **Extension d'un natif insuffisant** — `<dialog>` → `<ar-dialog>` qui l'étend.
+
+Un composant est **exclu** si :
+
+- Il réplique un natif qui fait déjà bien le job (`<button>`, `<input>`, `<select>` de base).
+- Sa valeur ajoutée est purement graphique sans apport a11y ou comportemental.
+
+### Ergonomie de l'API
+
+Intuitive par rapport aux natifs : un breadcrumb se compose comme un `<ul>/<li>`,
+pas comme un JSON stringifié. Préférer des éléments enfants slottés aux props complexes.
+
+### Thémabilité et accessibilité
+
+- Les aspects visuels sont exposés via CSS custom properties (`--ar-*`).
+- Les aspects qui garantissent l'accessibilité (focus management, bouton de fermeture) sont non négociables.
+- Le thème par défaut satisfait les ratios de contraste **WCAG 2.2 AA** sans configuration supplémentaire.
+
+---
+
+## Proposer un nouveau composant
+
+1. **Ouvrir une issue** en expliquant le besoin, les critères d'inclusion satisfaits, et une esquisse d'API.
+2. **Discussion** — attendre un retour avant de commencer l'implémentation.
+3. **PR sur `dev`** une fois l'issue validée.
+
+---
+
+## Workflow PR
+
+Toutes les contributions passent par une Pull Request sur la branche `dev`.
+
+```bash
+git clone https://github.com/jogo-labs/ariane
+cd ariane
+nvm use
+npm install
+git checkout -b feat/mon-composant
+```
+````
+
+---
+
+## Conventions de commit
+
+Les commits suivent **Conventional Commits**, vérifiés par commitlint + Husky.
+
+```
+feat(button): ajoute la prop `loading`
+fix(stepper): corrige la navigation au clavier
+docs(alert): met à jour les exemples
+test(button): ajoute les cas disabled
+chore(deps): met à jour esbuild
+```
+
+Types autorisés : `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `perf`, `ci`.
+
+````
+
+- [ ] **Étape 2 : Vérifier le lint**
+
+```bash
+npm run format
+````
+
+- [ ] **Étape 3 : Commit**
+
+```bash
+git add CONTRIBUTING.md
+git commit -m "docs: refocus CONTRIBUTING.md — positionnement + philosophie + workflow"
+```
+
+---
+
+## Tâche 3 — Alléger `README.md`
+
+Retirer le contenu orienté développeur, garder uniquement ce dont l'intégrateur a besoin.
+
+**Fichiers :**
+
+- Modifier : `README.md`
+
+- [ ] **Étape 1 : Supprimer la section "Structure du monorepo"**
+
+Supprimer entièrement la section `## Structure du monorepo` (le bloc texte + la structure arborescente).
+
+- [ ] **Étape 2 : Remplacer la section "Démarrage rapide"**
+
+Remplacer la section `## Démarrage rapide` par :
+
+````markdown
+## Installation
+
+### Via CDN (sans bundler)
+
+```html
+<script type="module" src="https://unpkg.com/@ariane-ui/core/cdn/index.js"></script>
+<link rel="stylesheet" href="https://unpkg.com/@ariane-ui/core/themes/default.css" />
+
+<ar-button>Cliquez-moi</ar-button>
+```
+````
+
+### Via npm
+
+```bash
+npm install @ariane-ui/core
+```
+
+```typescript
+import '@ariane-ui/core';
+import '@ariane-ui/core/themes/default.css';
+
+// ou import individuel (tree-shaking)
+import '@ariane-ui/core/dist/components/button/button.js';
+
+// attendre que des composants spécifiques soient prêts
+import { whenAllDefined } from '@ariane-ui/core';
+await whenAllDefined('ar-button', 'ar-stepper');
+```
+
+### Autoloader CDN
+
+```html
+<script type="module" src="/cdn/autoloader.js"></script>
+```
+
+````
+
+- [ ] **Étape 3 : Supprimer la section "Commandes racine"**
+
+Supprimer entièrement `## Commandes racine` (table de commandes). Ces infos vont dans `DEVELOPMENT.md`.
+
+- [ ] **Étape 4 : Mettre à jour la section "Contribution"**
+
+Remplacer :
+
+```markdown
+## Contribution
+
+Voir [CONTRIBUTING.md](CONTRIBUTING.md) pour les conventions et le workflow.
+Pour modifier le site de documentation, voir [apps/docs/CONTRIBUTING.md](apps/docs/CONTRIBUTING.md).
+````
+
+par :
+
+```markdown
+## Contribution
+
+Voir [CONTRIBUTING.md](CONTRIBUTING.md) pour la philosophie et le workflow de contribution.
+Pour le setup et les commandes de développement, voir [DEVELOPMENT.md](DEVELOPMENT.md).
+```
+
+- [ ] **Étape 5 : Vérifier le lint et le build**
+
+```bash
+npm run format
+npm run build:manifest --workspace=packages/core
+npm run build --workspace=apps/docs
+```
+
+Résultat attendu : build sans erreur, pas de liens cassés.
+
+- [ ] **Étape 6 : Commit**
+
+```bash
+git add README.md
+git commit -m "docs: allège README.md — orienté intégrateur uniquement"
+```
+
+---
+
+## Tâche 4 — Créer les ADRs
+
+Migrer les décisions architecturales clés depuis `CLAUDE.md` vers `docs/decisions/`.
+Les gotchas framework vont dans `DEVELOPMENT.md` (déjà fait en Tâche 1).
+
+**Fichiers :**
+
+- Créer : `docs/decisions/ADR-001-highlight-js-vs-shiki.md`
+- Créer : `docs/decisions/ADR-002-ci-workflows-separes.md`
+- Créer : `docs/decisions/ADR-003-stack-tests-vitest-wtr.md`
+
+- [ ] **Étape 1 : Créer `docs/decisions/ADR-001-highlight-js-vs-shiki.md`**
+
+```markdown
+# ADR-001 : Highlight.js plutôt que Shiki pour la coloration syntaxique
+
+**Statut :** Adopté
+**Date :** 2026-01-15
+
+## Contexte
+
+Le site de documentation affiche des blocs de code avec coloration syntaxique.
+Le playground interactif régénère le HTML de ces blocs côté client après chaque
+changement de contrôle — il faut donc pouvoir re-coloriser à la demande.
+
+## Décision
+
+Utiliser **highlight.js** via CDN (thème `github-dark`, chargé via `is:inline`).
+Appeler `hljs.highlightAll()` au chargement initial, et `hljs.highlightElement(el)`
+après chaque mise à jour du playground (après avoir réinitialisé `data-highlighted`).
+
+## Alternatives rejetées
+
+- **Shiki** — 100% serveur. Impossible de re-coloriser côté client après que le
+  playground ait réécrit le DOM. Éliminé d'emblée.
+
+## Conséquences
+
+- La coloration syntaxique est uniforme sur toute la doc (même outil, même thème).
+- Ne pas mélanger Shiki et highlight.js — leurs palettes divergent même avec le
+  même nom de thème.
+- Le script highlight.js doit être dans `<head>` avec `is:inline` et le code
+  enveloppé dans `DOMContentLoaded` (cf. ADR-001 note d'implémentation).
+```
+
+- [ ] **Étape 2 : Créer `docs/decisions/ADR-002-ci-workflows-separes.md`**
+
+```markdown
+# ADR-002 : Deux workflows CI séparés (core / docs)
+
+**Statut :** Adopté
+**Date :** 2026-03-20
+
+## Contexte
+
+Le projet a un monorepo avec deux packages distincts : `packages/core` et `apps/docs`.
+Un seul workflow CI lançait tous les jobs à chaque PR, même celles ne touchant qu'un seul package.
+
+## Décision
+
+Deux fichiers de workflow séparés avec filtres `on.pull_request.paths` natifs GitHub :
+
+- `.github/workflows/ci-core.yml` — déclenché uniquement si `packages/core/**` ou les fichiers
+  de config racine sont modifiés.
+- `.github/workflows/ci-docs.yml` — déclenché uniquement si `apps/docs/**` ou `packages/core/**`
+  sont modifiés (la doc dépend du core).
+
+## Alternatives rejetées
+
+- **`dorny/paths-filter` action** — filtre par job dans un seul workflow. Plus complexe,
+  génère des warnings de dépréciation Node 20, et ne réduit pas vraiment les runs CI.
+- **`on.pull_request.paths` dans un seul fichier avec jobs conditionnels** — les conditions
+  `if:` sur les jobs ne permettent pas de filtrer le déclenchement du workflow lui-même.
+
+## Conséquences
+
+- Les paths filters s'appliquent au niveau `pull_request` seulement — pas sur les `push`
+  directs sur les branches protégées.
+- GitHub évalue les paths sur l'ensemble du diff PR (pas seulement le dernier commit) :
+  si `package.json` est modifié dans un commit antérieur de la PR, les deux workflows
+  se déclenchent sur chaque push ultérieur.
+- Le lint core est isolé : `npm run lint --workspace=packages/core` (pas turbo global).
+```
+
+- [ ] **Étape 3 : Créer `docs/decisions/ADR-003-stack-tests-vitest-wtr.md`**
+
+```markdown
+# ADR-003 : Stack de tests dual — Vitest + @web/test-runner
+
+**Statut :** Adopté
+**Date :** 2026-02-10
+
+## Contexte
+
+Les composants Lit ont deux types de besoins de test distincts :
+
+1. Tests unitaires rapides (logique, état, attributs) — pas besoin d'un vrai navigateur.
+2. Tests d'accessibilité et de comportement Shadow DOM — nécessitent un vrai navigateur
+   car happy-dom ne supporte pas correctement certains comportements Shadow DOM.
+
+## Décision
+
+Stack dual :
+
+- **Vitest + happy-dom** pour les tests unitaires (`*.test.ts`). Rapide, pas de navigateur,
+  couverture de code native.
+- **@web/test-runner + Playwright (Chromium) + @open-wc/testing + axe-core** pour les tests
+  browser (`*.browser.test.ts`, `*.a11y.test.ts`). Vrai navigateur, Shadow DOM réel,
+  axe-core pour les audits d'accessibilité automatisés.
+
+Les deux sont orchestrés depuis la racine via Turborepo (`test` et `test:browser`).
+
+## Alternatives rejetées
+
+- **Vitest browser mode** — en beta au moment du choix, API instable, support Shadow DOM
+  limité pour les tests axe-core.
+- **Jest + jsdom** — jsdom supporte encore moins bien le Shadow DOM que happy-dom.
+  Moins adapté à l'écosystème ESM/Lit.
+- **Migration complète vers WTR** — WTR ne produit pas de rapport de couverture de code
+  natif, nécessiterait une consolidation manuelle. Objectif long terme possible.
+
+## Conséquences
+
+- Deux commandes séparées : `npm run test` (Vitest) et `npm run test:browser` (WTR).
+- `npm run test:all` depuis la racine lance les deux.
+- Les tests browser nécessitent Playwright Chromium installé (géré automatiquement en CI
+  via `npx playwright install --with-deps chromium`).
+- En local, Playwright Chromium doit être installé manuellement au premier setup :
+  `npx playwright install chromium`.
+```
+
+- [ ] **Étape 4 : Vérifier le lint**
+
+```bash
+npm run format
+```
+
+- [ ] **Étape 5 : Commit**
+
+```bash
+git add docs/decisions/
+git commit -m "docs: crée docs/decisions/ avec ADR-001, ADR-002, ADR-003"
+```
+
+---
+
+## Tâche 5 — Alléger `CLAUDE.md`
+
+Supprimer le contenu migré vers les autres fichiers. Ajouter les pointeurs.
+
+**Fichiers :**
+
+- Modifier : `CLAUDE.md`
+
+- [ ] **Étape 1 : Supprimer la section "Lessons — docs site"**
+
+Supprimer les sous-sections suivantes de `CLAUDE.md` (migrées en ADRs ou dans DEVELOPMENT.md) :
+
+- "Highlight.js plutôt que Shiki" → ADR-001
+- "Overlay nav mobile — pointer-events" → DEVELOPMENT.md (pièges courants)
+- "IntersectionObserver double-init" → DEVELOPMENT.md (pièges courants)
+- "Sous-composants : @parent JSDoc seul suffit" → DEVELOPMENT.md (conventions)
+- "Types CEM : ne pas dupliquer" → DEVELOPMENT.md
+- "Astro scoped styles" → DEVELOPMENT.md
+- "`<script is:inline>` plutôt que defer" → DEVELOPMENT.md
+- "Scripts `is:inline src` dans `<head>` — DOMContentLoaded" → DEVELOPMENT.md
+- "Preview indépendante du thème global" → DEVELOPMENT.md
+- "Variables CSS `--doc-*`" → DEVELOPMENT.md
+
+Garder les sections "Package core" qui sont des règles actives courtes :
+
+- "Convention de dépréciation" (reste — règle active avec code d'exemple)
+- "`reflect: true` obligatoire" (reste)
+- "`{ bubbles, composed }` sur tous les événements" (reste)
+- Les pièges de tests happy-dom (peuvent migrer dans DEVELOPMENT.md à la prochaine révision)
+
+- [ ] **Étape 2 : Remplacer la section "Lessons" par des pointeurs**
+
+Ajouter après la section "Méthode de travail" :
+
+```markdown
+## Références
+
+- **Philosophie et critères d'inclusion** → [CONTRIBUTING.md](CONTRIBUTING.md)
+- **Setup, commandes, architecture, patterns** → [DEVELOPMENT.md](DEVELOPMENT.md)
+- **Décisions techniques détaillées** → [`docs/decisions/`](docs/decisions/) — indexées par context-mode, utiliser `ctx_search` pour les retrouver
+```
+
+- [ ] **Étape 3 : Vérifier que les règles actives critiques sont toujours présentes**
+
+S'assurer que ces éléments restent dans `CLAUDE.md` :
+
+- Naming conventions (tag `ar-`, classe `Ar`, events `ar-`, CSS props `--ar-`)
+- `reflect: true` obligatoire
+- `bubbles: true, composed: true` sur les events
+- Convention `warnDeprecated()`
+- Section "Méthode de travail" (inchangée)
+- Section "Lessons — package core" (règles actives, pas des gotchas)
+
+- [ ] **Étape 4 : Vérifier le lint**
+
+```bash
+npm run format
+npm run lint
+```
+
+- [ ] **Étape 5 : Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(claude): allège CLAUDE.md — pointeurs vers DEVELOPMENT.md et ADRs"
+```
+
+---
+
+## Tâche 6 — Hook SessionStart pour indexer les ADRs
+
+Configurer un hook Claude Code projet qui indexe `docs/decisions/` au démarrage de session.
+
+**Fichiers :**
+
+- Créer ou modifier : `.claude/settings.json`
+
+- [ ] **Étape 1 : Vérifier si `.claude/settings.json` existe**
+
+```bash
+ls .claude/
+```
+
+- [ ] **Étape 2 : Créer ou compléter `.claude/settings.json`**
+
+Si le fichier n'existe pas, créer `.claude/` et le fichier :
+
+```json
+{
+    "hooks": {
+        "SessionStart": [
+            {
+                "matcher": "",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "node -e \"const {readdirSync, readFileSync} = require('fs'); const {resolve} = require('path'); const dir = resolve(process.cwd(), 'docs/decisions'); try { const files = readdirSync(dir).filter(f => f.endsWith('.md')); if (files.length > 0) console.log('[hook] ' + files.length + ' ADR(s) disponibles dans docs/decisions/ — utilise ctx_search pour les consulter.'); } catch {}\""
+                    }
+                ]
+            }
+        ]
+    }
+}
+```
+
+> Note : ce hook affiche simplement un rappel en début de session. L'indexation réelle via context-mode est gérée par le hook context-mode existant dans `.github/hooks/context-mode.json`. Si context-mode expose une API d'indexation de répertoire, l'étendre pour pointer vers `docs/decisions/` — à investiguer selon la version installée.
+
+- [ ] **Étape 3 : Ajouter `.claude/` au `.gitignore` si nécessaire**
+
+Vérifier que `.gitignore` contient déjà `.claude` (il le contient — vérifié).
+
+- [ ] **Étape 4 : Commit**
+
+```bash
+git add .claude/settings.json
+git commit -m "chore(claude): hook SessionStart — rappel ADRs disponibles"
+```
+
+---
+
+## Tâche 7 — PR, CI et merge
+
+- [ ] **Étape 1 : Pousser la branche et créer la PR**
+
+```bash
+git push -u origin docs/readme-contributing-update
+gh pr create --title "docs: restructuration architecture de l'information" --base dev
+```
+
+- [ ] **Étape 2 : Attendre la CI verte**
+
+```bash
+gh pr checks <PR_NUMBER>
+```
+
+- [ ] **Étape 3 : Merger**
+
+```bash
+gh pr merge <PR_NUMBER> --squash --delete-branch
+```

--- a/docs/superpowers/specs/2026-03-27-information-architecture-design.md
+++ b/docs/superpowers/specs/2026-03-27-information-architecture-design.md
@@ -1,0 +1,189 @@
+# Design : Architecture de l'information du projet Ariane
+
+**Date :** 2026-03-27
+**Statut :** Approuvé
+
+---
+
+## Contexte
+
+L'organisation actuelle de la documentation souffre de deux problèmes principaux :
+
+- **Pas de règle claire sur où mettre une nouvelle information** — le contenu atterrit là où ça tombe (CLAUDE.md, CONTRIBUTING.md, README)
+- **Duplication et dérive** — les mêmes informations existent à plusieurs endroits et se désynchronisent
+
+Le projet anticipe deux profils d'utilisateurs principaux : des développeurs qui évaluent la librairie pour l'intégrer (profil dominant), et des développeurs qui souhaitent contribuer. Les deux peuvent se succéder pour la même personne.
+
+---
+
+## Architecture cible
+
+Cinq couches, chacune avec une audience unique et une responsabilité unique.
+
+```text
+┌─────────────────────────────────────────────────────┐
+│  GITHUB VISITOR / INTÉGRATEUR                       │
+│  README.md                                          │
+├─────────────────────────────────────────────────────┤
+│  CONTRIBUTEUR EXTERNE                               │
+│  CONTRIBUTING.md                                    │
+├─────────────────────────────────────────────────────┤
+│  DÉVELOPPEUR INTERNE                                │
+│  DEVELOPMENT.md                                     │
+├─────────────────────────────────────────────────────┤
+│  DÉCISIONS TECHNIQUES                               │
+│  docs/decisions/                                    │
+├─────────────────────────────────────────────────────┤
+│  CONTEXTE CLAUDE                                    │
+│  CLAUDE.md (allégé)                                 │
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+## Règle de routage
+
+Avant d'ajouter une information, une seule question suffit :
+
+| Question                                                                | Fichier           |
+| ----------------------------------------------------------------------- | ----------------- |
+| Un utilisateur a besoin de ça pour intégrer la lib ?                    | `README.md`       |
+| C'est la philosophie ou le processus de contribution ?                  | `CONTRIBUTING.md` |
+| C'est du setup, une commande, ou une convention technique interne ?     | `DEVELOPMENT.md`  |
+| C'est une décision avec un contexte et des alternatives rejetées ?      | `docs/decisions/` |
+| C'est une règle que Claude doit appliquer activement à chaque session ? | `CLAUDE.md`       |
+
+---
+
+## Contenu de chaque fichier
+
+### `README.md` — Intégrateur/évaluateur
+
+**Contient :**
+
+- Pitch (2-3 lignes) : ce que c'est, pourquoi ça existe
+- Exemple de code immédiat
+- Installation rapide (CDN + npm)
+- Personnalisation (CSS custom properties)
+- Tableau stack technique (court)
+- Liens : site de documentation, `CONTRIBUTING.md`
+
+**Ne contient plus :** structure du monorepo, commandes de dev, conventions internes.
+
+---
+
+### `CONTRIBUTING.md` — Contributeur externe
+
+GitHub affiche ce fichier en lien prioritaire dans les formulaires d'issue et de PR — son audience naturelle est le contributeur externe qui découvre le projet.
+
+**Contient :**
+
+- **Positionnement explicite** — ce qu'Ariane est et n'est pas, avec des références concrètes :
+    - _Web Awesome / Shoelace_ → design system complet et opiniaté, l'intégrateur adopte le look
+    - _Radix UI / Headless UI_ → composants sans style, l'intégrateur apporte tout le CSS
+    - _Ariane_ → entre les deux : comportement accessible + tokens thémables, aucune opinion visuelle forte — la fondation sur laquelle construire son propre design system
+- Philosophie et critères d'inclusion d'un composant (source de vérité unique)
+- Comment proposer un nouveau composant (issue d'abord, discussion, PR)
+- Workflow PR (`dev` → review → merge)
+- Conventions de commit (Conventional Commits)
+- Lien vers `DEVELOPMENT.md` pour le setup technique
+
+**Ne contient plus :** détails de build, patterns de test, commandes détaillées.
+
+> Note : la philosophie vit ici. `DEVELOPMENT.md` et `CLAUDE.md` y pointent — ils ne la dupliquent pas.
+
+---
+
+### `DEVELOPMENT.md` _(nouveau)_ — Développeur interne
+
+Fichier de référence pour toute personne qui travaille sur le code du projet (nouveau dans l'équipe ou expérimenté).
+
+**Contient :**
+
+- Lien vers `CONTRIBUTING.md` pour la philosophie (ne la duplique pas)
+- Prérequis et setup complet (Node, npm, nvm, clone, install)
+- Toutes les commandes racine et par workspace (build, test, dev, lint, format)
+- Architecture du monorepo et conventions de fichiers
+- Patterns de code : `reflect: true`, events, tests, CEM JSDoc
+- Scaffolding d'un composant (`npm run create`)
+- Mise à jour du CEM, outputs de build
+
+---
+
+### `docs/decisions/` _(nouveau)_ — Décisions techniques
+
+Un fichier par décision. Nommage : `ADR-NNN-titre-court.md`.
+
+**Format :**
+
+```markdown
+# ADR-NNN : Titre de la décision
+
+**Statut :** Adopté | Déprécié | Remplacé par ADR-YYY
+**Date :** YYYY-MM-DD
+
+## Contexte
+
+Pourquoi cette décision était nécessaire.
+
+## Décision
+
+Ce qu'on a choisi.
+
+## Alternatives rejetées
+
+- Option A — pourquoi non
+- Option B — pourquoi non
+
+## Conséquences
+
+Ce que ça implique pour le projet.
+```
+
+Les premières ADRs sont issues des "Lessons" actuellement dans `CLAUDE.md`.
+
+**Intégration context-mode :** le hook `SessionStart` est étendu pour auto-indexer `docs/decisions/`. Les ADRs sont accessibles via `ctx_search()` sans consommer de tokens au démarrage de chaque session.
+
+---
+
+### `CLAUDE.md` _(allégé)_ — Contexte Claude Code
+
+**Contient :**
+
+- Vue d'ensemble du projet (court — 5-10 lignes)
+- Règles actives critiques : naming, `reflect: true`, events, tokens CSS, méthode de travail
+- Pointeurs explicites vers les autres couches :
+    - _"Philosophie et positionnement → `CONTRIBUTING.md`"_
+    - _"Setup et commandes → `DEVELOPMENT.md`"_
+    - _"Décisions techniques → `docs/decisions/` (indexé par context-mode)"_
+
+**Ne contient plus :** les Lessons détaillées (→ ADRs), le contenu dupliqué dans DEVELOPMENT.md.
+
+---
+
+## Skill projet _(phase 2)_
+
+Un skill `.claude/skills/project-context.md` chargera à la demande les ADRs pertinents et les sections clés de `DEVELOPMENT.md`. À créer quand le volume d'ADRs le justifie — pas dans la migration initiale.
+
+---
+
+## Plan de migration
+
+Chaque étape est une PR indépendante sur `dev`.
+
+| Étape | Action                                                              | Fichiers                   |
+| ----- | ------------------------------------------------------------------- | -------------------------- |
+| 1     | Créer `DEVELOPMENT.md` depuis CONTRIBUTING.md + CLAUDE.md           | `DEVELOPMENT.md` (nouveau) |
+| 2     | Alléger `CONTRIBUTING.md` (positionnement + philosophie + workflow) | `CONTRIBUTING.md`          |
+| 3     | Alléger `README.md` (retirer le contenu dev)                        | `README.md`                |
+| 4     | Créer `docs/decisions/` + migrer les Lessons en ADRs                | `docs/decisions/*.md`      |
+| 5     | Alléger `CLAUDE.md` (pointeurs + règles actives uniquement)         | `CLAUDE.md`                |
+| 6     | Étendre le hook SessionStart pour indexer `docs/decisions/`         | `.github/hooks/`           |
+
+---
+
+## Ce qui ne change pas
+
+- `CLAUDE.md` reste la source de vérité pour les règles que Claude doit appliquer activement
+- Le memory system (`/memory/`) reste pour les informations inter-sessions sur l'utilisateur et le projet
+- `apps/docs/CONTRIBUTING.md` reste en place pour les contributeurs de la doc Astro


### PR DESCRIPTION
## Summary

- Corrige la définition d'Ariane : fondation sur laquelle construire un design system, pas un design system en soi
- TypeScript 5 → 6 dans le tableau stack
- Supprime la note obsolète sur le `build:manifest` manuel (plus nécessaire depuis que `npm run dev` le pré-build)
- Ajoute `npm run test:all` dans le tableau des commandes
- Ajoute `@web/test-runner` + Playwright + axe-core dans le tableau stack
- Section "Tests browser" dans CONTRIBUTING.md (WTR, `test:browser`, `test:all`, pattern de nommage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)