### PR TITLE
feat(stepper): téléportation DOM adaptive (desktop-target / desktop-from)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ Thumbs.db
 .claude
 .superpowers/
 .github/hooks/
+.codeium/windsurf/skills/speakeasy-context
+.cursor/skills/speakeasy-context
+.github/copilot/skills/speakeasy-context
+.agents/skills/speakeasy-context/SKILL.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,153 +1,41 @@
-# CLAUDE.md
+# Ariane
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Web components library pour patterns UI accessibles, Lit 3 + TypeScript. Monorepo npm workspaces orchestré par Turborepo. Pas un design system — une fondation pour en construire un.
 
-## Project Overview
+## Key Directories
 
-**Ariane** is an accessible web components library (`@ariane-ui/core`) built with **Lit 3** and **TypeScript**. npm workspaces monorepo orchestrated by Turborepo. Dual distribution: NPM (tree-shakeable ESM) + CDN (self-contained bundle with autoloader).
+- `packages/core/src/components/` — composants LitElement (`ar-<name>.ts`, styles, tests)
+- `packages/core/src/index.ts` — export barrel
+- `apps/docs/` — site documentation Astro + MDX
 
-Ariane is a **foundation** for building design systems — not a design system itself. It handles patterns where correct accessible implementation is a real obstacle. It does not rewrite native elements that already work well.
+## Standards
 
-## Références
+- Prettier : 100 char, 4 spaces, single quotes
+- Toujours `import type` pour les imports de types
+- Conventional Commits (commitlint + Husky)
+- CSS tokens `--doc-*` (`apps/docs/`) ne forcent jamais un ajout dans `packages/core`
 
-- **Philosophie, positionnement et critères d'inclusion** → [CONTRIBUTING.md](CONTRIBUTING.md)
-- **Setup, commandes, architecture, patterns de code** → [DEVELOPMENT.md](DEVELOPMENT.md)
-- **Décisions techniques détaillées** → [`docs/decisions/`](docs/decisions/) — indexées par context-mode, utiliser `ctx_search` pour les retrouver
+## Common Commands
 
