### PR TITLE
docs: section accessibilité dans les pages composants

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,21 @@ pas comme un JSON stringifié. Préférer des éléments enfants slottés aux pr
 - Les aspects qui garantissent l'accessibilité (focus management, bouton de fermeture) sont non négociables.
 - Le thème par défaut satisfait les ratios de contraste **WCAG 2.2 AA** sans configuration supplémentaire.
 
+### Périmètre de l'accessibilité
+
+Ariane distingue deux niveaux de responsabilité :
+
+**Accessibilité structurelle** — ce que le composant peut garantir techniquement : rôles ARIA corrects,
+attributs, gestion du focus, icônes masquées aux AT. C'est non négociable et documenté dans la section
+"Pris en charge automatiquement" de chaque page de composant.
+
+**Accessibilité éditoriale** — ce que l'auteur du contenu doit fournir : messages compréhensibles hors
+contexte visuel, niveau de sévérité cohérent, labels significatifs. Ariane ne peut pas valider cela
+techniquement — elle le documente dans la section "À la charge de l'auteur" de chaque page de composant.
+
+Les équipes qui souhaitent imposer des contraintes éditoriales (titre obligatoire, validation de contenu)
+peuvent étendre les classes Ariane dans leur propre design system — voir le pattern de réexportation.
+
 ---
 
 ## Proposer un nouveau composant

--- a/apps/docs/CONTRIBUTING.md
+++ b/apps/docs/CONTRIBUTING.md
@@ -172,6 +172,8 @@ apps/docs/
 ├── src/
 │   ├── components/
 │   │   ├── ComponentApi.astro      ← Tables de référence API (attributs, events, slots…)
+│   │   ├── NarrativeHeading.astro  ← Composant MDX custom : h2 avec id slugifié (ancres TOC)
+│   │   ├── NarrativeList.astro     ← Composant MDX custom : ul avec classe .narrative-list
 │   │   ├── Playground.astro        ← Variantes + playground + controls
 │   │   ├── SiteNav.astro           ← Navigation gauche (auto-générée depuis CEM + MDX)
 │   │   └── TableOfContents.astro   ← TOC sticky droite + collapse mobile
@@ -202,16 +204,20 @@ apps/docs/
 
 ```
 [slug].astro
-  ├── manifest (@cem)        → CemDeclaration (API, membres, events…)
+  ├── manifest (@cem)             → CemDeclaration (API, membres, events…)
   │     └── getCustomElements()  → liste de tous les custom elements
   ├── getCollection('components') → données MDX (titre, variantes, description)
-  ├── buildControls()        → contrôles playground depuis les membres CEM
-  └── tocEntries[]           → entrées TOC (Exemples > variantes, Playground, API)
+  ├── render(mdx)                 → { Content, headings[] }
+  │     └── headings (depth=2)   → narrativeTocEntries (ancres depuis les h2 MDX)
+  ├── buildControls()             → contrôles playground depuis les membres CEM
+  └── tocEntries[]                → narrativeTocEntries + Exemples + Playground + API
         ↓
   Layout.astro (3 colonnes)
-    ├── SiteNav.astro        ← nav gauche
-    ├── Playground.astro     ← variantes + playground + ComponentApi
-    └── TableOfContents      ← TOC droite (slot="toc")
+    ├── SiteNav.astro             ← nav gauche
+    ├── <section class="narrative">
+    │     └── <Content components={{ h2: NarrativeHeading, ul: NarrativeList }} />
+    ├── Playground.astro          ← variantes + playground + ComponentApi
+    └── TableOfContents           ← TOC droite (slot="toc")
 ```
 
 ---
@@ -306,6 +312,50 @@ Lors d'une PR qui modifie l'un des éléments ci-dessous, mettre à jour la sect
 - Ajout d'une nouvelle page ou section → mettre à jour l'arborescence "Architecture des fichiers"
 - Changement dans le flux de données CEM → mettre à jour le schéma "Flux de données par page composant"
 - Nouvelle convention ou pattern CSS → documenter dans "Convention CSS"
