### PR TITLE
refactor(stepper): custom properties, dépréfixage CSS, attribut align

### DIFF
--- a/apps/docs/src/content/components/ar-stepper.mdx
+++ b/apps/docs/src/content/components/ar-stepper.mdx
@@ -8,7 +8,7 @@ variants:
       label: Par défaut
       description: Rendu par défaut du composant.
       html: |
-          <ar-stepper class="align-left" current-path="etape-1-2">
+          <ar-stepper current-path="etape-1-2">
             <!-- Étape 1 -->
             <ar-stepper-item path="etape-1" label="Mes informations" href="#">
                 <ar-stepper-item path="etape-1-1" label="Mon état civil" href="#"></ar-stepper-item>
@@ -29,7 +29,7 @@ variants:
       label: Mode édition
       description: Rendu par défaut du composant.
       html: |
-          <ar-stepper class="align-left" current-path="etape-1-2" mode="edit">
+          <ar-stepper current-path="etape-1-2" mode="edit">
             <!-- Étape 1 -->
             <ar-stepper-item path="etape-1" label="Mes informations" href="#">
                 <ar-stepper-item path="etape-1-1" label="Mon état civil" href="#"></ar-stepper-item>

--- a/apps/docs/src/content/components/ar-stepper.mdx
+++ b/apps/docs/src/content/components/ar-stepper.mdx
@@ -1,7 +1,7 @@
 ---
 tagName: ar-stepper
 title: Stepper
-description: Description du composant ar-stepper.
+description: Composant de navigation par étapes avec support de sous-étapes, responsive et accessible.
 playgroundTemplate: default
 variants:
     - name: default
@@ -43,6 +43,25 @@ variants:
                 <ar-stepper-item path="etape-2-2" label="Mes langues" href="#etape-2-2"></ar-stepper-item>
             </ar-stepper-item>
 
+            <!-- Étape 3 -->
+            <ar-stepper-item path="etape-3" label="Récapitulatif"></ar-stepper-item>
+          </ar-stepper>
+    - name: align-right
+      label: Alignement droite
+      description: Le stepper peut être aligné à droite en mode desktop via l'attribut align.
+      html: |
+          <ar-stepper current-path="etape-1-2" align="right">
+            <!-- Étape 1 -->
+            <ar-stepper-item path="etape-1" label="Mes informations" href="#">
+                <ar-stepper-item path="etape-1-1" label="Mon état civil" href="#"></ar-stepper-item>
+                <ar-stepper-item path="etape-1-2" label="Mes coordonnées" href="#"></ar-stepper-item>
+                <ar-stepper-item path="etape-1-3" label="Mes identifiants" href="#"></ar-stepper-item>
+            </ar-stepper-item>
+            <!-- Étape 2 -->
+            <ar-stepper-item path="etape-2" label="Mes préférences" href="#">
+                <ar-stepper-item path="etape-2-1" label="Mes notifications" href="#etape-2-1"></ar-stepper-item>
+                <ar-stepper-item path="etape-2-2" label="Mes langues" href="#etape-2-2"></ar-stepper-item>
+            </ar-stepper-item>
             <!-- Étape 3 -->
             <ar-stepper-item path="etape-3" label="Récapitulatif"></ar-stepper-item>
           </ar-stepper>