-## Règles actives
-
-### Naming
-
-- Tag: `ar-<name>` · Class: `Ar<Name>` · Events: `ar-<event>`
-- CSS custom properties: `--ar-<component>-<property>` (e.g. `--ar-alert-padding`)
-- CSS parts: `part="base"`, `part="label"`, `part="prefix"`, `part="suffix"`
-
-### Properties — always `reflect: true`
-
-Without `reflect: true`, the HTML attribute won't sync with the JS property — the playground's `outerHTML` will show missing attributes.
-
-### Custom events — always `{ bubbles: true, composed: true }`
-
-Without `composed: true`, events don't cross Shadow DOM boundary. Without `bubbles: true`, they don't bubble up through the light DOM either.
-
-### Global type declaration
-
-Every component file ends with:
-
-```typescript
-declare global {
-    interface HTMLElementTagNameMap {
-        'ar-<name>': Ar<Name>;
-    }
-}
+```bash
+npm run dev                # Watch core + docs en parallèle
+npm run test               # Vitest passe unique (racine)
+npm run test:all           # Vitest + WTR browser
+npm run create ar-<nom>    # Scaffold nouveau composant
+npm run build:manifest     # Regénère custom-elements.json
 ```
 
-### Tokens: doc vs. library
+## Git Workflow
 
-`--doc-*` variables (in `apps/docs/`) may reference existing `--ar-*` tokens but must never force adding a token to `packages/core` for a documentation-only need. **A token only enters `packages/core` if a component needs it.**
+- Branches : `feat/<desc>`, `fix/<desc>`, `chore/<desc>` créées depuis `dev`
+- PRs vers `dev` — jamais de push direct sur `main`, et sur `dev` demander l'autorisation
+- `main` ← PR depuis `dev` uniquement, pour les releases
+- Release : tag `vX.Y.Z` → CI publie sur npm + crée la GitHub Release automatiquement
+- Tag npm : `-alpha.*` → `alpha`, `-beta.*` → `beta`, stable → `latest`
 
-### Component variant
+## Notes
 
-If `variant` is set explicitly on a component, it overrides the system theme. If unset, the component follows the system theme via semantic tokens.
+Toujours vérifier la branche active avant de commiter — ne jamais commiter sur `main`, et si `dev` est active, demander confirmation à l'utilsateur.
 
----
-
-## Docs site architecture (`apps/docs/`)
-
-Custom Astro + MDX static site. No Starlight, no api-viewer.
-
-**Key files:**
-
-| File                                   | Role                                                                                  |
-| -------------------------------------- | ------------------------------------------------------------------------------------- |
-| `src/pages/components/[slug].astro`    | Dynamic route — resolves playground HTML, calls `buildControls()`, builds TOC entries |
-| `src/components/Playground.astro`      | Variants + playground + ComponentApi; loads `public/js/playground.js`                 |
-| `src/components/ComponentApi.astro`    | API tables from CEM; color swatches on CSS custom property defaults                   |
-| `src/components/TableOfContents.astro` | Sticky TOC right column; receives `entries[]` via props                               |
-| `src/components/SiteNav.astro`         | Left nav; auto-generated from CEM with parent/child hierarchy                         |
-| `src/layouts/Layout.astro`             | 3-column grid (`260px 1fr 220px`) when `showToc={true}`                               |
-| `src/content/config.ts`                | Zod schema for MDX frontmatter                                                        |
-| `public/js/playground.js`              | Copy buttons + live attribute manipulation via `setAttribute`                         |
-| `src/utils/cem-types.ts`               | Shared CEM TypeScript types + helpers (`getCustomElements`, `buildControls`)          |
-| `src/utils/parse-tokens.ts`            | Parses `default.css` and categorizes CSS custom properties                            |
-| `src/utils/tag-name.ts`                | `getSlug()`, `getPrefix()`, `groupByPrefix()` helpers                                 |
-| `src/styles/doc-table.css`             | Shared table styles used by ComponentApi and tokens page                              |
-| `src/pages/foundations/tokens.astro`   | Design tokens page; auto-extracts from theme CSS                                      |
-
-**MDX frontmatter schema** (per component content file):
-
-```yaml
-tagName: ar-alert # required
-title: Alerte # required
-description: … # optional, shown under title
-playgroundTemplate: default # optional, name of variant used to init playground (defaults to first)
-variants:
-    - name: default
-      label: Par défaut
-      description: …
-      html: '<ar-alert variant="info">Message informatif.</ar-alert>'
-```
-
-> **Sub-components**: use only `@parent ar-<tag>` JSDoc in the Lit class. No MDX field needed — the CEM `x-parent` field is read directly by the nav and home page.
-
-**Playground control type detection** (`src/utils/cem-types.ts` → `buildControls()`):
-
-| CEM type                         | Control                                              |
-| -------------------------------- | ---------------------------------------------------- |
-| `'a' \| 'b' \| …` (string union) | `<select>`                                           |
-| `'a' \| 'b' \| undefined`        | `<select>` with "Par défaut" first option (value="") |
-| `boolean`                        | `<input type="checkbox">`                            |
-| `number` / `number \| undefined` | `<input type="number">`                              |
-| anything else                    | `<input type="text">`                                |
-
----
-
-## Tooling Notes
-
-- **Commits**: Conventional Commits enforced by commitlint + Husky
-- **Pre-commit**: lint-staged runs ESLint + Prettier on staged files
-- **TypeScript**: strict mode; use inline type imports (`import type`)
-- **Prettier config**: 100 char width, 4 spaces, single quotes
-- **Node requirement**: >=24, npm >=11
-
----
-
-## Méthode de travail
-
-**Remettre en cause la demande après 3 essais infructueux**
-Si un correctif échoue 3 fois de suite, ne pas insister. S'arrêter et questionner la logique de la demande elle-même : est-ce rationnel ? Est-ce que ça va à l'encontre des conventions du domaine ? Est-ce que le problème vient du _quoi_ plutôt que du _comment_ ? Exposer le doute clairement à l'utilisateur et proposer une alternative avant de continuer.
-
----
-
-## Lessons — package core
-
-**Convention de dépréciation**
-Utiliser `warnDeprecated(tag, member, message)` depuis `src/utils/deprecated.ts`. Le warning ne s'affiche qu'une fois par session (garde en `Set`). Toujours annoter avec `@deprecated` en JSDoc. Annoncer la suppression cible dans le message.
-
-```typescript
-import { warnDeprecated } from '../../utils/deprecated.js';
-
-// Dans updated() :
-if (this.links !== undefined) {
-    warnDeprecated(
-        'ar-breadcrumb',
-        'links',
-        'Utilisez des éléments <a> slottés. Sera supprimé en v1.0.0.',
-    );
-}
-```
-
-**Tests : `textContent` des Text nodes Lit interpolés dans happy-dom**
-`element.textContent` retourne `''` même si le rendu est correct. Tester la propriété JS directement (`el.myProp`). Les attributs, `hasAttribute`, `getAttribute` et la structure DOM fonctionnent correctement.
-
-**Tests : helpers `fixture()`, `waitForUpdate()`, `getPart()`**
-Extraire ces trois helpers dans chaque fichier de test pour éviter les non-null assertions (`!`) bloquées par `lint-staged --max-warnings=0`. `getPart(el, 'name')` cible les éléments par `part="…"`.
-
-**Tests : `.ariaCurrent` (et autres propriétés ARIA Lit) ne reflètent pas en attribut dans happy-dom**
-Tester la propriété JS directement : `(el as unknown as { ariaCurrent: string }).ariaCurrent`.
-
-**Tests : `MediaQueryList` mock**
-Toujours inclure `addEventListener` et `removeEventListener` : `{ matches: true, addEventListener: vi.fn(), removeEventListener: vi.fn() } as unknown as MediaQueryList`.
-
-**Tests : `queueMicrotask` — double `updateComplete`**
-Quand le rendu est déclenché depuis un `queueMicrotask`, `await updateComplete` deux fois de suite pour absorber le cycle initial + le cycle du microtask.
+Dépréciation : `warnDeprecated(tag, member, msg)` depuis `src/utils/deprecated.ts` + `@deprecated` JSDoc — pas nécessaire en alpha.
+Si un correctif échoue 3 fois de suite, remettre en cause la demande avant de continuer.

--- a/apps/docs/src/content/components/ar-stepper.mdx
+++ b/apps/docs/src/content/components/ar-stepper.mdx
@@ -25,33 +25,6 @@ variants:
             <!-- Étape 3 -->
             <ar-stepper-item path="etape-3" label="Récapitulatif"></ar-stepper-item>
           </ar-stepper>
-    - name: responsive
-      label: Responsive
-      description: Exemple configuré avec un conteneur desktop cible pour démontrer la téléportation responsive.
-      html: |
-          <aside id="stepper-sidebar"></aside>
-          <ar-stepper
-            class="align-left"
-            current-path="etape-1-2"
-            desktop-target="stepper-sidebar"
-            desktop-from="992"
-          >
-            <!-- Étape 1 -->
-            <ar-stepper-item path="etape-1" label="Mes informations" href="#">
-                <ar-stepper-item path="etape-1-1" label="Mon état civil" href="#"></ar-stepper-item>
-                <ar-stepper-item path="etape-1-2" label="Mes coordonnées" href="#"></ar-stepper-item>
-                <ar-stepper-item path="etape-1-3" label="Mes identifiants" href="#"></ar-stepper-item>
-            </ar-stepper-item>
-
-            <!-- Étape 2 -->
-            <ar-stepper-item path="etape-2" label="Mes préférences" href="#">
-                <ar-stepper-item path="etape-2-1" label="Mes notifications" href="#etape-2-1"></ar-stepper-item>
-                <ar-stepper-item path="etape-2-2" label="Mes langues" href="#etape-2-2"></ar-stepper-item>
-            </ar-stepper-item>
-
-            <!-- Étape 3 -->
-            <ar-stepper-item path="etape-3" label="Récapitulatif"></ar-stepper-item>
-          </ar-stepper>
     - name: edit
       label: Mode édition
       description: Rendu par défaut du composant.
@@ -97,11 +70,16 @@ variants:
 
 ## Comportement responsive
 
-Quand `desktop-target` est renseigné, le composant adapte automatiquement son rendu selon la
-largeur de l'écran :
+Le composant adapte son rendu selon la largeur de l'écran, au niveau du breakpoint `desktop-from`
+(992 px par défaut) :
 
-- En dessous de `desktop-from`, il reste à sa position d'origine et utilise le rendu dropdown.
-- À partir de `desktop-from`, il se téléporte dans l'élément ciblé par `desktop-target` et
-  affiche la liste desktop.
+- En dessous de `desktop-from` : rendu dropdown (mobile).
+- À partir de `desktop-from` : liste verticale (desktop).
 
-Pour observer ce comportement, utiliser les DevTools du navigateur en mode responsive.
+Quand `desktop-target` est renseigné, la téléportation DOM est également activée : le composant
+se déplace dans l'élément ciblé sur desktop, et revient à sa position d'origine sur mobile.
+
+```html
+<aside id="stepper-sidebar"></aside>
+<ar-stepper desktop-target="stepper-sidebar" desktop-from="992"> ... </ar-stepper>
+```

--- a/apps/docs/src/content/components/ar-stepper.mdx
+++ b/apps/docs/src/content/components/ar-stepper.mdx
@@ -25,11 +25,17 @@ variants:
             <!-- Étape 3 -->
             <ar-stepper-item path="etape-3" label="Récapitulatif"></ar-stepper-item>
           </ar-stepper>
-    - name: mobile
-      label: Version mobile
-      description: Rendu par défaut du composant.
+    - name: responsive
+      label: Responsive
+      description: Exemple configuré avec un conteneur desktop cible pour démontrer la téléportation responsive.
       html: |
-          <ar-stepper class="align-left" current-path="etape-1-2" version="mobile">
+          <aside id="stepper-sidebar"></aside>
+          <ar-stepper
+            class="align-left"
+            current-path="etape-1-2"
+            desktop-target="stepper-sidebar"
+            desktop-from="992"
+          >
             <!-- Étape 1 -->
             <ar-stepper-item path="etape-1" label="Mes informations" href="#">
                 <ar-stepper-item path="etape-1-1" label="Mon état civil" href="#"></ar-stepper-item>
@@ -88,3 +94,14 @@ variants:
 - **Les items sans `href` ne sont pas des liens.** Un item sans destination est rendu comme
   un élément non interactif — ne pas en faire la cible de `current-path` si l'utilisateur
   doit pouvoir y naviguer.
+
+## Comportement responsive
+
+Quand `desktop-target` est renseigné, le composant adapte automatiquement son rendu selon la
+largeur de l'écran :
+
+- En dessous de `desktop-from`, il reste à sa position d'origine et utilise le rendu dropdown.
+- À partir de `desktop-from`, il se téléporte dans l'élément ciblé par `desktop-target` et
+  affiche la liste desktop.
+
+Pour observer ce comportement, utiliser les DevTools du navigateur en mode responsive.

--- a/apps/docs/src/pages/components/[slug].astro
+++ b/apps/docs/src/pages/components/[slug].astro
@@ -164,7 +164,7 @@ const tocEntries = [
     .narrative :global(p) {
         font-size: 0.9rem;
         line-height: 1.75;
-        color: var(--doc-text-muted, #4b5563);
+        color: var(--doc-text, #374151);
         margin: 0;
     }
 

--- a/docs/superpowers/plans/2026-03-31-stepper-teleport.md
+++ b/docs/superpowers/plans/2026-03-31-stepper-teleport.md
@@ -1,0 +1,799 @@
+# Stepper Teleport Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remplacer la prop `version="mobile"` par une téléportation DOM automatique (`desktop-target` + `desktop-from`) pilotée par `matchMedia`, éliminant le besoin de dupliquer le composant dans la page.
+
+**Architecture:** `connectedCallback` mémorise la position d'origine (parent + nextSibling) et installe un listener `matchMedia`. Quand le breakpoint est franchi, le composant se déplace via `appendChild`/`insertBefore` natifs. Le state interne `_isDesktop` pilote le choix de rendu (`renderDesktop` / `renderMobile`). Aucune modification de `stepper.renderer.ts` ni `stepper.styles.ts`.
+
+**Tech Stack:** Lit 3, TypeScript strict, Vitest + happy-dom, `window.matchMedia`
+
+---
+
+## Fichiers modifiés
+
+| Fichier                                                | Action                                                                                        |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| `packages/core/src/components/stepper/stepper.ts`      | Supprimer `version`, ajouter `desktopTarget`/`desktopFrom`, state téléportation, cycle de vie |
+| `packages/core/src/components/stepper/stepper.test.ts` | Supprimer tests `version`, ajouter suite téléportation                                        |
+| `apps/docs/src/content/components/ar-stepper.mdx`      | Supprimer variante `mobile`, maj variante `default`, ajouter section responsive               |
+
+`stepper.renderer.ts` et `stepper.styles.ts` : non modifiés.
+
+---
+
+### Task 1 : Supprimer `version` et nettoyer les tests associés
+
+**Files:**
+
+- Modify: `packages/core/src/components/stepper/stepper.ts:79-85`
+- Modify: `packages/core/src/components/stepper/stepper.ts:177-191`
+- Modify: `packages/core/src/components/stepper/stepper.test.ts`
+
+- [ ] **Step 1 : Écrire les tests qui valident l'absence de `version`**
+
+Dans `stepper.test.ts`, remplacer le bloc `describe('propriétés')` existant par :
+
+```typescript
+describe('propriétés', () => {
+    it('currentPath par défaut vaut ""', async () => {
+        const el = await fixture<ArStepper>('<ar-stepper></ar-stepper>');
+        expect(el.currentPath).toBe('');
+    });
+
+    it('mode par défaut vaut "create"', async () => {
+        const el = await fixture<ArStepper>('<ar-stepper></ar-stepper>');
+        expect(el.mode).toBe('create');
+    });
+
+    it('followScroll par défaut vaut false', async () => {
+        const el = await fixture<ArStepper>('<ar-stepper></ar-stepper>');
+        expect(el.followScroll).toBe(false);
+    });
+
+    it("version n'est plus une propriété du composant", async () => {
+        const el = await fixture<ArStepper>('<ar-stepper></ar-stepper>');
+        expect('version' in el).toBe(false);
+    });
+
+    it('lit les attributs depuis le HTML', async () => {
+        const el = await fixture<ArStepper>(
+            '<ar-stepper current-path="/b" mode="edit" follow-scroll></ar-stepper>',
+        );
+        expect(el.currentPath).toBe('/b');
+        expect(el.mode).toBe('edit');
+        expect(el.followScroll).toBe(true);
+    });
+});
+```
+
+Supprimer aussi intégralement les deux `describe` suivants qui testent `version` :
+
+- `describe('rendu desktop', ...)` — les tests utilisant `version="desktop"` seront réécrits en Task 3
+- `describe('rendu mobile', ...)` — les tests utilisant `version="mobile"` seront réécrits en Task 3
+
+- [ ] **Step 2 : Lancer les tests pour vérifier qu'ils échouent**
+
+```bash
+cd /path/to/ariane && npm run test --workspace=packages/core -- --reporter=verbose 2>&1 | grep -E "FAIL|PASS|✓|×|version"
+```
+
+Expected : certains tests échouent car `version` existe encore.
+
+- [ ] **Step 3 : Supprimer la prop `version` dans `stepper.ts`**
+
+Supprimer ces lignes (79-85) :
+
+```typescript
+/**
+ * Version d'affichage. Passer `mobile` pour activer le rendu dropdown.
+ * En pratique, gérer ce changement via un `ResizeObserver` ou une media query externe.
+ * @attr version
+ */
+@property({ type: String })
+version: 'desktop' | 'mobile' = 'desktop';
+```
+
+- [ ] **Step 4 : Remplacer la condition `version` dans `render()` par `false` temporaire**
+
+Dans `render()` (lignes 177-191), remplacer :
+
+```typescript
+const content =
+    this.version === 'mobile'
+        ? renderMobile(...)
+        : renderDesktop(...);
+```
+
+Par (temporaire — sera remplacé en Task 2) :
+
+```typescript
+const content = renderDesktop(steps, this.mode, this.onClickLink);
+```
+
+- [ ] **Step 5 : Mettre à jour le JSDoc `@summary`**
+
+Remplacer :
+
+```typescript
+ * @summary Stepper de navigation accessible, adaptatif desktop/mobile.
+ * @display demo
+ *
+ * Les étapes sont déclarées via des éléments `<ar-stepper-item>` enfants.
+ * Le composant les collecte automatiquement via `@lit/context` et construit
+ * l'arbre de navigation. Un item peut avoir des sous-étapes (enfants imbriqués).
+ *
+ * En mode `mobile`, les étapes sont affichées dans un dropdown.
+ * En mode `desktop`, elles sont affichées dans une liste verticale.
+```
+
+Par :
+
+```typescript
+ * @summary Stepper de navigation accessible avec téléportation DOM adaptive.
+ * @display demo
+ *
+ * Les étapes sont déclarées via des éléments `<ar-stepper-item>` enfants.
+ * Le composant les collecte automatiquement via `@lit/context` et construit
+ * l'arbre de navigation. Un item peut avoir des sous-étapes (enfants imbriqués).
+ *
+ * Fournir `desktop-target` (ID d'un élément) pour activer la téléportation automatique :
+ * en dessous de `desktop-from` px le composant affiche le rendu dropdown à sa position
+ * d'origine ; au-dessus il se déplace dans l'élément cible et affiche la liste verticale.
+```
+
+Mettre aussi à jour les `@csspart` — supprimer la mention "(mobile uniquement)" :
+
+```typescript
+ * @csspart dropdown     - Le conteneur dropdown.
+ * @csspart dropdown-btn - Le bouton d'ouverture du dropdown.
+```
+
+- [ ] **Step 6 : Lancer les tests**
+
+```bash
+npm run test --workspace=packages/core -- --reporter=verbose 2>&1 | grep -E "FAIL|PASS|✓|×"
+```
+
+Expected : les tests `version n'est plus une propriété` passent, les autres tests de rendu peuvent échouer.
+
+- [ ] **Step 7 : Commit**
+
+```bash
+git add packages/core/src/components/stepper/stepper.ts \
+        packages/core/src/components/stepper/stepper.test.ts
+git commit -m "refactor(stepper): suppression prop version"
+```
+
+---
+
+### Task 2 : Ajouter props `desktopTarget`/`desktopFrom` + mécanisme de téléportation
+
+**Files:**
+
+- Modify: `packages/core/src/components/stepper/stepper.ts`
+
+- [ ] **Step 1 : Écrire les tests de téléportation (ils échouent)**
+
+Dans `stepper.test.ts`, ajouter un nouveau `describe('téléportation')` après les tests existants :
+
+```typescript
+describe('téléportation', () => {
+    // Helper : crée un matchMedia mock qui retourne `matches`
+    function mockMatchMedia(matches: boolean) {
+        return vi.spyOn(window, 'matchMedia').mockReturnValue({
+            matches,
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+        } as unknown as MediaQueryList);
+    }
+
+    it('desktopTarget vaut undefined par défaut', async () => {
+        const el = await fixture<ArStepper>('<ar-stepper></ar-stepper>');
+        expect(el.desktopTarget).toBeUndefined();
+    });
+
+    it('desktopFrom vaut 992 par défaut', async () => {
+        const el = await fixture<ArStepper>('<ar-stepper></ar-stepper>');
+        expect(el.desktopFrom).toBe(992);
+    });
+
+    it('sans desktop-target : pas de matchMedia, composant reste en place', async () => {
+        const spy = vi.spyOn(window, 'matchMedia');
+        await fixture<ArStepper>('<ar-stepper></ar-stepper>');
+        expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('avec desktop-target valide + viewport desktop : téléporte dans la cible', async () => {
+        mockMatchMedia(true);
+
+        const target = document.createElement('div');
+        target.id = 'sidebar';
+        document.body.appendChild(target);
+
+        const el = await fixtureWithItems(`
+            <ar-stepper desktop-target="sidebar" current-path="/a">
+                <ar-stepper-item path="/a" label="A"></ar-stepper-item>
+            </ar-stepper>
+        `);
+
+        expect(el.parentElement).toBe(target);
+        expect((el as unknown as { _isDesktop: boolean })._isDesktop).toBe(true);
+    });
+
+    it('avec desktop-target valide + viewport mobile : reste à sa position', async () => {
+        mockMatchMedia(false);
+
+        const target = document.createElement('div');
+        target.id = 'sidebar2';
+        document.body.appendChild(target);
+
+        const container = document.createElement('div');
+        document.body.appendChild(container);
+        container.innerHTML = `
+            <ar-stepper desktop-target="sidebar2" current-path="/a">
+                <ar-stepper-item path="/a" label="A"></ar-stepper-item>
+            </ar-stepper>
+        `;
+        const el = container.querySelector('ar-stepper')!;
+        await waitForUpdate(el as ArStepper);
+
+        expect(el.parentElement).toBe(container);
+        expect((el as unknown as { _isDesktop: boolean })._isDesktop).toBe(false);
+    });
+
+    it('desktop-target avec ID inexistant : console.warn, composant non déplacé', async () => {
+        mockMatchMedia(true);
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const container = document.createElement('div');
+        document.body.appendChild(container);
+        container.innerHTML = `
+            <ar-stepper desktop-target="inexistant" current-path="/a">
+                <ar-stepper-item path="/a" label="A"></ar-stepper-item>
+            </ar-stepper>
+        `;
+        const el = container.querySelector('ar-stepper')!;
+        await waitForUpdate(el as ArStepper);
+
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('inexistant'));
+        expect(el.parentElement).toBe(container);
+    });
+
+    it('disconnectedCallback débranche le listener matchMedia', async () => {
+        const removeListenerSpy = vi.fn();
+        vi.spyOn(window, 'matchMedia').mockReturnValue({
+            matches: false,
+            addEventListener: vi.fn(),
+            removeEventListener: removeListenerSpy,
+        } as unknown as MediaQueryList);
+
+        const target = document.createElement('div');
+        target.id = 'sidebar3';
+        document.body.appendChild(target);
+
+        const el = await fixture<ArStepper>('<ar-stepper desktop-target="sidebar3"></ar-stepper>');
+        el.remove();
+
+        expect(removeListenerSpy).toHaveBeenCalledTimes(1);
+    });
+});
+```
+
+- [ ] **Step 2 : Lancer les tests pour vérifier qu'ils échouent**
+
+```bash
+npm run test --workspace=packages/core -- --reporter=verbose 2>&1 | grep -E "téléportation|FAIL|×"
+```
+
+Expected : tous les tests `téléportation` échouent.
+
+- [ ] **Step 3 : Ajouter les props publiques dans `stepper.ts`**
+
+Après la prop `followScroll` (ligne ~93), ajouter :
+
+```typescript
+/**
+ * ID de l'élément vers lequel le composant se téléporte en mode desktop.
+ * Sans cet attribut, le composant reste à sa position d'origine et affiche toujours le rendu mobile.
+ * @attr desktop-target
+ */
+@property({ type: String, attribute: 'desktop-target', reflect: true })
+desktopTarget: string | undefined = undefined;
+
+/**
+ * Largeur de viewport en px à partir de laquelle le mode desktop est activé.
+ * @attr desktop-from
+ */
+@property({ type: Number, attribute: 'desktop-from', reflect: true })
+desktopFrom = 992;
+```
+
+- [ ] **Step 4 : Ajouter le state interne et les champs privés**
+
+Après `private _currentStepIndex = 0;` (ligne ~95), ajouter :
+
+```typescript
+/** Position d'origine mémorisée au premier connectedCallback. */
+private _originalParent: Element | null = null;
+private _originalNextSibling: Node | null = null;
+/** true dès que la position d'origine est mémorisée — évite de la re-mémoriser après téléportation. */
+private _positioned = false;
+
+/** État courant : true = téléporté dans la cible desktop. Pilote le choix de rendu. */
+@state()
+private _isDesktop = false;
+
+/** Instance matchMedia + listener, pour pouvoir les déconnecter. */
+private _mq: MediaQueryList | null = null;
+private _mqListener: ((e: MediaQueryListEvent) => void) | null = null;
+```
+
+Ajouter l'import manquant en haut du fichier :
+
+```typescript
+import { LitElement, html, type TemplateResult, type CSSResultGroup } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+```
+
+- [ ] **Step 5 : Mettre à jour `connectedCallback`**
+
+Remplacer le `connectedCallback` existant par :
+
+```typescript
+override connectedCallback() {
+    super.connectedCallback();
+
+    // Mémoriser la position d'origine une seule fois (pas après téléportation)
+    if (!this._positioned) {
+        this._originalParent = this.parentElement;
+        this._originalNextSibling = this.nextSibling;
+        this._positioned = true;
+    }
+
+    // Installer matchMedia si desktop-target est fourni
+    if (this.desktopTarget && typeof window !== 'undefined') {
+        this._setupMatchMedia();
+    }
+
+    this.addEventListener('scroll-follow-change', this.handleScrollChange as EventListener);
+
+    customElements.whenDefined('ar-stepper-item').then(() => {
+        if (!this.isConnected) return;
+        this.collectExistingItems();
+    });
+}
+```
+
+- [ ] **Step 6 : Ajouter la méthode `_setupMatchMedia`**
+
+Après `connectedCallback`, ajouter :
+
+```typescript
+private _setupMatchMedia(): void {
+    // Nettoyer un éventuel listener précédent
+    if (this._mq && this._mqListener) {
+        this._mq.removeEventListener('change', this._mqListener);
+    }
+
+    this._mq = window.matchMedia(`(min-width: ${this.desktopFrom}px)`);
+    this._mqListener = (e: MediaQueryListEvent) => this._onBreakpointChange(e.matches);
+    this._mq.addEventListener('change', this._mqListener);
+
+    // État initial
+    this._onBreakpointChange(this._mq.matches);
+}
+
+private _onBreakpointChange(matches: boolean): void {
+    if (matches && !this._isDesktop) {
+        const target = document.getElementById(this.desktopTarget!);
+        if (!target) {
+            console.warn(`[ar-stepper] desktop-target: aucun élément trouvé avec l'id "${this.desktopTarget}"`);
+            return;
+        }
+        target.appendChild(this);
+        this._isDesktop = true;
+    } else if (!matches && this._isDesktop) {
+        if (this._originalNextSibling && this._originalNextSibling.isConnected) {
+            this._originalParent?.insertBefore(this, this._originalNextSibling);
+        } else {
+            this._originalParent?.appendChild(this);
+        }
+        this._isDesktop = false;
+    }
+}
+```
+
+- [ ] **Step 7 : Mettre à jour `disconnectedCallback`**
+
+Remplacer le `disconnectedCallback` existant par :
+
+```typescript
+override disconnectedCallback() {
+    if (this._mq && this._mqListener) {
+        this._mq.removeEventListener('change', this._mqListener);
+    }
+    this.removeEventListener('scroll-follow-change', this.handleScrollChange as EventListener);
+    super.disconnectedCallback();
+}
+```
+
+- [ ] **Step 8 : Mettre à jour `updated()` pour réagir aux changements de props**
+
+Après `willUpdate()`, ajouter :
+
+```typescript
+protected override updated(changed: Map<PropertyKey, unknown>): void {
+    super.updated(changed);
+    if (
+        (changed.has('desktopTarget') || changed.has('desktopFrom')) &&
+        this.desktopTarget &&
+        typeof window !== 'undefined'
+    ) {
+        this._setupMatchMedia();
+    }
+}
+```
+
+- [ ] **Step 9 : Mettre à jour `render()` pour utiliser `_isDesktop`**
+
+Remplacer le rendu temporaire de Task 1 par :
+
+```typescript
+const content = this._isDesktop
+    ? renderDesktop(steps, this.mode, this.onClickLink)
+    : renderMobile(
+          steps,
+          {
+              isOpen: this.dropdown.isOpen,
+              currentStepIndex: this._currentStepIndex,
+              currentStepLabel: this.getCurrentStepLabel(),
+              currentSubStepLabel: this.getCurrentSubStepLabel(),
+              onToggle: this._onDropdownToggle,
+          },
+          this.mode,
+          this.onClickLink,
+      );
+```
+
+- [ ] **Step 10 : Lancer les tests**
+
+```bash
+npm run test --workspace=packages/core -- --reporter=verbose 2>&1 | grep -E "téléportation|FAIL|PASS|✓|×"
+```
+
+Expected : tous les tests `téléportation` passent.
+
+- [ ] **Step 11 : Commit**
+
+```bash
+git add packages/core/src/components/stepper/stepper.ts \
+        packages/core/src/components/stepper/stepper.test.ts
+git commit -m "feat(stepper): téléportation DOM adaptive via desktop-target + desktop-from"
+```
+
+---
+
+### Task 3 : Réécrire les tests de rendu desktop/mobile sans `version`
+
+**Files:**
+
+- Modify: `packages/core/src/components/stepper/stepper.test.ts`
+
+- [ ] **Step 1 : Écrire les tests de rendu conditionnels (ils échouent)**
+
+Ajouter un `describe('rendu conditionnel')` dans `stepper.test.ts` :
+
+```typescript
+describe('rendu conditionnel', () => {
+    function mockMatchMedia(matches: boolean) {
+        return vi.spyOn(window, 'matchMedia').mockReturnValue({
+            matches,
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+        } as unknown as MediaQueryList);
+    }
+
+    it('sans desktop-target : rendu mobile par défaut (dropdown)', async () => {
+        const el = await fixtureWithItems(`
+            <ar-stepper current-path="/a">
+                <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
+                <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
+            </ar-stepper>
+        `);
+        expect(el.shadowRoot!.querySelector('.dropdown')).not.toBeNull();
+        expect(el.shadowRoot!.querySelector('ol.stepper-desktop')).toBeNull();
+    });
+
+    it('_isDesktop = true : rendu desktop (ol.stepper-desktop)', async () => {
+        mockMatchMedia(true);
+
+        const target = document.createElement('div');
+        target.id = 'sidebar-render';
+        document.body.appendChild(target);
+
+        const el = await fixtureWithItems(`
+            <ar-stepper desktop-target="sidebar-render" current-path="/a">
+                <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
+                <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
+            </ar-stepper>
+        `);
+
+        expect(el.shadowRoot!.querySelector('ol.stepper-desktop')).not.toBeNull();
+        expect(el.shadowRoot!.querySelector('.dropdown')).toBeNull();
+    });
+
+    it("l'étape courante a la classe active (rendu desktop)", async () => {
+        mockMatchMedia(true);
+
+        const target = document.createElement('div');
+        target.id = 'sidebar-active';
+        document.body.appendChild(target);
+
+        const el = await fixtureWithItems(`
+            <ar-stepper desktop-target="sidebar-active" current-path="/b">
+                <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
+                <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
+            </ar-stepper>
+        `);
+        const items = el.shadowRoot!.querySelectorAll('li.stepper-item');
+        expect(items[0]?.classList.contains('active')).toBe(false);
+        expect(items[1]?.classList.contains('active')).toBe(true);
+    });
+
+    it('le dropdown est fermé par défaut (rendu mobile)', async () => {
+        const el = await fixtureWithItems(`
+            <ar-stepper current-path="/a">
+                <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
+                <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
+            </ar-stepper>
+        `);
+        expect(el.shadowRoot!.querySelector('.dropdown')?.classList.contains('show')).toBe(false);
+    });
+
+    it('cliquer sur le bouton toggle ouvre le dropdown (rendu mobile)', async () => {
+        const el = await fixtureWithItems(`
+            <ar-stepper current-path="/a">
+                <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
+                <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
+            </ar-stepper>
+        `);
+        const btn = el.shadowRoot!.querySelector<HTMLButtonElement>('button.dropdown-toggle');
+        btn?.click();
+        await waitForUpdate(el);
+        expect(el.shadowRoot!.querySelector('.dropdown')?.classList.contains('show')).toBe(true);
+    });
+
+    it('en mode edit les étapes complétées sont des liens (rendu desktop)', async () => {
+        mockMatchMedia(true);
+
+        const target = document.createElement('div');
+        target.id = 'sidebar-edit';
+        document.body.appendChild(target);
+
+        const el = await fixtureWithItems(`
+            <ar-stepper desktop-target="sidebar-edit" current-path="/b" mode="edit">
+                <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
+                <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
+            </ar-stepper>
+        `);
+        expect(el.shadowRoot!.querySelectorAll('a.stepper-link').length).toBeGreaterThan(0);
+    });
+});
+```
+
+- [ ] **Step 2 : Lancer les tests pour vérifier qu'ils échouent**
+
+```bash
+npm run test --workspace=packages/core -- --reporter=verbose 2>&1 | grep -E "rendu conditionnel|FAIL|×"
+```
+
+Expected : les nouveaux tests `rendu conditionnel` échouent (l'implémentation est déjà là, mais les IDs DOM n'existent pas encore — ils sont créés dans les tests eux-mêmes, donc ils doivent passer).
+
+> Note : si les tests passent immédiatement, c'est normal — l'implémentation de Task 2 est déjà en place. Vérifier que les tests existants ne régressent pas.
+
+- [ ] **Step 3 : Lancer la suite complète**
+
+```bash
+npm run test --workspace=packages/core -- --reporter=verbose 2>&1 | tail -20
+```
+
+Expected : toutes les suites passent.
+
+- [ ] **Step 4 : Commit**
+
+```bash
+git add packages/core/src/components/stepper/stepper.test.ts
+git commit -m "test(stepper): réécriture tests rendu sans prop version"
+```
+
+---
+
+### Task 4 : Mettre à jour `ar-stepper.mdx`
+
+**Files:**
+
+- Modify: `apps/docs/src/content/components/ar-stepper.mdx`
+
+Le fichier actuel contient 3 variantes : `default`, `mobile`, `edit`. La variante `mobile` est supprimée. La variante `default` est mise à jour pour démontrer `desktop-target`. La section `## Comportement responsive` est ajoutée.
+
+- [ ] **Step 1 : Mettre à jour le fichier MDX**
+
+Remplacer l'intégralité de `apps/docs/src/content/components/ar-stepper.mdx` par :
+
+```mdx
+---
+tagName: ar-stepper
+title: Stepper
+description: Stepper de navigation accessible avec affichage adaptatif mobile/desktop.
+playgroundTemplate: default
+variants:
+    - name: default
+      label: Par défaut
+      description: Le composant est placé à sa position mobile. Fournir desktop-target pour activer la téléportation.
+      html: |
+          <div style="display: flex; gap: 2rem; align-items: flex-start;">
+            <div id="stepper-sidebar" style="min-width: 200px; border: 1px dashed #ccc; padding: 1rem; border-radius: 4px;">
+              <p style="font-size: 0.75rem; color: #999; margin: 0 0 0.5rem;">Cible desktop (id="stepper-sidebar")</p>
+            </div>
+            <div>
+              <p style="font-size: 0.75rem; color: #999; margin: 0 0 0.5rem;">Position mobile (origine)</p>
+              <ar-stepper desktop-target="stepper-sidebar" current-path="etape-1-2">
+                <ar-stepper-item path="etape-1" label="Mes informations" href="#">
+                    <ar-stepper-item path="etape-1-1" label="Mon état civil" href="#"></ar-stepper-item>
+                    <ar-stepper-item path="etape-1-2" label="Mes coordonnées" href="#"></ar-stepper-item>
+                    <ar-stepper-item path="etape-1-3" label="Mes identifiants" href="#"></ar-stepper-item>
+                </ar-stepper-item>
+                <ar-stepper-item path="etape-2" label="Mes préférences" href="#">
+                    <ar-stepper-item path="etape-2-1" label="Mes notifications" href="#etape-2-1"></ar-stepper-item>
+                    <ar-stepper-item path="etape-2-2" label="Mes langues" href="#etape-2-2"></ar-stepper-item>
+                </ar-stepper-item>
+                <ar-stepper-item path="etape-3" label="Récapitulatif"></ar-stepper-item>
+              </ar-stepper>
+            </div>
+          </div>
+    - name: edit
+      label: Mode édition
+      description: En mode édition, toutes les étapes sont accessibles au clic.
+      html: |
+          <ar-stepper class="align-left" current-path="etape-1-2" mode="edit">
+            <!-- Étape 1 -->
+            <ar-stepper-item path="etape-1" label="Mes informations" href="#">
+                <ar-stepper-item path="etape-1-1" label="Mon état civil" href="#"></ar-stepper-item>
+                <ar-stepper-item path="etape-1-2" label="Mes coordonnées" href="#"></ar-stepper-item>
+                <ar-stepper-item path="etape-1-3" label="Mes identifiants" href="#"></ar-stepper-item>
+            </ar-stepper-item>
+
+            <!-- Étape 2 -->
+            <ar-stepper-item path="etape-2" label="Mes préférences" href="#">
+                <ar-stepper-item path="etape-2-1" label="Mes notifications" href="#etape-2-1"></ar-stepper-item>
+                <ar-stepper-item path="etape-2-2" label="Mes langues" href="#etape-2-2"></ar-stepper-item>
+            </ar-stepper-item>
+
+            <!-- Étape 3 -->
+            <ar-stepper-item path="etape-3" label="Récapitulatif"></ar-stepper-item>
+          </ar-stepper>
+---
+
+## Accessibilité
+
+### Pris en charge automatiquement
+
+- `role="navigation"` et `aria-labelledby` posés sur le conteneur — la région est annoncée
+  et identifiable par les lecteurs d'écran.
+- L'état courant (`current-path`) est reflété visuellement et structurellement — les items
+  actifs, complétés et désactivés sont distingués.
+
+### À la charge de l'auteur
+
+- **Labels descriptifs sur chaque `ar-stepper-item`.** Le `label` est le seul texte vocalisé
+  pour chaque étape — évitez les labels génériques (\"Étape 1\") au profit de libellés métier
+  (\"Mes informations\", \"Récapitulatif\").
+- **`current-path` doit correspondre au `path` d'un item existant.** Une valeur incorrecte
+  n'active aucun item — aucun feedback visuel ni vocal ne signale l'étape courante.
+- **Les items sans `href` ne sont pas des liens.** Un item sans destination est rendu comme
+  un élément non interactif — ne pas en faire la cible de `current-path` si l'utilisateur
+  doit pouvoir y naviguer.
+
+## Comportement responsive
+
+En dessous de **992px** (configurable via `desktop-from`), le composant affiche un dropdown
+condensé — l'étape courante et son numéro sont visibles sans déployer la liste.
+
+Au-dessus du breakpoint, le composant se **téléporte automatiquement** dans l'élément
+identifié par `desktop-target` et affiche la liste verticale complète.
+
+### À la charge de l'auteur
+
+- **Fournir `desktop-target`** pour activer la téléportation. Sans cet attribut, le composant
+  reste à sa position d'origine et affiche toujours le rendu mobile.
+- **Placer le composant à l'emplacement mobile** dans le HTML (mobile-first). C'est depuis
+  cette position qu'il se téléporte vers le desktop.
+- **S'assurer que l'élément `desktop-target` existe dans le DOM** au moment où le composant
+  se connecte. Un ID manquant laisse le composant à sa position mobile sans erreur visible
+  pour l'utilisateur (seul un `console.warn` est émis).
+```
+
+- [ ] **Step 2 : Vérifier visuellement**
+
+```bash
+npm run dev
+```
+
+Ouvrir `http://localhost:4321/components/stepper` et vérifier :
+
+- La variante `mobile` n'apparaît plus dans les onglets
+- La variante `default` affiche deux zones côte à côte (cible desktop + position mobile)
+- Les sections `## Accessibilité` et `## Comportement responsive` apparaissent dans le contenu narratif et la TOC
+
+- [ ] **Step 3 : Commit**
+
+```bash
+git add apps/docs/src/content/components/ar-stepper.mdx
+git commit -m "docs(stepper): mise à jour MDX — desktop-target, suppression variante mobile, section responsive"
+```
+
+---
+
+### Task 5 : Nettoyage `stepper.styles.ts` + vérification finale
+
+**Files:**
+
+- Modify: `packages/core/src/components/stepper/stepper.styles.ts`
+
+La prop `version='mobile'` est référencée dans un sélecteur CSS de `stepper.styles.ts` (ligne 7). Ce sélecteur doit être nettoyé.
+
+- [ ] **Step 1 : Nettoyer le sélecteur `[version='mobile']` dans les styles**
+
+Ligne 7 de `stepper.styles.ts` :
+
+```css
+:host(:not(.align-left, [version='mobile'])) {
+```
+
+Remplacer par :
+
+```css
+:host(:not(.align-left)) {
+```
+
+- [ ] **Step 2 : Supprimer les commentaires CSS obsolètes**
+
+Supprimer les blocs commentés (lignes 57-59 et 291-295) :
+
+```css
+/* .stepper-desktop {
+    display: none;
+} */
+```
+
+et
+
+```css
+/* .stepper-dropdown {
+    display:none!important
+} */
+```
+
+- [ ] **Step 3 : Lancer la suite de tests complète**
+
+```bash
+npm run test --workspace=packages/core -- --reporter=verbose 2>&1 | tail -30
+```
+
+Expected : toutes les suites passent, 0 échec.
+
+- [ ] **Step 4 : Lancer le build complet**
+
+```bash
+npm run build --workspace=packages/core 2>&1 | tail -10
+```
+
+Expected : `✓ Build complete`
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add packages/core/src/components/stepper/stepper.styles.ts
+git commit -m "style(stepper): nettoyage sélecteur version + commentaires obsolètes"
+```

--- a/docs/superpowers/specs/2026-03-31-stepper-teleport-design.md
+++ b/docs/superpowers/specs/2026-03-31-stepper-teleport-design.md
@@ -1,0 +1,224 @@
+# Stepper — Téléportation DOM adaptive
+
+## Contexte
+
+Le composant `ar-stepper` expose aujourd'hui une prop `version="mobile"` qui force
+l'intégrateur à dupliquer le composant dans sa page (une fois sans `version`, une
+fois avec), puis à gérer lui-même le CSS `display: none` selon le viewport.
+
+Ce pattern est une mauvaise DX : il crée deux sources de vérité, deux instances à
+synchroniser, et expose un détail d'implémentation (la mécanique de rendu) au lieu
+d'exprimer l'intention (où le composant doit se trouver selon le viewport).
+
+Le composant est en alpha, non utilisé en production — pas de processus de
+dépréciation nécessaire.
+
+---
+
+## Objectif
+
+L'intégrateur instancie `<ar-stepper>` **une seule fois** à son emplacement mobile
+(mobile-first, dans le header ou au-dessus du contenu). Il fournit un ID pointant
+vers le conteneur desktop. Le composant se téléporte automatiquement selon la
+largeur du viewport — sans duplication, sans JS côté intégrateur.
+
+---
+
+## Props publiques
+
+| Attribut         | Type     | Défaut      | Description                                                                                          |
+| ---------------- | -------- | ----------- | ---------------------------------------------------------------------------------------------------- |
+| `desktop-target` | `string` | `undefined` | ID (sans `#`) du conteneur desktop vers lequel se téléporter. Sans cette prop, pas de téléportation. |
+| `desktop-from`   | `number` | `992`       | Largeur en px à partir de laquelle le composant est en mode desktop.                                 |
+
+Les props existantes (`current-path`, `mode`, `follow-scroll`) sont inchangées.
+
+La prop `version` est **supprimée** (alpha, aucun utilisateur externe).
+
+### Pourquoi un ID et non un sélecteur CSS arbitraire
+
+Un sélecteur de classe (`'.sidebar'`) peut matcher plusieurs éléments — le comportement
+serait ambigu. Un ID garantit une cible unique et une erreur claire si absente.
+L'API reste simple et découvrable dans la doc sans magie implicite.
+
+---
+
+## State interne
+
+| Champ                  | Type                     | Description                                                                                      |
+| ---------------------- | ------------------------ | ------------------------------------------------------------------------------------------------ |
+| `_originalParent`      | `Element \| null`        | Parent au moment du premier `connectedCallback`. Mémorisé une seule fois.                        |
+| `_originalNextSibling` | `Node \| null`           | Nœud suivant au moment du premier `connectedCallback`. Permet de réinsérer au bon endroit.       |
+| `_isDesktop`           | `boolean` (state Lit)    | `true` quand le composant est téléporté. Pilote `renderDesktop()` vs `renderMobile()`.           |
+| `_mq`                  | `MediaQueryList \| null` | Instance `matchMedia` créée à l'initialisation.                                                  |
+| `_mqListener`          | function                 | Listener branché sur `_mq`. Stocké pour pouvoir être débranché.                                  |
+| `_positioned`          | `boolean`                | Flag — `true` dès que `_originalParent` est mémorisé. Évite de re-mémoriser après téléportation. |
+
+---
+
+## Cycle de vie
+
+### `connectedCallback()`
+
+```
+1. super.connectedCallback()
+2. Si !_positioned :
+   - mémoriser _originalParent = this.parentElement
+   - mémoriser _originalNextSibling = this.nextSibling
+   - _positioned = true
+3. Si desktopTarget est défini ET typeof window !== 'undefined' :
+   - créer _mq = window.matchMedia(`(min-width: ${desktopFrom}px)`)
+   - créer _mqListener = (e) => this._onBreakpointChange(e.matches)
+   - _mq.addEventListener('change', _mqListener)
+   - appel immédiat : _onBreakpointChange(_mq.matches)
+4. Logique existante (scroll-follow, collectExistingItems…)
+```
+
+### `disconnectedCallback()`
+
+```
+1. Si _mq : _mq.removeEventListener('change', _mqListener)
+2. super.disconnectedCallback()
+3. Logique existante
+```
+
+### `_onBreakpointChange(matches: boolean)`
+
+```
+Si matches && !_isDesktop :
+  - cible = document.getElementById(desktopTarget)
+  - si cible introuvable : console.warn('[ar-stepper] desktop-target: aucun élément trouvé avec l\'id "…"')
+  - si cible trouvée : cible.appendChild(this)
+  - _isDesktop = true  → requestUpdate()
+
+Si !matches && _isDesktop :
+  - si _originalNextSibling && _originalNextSibling.isConnected :
+      _originalParent.insertBefore(this, _originalNextSibling)
+  - sinon :
+      _originalParent.appendChild(this)
+  - _isDesktop = false  → requestUpdate()
+```
+
+> **Note :** `appendChild` et `insertBefore` déclenchent `disconnectedCallback` +
+> `connectedCallback`. Le flag `_positioned` empêche de re-mémoriser le parent
+> après téléportation.
+
+### `updated(changed)`
+
+Quand `desktopTarget` ou `desktopFrom` change (rare mais possible via JS) :
+
+- Déconnecter l'ancien `_mq` listener
+- Recréer `_mq` avec le nouveau breakpoint
+- Appeler `_onBreakpointChange(_mq.matches)` immédiatement
+
+---
+
+## Rendu
+
+Le `render()` remplace `this.version === 'mobile'` par `!this._isDesktop` :
+
+```typescript
+const content = this._isDesktop
+    ? renderDesktop(steps, this.mode, this.onClickLink)
+    : renderMobile(steps, { … }, this.mode, this.onClickLink);
+```
+
+Sans `desktop-target`, `_isDesktop` reste `false` → rendu mobile uniquement
+(comportement utile si l'intégrateur n'a pas besoin de téléportation).
+
+---
+
+## Suppression de `version`
+
+- Supprimer la prop `@property version` dans `stepper.ts`
+- Supprimer la condition `this.version === 'mobile'` dans `render()`
+- Supprimer la variante `mobile` dans `ar-stepper.mdx`
+- Mettre à jour le JSDoc `@summary`
+
+---
+
+## Cas limites
+
+| Cas                                           | Comportement attendu                                                                   |
+| --------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `desktop-target` pointe vers un ID inexistant | `console.warn`, pas de téléportation. Le composant reste à sa position mobile.         |
+| `desktop-target` non fourni                   | Pas de `matchMedia`, rendu mobile fixe.                                                |
+| `_originalParent` supprimé du DOM entre-temps | `appendChild` sur `_originalParent` — comportement natif. `console.warn`.              |
+| SSR / pas de `window`                         | Guarde `typeof window !== 'undefined'` avant `matchMedia`. `_isDesktop` reste `false`. |
+
+---
+
+## Tests (TDD)
+
+Les tests existants référençant `version` sont à supprimer ou adapter.
+Nouveaux cas à couvrir dans `stepper.test.ts` :
+
+### Props
+
+- `desktopTarget` vaut `undefined` par défaut
+- `desktopFrom` vaut `992` par défaut
+- `version` n'existe plus (pas de prop)
+
+### Téléportation
+
+Setup commun : `matchMedia` mocké (pattern existant dans la codebase) :
+
+```typescript
+vi.spyOn(window, 'matchMedia').mockReturnValue({
+    matches: true,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+} as unknown as MediaQueryList);
+```
+
+- **Sans `desktop-target`** : `_isDesktop` reste `false`, rendu mobile, pas de `matchMedia` créé
+- **Avec `desktop-target` valide + viewport desktop** : le composant est déplacé dans la cible, `_isDesktop === true`, rendu desktop
+- **Avec `desktop-target` valide + viewport mobile** : le composant reste à sa position d'origine, `_isDesktop === false`, rendu mobile
+- **Passage desktop → mobile** : le composant revient dans `_originalParent` avant `_originalNextSibling`
+- **`desktop-target` pointe vers un ID inexistant** : `console.warn` appelé, composant non déplacé
+- **`disconnectedCallback`** : le listener `matchMedia` est bien débranché
+
+### Rendu conditionnel
+
+- `_isDesktop === true` → `ol.stepper-desktop` présent dans le shadow DOM
+- `_isDesktop === false` → `.dropdown` présent dans le shadow DOM (rendu mobile)
+
+---
+
+## Documentation MDX (`ar-stepper.mdx`)
+
+- Supprimer la variante `name: mobile`
+- Mettre à jour la variante `default` : ajouter `desktop-target="stepper-sidebar"` et un `<div id="stepper-sidebar" style="min-height: 200px; border: 1px dashed #ccc; padding: 1rem;">` dans le HTML de démonstration du playground
+- Ajouter la section `## Comportement responsive` (dans cette même PR) :
+
+```markdown
+## Comportement responsive
+
+En dessous de **992px** (configurable via `desktop-from`), le composant affiche un dropdown
+condensé — l'étape courante et son numéro sont visibles sans déployer la liste.
+
+Au-dessus du breakpoint, le composant se **téléporte automatiquement** dans l'élément
+identifié par `desktop-target` et affiche la liste verticale complète.
+
+### À la charge de l'auteur
+
+- **Fournir `desktop-target`** pour activer la téléportation. Sans cet attribut, le composant
+  reste à sa position d'origine et affiche toujours le rendu mobile.
+- **Placer le composant à l'emplacement mobile** dans le HTML (mobile-first). C'est depuis
+  cette position qu'il se téléporte vers le desktop.
+- **S'assurer que l'élément `desktop-target` existe dans le DOM** au moment où le composant
+  se connecte. Un ID manquant laisse le composant à sa position mobile sans erreur visible
+  pour l'utilisateur (seul un `console.warn` est émis).
+```
+
+---
+
+## Fichiers modifiés
+
+| Fichier                                                | Action                                                                                              |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| `packages/core/src/components/stepper/stepper.ts`      | Supprimer `version`, ajouter `desktopTarget`, `desktopFrom`, state interne, cycle de vie            |
+| `packages/core/src/components/stepper/stepper.test.ts` | Supprimer tests `version`, ajouter tests téléportation                                              |
+| `apps/docs/src/content/components/ar-stepper.mdx`      | Supprimer variante `mobile`, mettre à jour variante `default`, ajouter `## Comportement responsive` |
+
+`stepper.renderer.ts` et `stepper.styles.ts` ne sont pas modifiés.