+
+---
+
+## Contenu narratif MDX
+
+Le corps d'un fichier MDX (sous le frontmatter) est affiché dans une `<section class="narrative">`
+entre le header de la page et les exemples. C'est l'endroit pour documenter l'usage et l'accessibilité.
+
+### Composants MDX custom
+
+Certains éléments HTML générés par le MDX sont remplacés par des composants Astro afin de contrôler
+précisément le rendu. Le mapping est déclaré dans `[slug].astro` via la prop `components` de `<Content>` :
+
+| Élément MDX | Composant Astro          | Rôle                                                       |
+| ----------- | ------------------------ | ---------------------------------------------------------- |
+| `ul`        | `NarrativeList.astro`    | Ajoute la classe `.narrative-list` pour le ciblage CSS     |
+| `h2`        | `NarrativeHeading.astro` | Génère un `id` slugifié automatiquement (ancre TOC + lien) |
+
+**Ajouter un nouveau composant custom :** créer `src/components/Narrative<Nom>.astro`, l'importer
+dans `[slug].astro` et l'ajouter dans le spread `components={{ … }}`.
+
+### TOC automatique depuis les `h2`
+
+Les titres `## Titre` du MDX sont **automatiquement ajoutés à la TOC** — il n'y a rien à déclarer
+dans le frontmatter. Le mécanisme fonctionne ainsi :
+
+1. `render(mdx)` retourne un tableau `headings` (fourni par Astro/remark)
+2. `[slug].astro` filtre les `depth === 2` et les injecte dans `tocEntries` avant les exemples
+3. `NarrativeHeading.astro` pose le même `id` sur le `h2` rendu, via `github-slugger` — le même
+   algorithme qu'Astro, ce qui garantit que l'ancre et l'entrée TOC sont toujours synchronisées
+
+**Conséquence :** renommer un `h2` dans le MDX met à jour l'ancre et la TOC simultanément, sans
+aucune intervention manuelle.
+
+### Flux de données narratif
+
+```text
+ar-alert.mdx (corps)
+  → render(mdx) → { Content, headings[] }
+  → headings filtrés depth=2 → narrativeTocEntries → tocEntries[]
+  → <Content components={{ ul: NarrativeList, h2: NarrativeHeading }} />
+      → h2 "Accessibilité" → <NarrativeHeading> → <h2 id="accessibilité">
+      → ul → <NarrativeList> → <ul class="narrative-list">
+```
 
 ---
 

--- a/apps/docs/CONTRIBUTING.md
+++ b/apps/docs/CONTRIBUTING.md
@@ -61,7 +61,19 @@ variants:
       description: Utilisé pour les erreurs critiques.
       html: '<ar-alert variant="error">Une erreur est survenue.</ar-alert>'
 ---
+## Utilisation
+
 Texte narratif optionnel en MDX (affiché sous la référence API).