--- a/packages/core/src/components/stepper/stepper.styles.ts
+++ b/packages/core/src/components/stepper/stepper.styles.ts
@@ -23,9 +23,6 @@ export default css`
 
     .stepper-list {
         counter-reset: step;
-        display: flex;
-        flex-direction: column;
-        gap: var(--ar-stepper-gap);
     }
 
     .stepper-item-inner {
@@ -130,7 +127,7 @@ export default css`
 
     .stepper-list:not(.stepper-horizontal) .stepper-item:after {
         width: 2.25rem;
-        height: 1.5rem;
+        height: var(--ar-stepper-gap, 1.5rem);
         background-image: linear-gradient(
             var(--ar-stepper-connector-color, var(--ar-color-neutral-80, #cdcfd8)) 25%,
             transparent 0
@@ -148,7 +145,7 @@ export default css`
         content: '';
         display: block;
         width: 2.25rem;
-        height: 1rem;
+        height: var(--ar-stepper-substep-gap, 1rem);
         background-image: linear-gradient(
             var(--ar-stepper-connector-color, var(--ar-color-neutral-80, #cdcfd8)) 25%,
             transparent 0

--- a/packages/core/src/components/stepper/stepper.styles.ts
+++ b/packages/core/src/components/stepper/stepper.styles.ts
@@ -23,6 +23,8 @@ export default css`
 
     .stepper-list {
         counter-reset: step;
+        display: flex;
+        flex-direction: column;
         gap: var(--ar-stepper-gap);
     }
 
@@ -118,7 +120,7 @@ export default css`
 
     .stepper-link .stepper-item-bullet {
         color: var(--ar-stepper-bullet-color, var(--ar-color-interactive, #283276));
-        background-color: var(--ar-stepper-bullet-bg, #b0bff0);
+        background-color: var(--ar-stepper-bullet-bg, var(--ar-color-primary-80, #b0bff0));
     }
 
     .stepper-list.stepper-desktop,
@@ -183,7 +185,7 @@ export default css`
 
     .stepper-edition .stepper-item-bullet {
         color: var(--ar-stepper-bullet-color, var(--ar-color-interactive, #283276));
-        background-color: var(--ar-stepper-bullet-bg, #b0bff0);
+        background-color: var(--ar-stepper-bullet-bg, var(--ar-color-primary-80, #b0bff0));
     }
 
     :host([align='right']) .stepper-list .stepper-item {

--- a/packages/core/src/components/stepper/stepper.styles.ts
+++ b/packages/core/src/components/stepper/stepper.styles.ts
@@ -188,28 +188,28 @@ export default css`
         background-color: var(--ar-stepper-bullet-bg, var(--ar-color-primary-80, #b0bff0));
     }
 
-    :host([align='right']) .stepper-list .stepper-item {
+    :host([align='right']) .stepper-desktop .stepper-item {
         align-items: flex-end;
         text-align: right;
     }
 
-    :host([align='right']) .stepper-list .stepper-item::after {
+    :host([align='right']) .stepper-desktop .stepper-item::after {
         margin-left: auto;
     }
 
-    :host([align='right']) .stepper-list .stepper-item-inner {
+    :host([align='right']) .stepper-desktop .stepper-item-inner {
         justify-content: flex-end;
         margin-left: auto;
         text-align: right;
     }
 
-    :host([align='right']) .stepper-list .stepper-item-bullet {
+    :host([align='right']) .stepper-desktop .stepper-item-bullet {
         order: 2;
         margin-right: 0;
         margin-left: 0.5rem;
     }
 
-    :host([align='right']) .stepper-list .stepper-list .stepper-item-bullet {
+    :host([align='right']) .stepper-desktop .stepper-list .stepper-item-bullet {
         margin-left: 1.25rem;
         margin-right: 0.75rem;
     }

--- a/packages/core/src/components/stepper/stepper.styles.ts
+++ b/packages/core/src/components/stepper/stepper.styles.ts
@@ -4,59 +4,8 @@ export default css`
     :host(.loading) {
         display: none !important;
     }
-    :host(:not(.align-left)) {
-        .stepper-list {
-            .stepper-item::after {
-                width: 2.25rem;
-                height: 1.5rem;
-                background-image: -webkit-gradient(
-                    linear,
-                    left top,
-                    left bottom,
-                    color-stop(25%, var(--ar-color-neutral-80, #cdcfd8)),
-                    color-stop(25%, transparent)
-                );
-                background-image: linear-gradient(
-                    var(--ar-color-neutral-80, #cdcfd8) 25%,
-                    transparent 25%
-                );
-                background-size: 2px 8px;
-                background-position: center 3px;
-                background-repeat: repeat-y;
-            }
-            .stepper-item {
-                -webkit-box-align: end;
-                -ms-flex-align: end;
-                align-items: flex-end;
-                text-align: right;
-            }
-            .stepper-item::after {
-                margin-left: auto;
-            }
-            .stepper-item-inner {
-                -webkit-box-pack: end;
-                -ms-flex-pack: end;
-                justify-content: flex-end;
-                margin-left: auto;
-                text-align: right;
-            }
-            .stepper-item-bullet {
-                -webkit-box-ordinal-group: 3;
-                -ms-flex-order: 2;
-                order: 2;
-                margin-right: 0;
-                margin-left: 0.5rem;
-            }
-            .stepper-list .stepper-item-bullet {
-                margin-left: 1.25rem;
-                margin-right: 0.75rem;
-            }
-        }
-    }
 
     .stepper-dropdown {
-        display: -webkit-box;
-        display: -ms-flexbox;
         display: flex;
     }
 
@@ -74,41 +23,30 @@ export default css`
 
     .stepper-list {
         counter-reset: step;
+        gap: var(--ar-stepper-gap);
     }
 
     .stepper-item-inner {
-        display: -webkit-inline-box;
-        display: -ms-inline-flexbox;
         display: inline-flex;
         counter-increment: step;
     }
 
     .stepper-item-bullet,
     .stepper-item-inner {
-        -webkit-box-align: center;
-        -ms-flex-align: center;
         align-items: center;
-        color: var(--ar-color-text-muted, #5b5d65);
+        color: var(--ar-stepper-label-color, var(--ar-color-text-muted, #5b5d65));
     }
 
     .stepper-item-bullet {
         width: 2.25rem;
         height: 2.25rem;
-        display: -webkit-box;
-        display: -ms-flexbox;
         display: flex;
-        -ms-flex-negative: 0;
         flex-shrink: 0;
-        -webkit-box-pack: center;
-        -ms-flex-pack: center;
         justify-content: center;
-        border-radius: 0.75rem;
+        border-radius: var(--ar-stepper-bullet-radius, 0.75rem);
         padding-bottom: 0.125rem;
         margin-right: 0.5rem;
-        -webkit-transform: translateY(1px);
         transform: translateY(1px);
-        -webkit-box-shadow: 0 0 0 1px
-            var(--ar-stepper-bullet-border-color, var(--ar-color-neutral-80, #b0bff0)) inset;
         box-shadow: 0 0 0 1px
             var(--ar-stepper-bullet-border-color, var(--ar-color-neutral-80, #b0bff0)) inset;
         background-color: transparent;
@@ -120,15 +58,8 @@ export default css`
 
     .stepper-item {
         position: relative;
-        display: -webkit-box;
-        display: -ms-flexbox;
         display: flex;
-        -webkit-box-orient: vertical;
-        -webkit-box-direction: normal;
-        -ms-flex-direction: column;
         flex-direction: column;
-        -webkit-box-align: start;
-        -ms-flex-align: start;
         align-items: flex-start;
     }
 
@@ -142,7 +73,7 @@ export default css`
 
     .stepper-item .stepper-link:focus,
     .stepper-item .stepper-link:hover {
-        color: var(--ar-stepper-bullet-hover-color, var(--ar-color-text-muted, #5b5d65));
+        color: var(--ar-stepper-bullet-hover-bg, var(--ar-color-text-muted, #5b5d65));
     }
 
     .stepper-item .stepper-link:focus:before,
@@ -159,8 +90,7 @@ export default css`
     .stepper-item .stepper-link:focus .stepper-item-bullet,
     .stepper-item .stepper-link:hover .stepper-item-bullet {
         color: var(--ar-color-text-inverse, #fff);
-        background-color: var(--ar-stepper-bullet-hover-color, var(--ar-color-text-muted, #5b5d65));
-        -webkit-box-shadow: none;
+        background-color: var(--ar-stepper-bullet-hover-bg, var(--ar-color-text-muted, #5b5d65));
         box-shadow: none;
     }
 
@@ -171,14 +101,13 @@ export default css`
     }
 
     .stepper-item.active > .stepper-item-inner {
-        color: var(--ar-color-interactive, #283276);
+        color: var(--ar-stepper-active-label-color, var(--ar-color-interactive, #283276));
         font-weight: 700;
     }
 
     .stepper-item.active > .stepper-item-inner .stepper-item-bullet {
-        color: var(--ar-color-text-inverse, #fff);
+        color: var(--ar-stepper-active-bullet-color, var(--ar-color-text-inverse, #fff));
         background-color: var(--ar-stepper-active-bullet-bg, var(--ar-color-interactive, #283276));
-        -webkit-box-shadow: none;
         box-shadow: none;
     }
 
@@ -188,7 +117,7 @@ export default css`
     }
 
     .stepper-link .stepper-item-bullet {
-        color: var(--ar-color-interactive, #283276);
+        color: var(--ar-stepper-bullet-color, var(--ar-color-interactive, #283276));
         background-color: var(--ar-stepper-bullet-bg, #b0bff0);
     }
 
@@ -197,53 +126,16 @@ export default css`
         margin-bottom: 0;
     }
 
-    .stepper-list.stepper-right .stepper-item:after,
     .stepper-list:not(.stepper-horizontal) .stepper-item:after {
         width: 2.25rem;
         height: 1.5rem;
-        background-image: -webkit-gradient(
-            linear,
-            left top,
-            left bottom,
-            color-stop(25%, var(--ar-color-neutral-80, #cdcfd8)),
-            color-stop(25%, transparent)
+        background-image: linear-gradient(
+            var(--ar-stepper-connector-color, var(--ar-color-neutral-80, #cdcfd8)) 25%,
+            transparent 0
         );
-        background-image: linear-gradient(var(--ar-color-neutral-80, #cdcfd8) 25%, transparent 0);
         background-size: 2px 8px;
         background-position: center 3px;
         background-repeat: repeat-y;
-    }
-
-    .stepper-list.stepper-right .stepper-item {
-        -webkit-box-align: end;
-        -ms-flex-align: end;
-        align-items: flex-end;
-        text-align: right;
-    }
-
-    .stepper-list.stepper-right .stepper-item:after {
-        margin-left: auto;
-    }
-
-    .stepper-list.stepper-right .stepper-item-inner {
-        -webkit-box-pack: end;
-        -ms-flex-pack: end;
-        justify-content: flex-end;
-        margin-left: auto;
-        text-align: right;
-    }
-
-    .stepper-list.stepper-right .stepper-item-bullet {
-        -webkit-box-ordinal-group: 3;
-        -ms-flex-order: 2;
-        order: 2;
-        margin-right: 0;
-        margin-left: 0.5rem;
-    }
-
-    .stepper-list.stepper-right .stepper-list .stepper-item-bullet {
-        margin-left: 1.25rem;
-        margin-right: 0.75rem;
     }
 
     .stepper-list .stepper-list .stepper-item:after {
@@ -255,14 +147,10 @@ export default css`
         display: block;
         width: 2.25rem;
         height: 1rem;
-        background-image: -webkit-gradient(
-            linear,
-            left top,
-            left bottom,
-            color-stop(25%, var(--ar-color-neutral-80, #cdcfd8)),
-            color-stop(25%, transparent)
+        background-image: linear-gradient(
+            var(--ar-stepper-connector-color, var(--ar-color-neutral-80, #cdcfd8)) 25%,
+            transparent 0
         );
-        background-image: linear-gradient(var(--ar-color-neutral-80, #cdcfd8) 25%, transparent 0);
         background-size: 2px 8px;
         background-position: center 4px;
         background-repeat: repeat-y;
@@ -281,19 +169,9 @@ export default css`
         content: '';
     }
 
-    .stepper-right .stepper-list .stepper-item:before {
-        margin-left: auto;
-        margin-left: 0;
-    }
-
     @media (min-width: 992px) {
         .stepper-desktop {
-            display: -webkit-box !important;
-            display: -ms-flexbox !important;
             display: flex !important;
-            -webkit-box-orient: vertical !important;
-            -webkit-box-direction: normal !important;
-            -ms-flex-flow: column !important;
             flex-flow: column !important;
         }
     }
@@ -304,7 +182,33 @@ export default css`
     }
 
     .stepper-edition .stepper-item-bullet {
-        color: var(--ar-color-interactive, #283276);
+        color: var(--ar-stepper-bullet-color, var(--ar-color-interactive, #283276));
         background-color: var(--ar-stepper-bullet-bg, #b0bff0);
+    }
+
+    :host([align='right']) .stepper-list .stepper-item {
+        align-items: flex-end;
+        text-align: right;
+    }
+
+    :host([align='right']) .stepper-list .stepper-item::after {
+        margin-left: auto;
+    }
+
+    :host([align='right']) .stepper-list .stepper-item-inner {
+        justify-content: flex-end;
+        margin-left: auto;
+        text-align: right;
+    }
+
+    :host([align='right']) .stepper-list .stepper-item-bullet {
+        order: 2;
+        margin-right: 0;
+        margin-left: 0.5rem;
+    }
+
+    :host([align='right']) .stepper-list .stepper-list .stepper-item-bullet {
+        margin-left: 1.25rem;
+        margin-right: 0.75rem;
     }
 `;

--- a/packages/core/src/components/stepper/stepper.test.ts
+++ b/packages/core/src/components/stepper/stepper.test.ts
@@ -321,6 +321,21 @@ describe('ArStepper', () => {
         });
     });
 
+    // ── Alignement ────────────────────────────────────────────────────────────
+
+    describe('align', () => {
+        it('vaut "left" par défaut', async () => {
+            const el = await fixture<ArStepper>(`<ar-stepper></ar-stepper>`);
+            expect(el.align).toBe('left');
+        });
+
+        it('est réfléchi comme attribut HTML', async () => {
+            const el = await fixture<ArStepper>(`<ar-stepper align="right"></ar-stepper>`);
+            expect(el.getAttribute('align')).toBe('right');
+            expect(el.align).toBe('right');
+        });
+    });
+
     describe('rendu responsive', () => {
         it('sans desktop-target + viewport mobile : rendu dropdown', async () => {
             vi.spyOn(window, 'matchMedia').mockReturnValue({

--- a/packages/core/src/components/stepper/stepper.ts
+++ b/packages/core/src/components/stepper/stepper.ts
@@ -107,6 +107,8 @@ export class ArStepper extends LitElement {
 
     /**
      * Alignement de la liste d'étapes : `left` (défaut) ou `right`.
+     * **Note** — l'alignement `right` ne s'applique qu'en mode desktop (rendu liste verticale).
+     * En mode mobile (dropdown), les items restent alignés à gauche.
      * @attr align
      */
     @property({ type: String, attribute: 'align', reflect: true })

--- a/packages/core/src/components/stepper/stepper.ts
+++ b/packages/core/src/components/stepper/stepper.ts
@@ -43,11 +43,17 @@ export interface ArStepperStepChangeDetail {
  * @csspart dropdown     - Le conteneur dropdown.
  * @csspart dropdown-btn - Le bouton d'ouverture du dropdown.
  *
- * @cssprop --ar-stepper-gap                                                 - Espacement entre les étapes.
- * @cssprop [--ar-stepper-active-bullet-bg=var(--ar-color-interactive)]    - Fond de la puce de l'étape active.
- * @cssprop [--ar-stepper-bullet-bg=var(--ar-color-primary-80)]            - Fond des puces des étapes visitables.
- * @cssprop [--ar-stepper-bullet-border-color=var(--ar-color-neutral-80)] - Bordure des puces des étapes suivantes.
- * @cssprop [--ar-stepper-bullet-hover-color=var(--ar-color-text-muted)]   - Couleur au survol des liens d'étapes.
+ * @cssprop --ar-stepper-gap                                                                   - Espacement entre les étapes (gap de la liste flex).
+ * @cssprop [--ar-stepper-connector-color=var(--ar-color-neutral-80)]                         - Couleur du connecteur pointillé entre les étapes.
+ * @cssprop [--ar-stepper-active-bullet-bg=var(--ar-color-interactive)]                       - Fond de la puce de l'étape active.
+ * @cssprop [--ar-stepper-active-bullet-color=var(--ar-color-text-inverse)]                   - Couleur du numéro dans la puce active.
+ * @cssprop [--ar-stepper-bullet-bg=var(--ar-color-primary-80)]                               - Fond des puces des étapes visitables.
+ * @cssprop [--ar-stepper-bullet-color=var(--ar-color-interactive)]                           - Couleur du numéro dans les puces visitables.
+ * @cssprop [--ar-stepper-bullet-border-color=var(--ar-color-neutral-80)]                     - Bordure des puces des étapes suivantes.
+ * @cssprop [--ar-stepper-bullet-hover-bg=var(--ar-color-text-muted)]                         - Fond de la puce au survol.
+ * @cssprop [--ar-stepper-bullet-radius=0.75rem]                                              - Border-radius de la puce.
+ * @cssprop [--ar-stepper-label-color=var(--ar-color-text-muted)]                             - Couleur des labels des étapes inactives.
+ * @cssprop [--ar-stepper-active-label-color=var(--ar-color-interactive)]                     - Couleur du label de l'étape active.
  *
  * @event {CustomEvent<{ path: string }>} ar-stepper-step-changed - Émis au clic sur une étape.
  */
@@ -98,6 +104,13 @@ export class ArStepper extends LitElement {
      */
     @property({ type: Number, attribute: 'desktop-from', reflect: true })
     desktopFrom = 992;
+
+    /**
+     * Alignement de la liste d'étapes : `left` (défaut) ou `right`.
+     * @attr align
+     */
+    @property({ type: String, attribute: 'align', reflect: true })
+    align: 'left' | 'right' = 'left';
 
     @state()
     private _currentStepIndex = 0;

--- a/packages/core/src/components/stepper/stepper.ts
+++ b/packages/core/src/components/stepper/stepper.ts
@@ -43,7 +43,8 @@ export interface ArStepperStepChangeDetail {
  * @csspart dropdown     - Le conteneur dropdown.
  * @csspart dropdown-btn - Le bouton d'ouverture du dropdown.
  *
- * @cssprop --ar-stepper-gap                                                                   - Espacement entre les étapes (gap de la liste flex).
+ * @cssprop [--ar-stepper-gap=1.5rem]                                                          - Hauteur du connecteur entre les étapes principales.
+ * @cssprop [--ar-stepper-substep-gap=1rem]                                                    - Hauteur du connecteur entre les sous-étapes.
  * @cssprop [--ar-stepper-connector-color=var(--ar-color-neutral-80)]                         - Couleur du connecteur pointillé entre les étapes.
  * @cssprop [--ar-stepper-active-bullet-bg=var(--ar-color-interactive)]                       - Fond de la puce de l'étape active.
  * @cssprop [--ar-stepper-active-bullet-color=var(--ar-color-text-inverse)]                   - Couleur du numéro dans la puce active.


### PR DESCRIPTION
## Summary

- **Custom properties complètes** (12 tokens) — connecteur, puces (fond/couleur/bordure/survol/radius), labels, et deux propriétés de hauteur pour les connecteurs :
  - `--ar-stepper-gap` : hauteur du connecteur entre étapes principales (défaut `1.5rem`)
  - `--ar-stepper-substep-gap` : hauteur du connecteur entre sous-étapes (défaut `1rem`)
  - Renomme `--ar-stepper-bullet-hover-color` → `--ar-stepper-bullet-hover-bg`
- **Suppression des vendor prefixes obsolètes** — `-webkit-box`, `-ms-flexbox`, `-webkit-gradient` et tous les alias IE/vieux WebKit supprimés (~40 % de bruit en moins)
- **Refacto alignement** — supprime le double mécanisme (`:host(:not(.align-left))` + `.stepper-right`) au profit d'un attribut `align="right"` (Lit `@property`, reflect, défaut `left`) ; l'alignement droit ne s'applique qu'au rendu desktop

## Test plan

- [x] Tests Vitest verts (CI)
- [x] `align="right"` visible dans le playground (variante ajoutée)
- [x] DevTools : `--ar-stepper-bullet-radius: 50%` → puces rondes
- [x] DevTools : `--ar-stepper-connector-color: red` → connecteur rouge
- [x] DevTools : `--ar-stepper-gap: 3rem` → connecteur principal plus haut
- [x] DevTools : `--ar-stepper-substep-gap: 2rem` → connecteur sous-étapes plus haut
- [x] Rendu mobile inchangé avec `align="right"` (dropdown non affecté)

🤖 Generated with [Claude Code](https://claude.com/claude-code)