--- a/packages/core/src/components/stepper/stepper.styles.ts
+++ b/packages/core/src/components/stepper/stepper.styles.ts
@@ -68,6 +68,8 @@ export default css`
     .stepper-dropdown-menu {
         padding: 0.75rem;
         width: 100%;
+        background-color: var(--ar-color-bg, #fff);
+        color: var(--ar-color-text, #2e2e31);
     }
 
     .stepper-list {

--- a/packages/core/src/components/stepper/stepper.styles.ts
+++ b/packages/core/src/components/stepper/stepper.styles.ts
@@ -4,7 +4,7 @@ export default css`
     :host(.loading) {
         display: none !important;
     }
-    :host(:not(.align-left, [version='mobile'])) {
+    :host(:not(.align-left)) {
         .stepper-list {
             .stepper-item::after {
                 width: 2.25rem;
@@ -53,10 +53,6 @@ export default css`
             }
         }
     }
-
-    /* .stepper-desktop {
-        display: none;
-    } */
 
     .stepper-dropdown {
         display: -webkit-box;
@@ -289,10 +285,6 @@ export default css`
     }
 
     @media (min-width: 992px) {
-        /* .stepper-dropdown {
-            display:none!important
-        } */
-
         .stepper-desktop {
             display: -webkit-box !important;
             display: -ms-flexbox !important;

--- a/packages/core/src/components/stepper/stepper.test.ts
+++ b/packages/core/src/components/stepper/stepper.test.ts
@@ -68,113 +68,23 @@ describe('ArStepper', () => {
             expect(el.mode).toBe('create');
         });
 
-        it('version par défaut vaut "desktop"', async () => {
-            const el = await fixture<ArStepper>('<ar-stepper></ar-stepper>');
-            expect(el.version).toBe('desktop');
-        });
-
         it('followScroll par défaut vaut false', async () => {
             const el = await fixture<ArStepper>('<ar-stepper></ar-stepper>');
             expect(el.followScroll).toBe(false);
         });
 
+        it("version n'est plus une propriété du composant", async () => {
+            const el = await fixture<ArStepper>('<ar-stepper></ar-stepper>');
+            expect('version' in el).toBe(false);
+        });
+
         it('lit les attributs depuis le HTML', async () => {
             const el = await fixture<ArStepper>(
-                '<ar-stepper current-path="/b" mode="edit" version="mobile" follow-scroll></ar-stepper>',
+                '<ar-stepper current-path="/b" mode="edit" follow-scroll></ar-stepper>',
             );
             expect(el.currentPath).toBe('/b');
             expect(el.mode).toBe('edit');
-            expect(el.version).toBe('mobile');
             expect(el.followScroll).toBe(true);
-        });
-    });
-
-    // ── Rendu desktop ─────────────────────────────────────────────────────────
-
-    describe('rendu desktop', () => {
-        it('affiche les étapes dans une liste ol.stepper-desktop', async () => {
-            const el = await fixtureWithItems(`
-                <ar-stepper current-path="/a" version="desktop">
-                    <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
-                    <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
-                </ar-stepper>
-            `);
-            const list = shadow(el).querySelector('ol.stepper-desktop');
-            expect(list).not.toBeNull();
-            expect(list?.querySelectorAll('li').length).toBe(2);
-        });
-
-        it("l'étape courante a la classe active", async () => {
-            const el = await fixtureWithItems(`
-                <ar-stepper current-path="/b">
-                    <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
-                    <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
-                </ar-stepper>
-            `);
-            const items = shadow(el).querySelectorAll('li.stepper-item');
-            expect(items[0]?.classList.contains('active')).toBe(false);
-            expect(items[1]?.classList.contains('active')).toBe(true);
-        });
-
-        it('en mode edit les étapes complétées sont des liens', async () => {
-            const el = await fixtureWithItems(`
-                <ar-stepper current-path="/b" mode="edit">
-                    <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
-                    <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
-                </ar-stepper>
-            `);
-            const links = shadow(el).querySelectorAll('a.stepper-link');
-            expect(links.length).toBeGreaterThan(0);
-        });
-    });
-
-    // ── Rendu mobile ──────────────────────────────────────────────────────────
-
-    describe('rendu mobile', () => {
-        it('affiche un bouton dropdown en mode mobile', async () => {
-            const el = await fixtureWithItems(`
-                <ar-stepper current-path="/a" version="mobile">
-                    <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
-                    <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
-                </ar-stepper>
-            `);
-            const btn = shadow(el).querySelector('button.dropdown-toggle');
-            expect(btn).not.toBeNull();
-        });
-
-        it('le dropdown est fermé par défaut', async () => {
-            const el = await fixtureWithItems(`
-                <ar-stepper current-path="/a" version="mobile">
-                    <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
-                    <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
-                </ar-stepper>
-            `);
-            const dropdown = shadow(el).querySelector('.dropdown');
-            expect(dropdown?.classList.contains('show')).toBe(false);
-        });
-
-        it('cliquer sur le bouton toggle ouvre le dropdown', async () => {
-            const el = await fixtureWithItems(`
-                <ar-stepper current-path="/a" version="mobile">
-                    <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
-                    <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
-                </ar-stepper>
-            `);
-            const btn = shadow(el).querySelector<HTMLButtonElement>('button.dropdown-toggle');
-            btn?.click();
-            await waitForUpdate(el);
-            const dropdown = shadow(el).querySelector('.dropdown');
-            expect(dropdown?.classList.contains('show')).toBe(true);
-        });
-
-        it("affiche le label de l'étape courante dans le bouton", async () => {
-            const el = await fixtureWithItems(`
-                <ar-stepper current-path="/b" version="mobile">
-                    <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
-                    <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
-                </ar-stepper>
-            `);
-            expect(el.currentPath).toBe('/b');
         });
     });
 

--- a/packages/core/src/components/stepper/stepper.test.ts
+++ b/packages/core/src/components/stepper/stepper.test.ts
@@ -211,10 +211,11 @@ describe('ArStepper', () => {
             expect(el.desktopFrom).toBe(992);
         });
 
-        it('sans desktop-target : pas de matchMedia, composant reste en place', async () => {
-            const spy = vi.spyOn(window, 'matchMedia');
-            await fixture<ArStepper>('<ar-stepper></ar-stepper>');
-            expect(spy).not.toHaveBeenCalled();
+        it('sans desktop-target : écoute le breakpoint mais ne déplace pas le composant', async () => {
+            const spy = mockMatchMedia(false);
+            const el = await fixture<ArStepper>('<ar-stepper></ar-stepper>');
+            expect(spy).toHaveBeenCalled();
+            expect(el.parentElement).toBe(document.body);
         });
 
         it('avec desktop-target valide + viewport desktop : téléporte dans la cible', async () => {
@@ -255,7 +256,7 @@ describe('ArStepper', () => {
             expect((el as unknown as { _isDesktop: boolean })._isDesktop).toBe(false);
         });
 
-        it('desktop-target avec ID inexistant : console.warn, composant non déplacé', async () => {
+        it('desktop-target avec ID inexistant : console.warn, composant non déplacé, rendu desktop', async () => {
             mockMatchMedia(true);
             const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
@@ -271,25 +272,8 @@ describe('ArStepper', () => {
 
             expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('inexistant'));
             expect(el.parentElement).toBe(container);
-            expect((el as unknown as { _isDesktop: boolean })._isDesktop).toBe(false);
-        });
-
-        it('desktop-target absent au connect : _isDesktop reste false (pas de rendu desktop)', async () => {
-            mockMatchMedia(true);
-            vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-            const container = document.createElement('div');
-            document.body.appendChild(container);
-            container.innerHTML = `
-                <ar-stepper desktop-target="target-absent" current-path="/a">
-                    <ar-stepper-item path="/a" label="A"></ar-stepper-item>
-                </ar-stepper>
-            `;
-            const el = requireQuery<ArStepper>(container, 'ar-stepper');
-            await waitForUpdate(el as ArStepper);
-
-            expect((el as unknown as { _isDesktop: boolean })._isDesktop).toBe(false);
-            expect(el.parentElement).toBe(container);
+            // La téléportation échoue mais le rendu suit quand même le viewport
+            expect((el as unknown as { _isDesktop: boolean })._isDesktop).toBe(true);
         });
 
         it('suppression de desktop-target après téléportation : restaure la position originale', async () => {
@@ -312,7 +296,8 @@ describe('ArStepper', () => {
             await waitForUpdate(el);
 
             expect(el.parentElement).toBe(document.body);
-            expect((el as unknown as { _isDesktop: boolean })._isDesktop).toBe(false);
+            // Le viewport est toujours desktop → _isDesktop reste true, seule la téléportation est annulée
+            expect((el as unknown as { _isDesktop: boolean })._isDesktop).toBe(true);
         });
 
         it('disconnectedCallback débranche le listener matchMedia', async () => {
@@ -337,7 +322,13 @@ describe('ArStepper', () => {
     });
 
     describe('rendu responsive', () => {
-        it('sans desktop-target : rendu mobile par défaut (dropdown)', async () => {
+        it('sans desktop-target + viewport mobile : rendu dropdown', async () => {
+            vi.spyOn(window, 'matchMedia').mockReturnValue({
+                matches: false,
+                addEventListener: vi.fn(),
+                removeEventListener: vi.fn(),
+            } as unknown as MediaQueryList);
+
             const el = await fixtureWithItems(`
                 <ar-stepper current-path="/a">
                     <ar-stepper-item path="/a" label="A"></ar-stepper-item>
@@ -347,6 +338,26 @@ describe('ArStepper', () => {
 
             expect(shadow(el).querySelector('.stepper-dropdown')).not.toBeNull();
             expect(shadow(el).querySelector('.stepper-desktop')).toBeNull();
+        });
+
+        it('sans desktop-target + viewport desktop : rendu liste desktop sans téléportation', async () => {
+            vi.spyOn(window, 'matchMedia').mockReturnValue({
+                matches: true,
+                addEventListener: vi.fn(),
+                removeEventListener: vi.fn(),
+            } as unknown as MediaQueryList);
+
+            const el = await fixtureWithItems(`
+                <ar-stepper current-path="/a">
+                    <ar-stepper-item path="/a" label="A"></ar-stepper-item>
+                    <ar-stepper-item path="/b" label="B"></ar-stepper-item>
+                </ar-stepper>
+            `);
+
+            expect(shadow(el).querySelector('.stepper-desktop')).not.toBeNull();
+            expect(shadow(el).querySelector('.stepper-dropdown')).toBeNull();
+            // Pas de téléportation : reste dans document.body (où fixture() l'a inséré)
+            expect(el.parentElement).toBe(document.body);
         });
 
         it('avec desktop-target + viewport mobile : rend le dropdown mobile', async () => {

--- a/packages/core/src/components/stepper/stepper.test.ts
+++ b/packages/core/src/components/stepper/stepper.test.ts
@@ -12,6 +12,12 @@ function shadow(el: Element): ShadowRoot {
     return el.shadowRoot;
 }
 
+function requireQuery<T extends Element>(root: ParentNode, selector: string): T {
+    const el = root.querySelector<T>(selector);
+    if (!el) throw new Error(`Missing element for selector: ${selector}`);
+    return el;
+}
+
 /** Monte un stepper avec des items. Attend deux updateComplete pour absorber queueMicrotask. */
 async function fixtureWithItems(html: string): Promise<ArStepper> {
     const el = await fixture<ArStepper>(html);
@@ -181,6 +187,256 @@ describe('ArStepper', () => {
             const items = shadow(el).querySelectorAll('li.stepper-item');
             expect(items[0]?.classList.contains('active')).toBe(false);
             expect(items[1]?.classList.contains('active')).toBe(true);
+        });
+    });
+
+    // ── Téléportation ─────────────────────────────────────────────────────────
+
+    describe('téléportation', () => {
+        function mockMatchMedia(matches: boolean) {
+            return vi.spyOn(window, 'matchMedia').mockReturnValue({
+                matches,
+                addEventListener: vi.fn(),
+                removeEventListener: vi.fn(),
+            } as unknown as MediaQueryList);
+        }
+
+        it('desktopTarget vaut undefined par défaut', async () => {
+            const el = await fixture<ArStepper>('<ar-stepper></ar-stepper>');
+            expect(el.desktopTarget).toBeUndefined();
+        });
+
+        it('desktopFrom vaut 992 par défaut', async () => {
+            const el = await fixture<ArStepper>('<ar-stepper></ar-stepper>');
+            expect(el.desktopFrom).toBe(992);
+        });
+
+        it('sans desktop-target : pas de matchMedia, composant reste en place', async () => {
+            const spy = vi.spyOn(window, 'matchMedia');
+            await fixture<ArStepper>('<ar-stepper></ar-stepper>');
+            expect(spy).not.toHaveBeenCalled();
+        });
+
+        it('avec desktop-target valide + viewport desktop : téléporte dans la cible', async () => {
+            mockMatchMedia(true);
+
+            const target = document.createElement('div');
+            target.id = 'sidebar';
+            document.body.appendChild(target);
+
+            const el = await fixtureWithItems(`
+                <ar-stepper desktop-target="sidebar" current-path="/a">
+                    <ar-stepper-item path="/a" label="A"></ar-stepper-item>
+                </ar-stepper>
+            `);
+
+            expect(el.parentElement).toBe(target);
+            expect((el as unknown as { _isDesktop: boolean })._isDesktop).toBe(true);
+        });
+
+        it('avec desktop-target valide + viewport mobile : reste à sa position', async () => {
+            mockMatchMedia(false);
+
+            const target = document.createElement('div');
+            target.id = 'sidebar2';
+            document.body.appendChild(target);
+
+            const container = document.createElement('div');
+            document.body.appendChild(container);
+            container.innerHTML = `
+                <ar-stepper desktop-target="sidebar2" current-path="/a">
+                    <ar-stepper-item path="/a" label="A"></ar-stepper-item>
+                </ar-stepper>
+            `;
+            const el = requireQuery<ArStepper>(container, 'ar-stepper');
+            await waitForUpdate(el as ArStepper);
+
+            expect(el.parentElement).toBe(container);
+            expect((el as unknown as { _isDesktop: boolean })._isDesktop).toBe(false);
+        });
+
+        it('desktop-target avec ID inexistant : console.warn, composant non déplacé', async () => {
+            mockMatchMedia(true);
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            const container = document.createElement('div');
+            document.body.appendChild(container);
+            container.innerHTML = `
+                <ar-stepper desktop-target="inexistant" current-path="/a">
+                    <ar-stepper-item path="/a" label="A"></ar-stepper-item>
+                </ar-stepper>
+            `;
+            const el = requireQuery<ArStepper>(container, 'ar-stepper');
+            await waitForUpdate(el as ArStepper);
+
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('inexistant'));
+            expect(el.parentElement).toBe(container);
+            expect((el as unknown as { _isDesktop: boolean })._isDesktop).toBe(false);
+        });
+
+        it('desktop-target absent au connect : _isDesktop reste false (pas de rendu desktop)', async () => {
+            mockMatchMedia(true);
+            vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            const container = document.createElement('div');
+            document.body.appendChild(container);
+            container.innerHTML = `
+                <ar-stepper desktop-target="target-absent" current-path="/a">
+                    <ar-stepper-item path="/a" label="A"></ar-stepper-item>
+                </ar-stepper>
+            `;
+            const el = requireQuery<ArStepper>(container, 'ar-stepper');
+            await waitForUpdate(el as ArStepper);
+
+            expect((el as unknown as { _isDesktop: boolean })._isDesktop).toBe(false);
+            expect(el.parentElement).toBe(container);
+        });
+
+        it('suppression de desktop-target après téléportation : restaure la position originale', async () => {
+            mockMatchMedia(true);
+
+            const target = document.createElement('div');
+            target.id = 'sidebar-restore';
+            document.body.appendChild(target);
+
+            // fixture() appende dans document.body → _originalParent = document.body
+            const el = await fixtureWithItems(`
+                <ar-stepper desktop-target="sidebar-restore" current-path="/a">
+                    <ar-stepper-item path="/a" label="A"></ar-stepper-item>
+                </ar-stepper>
+            `);
+
+            expect(el.parentElement).toBe(target);
+
+            el.removeAttribute('desktop-target');
+            await waitForUpdate(el);
+
+            expect(el.parentElement).toBe(document.body);
+            expect((el as unknown as { _isDesktop: boolean })._isDesktop).toBe(false);
+        });
+
+        it('disconnectedCallback débranche le listener matchMedia', async () => {
+            const removeListenerSpy = vi.fn();
+            vi.spyOn(window, 'matchMedia').mockReturnValue({
+                matches: false,
+                addEventListener: vi.fn(),
+                removeEventListener: removeListenerSpy,
+            } as unknown as MediaQueryList);
+
+            const target = document.createElement('div');
+            target.id = 'sidebar3';
+            document.body.appendChild(target);
+
+            const el = await fixture<ArStepper>(
+                '<ar-stepper desktop-target="sidebar3"></ar-stepper>',
+            );
+            el.remove();
+
+            expect(removeListenerSpy).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('rendu responsive', () => {
+        it('sans desktop-target : rendu mobile par défaut (dropdown)', async () => {
+            const el = await fixtureWithItems(`
+                <ar-stepper current-path="/a">
+                    <ar-stepper-item path="/a" label="A"></ar-stepper-item>
+                    <ar-stepper-item path="/b" label="B"></ar-stepper-item>
+                </ar-stepper>
+            `);
+
+            expect(shadow(el).querySelector('.stepper-dropdown')).not.toBeNull();
+            expect(shadow(el).querySelector('.stepper-desktop')).toBeNull();
+        });
+
+        it('avec desktop-target + viewport mobile : rend le dropdown mobile', async () => {
+            vi.spyOn(window, 'matchMedia').mockReturnValue({
+                matches: false,
+                addEventListener: vi.fn(),
+                removeEventListener: vi.fn(),
+            } as unknown as MediaQueryList);
+
+            const target = document.createElement('div');
+            target.id = 'sidebar-mobile';
+            document.body.appendChild(target);
+
+            const el = await fixtureWithItems(`
+                <ar-stepper desktop-target="sidebar-mobile" current-path="/a">
+                    <ar-stepper-item path="/a" label="A"></ar-stepper-item>
+                    <ar-stepper-item path="/b" label="B"></ar-stepper-item>
+                </ar-stepper>
+            `);
+
+            expect(shadow(el).querySelector('.stepper-dropdown')).not.toBeNull();
+            expect(shadow(el).querySelector('.stepper-desktop')).toBeNull();
+        });
+
+        it('avec desktop-target + viewport desktop : rend la liste desktop', async () => {
+            vi.spyOn(window, 'matchMedia').mockReturnValue({
+                matches: true,
+                addEventListener: vi.fn(),
+                removeEventListener: vi.fn(),
+            } as unknown as MediaQueryList);
+
+            const target = document.createElement('div');
+            target.id = 'sidebar-desktop';
+            document.body.appendChild(target);
+
+            const el = await fixtureWithItems(`
+                <ar-stepper desktop-target="sidebar-desktop" current-path="/a">
+                    <ar-stepper-item path="/a" label="A"></ar-stepper-item>
+                    <ar-stepper-item path="/b" label="B"></ar-stepper-item>
+                </ar-stepper>
+            `);
+
+            expect(shadow(el).querySelector('.stepper-desktop')).not.toBeNull();
+            expect(shadow(el).querySelector('.stepper-dropdown')).toBeNull();
+        });
+
+        it('réinsère le composant à sa position d’origine quand le viewport repasse en mobile', async () => {
+            let matches = true;
+            let listener: ((event: MediaQueryListEvent) => void) | undefined;
+            vi.spyOn(window, 'matchMedia').mockReturnValue({
+                get matches() {
+                    return matches;
+                },
+                addEventListener: vi.fn((_type, cb) => {
+                    listener = cb as (event: MediaQueryListEvent) => void;
+                }),
+                removeEventListener: vi.fn(),
+            } as unknown as MediaQueryList);
+
+            const target = document.createElement('div');
+            target.id = 'sidebar-roundtrip';
+            document.body.appendChild(target);
+
+            const marker = document.createElement('div');
+            marker.id = 'marker';
+
+            const container = document.createElement('div');
+            document.body.append(container);
+            container.append(marker);
+            container.insertAdjacentHTML(
+                'beforeend',
+                `
+                    <ar-stepper desktop-target="sidebar-roundtrip" current-path="/a">
+                        <ar-stepper-item path="/a" label="A"></ar-stepper-item>
+                        <ar-stepper-item path="/b" label="B"></ar-stepper-item>
+                    </ar-stepper>
+                `,
+            );
+
+            const el = document.querySelector('ar-stepper') as ArStepper;
+            await waitForUpdate(el);
+            await waitForUpdate(el);
+
+            matches = false;
+            listener?.({ matches: false } as MediaQueryListEvent);
+            await waitForUpdate(el);
+
+            expect(el.parentElement).toBe(container);
+            expect(marker.nextElementSibling).toBe(el);
+            expect(shadow(el).querySelector('.stepper-dropdown')).not.toBeNull();
         });
     });
 });

--- a/packages/core/src/components/stepper/stepper.ts
+++ b/packages/core/src/components/stepper/stepper.ts
@@ -12,7 +12,7 @@ import { stepperContext, type StepperRegistry } from '../../context/stepper.cont
 import { NavigationTreeController } from '../../controllers/navigation-tree.controller.js';
 import { ScrollFollowController } from '../../controllers/scroll-follow.controller.js';
 import { DropdownController } from '../../controllers/dropdown.controller.js';
-import { renderDesktop, renderMobile } from './stepper.renderer.js';
+import { renderDesktop } from './stepper.renderer.js';
 import { type ArStepperItem } from '../stepper-item/stepper-item.js';
 
 /** Détail de l'événement émis lors d'un changement d'étape */
@@ -22,15 +22,16 @@ export interface ArStepperStepChangeDetail {
 }
 
 /**
- * @summary Stepper de navigation accessible, adaptatif desktop/mobile.
+ * @summary Stepper de navigation accessible avec téléportation DOM adaptive.
  * @display demo
  *
  * Les étapes sont déclarées via des éléments `<ar-stepper-item>` enfants.
  * Le composant les collecte automatiquement via `@lit/context` et construit
  * l'arbre de navigation. Un item peut avoir des sous-étapes (enfants imbriqués).
  *
- * En mode `mobile`, les étapes sont affichées dans un dropdown.
- * En mode `desktop`, elles sont affichées dans une liste verticale.
+ * Fournir `desktop-target` (ID d'un élément) pour activer la téléportation automatique :
+ * en dessous de `desktop-from` px le composant affiche le rendu dropdown à sa position
+ * d'origine ; au-dessus il se déplace dans l'élément cible et affiche la liste verticale.
  *
  * @slot - Un ou plusieurs composant <ar-stepper-items>, potentiellement imbriqués pour créer des sous-étapes.
  *
@@ -39,8 +40,8 @@ export interface ArStepperStepChangeDetail {
  * @csspart step         - Une étape de premier niveau.
  * @csspart substep      - Une sous-étape.
  * @csspart step-link    - Le lien d'une étape.
- * @csspart dropdown     - Le conteneur dropdown (mobile uniquement).
- * @csspart dropdown-btn - Le bouton d'ouverture du dropdown mobile.
+ * @csspart dropdown     - Le conteneur dropdown.
+ * @csspart dropdown-btn - Le bouton d'ouverture du dropdown.
  *
  * @cssprop --ar-stepper-gap                                                 - Espacement entre les étapes.
  * @cssprop [--ar-stepper-active-bullet-bg=var(--ar-color-interactive)]    - Fond de la puce de l'étape active.
@@ -75,14 +76,6 @@ export class ArStepper extends LitElement {
      */
     @property({ type: String, attribute: 'mode', useDefault: true })
     mode: 'create' | 'edit' = 'create';
-
-    /**
-     * Version d'affichage. Passer `mobile` pour activer le rendu dropdown.
-     * En pratique, gérer ce changement via un `ResizeObserver` ou une media query externe.
-     * @attr version
-     */
-    @property({ type: String })
-    version: 'desktop' | 'mobile' = 'desktop';
 
     /**
      * Active le mode "scroll follow" : la propriété `current-path` se met à jour
@@ -174,21 +167,7 @@ export class ArStepper extends LitElement {
             return html`<slot></slot>`;
         }
 
-        const content =
-            this.version === 'mobile'
-                ? renderMobile(
-                      steps,
-                      {
-                          isOpen: this.dropdown.isOpen,
-                          currentStepIndex: this._currentStepIndex,
-                          currentStepLabel: this.getCurrentStepLabel(),
-                          currentSubStepLabel: this.getCurrentSubStepLabel(),
-                          onToggle: this._onDropdownToggle,
-                      },
-                      this.mode,
-                      this.onClickLink,
-                  )
-                : renderDesktop(steps, this.mode, this.onClickLink);
+        const content = renderDesktop(steps, this.mode, this.onClickLink);
 
         return html` <nav
             part="nav"

--- a/packages/core/src/components/stepper/stepper.ts
+++ b/packages/core/src/components/stepper/stepper.ts
@@ -258,11 +258,14 @@ export class ArStepper extends LitElement {
     }
 
     private setupResponsiveMode(): void {
-        if (!this.isConnected || !this.desktopTarget) {
+        if (!this.isConnected) {
             this.teardownResponsiveMode();
-            this._isDesktop = false;
-            this._restoreToOriginalContainer();
             return;
+        }
+
+        // Si desktopTarget a été retiré, on restaure la position d'origine
+        if (!this.desktopTarget) {
+            this._restoreToOriginalContainer();
         }
 
         const query = `(min-width: ${this.desktopFrom}px)`;
@@ -286,35 +289,28 @@ export class ArStepper extends LitElement {
     }
 
     private applyResponsiveMode(matches: boolean): void {
-        if (!matches) {
-            this._isDesktop = false;
-            this.moveToResponsiveContainer();
-            return;
-        }
-        this._isDesktop = true;
-        if (!this.moveToResponsiveContainer()) {
-            this._isDesktop = false;
+        // Le mode de rendu suit le breakpoint, indépendamment de la téléportation
+        this._isDesktop = matches;
+
+        if (this.desktopTarget) {
+            if (matches) {
+                this._teleportToTarget();
+            } else {
+                this._restoreToOriginalContainer();
+            }
         }
     }
 
-    private moveToResponsiveContainer(): boolean {
-        if (!this.desktopTarget) return false;
-
-        if (this._isDesktop) {
-            const target = document.getElementById(this.desktopTarget);
-            if (!target) {
-                console.warn(`[ar-stepper] desktop target "${this.desktopTarget}" not found`);
-                return false;
-            }
-
-            if (this.parentNode !== target) {
-                target.appendChild(this);
-            }
-            return true;
+    private _teleportToTarget(): void {
+        if (!this.desktopTarget) return;
+        const target = document.getElementById(this.desktopTarget);
+        if (!target) {
+            console.warn(`[ar-stepper] desktop target "${this.desktopTarget}" not found`);
+            return;
         }
-
-        this._restoreToOriginalContainer();
-        return true;
+        if (this.parentNode !== target) {
+            target.appendChild(this);
+        }
     }
 
     private _restoreToOriginalContainer(): void {

--- a/packages/core/src/components/stepper/stepper.ts
+++ b/packages/core/src/components/stepper/stepper.ts
@@ -1,5 +1,5 @@
 import { LitElement, html, type TemplateResult, type CSSResultGroup } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { ContextProvider } from '@lit/context';
 
 import resetStyles from '../../styles/components/reset.styles.js';
@@ -12,7 +12,7 @@ import { stepperContext, type StepperRegistry } from '../../context/stepper.cont
 import { NavigationTreeController } from '../../controllers/navigation-tree.controller.js';
 import { ScrollFollowController } from '../../controllers/scroll-follow.controller.js';
 import { DropdownController } from '../../controllers/dropdown.controller.js';
-import { renderDesktop } from './stepper.renderer.js';
+import { renderDesktop, renderMobile } from './stepper.renderer.js';
 import { type ArStepperItem } from '../stepper-item/stepper-item.js';
 
 /** Détail de l'événement émis lors d'un changement d'étape */
@@ -85,7 +85,33 @@ export class ArStepper extends LitElement {
     @property({ type: Boolean, attribute: 'follow-scroll' })
     followScroll = false;
 
+    /**
+     * ID de l'élément cible qui accueille le stepper en mode desktop.
+     * @attr desktop-target
+     */
+    @property({ type: String, attribute: 'desktop-target', reflect: true })
+    desktopTarget?: string;
+
+    /**
+     * Breakpoint desktop à partir duquel la téléportation est activée.
+     * @attr desktop-from
+     */
+    @property({ type: Number, attribute: 'desktop-from', reflect: true })
+    desktopFrom = 992;
+
+    @state()
     private _currentStepIndex = 0;
+
+    @state()
+    private _isDesktop = false;
+
+    private _originalParent: ParentNode | null = null;
+    private _originalNextSibling: ChildNode | null = null;
+    private _mediaQueryList: MediaQueryList | undefined;
+    private _responsiveQuery: string | undefined;
+    private readonly _onMediaQueryChange = (event: MediaQueryListEvent) => {
+        this.applyResponsiveMode(event.matches);
+    };
 
     // ── Controllers ──────────────────────────────────────────────────────────
 
@@ -127,7 +153,13 @@ export class ArStepper extends LitElement {
     override connectedCallback() {
         super.connectedCallback();
 
+        if (!this._originalParent && this.parentNode) {
+            this._originalParent = this.parentNode;
+            this._originalNextSibling = this.nextSibling;
+        }
+
         this.addEventListener('scroll-follow-change', this.handleScrollChange as EventListener);
+        this.setupResponsiveMode();
 
         // Fallback pour les items déjà présents dans le DOM avant que le provider soit prêt
         customElements.whenDefined('ar-stepper-item').then(() => {
@@ -138,6 +170,7 @@ export class ArStepper extends LitElement {
 
     override disconnectedCallback() {
         this.removeEventListener('scroll-follow-change', this.handleScrollChange as EventListener);
+        this.teardownResponsiveMode();
         super.disconnectedCallback();
     }
 
@@ -155,6 +188,9 @@ export class ArStepper extends LitElement {
         if (changed.has('followScroll')) {
             this.scrollFollow.setEnabled(this.followScroll);
         }
+        if (changed.has('desktopTarget') || changed.has('desktopFrom')) {
+            this.setupResponsiveMode();
+        }
     }
 
     // ── Render ───────────────────────────────────────────────────────────────
@@ -167,7 +203,20 @@ export class ArStepper extends LitElement {
             return html`<slot></slot>`;
         }
 
-        const content = renderDesktop(steps, this.mode, this.onClickLink);
+        const content = this._isDesktop
+            ? renderDesktop(steps, this.mode, this.onClickLink)
+            : renderMobile(
+                  steps,
+                  {
+                      isOpen: this.dropdown.isOpen,
+                      currentStepIndex: this._currentStepIndex,
+                      currentStepLabel: this.getCurrentStepLabel(),
+                      currentSubStepLabel: this.getCurrentSubStepLabel(),
+                      onToggle: this._onDropdownToggle,
+                  },
+                  this.mode,
+                  this.onClickLink,
+              );
 
         return html` <nav
             part="nav"
@@ -206,6 +255,80 @@ export class ArStepper extends LitElement {
         this.querySelectorAll<ArStepperItem>('ar-stepper-item').forEach((item) =>
             item.setRegistry(this._registry),
         );
+    }
+
+    private setupResponsiveMode(): void {
+        if (!this.isConnected || !this.desktopTarget) {
+            this.teardownResponsiveMode();
+            this._isDesktop = false;
+            this._restoreToOriginalContainer();
+            return;
+        }
+
+        const query = `(min-width: ${this.desktopFrom}px)`;
+        if (this._mediaQueryList && this._responsiveQuery === query) {
+            this.applyResponsiveMode(this._mediaQueryList.matches);
+            return;
+        }
+
+        this.teardownResponsiveMode();
+
+        this._responsiveQuery = query;
+        this._mediaQueryList = window.matchMedia(query);
+        this._mediaQueryList.addEventListener('change', this._onMediaQueryChange);
+        this.applyResponsiveMode(this._mediaQueryList.matches);
+    }
+
+    private teardownResponsiveMode(): void {
+        this._mediaQueryList?.removeEventListener('change', this._onMediaQueryChange);
+        this._mediaQueryList = undefined;
+        this._responsiveQuery = undefined;
+    }
+
+    private applyResponsiveMode(matches: boolean): void {
+        if (!matches) {
+            this._isDesktop = false;
+            this.moveToResponsiveContainer();
+            return;
+        }
+        this._isDesktop = true;
+        if (!this.moveToResponsiveContainer()) {
+            this._isDesktop = false;
+        }
+    }
+
+    private moveToResponsiveContainer(): boolean {
+        if (!this.desktopTarget) return false;
+
+        if (this._isDesktop) {
+            const target = document.getElementById(this.desktopTarget);
+            if (!target) {
+                console.warn(`[ar-stepper] desktop target "${this.desktopTarget}" not found`);
+                return false;
+            }
+
+            if (this.parentNode !== target) {
+                target.appendChild(this);
+            }
+            return true;
+        }
+
+        this._restoreToOriginalContainer();
+        return true;
+    }
+
+    private _restoreToOriginalContainer(): void {
+        if (!this._originalParent || this.parentNode === this._originalParent) return;
+
+        if (
+            this._originalNextSibling &&
+            this._originalNextSibling.parentNode === this._originalParent
+        ) {
+            this._originalParent.insertBefore(this, this._originalNextSibling);
+            return;
+        }
+
+        this._originalParent.appendChild(this);
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────

--- a/packages/core/src/styles/components/button.styles.ts
+++ b/packages/core/src/styles/components/button.styles.ts
@@ -209,7 +209,7 @@ export default css`
     }
 
     .show > .btn.dropdown-toggle {
-        background-color: var(--ar-color-text, #2e2e31);
+        background-color: var(--ar-color-neutral-30, #44454b);
         color: var(--ar-color-white, #fff);
     }
 


### PR DESCRIPTION
## Résumé

Ajoute la **téléportation DOM adaptive** sur `ar-stepper` : le composant adapte son rendu et, optionnellement, sa position dans le DOM selon la largeur du viewport.

### Fonctionnement

- **Rendu adaptatif** (toujours actif) : en dessous de `desktop-from` (défaut 992 px) → dropdown mobile ; au-dessus → liste verticale desktop.
- **Téléportation** (optionnelle, via `desktop-target`) : sur desktop, le composant se déplace dans l'élément ciblé par l'ID fourni ; il revient à sa position d'origine sur mobile.

### Nouvelles propriétés

| Attribut | Type | Défaut | Rôle |
|---|---|---|---|
| `desktop-target` | `string` | — | ID de l'élément cible sur desktop |
| `desktop-from` | `number` | `992` | Breakpoint en px |

### Changements inclus

- `refactor(stepper)` : suppression de la prop `version` (nettoyage préalable)
- `feat(stepper)` : implémentation de la téléportation DOM via `matchMedia` avec restauration fiable à la position d'origine
- `fix(stepper)` : correction d'un bug où le rendu restait mobile sans `desktop-target` même sur viewport large
- `fix(stepper)` : correction du dark mode sur le dropdown mobile (texte blanc sur fond blanc, fond hardcodé)
- `docs(stepper)` : mise à jour de la page de documentation avec la section "Comportement responsive" et suppression d'une variante non démontrable en playground

## Plan de test

- [ ] CI verte (240 tests Vitest)
- [ ] Sans `desktop-target` : rendu dropdown sur < 992 px, liste desktop sur ≥ 992 px
- [ ] Avec `desktop-target` : téléportation dans le conteneur cible sur desktop, retour à l'origine sur mobile
- [ ] Dark mode : dropdown mobile lisible (fond sombre, texte clair)