+
+## Accessibilité
+
+### Pris en charge automatiquement
+
+- Ce que le composant garantit techniquement (role ARIA, focus management…)
+
+### À la charge de l'auteur
+
+- Ce que l'auteur du contenu doit respecter pour garantir l'accessibilité.
 ```
 
 C'est tout. La page `/components/button` sera générée automatiquement.
@@ -297,6 +309,24 @@ Lors d'une PR qui modifie l'un des éléments ci-dessous, mettre à jour la sect
 
 ---
 
+## Convention — Section accessibilité dans les MDX
+
+Chaque page de composant **doit** comporter une section `## Accessibilité` avec deux sous-sections :
+
+**`### Pris en charge automatiquement`** — liste factuelle de ce qu'Ariane garantit techniquement :
+rôles ARIA, attributs, focus management, tokens de contraste. Courte, rassurante.
+
+**`### À la charge de l'auteur`** — ce que l'utilisateur du composant doit fournir pour que
+l'expérience soit réellement accessible. Chaque item explique _pourquoi_, pas seulement _quoi_.
+
+Cette distinction reflète la ligne entre **accessibilité structurelle** (garantie par le composant)
+et **accessibilité éditoriale** (responsabilité de l'auteur du contenu). Ariane ne peut pas valider
+que le contenu slotté est compréhensible hors contexte visuel — la documentation est le seul levier.
+
+Voir [ar-alert.mdx](./src/content/components/ar-alert.mdx) comme référence.
+
+---
+
 ## Checklist pour ajouter un composant
 
 > **Utiliser le script de scaffolding** : `npm run create -- <nom>` génère automatiquement
@@ -307,6 +337,7 @@ Lors d'une PR qui modifie l'un des éléments ci-dessous, mettre à jour la sect
 - [ ] Implémenter le composant avec les annotations JSDoc
 - [ ] Régénérer le CEM : `cd packages/core && npm run build:manifest`
 - [ ] Compléter les variantes dans `apps/docs/src/content/components/ar-<nom>.mdx`
+- [ ] Ajouter la section `## Accessibilité` dans le MDX (voir convention ci-dessus)
 - [ ] Lancer `npm run dev` et vérifier la page `/components/<nom>`
 - [ ] Si sous-composant : ajouter uniquement `@parent ar-<parent>` dans la JSDoc (aucun champ MDX supplémentaire)
 

--- a/apps/docs/src/components/NarrativeHeading.astro
+++ b/apps/docs/src/components/NarrativeHeading.astro
@@ -1,0 +1,29 @@
+---
+/**
+ * NarrativeHeading.astro
+ *
+ * Composant MDX custom pour les titres h2 du contenu narratif des pages composant.
+ *
+ * Rôle : générer un `id` slugifié depuis le texte du titre, afin que chaque h2
+ * du MDX soit accessible comme ancre et apparaisse correctement dans la TOC.
+ *
+ * L'algorithme de slugification utilise `github-slugger` — le même qu'Astro/remark
+ * utilise pour construire le tableau `headings` retourné par `render()`.
+ * Cette cohérence garantit que l'id posé ici correspond toujours à l'entrée TOC
+ * construite dans [slug].astro, sans aucune synchronisation manuelle.
+ *
+ * Usage : injecté via <Content components={{ h2: NarrativeHeading }} /> dans [slug].astro.
+ * Ne pas utiliser directement dans les templates Astro.
+ */
+import GithubSlugger from 'github-slugger';
+
+interface Props {
+    id?: string;
+}
+
+const { id, ...rest } = Astro.props as Props & Record<string, unknown>;
+const text = await Astro.slots.render('default');
+const plainText = text.replace(/<[^>]+>/g, '').trim();
+const slug = id ?? new GithubSlugger().slug(plainText);
+---
+<h2 id={slug} {...rest}><slot /></h2>

--- a/apps/docs/src/components/NarrativeList.astro
+++ b/apps/docs/src/components/NarrativeList.astro
@@ -1,0 +1,15 @@
+---
+/**
+ * NarrativeList.astro
+ *
+ * Composant MDX custom pour les listes `ul` du contenu narratif des pages composant.
+ *
+ * Rôle : ajouter la classe `.narrative-list` sur le `ul` généré par le MDX,
+ * afin de pouvoir le cibler en CSS avec un sélecteur de classe plutôt qu'un
+ * sélecteur de tag (`ul`), conformément à la convention du projet.
+ *
+ * Usage : injecté via <Content components={{ ul: NarrativeList }} /> dans [slug].astro.
+ * Ne pas utiliser directement dans les templates Astro.
+ */
+---
+<ul class="narrative-list"><slot /></ul>

--- a/apps/docs/src/content/components/ar-alert.mdx
+++ b/apps/docs/src/content/components/ar-alert.mdx
@@ -32,4 +32,30 @@ variants:
           </div>
 ---
 
-Documentation narrative du composant `ar-alert`.
+## Utilisation
+
+`ar-alert` est destiné aux messages qui nécessitent l'attention de l'utilisateur :
+confirmations, avertissements, erreurs. Pour les messages purement informatifs et non
+urgents, préférer `variant="info"`.
+
+## Accessibilité
+
+### Pris en charge automatiquement
+
+- `role="alert"` (interruption immédiate) ou `role="status"` (annonce polie) posé sur
+  l'hôte selon le variant — `info` → `status`, tous les autres → `alert`.
+- L'icône est masquée aux lecteurs d'écran (`aria-hidden`). L'information de sévérité
+  est portée par le `role`, pas par l'icône.
+- Le focus est reporté sur l'élément cible (`next-focus`) à la fermeture — l'utilisateur
+  clavier ne se retrouve pas désorienté.
+
+### À la charge de l'auteur
+
+- **Message compréhensible hors contexte visuel.** Le contenu est lu dès l'apparition de
+  l'alerte. Évitez les messages vagues ("Une erreur s'est produite") — préférez
+  ("Le formulaire n'a pas pu être soumis : champ email manquant").
+- **Niveau de sévérité cohérent.** `error` pour les erreurs bloquantes, `warning` pour
+  les situations qui méritent attention sans bloquer, `success` pour les confirmations,
+  `info` pour les informations neutres.
+- **`next-focus` obligatoire sur les alertes dismissibles.** Un bouton de fermeture sans
+  destination de focus laisse l'utilisateur clavier sans repère.

--- a/apps/docs/src/content/components/ar-alert.mdx
+++ b/apps/docs/src/content/components/ar-alert.mdx
@@ -1,7 +1,9 @@
 ---
 tagName: ar-alert
 title: Alert
-description: Affiche un message d'alerte accessible avec différents niveaux de sévérité.
+description: >
+    Destiné aux messages qui nécessitent l'attention de l'utilisateur : confirmations,
+    avertissements, erreurs. Pour les messages informatifs non urgents, préférer `variant="info"`.
 variants:
     - name: default
       label: Défaut
@@ -32,12 +34,6 @@ variants:
           </div>
 ---
 
-## Utilisation
-
-`ar-alert` est destiné aux messages qui nécessitent l'attention de l'utilisateur :
-confirmations, avertissements, erreurs. Pour les messages purement informatifs et non
-urgents, préférer `variant="info"`.
-
 ## Accessibilité
 
 ### Pris en charge automatiquement
@@ -46,6 +42,10 @@ urgents, préférer `variant="info"`.
   l'hôte selon le variant — `info` → `status`, tous les autres → `alert`.
 - L'icône est masquée aux lecteurs d'écran (`aria-hidden`). L'information de sévérité
   est portée par le `role`, pas par l'icône.
+- Une icône par défaut est fournie pour chaque variant. Elle peut être remplacée via le
+  slot `icon`, mais il est déconseillé de la supprimer : elle constitue un repère visuel
+  non colorimétrique, important pour les utilisateurs daltoniens ou en environnement à
+  faible contraste.
 - Le focus est reporté sur l'élément cible (`next-focus`) à la fermeture — l'utilisateur
   clavier ne se retrouve pas désorienté.
 

--- a/apps/docs/src/content/components/ar-breadcrumb.mdx
+++ b/apps/docs/src/content/components/ar-breadcrumb.mdx
@@ -1,7 +1,7 @@
 ---
 tagName: ar-breadcrumb
 title: Breadcrumb
-description: Fil d'ariane accessible avec affichage adaptatif mobile/desktop.
+description: Fil d'ariane accessible avec affichage adaptatif mobile/desktop. En dessous de 768px de largeur de viewport, les liens intermédiaires sont masqués derrière un dropdown. Le premier lien reste visible sous forme d'un bouton "Retour". Pour voir ce comportement, utiliser les DevTools du navigateur (mode responsive).
 variants:
     - name: default
       label: Par défaut
@@ -23,5 +23,20 @@ variants:
           </ar-breadcrumb>
 ---
 
-En dessous de 768px de largeur de viewport, les liens intermédiaires sont masqués derrière un dropdown.
-Le premier lien reste visible sous forme d'un bouton "Retour". Pour voir ce comportement, utiliser les DevTools du navigateur (mode responsive).
+## Accessibilité
+
+### Pris en charge automatiquement
+
+- `role="navigation"` et `aria-labelledby` posés sur le conteneur — la région est identifiable
+  par les lecteurs d'écran sans configuration supplémentaire.
+- Le dernier item est automatiquement rendu comme texte (pas de lien), quel que soit son
+  attribut `href`. `aria-current="page"` lui est appliqué automatiquement.
+- Les icônes de séparation sont masquées aux lecteurs d'écran (`aria-hidden`).
+- En mobile, le bouton "dropdown" expose son état via `aria-expanded`. Son label est vocalisé
+  via une classe `.sr-only` — accessible sans être visible.
+
+### À la charge de l'auteur
+
+- **Labels descriptifs sur chaque item.** Le `label` est le seul texte vocalisé — évitez les
+  labels génériques ("Page 1", "Étape") au profit de libellés qui situent l'utilisateur
+  ("Mon espace personnel", "Résultats de recherche").

--- a/apps/docs/src/content/components/ar-pagination.mdx
+++ b/apps/docs/src/content/components/ar-pagination.mdx
@@ -25,4 +25,19 @@ variants:
           <ar-pagination current="18" total="20"></ar-pagination>
 ---
 
-Documentation narrative du composant `ar-pagination`.
+## Accessibilité
+
+### Pris en charge automatiquement
+
+- `role="navigation"` et `aria-labelledby` posés sur le conteneur — la région est annoncée
+  par les lecteurs d'écran comme zone de navigation.
+- Les boutons "précédent" et "suivant" ont `aria-disabled` synchronisé avec leur état désactivé.
+- Les séparateurs et points de suspension sont masqués aux lecteurs d'écran (`aria-hidden`).
+
+### À la charge de l'auteur
+
+- **Annoncer le changement de page.** La pagination ne gère pas le rechargement de contenu —
+  c'est à l'intégrateur d'annoncer le nouveau contenu chargé (via une live region ou un focus
+  management) pour que l'utilisateur clavier sache que la page a changé.
+- **`current` et `total` doivent rester cohérents.** Une valeur `current` hors de `[1, total]`
+  produit un état visuellement incohérent non corrigé par le composant.

--- a/apps/docs/src/content/components/ar-progressbar.mdx
+++ b/apps/docs/src/content/components/ar-progressbar.mdx
@@ -21,4 +21,19 @@ variants:
           </ar-progressbar>
 ---
 
-Documentation narrative du composant `ar-progressbar`.
+## Accessibilité
+
+### Pris en charge automatiquement
+
+- `role="progressbar"`, `aria-valuenow`, `aria-valuemin` et `aria-valuemax` posés sur la barre —
+  la progression est vocalisée automatiquement par les lecteurs d'écran.
+- La valeur de `aria-labelledby` pointe sur le label slotté, pas sur un texte invisible —
+  le contexte de la progression est toujours visible et vocalisé simultanément.
+
+### À la charge de l'auteur
+
+- **Fournir un label explicite dans le slot.** Sans slot, la barre n'a pas de contexte — le
+  lecteur d'écran annoncera "75%" sans préciser quoi. Utilisez un texte descriptif
+  ("Chargement du fichier", "Progression de l'inscription").
+- **Mettre à jour `percent` au fil de l'avancement.** Le composant ne suit pas l'avancement
+  automatiquement — c'est à l'intégrateur d'incrémenter la valeur au rythme réel de l'opération.

--- a/apps/docs/src/content/components/ar-spinner.mdx
+++ b/apps/docs/src/content/components/ar-spinner.mdx
@@ -33,4 +33,21 @@ variants:
           <ar-spinner size="lg"></ar-spinner>
 ---
 
-Documentation narrative du composant `ar-spinner`.
+## Accessibilité
+
+### Pris en charge automatiquement
+
+- L'animation SVG est masquée aux lecteurs d'écran (`aria-hidden`). Un `<div role="alert">`
+  invisible annonce les changements d'état — le passage "en cours → terminé" est vocalisé
+  sans intervention supplémentaire.
+- Les labels "en cours" (`loading-label`) et "terminé" (`done-label`) ont des valeurs par
+  défaut raisonnables utilisées si non fournis.
+
+### À la charge de l'auteur
+
+- **Adapter `loading-label` et `done-label` au contexte.** Les valeurs par défaut sont
+  génériques — préférez des labels qui décrivent l'opération en cours ("Envoi du formulaire…",
+  "Fichier chargé.") pour que l'annonce soit utile et non redondante.
+- **Ne pas afficher plusieurs spinners simultanément sans les différencier.** Chaque
+  `role="alert"` visible déclenche une annonce — des labels identiques sur plusieurs spinners
+  actifs simultanément créent une confusion pour les utilisateurs de lecteurs d'écran.

--- a/apps/docs/src/content/components/ar-stepper.mdx
+++ b/apps/docs/src/content/components/ar-stepper.mdx
@@ -69,4 +69,22 @@ variants:
           </ar-stepper>
 ---
 
-Documentation narrative du composant `ar-stepper`.
+## Accessibilité
+
+### Pris en charge automatiquement
+
+- `role="navigation"` et `aria-labelledby` posés sur le conteneur — la région est annoncée
+  et identifiable par les lecteurs d'écran.
+- L'état courant (`current-path`) est reflété visuellement et structurellement — les items
+  actifs, complétés et désactivés sont distingués.
+
+### À la charge de l'auteur
+
+- **Labels descriptifs sur chaque `ar-stepper-item`.** Le `label` est le seul texte vocalisé
+  pour chaque étape — évitez les labels génériques ("Étape 1") au profit de libellés métier
+  ("Mes informations", "Récapitulatif").
+- **`current-path` doit correspondre au `path` d'un item existant.** Une valeur incorrecte
+  n'active aucun item — aucun feedback visuel ni vocal ne signale l'étape courante.
+- **Les items sans `href` ne sont pas des liens.** Un item sans destination est rendu comme
+  un élément non interactif — ne pas en faire la cible de `current-path` si l'utilisateur
+  doit pouvoir y naviguer.

--- a/apps/docs/src/pages/components/[slug].astro
+++ b/apps/docs/src/pages/components/[slug].astro
@@ -3,6 +3,8 @@ import { getCollection, render } from 'astro:content';
 import Layout from '../../layouts/Layout.astro';
 import Playground from '../../components/Playground.astro';
 import TableOfContents from '../../components/TableOfContents.astro';
+import NarrativeList from '../../components/NarrativeList.astro';
+import NarrativeHeading from '../../components/NarrativeHeading.astro';
 import manifest from '@cem';
 import { getSlug } from '../../utils/tag-name.ts';
 import { type CemDeclaration, getCustomElements, buildControls } from '../../utils/cem-types.ts';
@@ -30,7 +32,7 @@ const { component, mdx } = Astro.props as {
     mdx: MdxEntry | null;
 };
 
-const { Content } = mdx ? await render(mdx) : { Content: null };
+const { Content, headings } = mdx ? await render(mdx) : { Content: null, headings: [] };
 
 const variants    = mdx?.data.variants ?? [];
 const pageTitle   = mdx?.data.title ?? component.name;
@@ -51,8 +53,22 @@ const playgroundHtml = playgroundVariant?.html ?? '';
 const controls = buildControls(component.members ?? []);
 
 // ─── TOC ──────────────────────────────────────────────────────────────────────
+//
+// Les h2 du MDX sont automatiquement injectés en tête de TOC.
+// `headings` est fourni par render() — Astro/remark les extrait à la compilation.
+// L'id utilisé ici doit correspondre exactement à celui posé par NarrativeHeading.astro,
+// qui utilise le même algorithme (github-slugger) pour garantir la synchronisation.
+
+const narrativeTocEntries = headings
+    .filter((h: { depth: number }) => h.depth === 2)
+    .map((h: { slug: string; text: string }) => ({
+        id:    h.slug,
+        label: h.text,
+        level: 1 as const,
+    }));
 
 const tocEntries = [
+    ...narrativeTocEntries,
     ...(variants.length > 0
         ? [
             { id: 'exemples', label: 'Exemples', level: 1 as const },
@@ -89,13 +105,21 @@ const tocEntries = [
             </div>
 
             {pageDesc && <p class="summary">{pageDesc}</p>}
+        </div>
 
-            {Content && (
+        {/*
+          * Contenu narratif du MDX (usage, accessibilité…).
+          * Les composants custom remplacent les éléments HTML natifs générés par le MDX :
+          *   - h2 → NarrativeHeading : pose un id slugifié pour les ancres TOC
+          *   - ul → NarrativeList    : ajoute .narrative-list pour le ciblage CSS sans sélecteur de tag
+          * Voir apps/docs/CONTRIBUTING.md § "Contenu narratif MDX" pour la documentation complète.
+          */}
+        {Content && (
             <section class="narrative">
-                <Content />
+                <Content components={{ ul: NarrativeList, h2: NarrativeHeading }} />
             </section>
         )}
-        </div>
+
         <Playground
             variants={variants}
             tagName={component.tagName!}
@@ -119,19 +143,36 @@ const tocEntries = [
         .toc-mobile-inline { display: block; }
     }
 
-    /* .narrative {
-        margin:      1.5rem 0;
-        color:       var(--doc-text, #374151);
-        line-height: 1.7;
-    } */
+    .narrative :global(h2) {
+        font-size: 1.25rem;
+        font-weight: 600;
+        border-bottom: 2px solid var(--doc-border, #e5e7eb);
+        padding-bottom: 1rem;
+        margin: 2rem 0 1rem;
+        color: var(--doc-text, #111827);
+    }
 
-    .narrative :global(p)    { margin-bottom: 0rem; }
+    .narrative :global(h2:first-child) { margin-top: 0; }
 
-    /* .narrative :global(code) {
-        font-size:     0.85em;
-        background:    var(--doc-code-bg, #f3f4f6);
-        color:         var(--doc-text, #111827);
-        padding:       0.1em 0.35em;
-        border-radius: 0.25em;
-    } */
+    .narrative :global(h3) {
+        font-size: 1.05rem;
+        font-weight: 600;
+        color: var(--doc-text-subtle, #374151);
+        margin: 1.25rem 0 0.5rem;
+    }
+
+    .narrative :global(p) {
+        font-size: 0.9rem;
+        line-height: 1.75;
+        color: var(--doc-text-muted, #4b5563);
+        margin: 0;
+    }
+
+    .narrative :global(.narrative-list) {
+        font-size: 0.9rem;
+        line-height: 1.75;
+        color: var(--doc-text, #374151);
+        margin: 0;
+        padding-left: 1.25rem;
+    }
 </style>


### PR DESCRIPTION
## Objectif

Établir la convention de documentation de l'accessibilité pour toutes les pages de composants, et l'appliquer à l'ensemble des composants existants.

## Contenu

- **Style narratif** : `h2`/`h3`/`p`/`ul` alignés sur les classes `.section-title`/`.subsection-title` existantes, bloc sorti du `page-header`
- **Composants MDX custom** : `NarrativeList.astro` (classe `.narrative-list`) et `NarrativeHeading.astro` (id slugifié via `github-slugger`) — TOC automatique depuis les `h2` du MDX sans déclaration manuelle dans le frontmatter
- **Convention documentée** dans `apps/docs/CONTRIBUTING.md` : mécanisme complet, flux de données, arborescence mise à jour
- **Section `## Accessibilité`** appliquée à tous les composants : `ar-alert`, `ar-breadcrumb`, `ar-pagination`, `ar-progressbar`, `ar-spinner`, `ar-stepper`

🤖 Generated with [Claude Code](https://claude.com/claude-code)