### PR TITLE
feat(dialog): add ar-dialog component

### DIFF
--- a/apps/docs/public/js/playground.js
+++ b/apps/docs/public/js/playground.js
@@ -57,6 +57,12 @@ document.addEventListener('DOMContentLoaded', function () {
             var el = preview.querySelector(tagName);
             if (!el || !codeEl) return;
             var html = el.outerHTML;
+            // Le DOM sérialise les attributs booléens en attr="" — on corrige en attr seul
+            controls.forEach(function (c) {
+                if (c.type === 'checkbox' && c.dataset.attr) {
+                    html = html.replace(' ' + c.dataset.attr + '=""', ' ' + c.dataset.attr);
+                }
+            });
             codeEl.textContent = html; // textContent = texte brut, pas d'injection HTML
             codeEl.removeAttribute('data-highlighted'); // permet à hljs de re-coloriser
             if (window.hljs) window.hljs.highlightElement(codeEl);

--- a/apps/docs/public/js/playground.js
+++ b/apps/docs/public/js/playground.js
@@ -54,13 +54,16 @@ document.addEventListener('DOMContentLoaded', function () {
 
         // Met à jour le bloc code et re-colore avec hljs
         function updateCode() {
-            var el = preview.querySelector(tagName);
-            if (!el || !codeEl) return;
-            var html = el.outerHTML;
+            if (!codeEl) return;
+            // Capture le HTML complet de la preview (bouton déclencheur + composant)
+            var html = preview.innerHTML.trim();
             // Le DOM sérialise les attributs booléens en attr="" — on corrige en attr seul
             controls.forEach(function (c) {
                 if (c.type === 'checkbox' && c.dataset.attr) {
-                    html = html.replace(' ' + c.dataset.attr + '=""', ' ' + c.dataset.attr);
+                    html = html.replace(
+                        new RegExp(' ' + c.dataset.attr + '=""', 'g'),
+                        ' ' + c.dataset.attr,
+                    );
                 }
             });
             codeEl.textContent = html; // textContent = texte brut, pas d'injection HTML
@@ -68,34 +71,45 @@ document.addEventListener('DOMContentLoaded', function () {
             if (window.hljs) window.hljs.highlightElement(codeEl);
         }
 
-        // Synchroniser l'état initial des contrôles avec les attributs du composant rendu
-        controls.forEach(function (ctrl) {
-            var attr = ctrl.dataset.attr;
-            if (!attr) return;
-            var el = preview.querySelector(tagName);
-            if (!el) return;
-            if (ctrl.type === 'checkbox') {
-                ctrl.checked = el.hasAttribute(attr);
-            } else {
-                var current = el.getAttribute(attr);
-                if (current !== null) ctrl.value = current;
-            }
-        });
+        // Synchroniser les contrôles depuis les attributs du composant (init + changements)
+        var compEl = preview.querySelector(tagName);
+
+        function syncControlsFromComponent() {
+            if (!compEl) return;
+            controls.forEach(function (ctrl) {
+                var attr = ctrl.dataset.attr;
+                if (!attr) return;
+                if (ctrl.type === 'checkbox') {
+                    ctrl.checked = compEl.hasAttribute(attr);
+                } else {
+                    var val = compEl.getAttribute(attr);
+                    if (val !== null) ctrl.value = val;
+                }
+            });
+        }
+
+        syncControlsFromComponent();
+
+        // Observer les changements d'attributs du composant pour maintenir la sync
+        if (compEl) {
+            new MutationObserver(function () {
+                syncControlsFromComponent();
+                updateCode();
+            }).observe(compEl, { attributes: true });
+        }
 
         // Écouter les changements sur les contrôles
         controls.forEach(function (ctrl) {
             var eventName = ctrl.type === 'checkbox' ? 'change' : 'input';
             ctrl.addEventListener(eventName, function () {
                 var attr = ctrl.dataset.attr;
-                if (!attr) return;
-                var el = preview.querySelector(tagName);
-                if (!el) return;
+                if (!attr || !compEl) return;
                 if (ctrl.type === 'checkbox') {
-                    el.toggleAttribute(attr, ctrl.checked);
+                    compEl.toggleAttribute(attr, ctrl.checked);
                 } else if (ctrl.value === '') {
-                    el.removeAttribute(attr);
+                    compEl.removeAttribute(attr);
                 } else {
-                    el.setAttribute(attr, ctrl.value);
+                    compEl.setAttribute(attr, ctrl.value);
                 }
                 updateCode();
             });

--- a/apps/docs/src/components/Playground.astro
+++ b/apps/docs/src/components/Playground.astro
@@ -448,9 +448,10 @@ const showPlayground = displayMode === 'demo';
 
     .preview :global(.btn-danger) {
         background: var(--ar-button-danger-bg, #d04442);
-        color:      var(--ar-button-danger-color, #fff);
+        color: #fff;
     }
     .preview :global(.btn-danger:hover) {
         background: var(--ar-color-danger-40, #a52c2b);
+        color: #fff;
     }
 </style>

--- a/apps/docs/src/components/Playground.astro
+++ b/apps/docs/src/components/Playground.astro
@@ -405,4 +405,52 @@ const showPlayground = displayMode === 'demo';
     }
 
     .parent-notice a:hover { text-decoration: underline; }
+
+    /* ── Boutons dans la preview (trigger + slotted)
+     * :global() nécessaire : les boutons sont injectés via set:html et n'ont pas
+     * l'attribut de portée Astro — la règle .preview.astro-xxx .btn.astro-xxx ne les atteint pas.
+     * ─────────────────────────────────────────────────────────────────────── */
+
+    .preview :global(.btn) {
+        display:         inline-flex;
+        align-items:     center;
+        justify-content: center;
+        padding:         0 var(--ar-button-padding-x, 1rem);
+        min-height:      var(--ar-button-height, 2.5rem);
+        border-radius:   var(--ar-button-border-radius, 0.375rem);
+        border:          1px solid transparent;
+        font-size:       var(--ar-font-size-md, 1rem);
+        font-weight:     var(--ar-button-font-weight, 500);
+        line-height:     1;
+        cursor:          pointer;
+        text-decoration: none;
+        font-family:     inherit;
+    }
+
+    .preview :global(.btn-primary) {
+        background:   var(--ar-button-bg, var(--ar-color-interactive, #283276));
+        color:        var(--ar-button-color, #fff);
+        border-color: var(--ar-button-border-color, var(--ar-color-interactive, #283276));
+    }
+    .preview :global(.btn-primary:hover) {
+        background:   var(--ar-button-bg-hover, var(--ar-color-interactive-hover, #1b2256));
+        border-color: var(--ar-button-bg-hover, var(--ar-color-interactive-hover, #1b2256));
+    }
+
+    .preview :global(.btn-secondary) {
+        background:   var(--ar-button-secondary-bg, #fff);
+        color:        var(--ar-color-text, #2e2e31);
+        border-color: var(--ar-color-border, #e5e7eb);
+    }
+    .preview :global(.btn-secondary:hover) {
+        background: var(--ar-color-bg-subtle, #f5f5f8);
+    }
+
+    .preview :global(.btn-danger) {
+        background: var(--ar-button-danger-bg, #d04442);
+        color:      var(--ar-button-danger-color, #fff);
+    }
+    .preview :global(.btn-danger:hover) {
+        background: var(--ar-color-danger-40, #a52c2b);
+    }
 </style>

--- a/apps/docs/src/content/components/ar-dialog.mdx
+++ b/apps/docs/src/content/components/ar-dialog.mdx
@@ -83,8 +83,8 @@ variants:
 
 ### Pris en charge automatiquement
 
-- Élément `<dialog>` natif avec `role="dialog"`, `aria-labelledby` et `aria-modal`.
-- Le focus est déplacé sur le premier élément focalisable du contenu à l'ouverture, ou sur le bouton de fermeture si aucun n'est présent.
+- Élément `<dialog>` natif avec `role="dialog"`, `aria-labelledby`, `aria-describedby` et `aria-modal`.
+- Le focus est déplacé à l'ouverture sur l'élément portant `autofocus`, ou à défaut sur le premier élément focalisable, ou sur le bouton de fermeture si aucun n'est présent.
 - Le focus est restauré sur l'élément déclencheur à la fermeture.
 - Le scroll du `<body>` est bloqué à l'ouverture et restauré à la fermeture, y compris avec plusieurs dialogs empilés.
 - La touche Escape passe par `ar-dialog-hide` : la fermeture peut donc être interceptée avec `event.preventDefault()`.
@@ -96,3 +96,5 @@ variants:
 - **Fournir un `label` descriptif.** Un fallback `Dialogue` existe, mais il doit rester un filet de sécurité, pas le libellé final du composant. Un avertissement est émis dans la console si ni `label` ni `slot="label"` ne sont fournis.
 - **Toujours proposer une issue claire.** Le backdrop est statique par défaut : prévoir un bouton de fermeture visible ou une action `data-ar-dismiss`.
 - **Si vous bloquez la fermeture, renseigner `prevented-message`.** Le message doit expliquer quoi faire pour continuer ou confirmer l'action.
+- **Piloter le focus initial si nécessaire.** Posez `autofocus` sur l'élément qui doit recevoir le focus à l'ouverture — utile par exemple pour un champ de saisie dans un drawer.
+- **Adapter `close-label` à la langue de l'interface.** Par défaut `"Fermer"` — à remplacer si l'interface n'est pas en français (`close-label="Close"`, `close-label="Schließen"`, etc.).

--- a/apps/docs/src/content/components/ar-dialog.mdx
+++ b/apps/docs/src/content/components/ar-dialog.mdx
@@ -88,11 +88,11 @@ variants:
 - Le focus est restauré sur l'élément déclencheur à la fermeture.
 - Le scroll du `<body>` est bloqué à l'ouverture et restauré à la fermeture, y compris avec plusieurs dialogs empilés.
 - La touche Escape passe par `ar-dialog-hide` : la fermeture peut donc être interceptée avec `event.preventDefault()`.
-- Quand une fermeture est bloquée, le composant secoue visuellement le dialog et annonce automatiquement `prevented-message` via une région `aria-live="assertive"`.
+- Quand une fermeture est bloquée, le composant secoue visuellement le dialog et annonce automatiquement `prevented-message` via la zone d'annonce globale de la librairie.
 - Les animations sont désactivées si `prefers-reduced-motion: reduce` est actif.
 
 ### À la charge de l'auteur
 
-- **Fournir un `label` descriptif.** C'est le titre annoncé aux technologies d'assistance.
+- **Fournir un `label` descriptif.** Un fallback `Dialogue` existe, mais il doit rester un filet de sécurité, pas le libellé final du composant. Un avertissement est émis dans la console si ni `label` ni `slot="label"` ne sont fournis.
 - **Toujours proposer une issue claire.** Le backdrop est statique par défaut : prévoir un bouton de fermeture visible ou une action `data-ar-dismiss`.
 - **Si vous bloquez la fermeture, renseigner `prevented-message`.** Le message doit expliquer quoi faire pour continuer ou confirmer l'action.

--- a/apps/docs/src/content/components/ar-dialog.mdx
+++ b/apps/docs/src/content/components/ar-dialog.mdx
@@ -46,6 +46,14 @@ variants:
               <button class="btn btn-secondary" slot="footer" data-ar-dismiss>Annuler</button>
               <button class="btn btn-danger" slot="footer" data-ar-accept>Supprimer</button>
           </ar-dialog>
+    - name: autofocus
+      label: Focus initial
+      description: Posez `autofocus` sur l'élément qui doit recevoir le focus à l'ouverture — ici un champ de recherche dans un drawer.
+      html: |
+          <button class="btn btn-primary" data-ar-dialog-open="demo-autofocus">Ouvrir le drawer</button>
+          <ar-dialog id="demo-autofocus" label="Rechercher" mode="drawer">
+              <input autofocus type="search" placeholder="Rechercher…" style="width:100%;padding:.5rem .75rem;border:1px solid var(--ar-color-border,#ccc);border-radius:.375rem;font-size:1rem;" />
+          </ar-dialog>
     - name: stacked
       label: Dialogs empilés
       description: Ouverture d'un second dialog depuis le premier — scroll lock et focus sont coordonnés. Escape ne ferme que le dialog au sommet.

--- a/apps/docs/src/content/components/ar-dialog.mdx
+++ b/apps/docs/src/content/components/ar-dialog.mdx
@@ -60,12 +60,11 @@ variants:
           </ar-dialog>
     - name: persistent
       label: Fermeture bloquée
-      description: "ar-dialog-hide est annulable : le composant secoue le dialog et un lecteur d'écran annonce le blocage. Seul le bouton Confirmer ferme."
+      description: "ar-dialog-hide est annulable : le composant secoue le dialog et annonce automatiquement le blocage aux lecteurs d'écran. Seul le bouton Confirmer ferme."
       html: |
           <button class="btn btn-primary" data-ar-dialog-open="demo-persistent">Ouvrir le dialog persistant</button>
-          <ar-dialog id="demo-persistent" label="Action requise">
+          <ar-dialog id="demo-persistent" label="Action requise" prevented-message="Fermeture bloquée — utilisez le bouton Confirmer.">
               <p>Ce dialog ne peut être fermé que via le bouton <strong>Confirmer</strong>. Escape et le bouton de fermeture sont interceptés.</p>
-              <p id="demo-persistent-status" aria-live="assertive" style="position:absolute;width:1px;height:1px;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap"></p>
               <button class="btn btn-primary" slot="footer" data-ar-accept>Confirmer</button>
           </ar-dialog>
           <script>
@@ -73,17 +72,9 @@ variants:
                   var dialog = document.getElementById('demo-persistent');
                   if (!dialog) return;
                   var confirming = false;
-                  function announce() {
-                      var s = document.getElementById('demo-persistent-status');
-                      if (!s) return;
-                      s.textContent = '';
-                      requestAnimationFrame(function () { s.textContent = 'Fermeture bloquée — utilisez le bouton Confirmer.'; });
-                  }
                   dialog.addEventListener('ar-dialog-accepted', function () { confirming = true; });
                   dialog.addEventListener('ar-dialog-hide', function (e) { if (!confirming) e.preventDefault(); confirming = false; });
                   dialog.addEventListener('ar-dialog-dismissed', function (e) { e.preventDefault(); });
-                  dialog.addEventListener('ar-dialog-hide-prevented', announce);
-                  dialog.addEventListener('ar-dialog-dismissed-prevented', announce);
               })();
           </script>
 ---
@@ -97,6 +88,7 @@ variants:
 - Le focus est restauré sur l'élément déclencheur à la fermeture.
 - Le scroll du `<body>` est bloqué à l'ouverture et restauré à la fermeture. Les dialogs empilés sont correctement gérés.
 - La touche Escape est interceptée et traitée via `ar-dialog-hide` (annulable) — la fermeture native du `<dialog>` est désactivée.
+- Quand une fermeture est bloquée (`ar-dialog-hide-prevented`, `ar-dialog-dismissed-prevented`, `ar-dialog-accepted-prevented`), le composant secoue visuellement le dialog et annonce automatiquement `prevented-message` via une région `aria-live="assertive"` dans son shadow DOM.
 - Les animations sont désactivées si `prefers-reduced-motion: reduce` est actif.
 
 ### À la charge de l'auteur

--- a/apps/docs/src/content/components/ar-dialog.mdx
+++ b/apps/docs/src/content/components/ar-dialog.mdx
@@ -8,44 +8,84 @@ variants:
       label: Modal
       description: Dialog centré avec backdrop. Cliquer sur le bouton pour l'ouvrir.
       html: |
-          <button data-ar-dialog-open="demo-modal">Ouvrir la modale</button>
+          <button class="btn btn-primary" data-ar-dialog-open="demo-modal">Ouvrir la modale</button>
           <ar-dialog id="demo-modal" label="Informations importantes">
               <p>Votre session expirera dans 5 minutes. Enregistrez votre travail pour ne pas perdre vos modifications.</p>
           </ar-dialog>
-    - name: panel
-      label: Panel droit
+    - name: drawer
+      label: Drawer droit
       description: Panneau latéral glissant depuis la droite.
       html: |
-          <button data-ar-dialog-open="demo-panel">Ouvrir le panel</button>
-          <ar-dialog id="demo-panel" label="Filtres de recherche" mode="panel">
-              <p>Contenu du panel latéral.</p>
+          <button class="btn btn-primary" data-ar-dialog-open="demo-drawer">Ouvrir le drawer</button>
+          <ar-dialog id="demo-drawer" label="Filtres de recherche" mode="drawer">
+              <p>Contenu du panneau latéral.</p>
           </ar-dialog>
-    - name: panel-left
-      label: Panel gauche
+    - name: drawer-left
+      label: Drawer gauche
       description: Panneau latéral glissant depuis la gauche.
       html: |
-          <button data-ar-dialog-open="demo-panel-left">Ouvrir le panel gauche</button>
-          <ar-dialog id="demo-panel-left" label="Menu de navigation" mode="panel" placement="left">
-              <p>Contenu du panel latéral gauche.</p>
+          <button class="btn btn-primary" data-ar-dialog-open="demo-drawer-left">Ouvrir le drawer gauche</button>
+          <ar-dialog id="demo-drawer-left" label="Menu de navigation" mode="drawer" placement="left">
+              <p>Contenu du panneau latéral gauche.</p>
           </ar-dialog>
-    - name: static-backdrop
-      label: Backdrop statique
-      description: Un clic sur le fond ne ferme pas le dialog — l'utilisateur doit agir explicitement.
+    - name: close-on-backdrop
+      label: Fermeture au clic backdrop
+      description: Par défaut, le backdrop est statique. Avec close-on-backdrop, un clic sur le fond ferme le dialog.
       html: |
-          <button data-ar-dialog-open="demo-static">Ouvrir (backdrop statique)</button>
-          <ar-dialog id="demo-static" label="Action requise" static-backdrop>
-              <p>Ce dialog ne se ferme pas en cliquant sur le fond.</p>
+          <button class="btn btn-primary" data-ar-dialog-open="demo-backdrop">Ouvrir (close-on-backdrop)</button>
+          <ar-dialog id="demo-backdrop" label="Informations" close-on-backdrop>
+              <p>Cliquez en dehors du dialog pour le fermer.</p>
           </ar-dialog>
     - name: with-footer
       label: Avec footer
       description: Zone d'actions en pied de page via slot="footer".
       html: |
-          <button data-ar-dialog-open="demo-footer">Ouvrir avec footer</button>
+          <button class="btn btn-primary" data-ar-dialog-open="demo-footer">Ouvrir avec footer</button>
           <ar-dialog id="demo-footer" label="Confirmer la suppression">
               <p>Cette action supprimera définitivement l'élément sélectionné.</p>
-              <button slot="footer" data-ar-dismiss>Annuler</button>
-              <button slot="footer" data-ar-accept>Supprimer</button>
+              <button class="btn btn-secondary" slot="footer" data-ar-dismiss>Annuler</button>
+              <button class="btn btn-danger" slot="footer" data-ar-accept>Supprimer</button>
           </ar-dialog>
+    - name: stacked
+      label: Dialogs empilés
+      description: Ouverture d'un second dialog depuis le premier — scroll lock et focus sont coordonnés. Escape ne ferme que le dialog au sommet.
+      html: |
+          <button class="btn btn-primary" data-ar-dialog-open="demo-stacked-1">Ouvrir le dialog</button>
+          <ar-dialog id="demo-stacked-1" label="Dialog principal">
+              <p>Ce dialog peut en ouvrir un second par-dessus.</p>
+              <button class="btn btn-secondary" data-ar-dialog-open="demo-stacked-2">Ouvrir un second dialog</button>
+          </ar-dialog>
+          <ar-dialog id="demo-stacked-2" label="Dialog secondaire">
+              <p>Dialog empilé. Escape ne ferme que ce dialog, pas le précédent.</p>
+          </ar-dialog>
+    - name: persistent
+      label: Fermeture bloquée
+      description: "ar-dialog-hide est annulable : le composant secoue le dialog et un lecteur d'écran annonce le blocage. Seul le bouton Confirmer ferme."
+      html: |
+          <button class="btn btn-primary" data-ar-dialog-open="demo-persistent">Ouvrir le dialog persistant</button>
+          <ar-dialog id="demo-persistent" label="Action requise">
+              <p>Ce dialog ne peut être fermé que via le bouton <strong>Confirmer</strong>. Escape et le bouton de fermeture sont interceptés.</p>
+              <p id="demo-persistent-status" aria-live="assertive" style="position:absolute;width:1px;height:1px;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap"></p>
+              <button class="btn btn-primary" slot="footer" data-ar-accept>Confirmer</button>
+          </ar-dialog>
+          <script>
+              (function () {
+                  var dialog = document.getElementById('demo-persistent');
+                  if (!dialog) return;
+                  var confirming = false;
+                  function announce() {
+                      var s = document.getElementById('demo-persistent-status');
+                      if (!s) return;
+                      s.textContent = '';
+                      requestAnimationFrame(function () { s.textContent = 'Fermeture bloquée — utilisez le bouton Confirmer.'; });
+                  }
+                  dialog.addEventListener('ar-dialog-accepted', function () { confirming = true; });
+                  dialog.addEventListener('ar-dialog-hide', function (e) { if (!confirming) e.preventDefault(); confirming = false; });
+                  dialog.addEventListener('ar-dialog-dismissed', function (e) { e.preventDefault(); });
+                  dialog.addEventListener('ar-dialog-hide-prevented', announce);
+                  dialog.addEventListener('ar-dialog-dismissed-prevented', announce);
+              })();
+          </script>
 ---
 
 ## Accessibilité
@@ -63,7 +103,7 @@ variants:
 
 - **Fournir un `label` descriptif.** C'est le texte vocalisé comme titre de la région — éviter les libellés génériques ("Modale", "Fenêtre").
 - **Toujours proposer un moyen de fermer.** Bouton de fermeture visible, action "Annuler" dans le footer, ou `data-ar-dismiss` sur un élément accessible au clavier.
-- **Ne pas désactiver le backdrop sans alternative.** Si `static-backdrop` est utilisé, un bouton d'annulation explicite est indispensable pour les utilisateurs ne pouvant pas utiliser Escape.
+- **Ne pas omettre de moyen de fermeture au clavier.** Par défaut le backdrop ne ferme pas le dialog — Escape et `data-ar-dismiss` restent les seules issues, veillez à ce qu'elles soient toujours accessibles.
 
 ## Déclenchement
 
@@ -86,7 +126,7 @@ document.querySelector('#mon-dialog').open = true;
 
 Plusieurs mécanismes ferment le dialog :
 
-- **Clic sur le backdrop** (sauf si `static-backdrop` est présent)
+- **Clic sur le backdrop** (uniquement si `close-on-backdrop` est présent — le backdrop est statique par défaut)
 - **Touche Escape** — passe par `ar-dialog-hide`, annulable
 - **`data-ar-dismiss`** sur tout élément du dialog — déclenche `ar-dialog-dismissed`
 - **`data-ar-accept`** sur tout élément du dialog — déclenche `ar-dialog-accepted`

--- a/apps/docs/src/content/components/ar-dialog.mdx
+++ b/apps/docs/src/content/components/ar-dialog.mdx
@@ -1,0 +1,14 @@
+---
+tagName: ar-dialog
+title: Dialog
+description: Description du composant ar-dialog.
+variants:
+    - name: Par défaut
+      description: Rendu par défaut du composant.
+      html: |
+          <ar-dialog label="Titre de ma modale">
+            Contenu de ma modale
+          </ar-dialog>
+---
+
+Documentation narrative du composant `ar-dialog`.

--- a/apps/docs/src/content/components/ar-dialog.mdx
+++ b/apps/docs/src/content/components/ar-dialog.mdx
@@ -1,14 +1,95 @@
 ---
 tagName: ar-dialog
 title: Dialog
-description: Description du composant ar-dialog.
+description: Boîte de dialogue modale ou panneau latéral, accessible et animée.
+playgroundTemplate: default
 variants:
-    - name: Par défaut
-      description: Rendu par défaut du composant.
+    - name: default
+      label: Modal
+      description: Dialog centré avec backdrop. Cliquer sur le bouton pour l'ouvrir.
       html: |
-          <ar-dialog label="Titre de ma modale">
-            Contenu de ma modale
+          <button data-ar-dialog-open="demo-modal">Ouvrir la modale</button>
+          <ar-dialog id="demo-modal" label="Informations importantes">
+              <p>Votre session expirera dans 5 minutes. Enregistrez votre travail pour ne pas perdre vos modifications.</p>
+          </ar-dialog>
+    - name: panel
+      label: Panel droit
+      description: Panneau latéral glissant depuis la droite.
+      html: |
+          <button data-ar-dialog-open="demo-panel">Ouvrir le panel</button>
+          <ar-dialog id="demo-panel" label="Filtres de recherche" mode="panel">
+              <p>Contenu du panel latéral.</p>
+          </ar-dialog>
+    - name: panel-left
+      label: Panel gauche
+      description: Panneau latéral glissant depuis la gauche.
+      html: |
+          <button data-ar-dialog-open="demo-panel-left">Ouvrir le panel gauche</button>
+          <ar-dialog id="demo-panel-left" label="Menu de navigation" mode="panel" placement="left">
+              <p>Contenu du panel latéral gauche.</p>
+          </ar-dialog>
+    - name: static-backdrop
+      label: Backdrop statique
+      description: Un clic sur le fond ne ferme pas le dialog — l'utilisateur doit agir explicitement.
+      html: |
+          <button data-ar-dialog-open="demo-static">Ouvrir (backdrop statique)</button>
+          <ar-dialog id="demo-static" label="Action requise" static-backdrop>
+              <p>Ce dialog ne se ferme pas en cliquant sur le fond.</p>
+          </ar-dialog>
+    - name: with-footer
+      label: Avec footer
+      description: Zone d'actions en pied de page via slot="footer".
+      html: |
+          <button data-ar-dialog-open="demo-footer">Ouvrir avec footer</button>
+          <ar-dialog id="demo-footer" label="Confirmer la suppression">
+              <p>Cette action supprimera définitivement l'élément sélectionné.</p>
+              <button slot="footer" data-ar-dismiss>Annuler</button>
+              <button slot="footer" data-ar-accept>Supprimer</button>
           </ar-dialog>
 ---
 
-Documentation narrative du composant `ar-dialog`.
+## Accessibilité
+
+### Pris en charge automatiquement
+
+- Élément `<dialog>` natif avec `role="dialog"`, `aria-labelledby` et `aria-modal` — la région est correctement annoncée par les lecteurs d'écran.
+- Le focus est déplacé sur le premier élément focalisable du contenu à l'ouverture, ou sur le bouton de fermeture si aucun n'est présent.
+- Le focus est restauré sur l'élément déclencheur à la fermeture.
+- Le scroll du `<body>` est bloqué à l'ouverture et restauré à la fermeture. Les dialogs empilés sont correctement gérés.
+- La touche Escape est interceptée et traitée via `ar-dialog-hide` (annulable) — la fermeture native du `<dialog>` est désactivée.
+- Les animations sont désactivées si `prefers-reduced-motion: reduce` est actif.
+
+### À la charge de l'auteur
+
+- **Fournir un `label` descriptif.** C'est le texte vocalisé comme titre de la région — éviter les libellés génériques ("Modale", "Fenêtre").
+- **Toujours proposer un moyen de fermer.** Bouton de fermeture visible, action "Annuler" dans le footer, ou `data-ar-dismiss` sur un élément accessible au clavier.
+- **Ne pas désactiver le backdrop sans alternative.** Si `static-backdrop` est utilisé, un bouton d'annulation explicite est indispensable pour les utilisateurs ne pouvant pas utiliser Escape.
+
+## Déclenchement
+
+Un dialog peut être ouvert de deux manières :
+
+**Via `data-ar-dialog-open`** — posé sur n'importe quel élément cliquable, sans JavaScript :
+
+```html
+<button data-ar-dialog-open="mon-dialog">Ouvrir</button>
+<ar-dialog id="mon-dialog" label="Mon titre">…</ar-dialog>
+```
+
+**Via la propriété `open`** — pour un contrôle programmatique :
+
+```js
+document.querySelector('#mon-dialog').open = true;
+```
+
+## Fermeture
+
+Plusieurs mécanismes ferment le dialog :
+
+- **Clic sur le backdrop** (sauf si `static-backdrop` est présent)
+- **Touche Escape** — passe par `ar-dialog-hide`, annulable
+- **`data-ar-dismiss`** sur tout élément du dialog — déclenche `ar-dialog-dismissed`
+- **`data-ar-accept`** sur tout élément du dialog — déclenche `ar-dialog-accepted`
+- **`open = false`** en JavaScript
+
+Les événements `ar-dialog-dismissed` et `ar-dialog-accepted` sont annulables via `event.preventDefault()` — utile pour bloquer la fermeture et afficher une confirmation.

--- a/apps/docs/src/content/components/ar-dialog.mdx
+++ b/apps/docs/src/content/components/ar-dialog.mdx
@@ -83,45 +83,16 @@ variants:
 
 ### Pris en charge automatiquement
 
-- Élément `<dialog>` natif avec `role="dialog"`, `aria-labelledby` et `aria-modal` — la région est correctement annoncée par les lecteurs d'écran.
+- Élément `<dialog>` natif avec `role="dialog"`, `aria-labelledby` et `aria-modal`.
 - Le focus est déplacé sur le premier élément focalisable du contenu à l'ouverture, ou sur le bouton de fermeture si aucun n'est présent.
 - Le focus est restauré sur l'élément déclencheur à la fermeture.
-- Le scroll du `<body>` est bloqué à l'ouverture et restauré à la fermeture. Les dialogs empilés sont correctement gérés.
-- La touche Escape est interceptée et traitée via `ar-dialog-hide` (annulable) — la fermeture native du `<dialog>` est désactivée.
-- Quand une fermeture est bloquée (`ar-dialog-hide-prevented`, `ar-dialog-dismissed-prevented`, `ar-dialog-accepted-prevented`), le composant secoue visuellement le dialog et annonce automatiquement `prevented-message` via une région `aria-live="assertive"` dans son shadow DOM.
+- Le scroll du `<body>` est bloqué à l'ouverture et restauré à la fermeture, y compris avec plusieurs dialogs empilés.
+- La touche Escape passe par `ar-dialog-hide` : la fermeture peut donc être interceptée avec `event.preventDefault()`.
+- Quand une fermeture est bloquée, le composant secoue visuellement le dialog et annonce automatiquement `prevented-message` via une région `aria-live="assertive"`.
 - Les animations sont désactivées si `prefers-reduced-motion: reduce` est actif.
 
 ### À la charge de l'auteur
 
-- **Fournir un `label` descriptif.** C'est le texte vocalisé comme titre de la région — éviter les libellés génériques ("Modale", "Fenêtre").
-- **Toujours proposer un moyen de fermer.** Bouton de fermeture visible, action "Annuler" dans le footer, ou `data-ar-dismiss` sur un élément accessible au clavier.
-- **Ne pas omettre de moyen de fermeture au clavier.** Par défaut le backdrop ne ferme pas le dialog — Escape et `data-ar-dismiss` restent les seules issues, veillez à ce qu'elles soient toujours accessibles.
-
-## Déclenchement
-
-Un dialog peut être ouvert de deux manières :
-
-**Via `data-ar-dialog-open`** — posé sur n'importe quel élément cliquable, sans JavaScript :
-
-```html
-<button data-ar-dialog-open="mon-dialog">Ouvrir</button>
-<ar-dialog id="mon-dialog" label="Mon titre">…</ar-dialog>
-```
-
-**Via la propriété `open`** — pour un contrôle programmatique :
-
-```js
-document.querySelector('#mon-dialog').open = true;
-```
-
-## Fermeture
-
-Plusieurs mécanismes ferment le dialog :
-
-- **Clic sur le backdrop** (uniquement si `close-on-backdrop` est présent — le backdrop est statique par défaut)
-- **Touche Escape** — passe par `ar-dialog-hide`, annulable
-- **`data-ar-dismiss`** sur tout élément du dialog — déclenche `ar-dialog-dismissed`
-- **`data-ar-accept`** sur tout élément du dialog — déclenche `ar-dialog-accepted`
-- **`open = false`** en JavaScript
-
-Les événements `ar-dialog-dismissed` et `ar-dialog-accepted` sont annulables via `event.preventDefault()` — utile pour bloquer la fermeture et afficher une confirmation.
+- **Fournir un `label` descriptif.** C'est le titre annoncé aux technologies d'assistance.
+- **Toujours proposer une issue claire.** Le backdrop est statique par défaut : prévoir un bouton de fermeture visible ou une action `data-ar-dismiss`.
+- **Si vous bloquez la fermeture, renseigner `prevented-message`.** Le message doit expliquer quoi faire pour continuer ou confirmer l'action.

--- a/apps/docs/src/pages/components/[slug].astro
+++ b/apps/docs/src/pages/components/[slug].astro
@@ -46,7 +46,13 @@ const playgroundVariantName = mdx?.data.playgroundTemplate;
 const playgroundVariant = playgroundVariantName
     ? variants.find((v: { name: string }) => v.name === playgroundVariantName)
     : variants[0];
-const playgroundHtml = playgroundVariant?.html ?? '';
+
+// Préfixe les id= et les data-*-open="id" du playground pour éviter les collisions
+// avec les aperçus de variantes qui utilisent le même HTML (même IDs).
+const rawPlaygroundHtml = playgroundVariant?.html ?? '';
+const playgroundHtml = rawPlaygroundHtml
+    .replace(/\bid="([\w-]+)"/g, 'id="pg-$1"')
+    .replace(/\bdata-ar-dialog-open="([\w-]+)"/g, 'data-ar-dialog-open="pg-$1"');
 
 // ─── Contrôles du playground ──────────────────────────────────────────────────
 

--- a/packages/core/src/a11y/announce-a11y.test.ts
+++ b/packages/core/src/a11y/announce-a11y.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { announceA11y } from './announce-a11y.js';
+
+describe('announceA11y', () => {
+    afterEach(() => {
+        document.querySelectorAll('[data-ar-live-region]').forEach((el) => el.remove());
+    });
+
+    it('crée une région assertive globale dans le document', async () => {
+        announceA11y('Action bloquée.', 'assertive');
+        await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+
+        const region = document.getElementById('ar-live-region-assertive');
+        expect(region).not.toBeNull();
+        expect(region?.getAttribute('aria-live')).toBe('assertive');
+        expect(region?.textContent).toBe('Action bloquée.');
+    });
+
+    it('réutilise la même région pour plusieurs annonces', async () => {
+        announceA11y('Premier message.', 'assertive');
+        await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+        announceA11y('Second message.', 'assertive');
+        await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+
+        const regions = document.querySelectorAll('#ar-live-region-assertive');
+        expect(regions).toHaveLength(1);
+        expect(regions[0]?.textContent).toBe('Second message.');
+    });
+
+    it('ignore les messages vides', async () => {
+        announceA11y('   ', 'assertive');
+        await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+
+        expect(document.getElementById('ar-live-region-assertive')).toBeNull();
+    });
+});

--- a/packages/core/src/a11y/announce-a11y.ts
+++ b/packages/core/src/a11y/announce-a11y.ts
@@ -1,0 +1,49 @@
+const LIVE_REGION_ID_PREFIX = 'ar-live-region';
+
+const VISUALLY_HIDDEN_STYLE = [
+    'position:absolute',
+    'width:1px',
+    'height:1px',
+    'padding:0',
+    'margin:-1px',
+    'overflow:hidden',
+    'clip:rect(0, 0, 0, 0)',
+    'white-space:nowrap',
+    'border:0',
+].join(';');
+
+export type AriaPoliteness = 'polite' | 'assertive';
+
+function getLiveRegion(politeness: AriaPoliteness): HTMLElement | null {
+    // Les annonces sont centralisées au niveau document pour être réutilisables
+    // par plusieurs composants et éviter de dépendre d'un shadow root spécifique.
+    if (typeof document === 'undefined' || !document.body) return null;
+
+    const id = `${LIVE_REGION_ID_PREFIX}-${politeness}`;
+    const existing = document.getElementById(id);
+    if (existing) return existing;
+
+    const region = document.createElement('div');
+    region.id = id;
+    region.setAttribute('aria-live', politeness);
+    region.setAttribute('aria-atomic', 'true');
+    region.setAttribute('data-ar-live-region', politeness);
+    region.style.cssText = VISUALLY_HIDDEN_STYLE;
+    document.body.appendChild(region);
+    return region;
+}
+
+export function announceA11y(message: string, politeness: AriaPoliteness = 'polite'): void {
+    const normalized = message.trim();
+    if (!normalized) return;
+
+    const region = getLiveRegion(politeness);
+    if (!region) return;
+
+    // Vider puis réécrire le message aide les lecteurs d'écran à réannoncer
+    // une même information déclenchée plusieurs fois.
+    region.textContent = '';
+    requestAnimationFrame(() => {
+        region.textContent = normalized;
+    });
+}

--- a/packages/core/src/autoloader.ts
+++ b/packages/core/src/autoloader.ts
@@ -24,6 +24,7 @@ const COMPONENT_MAP: Record<string, () => Promise<unknown>> = {
     'ar-spinner': () => import('./components/spinner/spinner.js'),
     'ar-stepper': () => import('./components/stepper/stepper.js'),
     'ar-stepper-item': () => import('./components/stepper-item/stepper-item.js'),
+    'ar-dialog': () => import('./components/dialog/dialog.js'),
     // ⚠ Mis à jour automatiquement par le script create-component.js
 };
 

--- a/packages/core/src/components/dialog/dialog.a11y.test.ts
+++ b/packages/core/src/components/dialog/dialog.a11y.test.ts
@@ -73,6 +73,16 @@ describe('ar-dialog — accessibilité', () => {
         expect(title.textContent?.trim()).to.equal('Dialogue');
     });
 
+    it('aria-describedby pointe vers le corps du dialog', () => {
+        const dialogEl = requireDialog(el);
+        const descId = dialogEl.getAttribute('aria-describedby');
+        expect(descId).not.to.equal(null);
+        if (!descId) throw new Error('aria-describedby absent');
+        const body = requireShadow(el).getElementById(descId);
+        expect(body).not.to.equal(null);
+        expect(body?.getAttribute('part')).to.equal('body');
+    });
+
     it('le drawer conserve les attributs ARIA du dialog', async () => {
         el.remove();
         el = await fixture(html`<ar-dialog label="Filtres" mode="drawer"></ar-dialog>`);

--- a/packages/core/src/components/dialog/dialog.a11y.test.ts
+++ b/packages/core/src/components/dialog/dialog.a11y.test.ts
@@ -1,0 +1,80 @@
+/// <reference types="mocha" />
+/**
+ * dialog.a11y.test.ts
+ *
+ * Tests d'accessibilité structurels pour ar-dialog, via @web/test-runner.
+ * Les comportements dynamiques dépendants de showModal() sont couverts dans
+ * dialog.browser.test.ts pour éviter les blocages du runner.
+ */
+import { fixture, html, expect } from '@open-wc/testing';
+import type { ArDialog } from './dialog.js';
+import './dialog.js';
+
+function requireShadow(el: Element): ShadowRoot {
+    if (!el.shadowRoot) throw new Error(`shadowRoot absent sur <${el.tagName.toLowerCase()}>`);
+    return el.shadowRoot;
+}
+
+function requireDialog(el: ArDialog): HTMLDialogElement {
+    const dialogEl = requireShadow(el).querySelector('dialog');
+    if (!(dialogEl instanceof HTMLDialogElement)) throw new Error('<dialog> introuvable');
+    return dialogEl;
+}
+
+describe('ar-dialog — accessibilité', () => {
+    let el: ArDialog;
+
+    afterEach(() => {
+        el?.remove();
+    });
+
+    beforeEach(async () => {
+        el = await fixture(html`<ar-dialog label="Mon titre"></ar-dialog>`);
+    });
+
+    it('l\'élément <dialog> a role="dialog"', () => {
+        const dialogEl = requireDialog(el);
+        expect(dialogEl.getAttribute('role')).to.equal('dialog');
+    });
+
+    it('l\'élément <dialog> a aria-modal="true"', () => {
+        const dialogEl = requireDialog(el);
+        expect(dialogEl.getAttribute('aria-modal')).to.equal('true');
+    });
+
+    it('aria-labelledby pointe vers le titre', () => {
+        const dialogEl = requireDialog(el);
+        const labelId = dialogEl.getAttribute('aria-labelledby');
+        expect(labelId).not.to.equal(null);
+        if (!labelId) throw new Error('aria-labelledby absent');
+        const title = requireShadow(el).getElementById(labelId);
+        expect(title).not.to.equal(null);
+        if (!title) throw new Error('titre référencé introuvable');
+        expect(title.textContent).to.include('Mon titre');
+    });
+
+    it('le bouton fermer a un nom accessible via sr-only', () => {
+        const closeBtn = requireShadow(el).querySelector('[data-ar-dismiss]');
+        if (!(closeBtn instanceof HTMLElement)) throw new Error('[data-ar-dismiss] introuvable');
+        const label = closeBtn.querySelector('.sr-only');
+        expect(label).not.to.equal(null);
+        if (!label) throw new Error('.sr-only introuvable');
+        expect(label.textContent?.trim()).to.equal('Fermer');
+    });
+
+    it('une région aria-live="assertive" est présente dans le shadow DOM', () => {
+        const liveRegion = requireShadow(el).getElementById('dialog-status');
+        expect(liveRegion).not.to.equal(null);
+        if (!liveRegion) throw new Error('#dialog-status introuvable');
+        expect(liveRegion.getAttribute('aria-live')).to.equal('assertive');
+        expect(liveRegion.getAttribute('aria-atomic')).to.equal('true');
+    });
+
+    it('le drawer conserve les attributs ARIA du dialog', async () => {
+        el.remove();
+        el = await fixture(html`<ar-dialog label="Filtres" mode="drawer"></ar-dialog>`);
+        const dialogEl = requireDialog(el);
+        expect(dialogEl.getAttribute('role')).to.equal('dialog');
+        expect(dialogEl.getAttribute('aria-modal')).to.equal('true');
+    });
+});

--- a/packages/core/src/components/dialog/dialog.a11y.test.ts
+++ b/packages/core/src/components/dialog/dialog.a11y.test.ts
@@ -3,8 +3,8 @@
  * dialog.a11y.test.ts
  *
  * Tests d'accessibilité structurels pour ar-dialog, via @web/test-runner.
- * Les comportements dynamiques dépendants de showModal() sont couverts dans
- * dialog.browser.test.ts pour éviter les blocages du runner.
+ * Les comportements dynamiques dépendants de showModal() ou des annonces
+ * document-level sont couverts ailleurs pour éviter les blocages du runner.
  */
 import { fixture, html, expect } from '@open-wc/testing';
 import type { ArDialog } from './dialog.js';
@@ -62,12 +62,15 @@ describe('ar-dialog — accessibilité', () => {
         expect(label.textContent?.trim()).to.equal('Fermer');
     });
 
-    it('une région aria-live="assertive" est présente dans le shadow DOM', () => {
-        const liveRegion = requireShadow(el).getElementById('dialog-status');
-        expect(liveRegion).not.to.equal(null);
-        if (!liveRegion) throw new Error('#dialog-status introuvable');
-        expect(liveRegion.getAttribute('aria-live')).to.equal('assertive');
-        expect(liveRegion.getAttribute('aria-atomic')).to.equal('true');
+    it('le fallback de titre fournit un nom accessible par défaut', async () => {
+        el.remove();
+        el = await fixture(html`<ar-dialog></ar-dialog>`);
+        const dialogEl = requireDialog(el);
+        const labelId = dialogEl.getAttribute('aria-labelledby');
+        if (!labelId) throw new Error('aria-labelledby absent');
+        const title = requireShadow(el).getElementById(labelId);
+        if (!title) throw new Error('titre référencé introuvable');
+        expect(title.textContent?.trim()).to.equal('Dialogue');
     });
 
     it('le drawer conserve les attributs ARIA du dialog', async () => {

--- a/packages/core/src/components/dialog/dialog.animations.ts
+++ b/packages/core/src/components/dialog/dialog.animations.ts
@@ -1,0 +1,80 @@
+import { css } from 'lit';
+
+export const dialogAnimations = css`
+    @keyframes showModal {
+        from {
+            opacity: 0;
+            transform: translateY(-16px);
+        }
+        to {
+            opacity: 1;
+            transform: translateY(0);
+        }
+    }
+
+    @keyframes hideModal {
+        from {
+            opacity: 1;
+            transform: translateY(0);
+        }
+        to {
+            opacity: 0;
+            transform: translateY(-16px);
+        }
+    }
+
+    @keyframes showDrawerRight {
+        from {
+            transform: translateX(100%);
+        }
+        to {
+            transform: translateX(0);
+        }
+    }
+
+    @keyframes hideDrawerRight {
+        from {
+            transform: translateX(0);
+        }
+        to {
+            transform: translateX(100%);
+        }
+    }
+
+    @keyframes showDrawerLeft {
+        from {
+            transform: translateX(-100%);
+        }
+        to {
+            transform: translateX(0);
+        }
+    }
+
+    @keyframes hideDrawerLeft {
+        from {
+            transform: translateX(0);
+        }
+        to {
+            transform: translateX(-100%);
+        }
+    }
+
+    @keyframes dialogShake {
+        0%,
+        100% {
+            transform: none;
+        }
+        20% {
+            transform: translateX(-8px);
+        }
+        40% {
+            transform: translateX(8px);
+        }
+        60% {
+            transform: translateX(-6px);
+        }
+        80% {
+            transform: translateX(4px);
+        }
+    }
+`;

--- a/packages/core/src/components/dialog/dialog.browser.test.ts
+++ b/packages/core/src/components/dialog/dialog.browser.test.ts
@@ -1,0 +1,164 @@
+/// <reference types="mocha" />
+/**
+ * dialog.browser.test.ts
+ *
+ * Tests nécessitant un vrai browser (Chromium via @web/test-runner) :
+ *   - Animations CSS réelles (animationend natif, pas de dispatch manuel)
+ *   - Cycle de vie des classes .opening / .closing / .shake
+ *   - Comportements dépendants de l'ordre des événements d'animation
+ *
+ * Les timeouts sont volontairement conservateurs (> durée max des animations).
+ */
+import { fixture, html, expect, aTimeout } from '@open-wc/testing';
+import type { ArDialog } from './dialog.js';
+import './dialog.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const ANIM_OPEN = 400; // showModal 250ms / showDrawer 300ms + marge
+const ANIM_CLOSE = 350; // hideModal 200ms / hideDrawer 250ms + marge
+const ANIM_SHAKE = 600; // dialogShake 400ms + marge
+
+function getDialogEl(el: ArDialog): HTMLDialogElement {
+    const dialogEl = el.shadowRoot?.querySelector('dialog');
+    if (!(dialogEl instanceof HTMLDialogElement)) throw new Error('<dialog> introuvable');
+    return dialogEl;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('ar-dialog — browser', () => {
+    let el: ArDialog;
+
+    afterEach(() => el?.remove());
+
+    // ── Fermeture avec animation réelle ───────────────────────────────────────
+
+    describe('fermeture', () => {
+        beforeEach(async () => {
+            el = await fixture(html`<ar-dialog open></ar-dialog>`);
+            await aTimeout(ANIM_OPEN);
+        });
+
+        it('ferme le <dialog> natif après animation de fermeture', async () => {
+            el.open = false;
+            await aTimeout(ANIM_CLOSE);
+            expect(getDialogEl(el).open).to.equal(false);
+        });
+
+        it('restaure le scroll du body après fermeture', async () => {
+            el.open = false;
+            await aTimeout(ANIM_CLOSE);
+            expect(document.body.style.overflow).not.to.equal('hidden');
+        });
+
+        it("émet ar-dialog-hidden après la fin de l'animation", async () => {
+            let fired = false;
+            el.addEventListener('ar-dialog-hidden', () => {
+                fired = true;
+            });
+            el.open = false;
+            await aTimeout(ANIM_CLOSE);
+            expect(fired).to.equal(true);
+        });
+
+        it('_isClosing bloque un double-appel : ar-dialog-hidden émis une seule fois', async () => {
+            let count = 0;
+            el.addEventListener('ar-dialog-hidden', () => {
+                count++;
+            });
+            el.open = false;
+            el.open = false; // second appel immédiat pendant la fermeture
+            await aTimeout(ANIM_CLOSE);
+            expect(count).to.equal(1);
+        });
+    });
+
+    // ── Scroll lock / unlock ─────────────────────────────────────────────────
+
+    describe('scroll', () => {
+        it("gèle le scroll à l'ouverture et le restaure à la fermeture", async () => {
+            el = await fixture(html`<ar-dialog></ar-dialog>`);
+            el.open = true;
+            await aTimeout(50);
+            expect(document.body.style.overflow).to.equal('hidden');
+
+            el.open = false;
+            await aTimeout(ANIM_CLOSE);
+            expect(document.body.style.overflow).not.to.equal('hidden');
+        });
+    });
+
+    // ── Animation d'ouverture (.opening) ─────────────────────────────────────
+
+    describe('animation ouverture', () => {
+        it("ajoute .opening à l'ouverture et la retire après animation", async () => {
+            el = await fixture(html`<ar-dialog></ar-dialog>`);
+            const dialogEl = getDialogEl(el);
+
+            el.open = true;
+            await aTimeout(20); // Lit update
+            expect(dialogEl.classList.contains('opening')).to.equal(true);
+
+            await aTimeout(ANIM_OPEN);
+            expect(dialogEl.classList.contains('opening')).to.equal(false);
+        });
+    });
+
+    // ── Shake ────────────────────────────────────────────────────────────────
+
+    describe('shake', () => {
+        beforeEach(async () => {
+            el = await fixture(html`<ar-dialog open></ar-dialog>`);
+            await aTimeout(ANIM_OPEN); // attendre la fin de l'animation d'ouverture
+        });
+
+        it("ajoute .shake lors d'un blocage de fermeture et la retire après animation", async () => {
+            const dialogEl = getDialogEl(el);
+            el.addEventListener('ar-dialog-hide', (e) => e.preventDefault());
+            el.open = false;
+            await aTimeout(20);
+            expect(dialogEl.classList.contains('shake')).to.equal(true);
+
+            await aTimeout(ANIM_SHAKE);
+            expect(dialogEl.classList.contains('shake')).to.equal(false);
+        });
+
+        it("shake ne relance pas l'animation showModal (régression #opening)", async () => {
+            const dialogEl = getDialogEl(el);
+
+            // Écouter les animationstart après la fin de l'animation d'ouverture
+            const started: string[] = [];
+            dialogEl.addEventListener('animationstart', (e: AnimationEvent) => {
+                started.push(e.animationName);
+            });
+
+            el.addEventListener('ar-dialog-hide', (e) => e.preventDefault());
+            el.open = false;
+            await aTimeout(ANIM_SHAKE);
+
+            expect(started).to.include('dialogShake');
+            expect(started).not.to.include('showModal');
+        });
+    });
+
+    // ── Gestion du focus ─────────────────────────────────────────────────────
+
+    describe('focus', () => {
+        it("retourne le focus à l'élément déclencheur à la fermeture", async () => {
+            const trigger = document.createElement('button');
+            document.body.appendChild(trigger);
+            trigger.focus();
+
+            el = await fixture(html`<ar-dialog></ar-dialog>`);
+            el.open = true;
+            await aTimeout(50);
+
+            el.open = false;
+            await aTimeout(ANIM_CLOSE);
+
+            expect(document.activeElement).to.equal(trigger);
+            trigger.remove();
+        });
+    });
+});

--- a/packages/core/src/components/dialog/dialog.styles.ts
+++ b/packages/core/src/components/dialog/dialog.styles.ts
@@ -1,110 +1,283 @@
 import { css } from 'lit';
 
 export default css`
+    /* ── Keyframes ────────────────────────────────────────────────────────── */
+
+    @keyframes showModal {
+        from {
+            opacity: 0;
+            transform: translateY(-16px);
+        }
+        to {
+            opacity: 1;
+            transform: translateY(0);
+        }
+    }
+
+    @keyframes hideModal {
+        from {
+            opacity: 1;
+            transform: translateY(0);
+        }
+        to {
+            opacity: 0;
+            transform: translateY(-16px);
+        }
+    }
+
+    @keyframes showDrawerRight {
+        from {
+            transform: translateX(100%);
+        }
+        to {
+            transform: translateX(0);
+        }
+    }
+
+    @keyframes hideDrawerRight {
+        from {
+            transform: translateX(0);
+        }
+        to {
+            transform: translateX(100%);
+        }
+    }
+
+    @keyframes showDrawerLeft {
+        from {
+            transform: translateX(-100%);
+        }
+        to {
+            transform: translateX(0);
+        }
+    }
+
+    @keyframes hideDrawerLeft {
+        from {
+            transform: translateX(0);
+        }
+        to {
+            transform: translateX(-100%);
+        }
+    }
+
+    /* ── Host & tailles ───────────────────────────────────────────────────── */
+
     :host {
         display: block;
-        box-sizing: border-box;
+
+        /* Taille modale par défaut (md = 500px). Surchargeable par --width sur l'instance. */
+        --width: 500px;
     }
 
-    /* Animation de l'apparition */
-    @keyframes showDialog {
-        from {
-            transform: translate(0, -50px);
-            opacity: 0;
-        }
-        to {
-            transform: translate(0, 0);
-            opacity: 1;
-        }
+    /* Tailles modal */
+    :host([size='sm']) {
+        --width: 360px;
+    }
+    :host([size='md']) {
+        --width: 500px;
+    }
+    :host([size='lg']) {
+        --width: 800px;
+    }
+    :host([size='xl']) {
+        --width: 1140px;
     }
 
-    @keyframes hideDialog {
-        from {
-            transform: translate(0, 0);
-            opacity: 1;
-        }
-        to {
-            transform: translate(0, -50px);
-            opacity: 0;
-        }
+    /* Tailles drawer — ont priorité sur les valeurs modal via la spécificité */
+    :host([mode='drawer']) {
+        --width: 720px;
+    }
+    :host([mode='drawer'][size='sm']) {
+        --width: 360px;
+    }
+    :host([mode='drawer'][size='md']) {
+        --width: 720px;
+    }
+    :host([mode='drawer'][size='lg']) {
+        --width: 960px;
+    }
+    :host([mode='drawer'][size='xl']) {
+        --width: 1440px;
     }
 
-    @keyframes showBackdrop {
-        from {
-            opacity: 0;
-        }
-        to {
-            opacity: 0.5;
-        }
-    }
+    /* ── Backdrop ─────────────────────────────────────────────────────────── */
 
     dialog::backdrop {
+        background: rgba(0, 0, 0, 0.5);
         opacity: 0;
-        background: black;
-        transition: opacity linear 0.4s;
+        transition: opacity 0.25s ease;
     }
 
-    dialog.closing::backdrop {
-        opacity: 0;
+    dialog[open]:not(.closing)::backdrop {
+        opacity: 1;
     }
 
-    dialog:where(:not(.closing))[open]::backdrop {
-        opacity: 0.5;
-        animation: showBackdrop 0.4s;
+    dialog[open].closing::backdrop {
+        opacity: 0;
+        transition: opacity 0.2s ease;
+    }
+
+    /* ── Base dialog ──────────────────────────────────────────────────────── */
+
+    /* Masquer explicitement quand non ouvert — évite que display:flex écrase le display:none natif */
+    dialog:not([open]) {
+        display: none;
     }
 
     dialog {
+        display: flex;
+        flex-direction: column;
         border: none;
-        background: none;
         padding: 0;
-        box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
+        overflow: hidden;
+        background: var(--ar-color-surface, #fff);
+        color: var(--ar-color-text, #1f2937);
+        box-shadow:
+            0 4px 6px -1px rgba(0, 0, 0, 0.1),
+            0 20px 50px -8px rgba(0, 0, 0, 0.2);
     }
 
-    dialog:not(.closing)[open] {
-        animation: showDialog 0.4s;
+    /* ── Modal ────────────────────────────────────────────────────────────── */
+
+    :host(:not([mode='drawer'])) dialog {
+        border-radius: 0.5rem;
+        /* max-width artificiel : la modale ne prend jamais toute la largeur même sur mobile */
+        width: min(var(--width), calc(100vw - 2rem));
+        max-height: min(90vh, calc(100dvh - 2rem));
     }
 
-    dialog[open].closing {
-        opacity: 0;
-        animation: hideDialog 0.4s;
+    :host(:not([mode='drawer'])) dialog:not(.closing)[open] {
+        animation: showModal 0.25s ease-out;
     }
+
+    :host(:not([mode='drawer'])) dialog[open].closing {
+        animation: hideModal 0.2s ease-in forwards;
+    }
+
+    /* ── Drawer ───────────────────────────────────────────────────────────── */
+
+    :host([mode='drawer']) dialog {
+        /* Sur petit écran, le drawer peut occuper 100% de la largeur */
+        width: min(var(--width), 100vw);
+        height: 100dvh;
+        max-height: 100dvh;
+        margin: 0;
+    }
+
+    /* Placement droite (défaut du composant) */
+    :host([mode='drawer']:not([placement='left'])) dialog {
+        margin-inline-start: auto;
+    }
+
+    /* Placement gauche */
+    :host([mode='drawer'][placement='left']) dialog {
+        margin-inline-end: auto;
+    }
+
+    :host([mode='drawer']:not([placement='left'])) dialog:not(.closing)[open] {
+        animation: showDrawerRight 0.3s ease-out;
+    }
+
+    :host([mode='drawer']:not([placement='left'])) dialog[open].closing {
+        animation: hideDrawerRight 0.25s ease-in forwards;
+    }
+
+    :host([mode='drawer'][placement='left']) dialog:not(.closing)[open] {
+        animation: showDrawerLeft 0.3s ease-out;
+    }
+
+    :host([mode='drawer'][placement='left']) dialog[open].closing {
+        animation: hideDrawerLeft 0.25s ease-in forwards;
+    }
+
+    /* ── Header ───────────────────────────────────────────────────────────── */
+
+    .dialog-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+        padding: 1.25rem 1.5rem;
+        border-bottom: 1px solid var(--ar-color-border, #e5e7eb);
+        flex-shrink: 0;
+    }
+
+    .dialog-title {
+        margin: 0;
+        font-size: 1rem;
+        font-weight: 600;
+        line-height: 1.4;
+        color: inherit;
+    }
+
+    .dialog-header .btn-ratio-square {
+        flex-shrink: 0;
+        align-self: flex-start;
+        /* @EvolutionDesign: taille forcée à 40×40 en attendant la migration vers la nouvelle charte */
+        min-height: 2.5rem;
+    }
+
+    .dialog-header .btn-ratio-square svg {
+        width: 1.25rem;
+        height: 1.25rem;
+        flex-shrink: 0;
+    }
+
+    /* ── Body ─────────────────────────────────────────────────────────────── */
+
+    .dialog-body {
+        flex: 1;
+        min-height: 0; /* autorise le shrink flex pour activer le scroll */
+        overflow-y: auto;
+        padding: var(--spacing, 1.5rem);
+    }
+
+    /* ── Footer ───────────────────────────────────────────────────────────── */
+
+    .dialog-footer {
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        padding: 1rem 1.5rem;
+        border-top: 1px solid var(--ar-color-border, #e5e7eb);
+        flex-shrink: 0;
+    }
+
+    /* ── Shake (fermeture bloquée) ────────────────────────────────────────── */
+
+    @keyframes dialogShake {
+        0%,
+        100% {
+            transform: none;
+        }
+        20% {
+            transform: translateX(-8px);
+        }
+        40% {
+            transform: translateX(8px);
+        }
+        60% {
+            transform: translateX(-6px);
+        }
+        80% {
+            transform: translateX(4px);
+        }
+    }
+
+    dialog.shake {
+        animation: dialogShake 0.4s ease-out;
+    }
+
+    /* ── prefers-reduced-motion ───────────────────────────────────────────── */
 
     @media (prefers-reduced-motion: reduce) {
         dialog,
-        dialog:not(.closing)[open],
-        dialog[open].closing {
-            transition: none;
-            animation: none;
+        dialog::backdrop {
+            animation: none !important;
+            transition: none !important;
         }
-
-        dialog::backdrop,
-        dialog[open]::backdrop,
-        dialog:where(:not(.closing))[open]::backdrop {
-            transition: none;
-            animation: none;
-        }
-    }
-
-    .modal-dialog {
-        margin: 0 !important;
-    }
-
-    .dialog-header {
-        -moz-column-gap: 0.75rem;
-        column-gap: 0.75rem;
-    }
-
-    .dialog-header .close {
-        ms-flex-item-align: start;
-        align-self: flex-start;
-        min-height: 2.5rem; /* @EvolutionDesign: On force la taille temporairement tant qu'on a pas migré sur la nouvelle charte pour s'assurer d'un bouton en 40x40 */
-    }
-
-    .dialog-content {
-        max-height: calc(100vh - 3.5rem);
-    }
-
-    .dialog-body {
-        overflow-y: auto;
     }
 `;

--- a/packages/core/src/components/dialog/dialog.styles.ts
+++ b/packages/core/src/components/dialog/dialog.styles.ts
@@ -70,13 +70,16 @@ export default css`
     }
 
     @media (prefers-reduced-motion: reduce) {
-        dialog {
+        dialog,
+        dialog:not(.closing)[open],
+        dialog[open].closing {
             transition: none;
             animation: none;
         }
 
         dialog::backdrop,
-        dialog[open]::backdrop {
+        dialog[open]::backdrop,
+        dialog:where(:not(.closing))[open]::backdrop {
             transition: none;
             animation: none;
         }

--- a/packages/core/src/components/dialog/dialog.styles.ts
+++ b/packages/core/src/components/dialog/dialog.styles.ts
@@ -147,7 +147,7 @@ export default css`
         max-height: min(90vh, calc(100dvh - 2rem));
     }
 
-    :host(:not([mode='drawer'])) dialog:not(.closing)[open] {
+    :host(:not([mode='drawer'])) dialog.opening {
         animation: showModal 0.25s ease-out;
     }
 
@@ -175,7 +175,7 @@ export default css`
         margin-inline-end: auto;
     }
 
-    :host([mode='drawer']:not([placement='left'])) dialog:not(.closing)[open] {
+    :host([mode='drawer']:not([placement='left'])) dialog.opening {
         animation: showDrawerRight 0.3s ease-out;
     }
 
@@ -183,7 +183,7 @@ export default css`
         animation: hideDrawerRight 0.25s ease-in forwards;
     }
 
-    :host([mode='drawer'][placement='left']) dialog:not(.closing)[open] {
+    :host([mode='drawer'][placement='left']) dialog.opening {
         animation: showDrawerLeft 0.3s ease-out;
     }
 
@@ -269,6 +269,14 @@ export default css`
 
     dialog.shake {
         animation: dialogShake 0.4s ease-out;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        dialog.shake {
+            animation: none;
+            outline: 3px solid var(--ar-color-danger, #d04442);
+            outline-offset: 2px;
+        }
     }
 
     /* ── prefers-reduced-motion ───────────────────────────────────────────── */

--- a/packages/core/src/components/dialog/dialog.styles.ts
+++ b/packages/core/src/components/dialog/dialog.styles.ts
@@ -1,291 +1,211 @@
 import { css } from 'lit';
+import { dialogAnimations } from './dialog.animations.js';
 
-export default css`
-    /* ── Keyframes ────────────────────────────────────────────────────────── */
+export default [
+    dialogAnimations,
+    css`
+        /* ── Host & tailles ───────────────────────────────────────────────────── */
 
-    @keyframes showModal {
-        from {
-            opacity: 0;
-            transform: translateY(-16px);
+        :host {
+            display: block;
+
+            /* Taille modale par défaut (md = 500px). Surchargeable par --width sur l'instance. */
+            --width: 500px;
         }
-        to {
-            opacity: 1;
-            transform: translateY(0);
+
+        /* Tailles modal */
+        :host([size='sm']) {
+            --width: 360px;
         }
-    }
-
-    @keyframes hideModal {
-        from {
-            opacity: 1;
-            transform: translateY(0);
+        :host([size='md']) {
+            --width: 500px;
         }
-        to {
-            opacity: 0;
-            transform: translateY(-16px);
+        :host([size='lg']) {
+            --width: 800px;
         }
-    }
-
-    @keyframes showDrawerRight {
-        from {
-            transform: translateX(100%);
+        :host([size='xl']) {
+            --width: 1140px;
         }
-        to {
-            transform: translateX(0);
+
+        /* Tailles drawer — ont priorité sur les valeurs modal via la spécificité */
+        :host([mode='drawer']) {
+            --width: 720px;
         }
-    }
-
-    @keyframes hideDrawerRight {
-        from {
-            transform: translateX(0);
+        :host([mode='drawer'][size='sm']) {
+            --width: 360px;
         }
-        to {
-            transform: translateX(100%);
+        :host([mode='drawer'][size='md']) {
+            --width: 720px;
         }
-    }
-
-    @keyframes showDrawerLeft {
-        from {
-            transform: translateX(-100%);
+        :host([mode='drawer'][size='lg']) {
+            --width: 960px;
         }
-        to {
-            transform: translateX(0);
+        :host([mode='drawer'][size='xl']) {
+            --width: 1440px;
         }
-    }
 
-    @keyframes hideDrawerLeft {
-        from {
-            transform: translateX(0);
-        }
-        to {
-            transform: translateX(-100%);
-        }
-    }
+        /* ── Backdrop ─────────────────────────────────────────────────────────── */
 
-    /* ── Host & tailles ───────────────────────────────────────────────────── */
-
-    :host {
-        display: block;
-
-        /* Taille modale par défaut (md = 500px). Surchargeable par --width sur l'instance. */
-        --width: 500px;
-    }
-
-    /* Tailles modal */
-    :host([size='sm']) {
-        --width: 360px;
-    }
-    :host([size='md']) {
-        --width: 500px;
-    }
-    :host([size='lg']) {
-        --width: 800px;
-    }
-    :host([size='xl']) {
-        --width: 1140px;
-    }
-
-    /* Tailles drawer — ont priorité sur les valeurs modal via la spécificité */
-    :host([mode='drawer']) {
-        --width: 720px;
-    }
-    :host([mode='drawer'][size='sm']) {
-        --width: 360px;
-    }
-    :host([mode='drawer'][size='md']) {
-        --width: 720px;
-    }
-    :host([mode='drawer'][size='lg']) {
-        --width: 960px;
-    }
-    :host([mode='drawer'][size='xl']) {
-        --width: 1440px;
-    }
-
-    /* ── Backdrop ─────────────────────────────────────────────────────────── */
-
-    dialog::backdrop {
-        background: rgba(0, 0, 0, 0.5);
-        opacity: 0;
-        transition: opacity 0.25s ease;
-    }
-
-    dialog[open]:not(.closing)::backdrop {
-        opacity: 1;
-    }
-
-    dialog[open].closing::backdrop {
-        opacity: 0;
-        transition: opacity 0.2s ease;
-    }
-
-    /* ── Base dialog ──────────────────────────────────────────────────────── */
-
-    /* Masquer explicitement quand non ouvert — évite que display:flex écrase le display:none natif */
-    dialog:not([open]) {
-        display: none;
-    }
-
-    dialog {
-        display: flex;
-        flex-direction: column;
-        border: none;
-        padding: 0;
-        overflow: hidden;
-        background: var(--ar-color-surface, #fff);
-        color: var(--ar-color-text, #1f2937);
-        box-shadow:
-            0 4px 6px -1px rgba(0, 0, 0, 0.1),
-            0 20px 50px -8px rgba(0, 0, 0, 0.2);
-    }
-
-    /* ── Modal ────────────────────────────────────────────────────────────── */
-
-    :host(:not([mode='drawer'])) dialog {
-        border-radius: 0.5rem;
-        /* max-width artificiel : la modale ne prend jamais toute la largeur même sur mobile */
-        width: min(var(--width), calc(100vw - 2rem));
-        max-height: min(90vh, calc(100dvh - 2rem));
-    }
-
-    :host(:not([mode='drawer'])) dialog.opening {
-        animation: showModal 0.25s ease-out;
-    }
-
-    :host(:not([mode='drawer'])) dialog[open].closing {
-        animation: hideModal 0.2s ease-in forwards;
-    }
-
-    /* ── Drawer ───────────────────────────────────────────────────────────── */
-
-    :host([mode='drawer']) dialog {
-        /* Sur petit écran, le drawer peut occuper 100% de la largeur */
-        width: min(var(--width), 100vw);
-        height: 100dvh;
-        max-height: 100dvh;
-        margin: 0;
-    }
-
-    /* Placement droite (défaut du composant) */
-    :host([mode='drawer']:not([placement='left'])) dialog {
-        margin-inline-start: auto;
-    }
-
-    /* Placement gauche */
-    :host([mode='drawer'][placement='left']) dialog {
-        margin-inline-end: auto;
-    }
-
-    :host([mode='drawer']:not([placement='left'])) dialog.opening {
-        animation: showDrawerRight 0.3s ease-out;
-    }
-
-    :host([mode='drawer']:not([placement='left'])) dialog[open].closing {
-        animation: hideDrawerRight 0.25s ease-in forwards;
-    }
-
-    :host([mode='drawer'][placement='left']) dialog.opening {
-        animation: showDrawerLeft 0.3s ease-out;
-    }
-
-    :host([mode='drawer'][placement='left']) dialog[open].closing {
-        animation: hideDrawerLeft 0.25s ease-in forwards;
-    }
-
-    /* ── Header ───────────────────────────────────────────────────────────── */
-
-    .dialog-header {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: 0.75rem;
-        padding: 1.25rem 1.5rem;
-        border-bottom: 1px solid var(--ar-color-border, #e5e7eb);
-        flex-shrink: 0;
-    }
-
-    .dialog-title {
-        margin: 0;
-        font-size: 1rem;
-        font-weight: 600;
-        line-height: 1.4;
-        color: inherit;
-    }
-
-    .dialog-header .btn-ratio-square {
-        flex-shrink: 0;
-        align-self: flex-start;
-        /* @EvolutionDesign: taille forcée à 40×40 en attendant la migration vers la nouvelle charte */
-        min-height: 2.5rem;
-    }
-
-    .dialog-header .btn-ratio-square svg {
-        width: 1.25rem;
-        height: 1.25rem;
-        flex-shrink: 0;
-    }
-
-    /* ── Body ─────────────────────────────────────────────────────────────── */
-
-    .dialog-body {
-        flex: 1;
-        min-height: 0; /* autorise le shrink flex pour activer le scroll */
-        overflow-y: auto;
-        padding: var(--spacing, 1.5rem);
-    }
-
-    /* ── Footer ───────────────────────────────────────────────────────────── */
-
-    .dialog-footer {
-        display: flex;
-        align-items: center;
-        justify-content: flex-end;
-        flex-wrap: wrap;
-        gap: 0.75rem;
-        padding: 1rem 1.5rem;
-        border-top: 1px solid var(--ar-color-border, #e5e7eb);
-        flex-shrink: 0;
-    }
-
-    /* ── Shake (fermeture bloquée) ────────────────────────────────────────── */
-
-    @keyframes dialogShake {
-        0%,
-        100% {
-            transform: none;
-        }
-        20% {
-            transform: translateX(-8px);
-        }
-        40% {
-            transform: translateX(8px);
-        }
-        60% {
-            transform: translateX(-6px);
-        }
-        80% {
-            transform: translateX(4px);
-        }
-    }
-
-    dialog.shake {
-        animation: dialogShake 0.4s ease-out;
-    }
-
-    @media (prefers-reduced-motion: reduce) {
-        dialog.shake {
-            animation: none;
-            outline: 3px solid var(--ar-color-danger, #d04442);
-            outline-offset: 2px;
-        }
-    }
-
-    /* ── prefers-reduced-motion ───────────────────────────────────────────── */
-
-    @media (prefers-reduced-motion: reduce) {
-        dialog,
         dialog::backdrop {
-            animation: none !important;
-            transition: none !important;
+            background: rgba(0, 0, 0, 0.5);
+            opacity: 0;
+            transition: opacity 0.25s ease;
         }
-    }
-`;
+
+        dialog[open]:not(.closing)::backdrop {
+            opacity: 1;
+        }
+
+        dialog[open].closing::backdrop {
+            opacity: 0;
+            transition: opacity 0.2s ease;
+        }
+
+        /* ── Base dialog ──────────────────────────────────────────────────────── */
+
+        /* Masquer explicitement quand non ouvert — évite que display:flex écrase le display:none natif */
+        dialog:not([open]) {
+            display: none;
+        }
+
+        dialog {
+            display: flex;
+            flex-direction: column;
+            border: none;
+            padding: 0;
+            overflow: hidden;
+            background: var(--ar-color-bg, #fff);
+            color: var(--ar-color-text, #2e2e31);
+            box-shadow:
+                0 4px 6px -1px rgba(0, 0, 0, 0.1),
+                0 20px 50px -8px rgba(0, 0, 0, 0.2);
+        }
+
+        /* ── Modal ────────────────────────────────────────────────────────────── */
+
+        :host(:not([mode='drawer'])) dialog {
+            border-radius: 0.5rem;
+            /* max-width artificiel : la modale ne prend jamais toute la largeur même sur mobile */
+            width: min(var(--width), calc(100vw - 2rem));
+            max-height: min(90vh, calc(100dvh - 2rem));
+        }
+
+        :host(:not([mode='drawer'])) dialog.opening {
+            animation: showModal 0.25s ease-out;
+        }
+
+        :host(:not([mode='drawer'])) dialog[open].closing {
+            animation: hideModal 0.2s ease-in forwards;
+        }
+
+        /* ── Drawer ───────────────────────────────────────────────────────────── */
+
+        :host([mode='drawer']) dialog {
+            /* Sur petit écran, le drawer peut occuper 100% de la largeur */
+            width: min(var(--width), 100vw);
+            height: 100dvh;
+            margin: 0;
+        }
+
+        /* Placement droite (défaut du composant) */
+        :host([mode='drawer']:not([placement='left'])) dialog {
+            margin-inline-start: auto;
+        }
+
+        /* Placement gauche */
+        :host([mode='drawer'][placement='left']) dialog {
+            margin-inline-end: auto;
+        }
+
+        :host([mode='drawer']:not([placement='left'])) dialog.opening {
+            animation: showDrawerRight 0.3s ease-out;
+        }
+
+        :host([mode='drawer']:not([placement='left'])) dialog[open].closing {
+            animation: hideDrawerRight 0.25s ease-in forwards;
+        }
+
+        :host([mode='drawer'][placement='left']) dialog.opening {
+            animation: showDrawerLeft 0.3s ease-out;
+        }
+
+        :host([mode='drawer'][placement='left']) dialog[open].closing {
+            animation: hideDrawerLeft 0.25s ease-in forwards;
+        }
+
+        /* ── Header ───────────────────────────────────────────────────────────── */
+
+        header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 0.75rem;
+            padding: 1.25rem 1.25rem 0;
+            flex-shrink: 0;
+        }
+
+        h1 {
+            margin: 0;
+            font-size: 1rem;
+            font-weight: 600;
+            line-height: 1.4;
+            color: inherit;
+        }
+
+        button {
+            flex-shrink: 0;
+            align-self: flex-start;
+            /* @EvolutionDesign: taille forcée à 40×40 en attendant la migration vers la nouvelle charte */
+            min-height: 2.5rem;
+        }
+
+        svg {
+            width: 1.25rem;
+            height: 1.25rem;
+            flex-shrink: 0;
+        }
+
+        /* ── Body ─────────────────────────────────────────────────────────────── */
+
+        main {
+            flex: 1;
+            min-height: 0; /* autorise le shrink flex pour activer le scroll */
+            overflow-y: auto;
+            padding: var(--spacing, 1.25rem);
+        }
+
+        /* ── Footer ───────────────────────────────────────────────────────────── */
+
+        footer {
+            display: flex;
+            align-items: center;
+            justify-content: flex-end;
+            flex-wrap: wrap;
+            gap: 0.75rem;
+            padding: 0 1.25rem 1.25rem;
+            flex-shrink: 0;
+        }
+
+        /* ── Shake (fermeture bloquée) ────────────────────────────────────────── */
+
+        dialog.shake {
+            animation: dialogShake 0.4s ease-out;
+        }
+
+        /* ── prefers-reduced-motion ───────────────────────────────────────────── */
+
+        @media (prefers-reduced-motion: reduce) {
+            dialog,
+            dialog::backdrop {
+                animation: none !important;
+                transition: none !important;
+            }
+
+            dialog.shake {
+                animation: none;
+                outline: 3px solid var(--ar-color-danger, #d04442);
+                outline-offset: 2px;
+            }
+        }
+    `,
+];

--- a/packages/core/src/components/dialog/dialog.styles.ts
+++ b/packages/core/src/components/dialog/dialog.styles.ts
@@ -1,0 +1,107 @@
+import { css } from 'lit';
+
+export default css`
+    :host {
+        display: block;
+        box-sizing: border-box;
+    }
+
+    /* Animation de l'apparition */
+    @keyframes showDialog {
+        from {
+            transform: translate(0, -50px);
+            opacity: 0;
+        }
+        to {
+            transform: translate(0, 0);
+            opacity: 1;
+        }
+    }
+
+    @keyframes hideDialog {
+        from {
+            transform: translate(0, 0);
+            opacity: 1;
+        }
+        to {
+            transform: translate(0, -50px);
+            opacity: 0;
+        }
+    }
+
+    @keyframes showBackdrop {
+        from {
+            opacity: 0;
+        }
+        to {
+            opacity: 0.5;
+        }
+    }
+
+    dialog::backdrop {
+        opacity: 0;
+        background: black;
+        transition: opacity linear 0.4s;
+    }
+
+    dialog.closing::backdrop {
+        opacity: 0;
+    }
+
+    dialog:where(:not(.closing))[open]::backdrop {
+        opacity: 0.5;
+        animation: showBackdrop 0.4s;
+    }
+
+    dialog {
+        border: none;
+        background: none;
+        padding: 0;
+        box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
+    }
+
+    dialog:not(.closing)[open] {
+        animation: showDialog 0.4s;
+    }
+
+    dialog[open].closing {
+        opacity: 0;
+        animation: hideDialog 0.4s;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        dialog {
+            transition: none;
+            animation: none;
+        }
+
+        dialog::backdrop,
+        dialog[open]::backdrop {
+            transition: none;
+            animation: none;
+        }
+    }
+
+    .modal-dialog {
+        margin: 0 !important;
+    }
+
+    .modal-header {
+        -moz-column-gap: 0.75rem;
+        column-gap: 0.75rem;
+    }
+
+    .modal-header .close {
+        ms-flex-item-align: start;
+        align-self: flex-start;
+        min-height: 2.5rem; /* @EvolutionDesign: On force la taille temporairement tant qu'on a pas migré sur la nouvelle charte pour s'assurer d'un bouton en 40x40 */
+    }
+
+    .modal-content {
+        max-height: calc(100vh - 3.5rem);
+    }
+
+    .modal-body {
+        overflow-y: auto;
+    }
+`;

--- a/packages/core/src/components/dialog/dialog.styles.ts
+++ b/packages/core/src/components/dialog/dialog.styles.ts
@@ -87,6 +87,8 @@ export default [
             border-radius: 0.5rem;
             /* max-width artificiel : la modale ne prend jamais toute la largeur même sur mobile */
             width: min(var(--width), calc(100vw - 2rem));
+            /* height + max-height : requis pour que flex:1 sur le body soit contraint en Safari */
+            height: min(90vh, calc(100dvh - 2rem));
             max-height: min(90vh, calc(100dvh - 2rem));
         }
 

--- a/packages/core/src/components/dialog/dialog.styles.ts
+++ b/packages/core/src/components/dialog/dialog.styles.ts
@@ -171,7 +171,8 @@ export default [
             flex: 1;
             min-height: 0; /* autorise le shrink flex pour activer le scroll */
             overflow-y: auto;
-            padding: var(--spacing, 1.25rem);
+            padding-block: var(--spacing-block, var(--spacing, 1.25rem));
+            padding-inline: var(--spacing-inline, var(--spacing, 1.25rem));
         }
 
         /* ── Footer ───────────────────────────────────────────────────────────── */

--- a/packages/core/src/components/dialog/dialog.styles.ts
+++ b/packages/core/src/components/dialog/dialog.styles.ts
@@ -87,8 +87,6 @@ export default [
             border-radius: 0.5rem;
             /* max-width artificiel : la modale ne prend jamais toute la largeur même sur mobile */
             width: min(var(--width), calc(100vw - 2rem));
-            /* height + max-height : requis pour que flex:1 sur le body soit contraint en Safari */
-            height: min(90vh, calc(100dvh - 2rem));
             max-height: min(90vh, calc(100dvh - 2rem));
         }
 
@@ -106,6 +104,8 @@ export default [
             /* Sur petit écran, le drawer peut occuper 100% de la largeur */
             width: min(var(--width), 100vw);
             height: 100dvh;
+            /* max-height: override le défaut UA qui plafonne à calc(100% - 6px - 2em) */
+            max-height: 100dvh;
             margin: 0;
         }
 
@@ -170,8 +170,8 @@ export default [
         /* ── Body ─────────────────────────────────────────────────────────────── */
 
         [part='body'] {
-            flex: 1;
-            min-height: 0; /* autorise le shrink flex pour activer le scroll */
+            flex: 1 1 auto;
+            min-height: 0;
             overflow-y: auto;
             padding-block: var(--spacing-block, var(--spacing, 1.25rem));
             padding-inline: var(--spacing-inline, var(--spacing, 1.25rem));

--- a/packages/core/src/components/dialog/dialog.styles.ts
+++ b/packages/core/src/components/dialog/dialog.styles.ts
@@ -86,22 +86,22 @@ export default css`
         margin: 0 !important;
     }
 
-    .modal-header {
+    .dialog-header {
         -moz-column-gap: 0.75rem;
         column-gap: 0.75rem;
     }
 
-    .modal-header .close {
+    .dialog-header .close {
         ms-flex-item-align: start;
         align-self: flex-start;
         min-height: 2.5rem; /* @EvolutionDesign: On force la taille temporairement tant qu'on a pas migré sur la nouvelle charte pour s'assurer d'un bouton en 40x40 */
     }
 
-    .modal-content {
+    .dialog-content {
         max-height: calc(100vh - 3.5rem);
     }
 
-    .modal-body {
+    .dialog-body {
         overflow-y: auto;
     }
 `;

--- a/packages/core/src/components/dialog/dialog.styles.ts
+++ b/packages/core/src/components/dialog/dialog.styles.ts
@@ -167,7 +167,7 @@ export default [
 
         /* ── Body ─────────────────────────────────────────────────────────────── */
 
-        main {
+        [part='body'] {
             flex: 1;
             min-height: 0; /* autorise le shrink flex pour activer le scroll */
             overflow-y: auto;

--- a/packages/core/src/components/dialog/dialog.test.ts
+++ b/packages/core/src/components/dialog/dialog.test.ts
@@ -108,9 +108,16 @@ describe('ArDialog', () => {
             expect(el.closeOnBackdrop).toBe(true);
         });
 
-        it('prevented-message est lu depuis l’attribut', async () => {
+        it("prevented-message est lu depuis l'attribut", async () => {
             el = await fixture('<ar-dialog prevented-message="Action refusée."></ar-dialog>');
             expect(el.preventedMessage).toBe('Action refusée.');
+        });
+
+        it('preventedMessage reflète en attribut', async () => {
+            el = await fixture('<ar-dialog></ar-dialog>');
+            el.preventedMessage = 'Bloqué.';
+            await waitForUpdate(el);
+            expect(el.getAttribute('prevented-message')).toBe('Bloqué.');
         });
     });
 
@@ -480,7 +487,7 @@ describe('ArDialog', () => {
             vi.restoreAllMocks();
         });
 
-        it('affiche un fallback visible si aucun label n’est fourni', async () => {
+        it("affiche un fallback visible si aucun label n'est fourni", async () => {
             el = await fixture('<ar-dialog></ar-dialog>');
             const title = requireShadow(el).getElementById('dialog-heading');
             expect(title?.textContent?.trim()).toBe('Dialogue');
@@ -501,7 +508,7 @@ describe('ArDialog', () => {
             expect(text).toBe('Titre personnalisé');
         });
 
-        it('affiche un warning si aucun label explicite n’est fourni', async () => {
+        it("affiche un warning si aucun label explicite n'est fourni", async () => {
             const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
             el = await fixture('<ar-dialog></ar-dialog>');
             expect(spy).toHaveBeenCalledWith(

--- a/packages/core/src/components/dialog/dialog.test.ts
+++ b/packages/core/src/components/dialog/dialog.test.ts
@@ -55,6 +55,13 @@ describe('ArDialog', () => {
         it('contient un bouton close avec data-ar-dismiss', () => {
             expect(requireShadow(el).querySelector('[data-ar-dismiss]')).not.toBeNull();
         });
+
+        it("le bouton close n'a pas d'aria-describedby", async () => {
+            el = await fixture('<ar-dialog></ar-dialog>');
+            const closeBtn = requireShadow(el).querySelector('[data-ar-dismiss]');
+            expect(closeBtn).not.toBeNull();
+            expect((closeBtn as HTMLElement).hasAttribute('aria-describedby')).toBe(false);
+        });
     });
 
     // ── Valeurs par défaut ────────────────────────────────────────────────────

--- a/packages/core/src/components/dialog/dialog.test.ts
+++ b/packages/core/src/components/dialog/dialog.test.ts
@@ -14,7 +14,10 @@ function getDialogEl(el: ArDialog): HTMLDialogElement {
 describe('ArDialog', () => {
     let el: ArDialog;
 
-    afterEach(() => el?.remove());
+    afterEach(() => {
+        el?.remove();
+        document.querySelectorAll('[data-ar-live-region]').forEach((node) => node.remove());
+    });
 
     // ── Rendu ─────────────────────────────────────────────────────────────────
 
@@ -128,18 +131,6 @@ describe('ArDialog', () => {
             expect(getPart(el, 'footer')).not.toBeNull();
         });
 
-        it('apparaît dynamiquement après injection d\'un enfant slot="footer"', async () => {
-            el = await fixture('<ar-dialog></ar-dialog>');
-            expect(getPart(el, 'footer')).toBeNull();
-
-            const btn = document.createElement('button');
-            btn.setAttribute('slot', 'footer');
-            el.appendChild(btn);
-            await waitForUpdate(el);
-
-            expect(getPart(el, 'footer')).not.toBeNull();
-        });
-
         it('disparaît dynamiquement si le slot="footer" est retiré', async () => {
             el = await fixture(`
                 <ar-dialog>
@@ -202,6 +193,7 @@ describe('ArDialog', () => {
             el.open = true;
             await waitForUpdate(el);
             expect(getDialogEl(el).open).toBe(false);
+            expect(el.open).toBe(false);
         });
 
         it('open=true deux fois ne double-appelle pas showModal', async () => {
@@ -223,6 +215,25 @@ describe('ArDialog', () => {
             el.open = true;
             await waitForUpdate(el);
             expect(detailId).toBe('dialog-events');
+        });
+
+        it('peut être rouvert après une ouverture annulée', async () => {
+            el = await fixture('<ar-dialog></ar-dialog>');
+            let prevented = true;
+            el.addEventListener('ar-dialog-show', (e) => {
+                if (prevented) {
+                    e.preventDefault();
+                    prevented = false;
+                }
+            });
+
+            el.open = true;
+            await waitForUpdate(el);
+            expect(el.open).toBe(false);
+
+            el.open = true;
+            await waitForUpdate(el);
+            expect(getDialogEl(el).open).toBe(true);
         });
     });
 
@@ -290,14 +301,15 @@ describe('ArDialog', () => {
 
         it('réannonce le message par défaut si preventedMessage est vide', async () => {
             el.preventedMessage = '   ';
-            const liveRegion = requireShadow(el).getElementById('dialog-status');
 
             el.addEventListener('ar-dialog-hide', (e) => e.preventDefault());
             el.open = false;
             await waitForUpdate(el);
             await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
 
-            expect(liveRegion?.textContent).toBe('Fermeture bloquée.');
+            expect(document.getElementById('ar-live-region-assertive')?.textContent).toBe(
+                'Fermeture bloquée.',
+            );
         });
     });
 
@@ -321,7 +333,7 @@ describe('ArDialog', () => {
             // On simule data-ar-accept sur un élément shadow DOM (même code path que composedPath).
             const handler = vi.fn();
             el.addEventListener('ar-dialog-accepted', handler);
-            const body = requireShadow(el).querySelector('.dialog-body') as HTMLElement;
+            const body = requireShadow(el).querySelector('[part="body"]') as HTMLElement;
             body.setAttribute('data-ar-accept', '');
             body.click();
             body.removeAttribute('data-ar-accept');
@@ -343,7 +355,7 @@ describe('ArDialog', () => {
             const prevented = vi.fn();
             el.addEventListener('ar-dialog-accepted', (e) => e.preventDefault());
             el.addEventListener('ar-dialog-accepted-prevented', prevented);
-            const body = requireShadow(el).querySelector('.dialog-body') as HTMLElement;
+            const body = requireShadow(el).querySelector('[part="body"]') as HTMLElement;
             body.setAttribute('data-ar-accept', '');
             body.click();
             body.removeAttribute('data-ar-accept');
@@ -382,7 +394,7 @@ describe('ArDialog', () => {
             el.closeOnBackdrop = true;
             await waitForUpdate(el);
             const dialogEl = getDialogEl(el);
-            const body = requireShadow(el).querySelector('.dialog-body') as Element;
+            const body = requireShadow(el).querySelector('[part="body"]') as Element;
             body.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
             dialogEl.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
             await waitForUpdate(el);
@@ -458,6 +470,52 @@ describe('ArDialog', () => {
             await waitForUpdate(el);
             await waitForUpdate(el);
             expect(focusSpy).toHaveBeenCalled();
+        });
+    });
+
+    // ── Label accessible ─────────────────────────────────────────────────────
+
+    describe('label accessible', () => {
+        afterEach(() => {
+            vi.restoreAllMocks();
+        });
+
+        it('affiche un fallback visible si aucun label n’est fourni', async () => {
+            el = await fixture('<ar-dialog></ar-dialog>');
+            const title = requireShadow(el).getElementById('dialog-heading');
+            expect(title?.textContent?.trim()).toBe('Dialogue');
+        });
+
+        it('utilise le slot label quand un libellé slotté est fourni', async () => {
+            el = await fixture(
+                '<ar-dialog><span slot="label">Titre personnalisé</span></ar-dialog>',
+            );
+            await waitForUpdate(el);
+            const slot = requireShadow(el).querySelector<HTMLSlotElement>('slot[name="label"]');
+            expect(slot).not.toBeNull();
+            const text = slot
+                ?.assignedNodes({ flatten: true })
+                .map((n) => n.textContent)
+                .join('')
+                .trim();
+            expect(text).toBe('Titre personnalisé');
+        });
+
+        it('affiche un warning si aucun label explicite n’est fourni', async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            el = await fixture('<ar-dialog></ar-dialog>');
+            expect(spy).toHaveBeenCalledWith(
+                expect.stringContaining('Aucun libellé accessible fourni'),
+                el,
+            );
+        });
+
+        it('ne répète pas le warning plusieurs fois pour la même instance', async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            el = await fixture('<ar-dialog></ar-dialog>');
+            el.appendChild(document.createTextNode(' '));
+            await waitForUpdate(el);
+            expect(spy).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/packages/core/src/components/dialog/dialog.test.ts
+++ b/packages/core/src/components/dialog/dialog.test.ts
@@ -1,39 +1,19 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ArDialog } from './dialog.js';
-import { fixture, getPart } from '../../test-utils.js';
-// import { fixture, waitForUpdate, getPart, requirePart } from '../../test-utils.js';
+import { fixture, waitForUpdate, getPart, requireShadow } from '../../test-utils.js';
 import './dialog.js';
 
-// ─── Aide-mémoire tests Lit ────────────────────────────────────────────────────
-//
-// fixture(html)          — monte un élément dans le DOM et attend le premier rendu
-// waitForUpdate(el)      — attend le prochain cycle de rendu après une mutation
-// getPart(el, 'name')    — retourne un part="name" du Shadow DOM (| null)
-//                          → utiliser pour les assertions .toBeNull() / .not.toBeNull()
-// requirePart(el, 'name')— idem, mais lance une erreur si absent
-//                          → utiliser quand on enchaîne .getAttribute, .classList, etc.
-//
-// ⚠ happy-dom ne sérialise pas les Text nodes dynamiques Lit en textContent.
-//   Tester le contenu textuel via la propriété JS (el.myProp) plutôt que textContent.
-//
-// ⚠ Les propriétés ARIA assignées via .ariaCurrent, .ariaExpanded, etc. (liaisons
-//   Lit) ne reflètent pas en attribut HTML dans happy-dom. Tester la propriété
-//   JS : (el as unknown as { ariaCurrent: string }).ariaCurrent.
-//
-// ─── Éléments à tester selon le type de composant ─────────────────────────────
-//
-// Composant standard (avec Shadow DOM) :
-//   - Rendu : shadowRoot non null, parts présents (getPart)
-//   - Valeurs par défaut : vérifier chaque propriété à l'état initial
-//   - Attributs reflect : el.prop = x → await waitForUpdate → el.getAttribute(...)
-//   - Comportement : interactions (clic, événements custom)
-//   - Accessibilité : role, aria-*, labels sr-only
-//
-// Sous-composant (sans Shadow DOM, createRenderRoot → this) :
-//   - shadowRoot est null
-//   - setRegistry() appelle registerItem / unregisterItem
-//   - disconnectedCallback() appelle unregisterItem
-//   - updated() appelle notifyItemChanged après le premier rendu seulement
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function getDialogEl(el: ArDialog): HTMLDialogElement {
+    return requireShadow(el).querySelector('dialog') as HTMLDialogElement;
+}
+
+/** Simule la fin de l'animation de fermeture. */
+function fireAnimationEnd(el: ArDialog): void {
+    getDialogEl(el).dispatchEvent(new Event('animationend'));
+}
+
 // ──────────────────────────────────────────────────────────────────────────────
 
 describe('ArDialog', () => {
@@ -52,16 +32,416 @@ describe('ArDialog', () => {
             expect(el.shadowRoot).not.toBeNull();
         });
 
-        it('contient un élément racine avec part="dialog"', () => {
+        it('contient part="dialog"', () => {
             expect(getPart(el, 'dialog')).not.toBeNull();
+        });
+
+        it('contient part="header"', () => {
+            expect(getPart(el, 'header')).not.toBeNull();
+        });
+
+        it('contient part="title"', () => {
+            expect(getPart(el, 'title')).not.toBeNull();
+        });
+
+        it('contient part="body"', () => {
+            expect(getPart(el, 'body')).not.toBeNull();
+        });
+
+        it('ne contient pas part="footer" sans slot footer', () => {
+            expect(getPart(el, 'footer')).toBeNull();
+        });
+
+        it('contient un bouton close avec data-ar-dismiss', () => {
+            expect(requireShadow(el).querySelector('[data-ar-dismiss]')).not.toBeNull();
         });
     });
 
     // ── Valeurs par défaut ────────────────────────────────────────────────────
 
-    // describe('valeurs par défaut', () => { ... });
+    describe('valeurs par défaut', () => {
+        beforeEach(async () => {
+            el = await fixture('<ar-dialog></ar-dialog>');
+        });
 
-    // ── Propriétés ────────────────────────────────────────────────────────────
+        it('open est false', () => expect(el.open).toBe(false));
+        it('staticBackdrop est false', () => expect(el.staticBackdrop).toBe(false));
+        it('label est vide', () => expect(el.label).toBe(''));
+        it('mode est modal', () => expect(el.mode).toBe('modal'));
+        it('placement est right', () => expect(el.placement).toBe('right'));
+        it('size est md', () => expect(el.size).toBe('md'));
+    });
 
-    // describe('propriétés', () => { ... });
+    // ── Propriétés reflect ────────────────────────────────────────────────────
+
+    describe('propriétés reflect', () => {
+        it('label reflète en attribut', async () => {
+            el = await fixture('<ar-dialog label="Mon titre"></ar-dialog>');
+            expect(el.getAttribute('label')).toBe('Mon titre');
+        });
+
+        it('mode reflète en attribut', async () => {
+            el = await fixture('<ar-dialog mode="panel"></ar-dialog>');
+            expect(el.getAttribute('mode')).toBe('panel');
+        });
+
+        it('size reflète en attribut', async () => {
+            el = await fixture('<ar-dialog size="lg"></ar-dialog>');
+            expect(el.getAttribute('size')).toBe('lg');
+        });
+
+        it('placement reflète en attribut', async () => {
+            el = await fixture('<ar-dialog placement="left"></ar-dialog>');
+            expect(el.getAttribute('placement')).toBe('left');
+        });
+
+        it('static-backdrop reflète en attribut', async () => {
+            el = await fixture('<ar-dialog static-backdrop></ar-dialog>');
+            expect(el.hasAttribute('static-backdrop')).toBe(true);
+            expect(el.staticBackdrop).toBe(true);
+        });
+    });
+
+    // ── Footer conditionnel ───────────────────────────────────────────────────
+
+    describe('footer conditionnel', () => {
+        it('est absent du DOM si aucun enfant slot="footer"', async () => {
+            el = await fixture('<ar-dialog></ar-dialog>');
+            expect(getPart(el, 'footer')).toBeNull();
+        });
+
+        it('est présent si un enfant slot="footer" est fourni', async () => {
+            el = await fixture(`
+                <ar-dialog>
+                    <button slot="footer">OK</button>
+                </ar-dialog>
+            `);
+            expect(getPart(el, 'footer')).not.toBeNull();
+        });
+
+        it('apparaît dynamiquement après injection d\'un enfant slot="footer"', async () => {
+            el = await fixture('<ar-dialog></ar-dialog>');
+            expect(getPart(el, 'footer')).toBeNull();
+
+            const btn = document.createElement('button');
+            btn.setAttribute('slot', 'footer');
+            el.appendChild(btn);
+            await waitForUpdate(el);
+
+            expect(getPart(el, 'footer')).not.toBeNull();
+        });
+
+        it('disparaît dynamiquement si le slot="footer" est retiré', async () => {
+            el = await fixture(`
+                <ar-dialog>
+                    <button slot="footer" id="f">OK</button>
+                </ar-dialog>
+            `);
+            expect(getPart(el, 'footer')).not.toBeNull();
+
+            (el.querySelector('#f') as Element).remove();
+            await waitForUpdate(el);
+
+            expect(getPart(el, 'footer')).toBeNull();
+        });
+    });
+
+    // ── Ouverture ─────────────────────────────────────────────────────────────
+
+    describe('ouverture', () => {
+        it('open=true appelle showModal et dialog.open est true', async () => {
+            el = await fixture('<ar-dialog></ar-dialog>');
+            const spy = vi.spyOn(getDialogEl(el), 'showModal');
+            el.open = true;
+            await waitForUpdate(el);
+            expect(spy).toHaveBeenCalledOnce();
+        });
+
+        it('firstUpdated ouvre le dialog si open=true au chargement', async () => {
+            el = await fixture('<ar-dialog open></ar-dialog>');
+            expect(getDialogEl(el).open).toBe(true);
+        });
+
+        it("gèle le scroll body à l'ouverture", async () => {
+            el = await fixture('<ar-dialog></ar-dialog>');
+            el.open = true;
+            await waitForUpdate(el);
+            expect(document.body.style.overflow).toBe('hidden');
+        });
+
+        it("émet ar-dialog-show avant l'ouverture", async () => {
+            el = await fixture('<ar-dialog></ar-dialog>');
+            const handler = vi.fn();
+            el.addEventListener('ar-dialog-show', handler);
+            el.open = true;
+            await waitForUpdate(el);
+            expect(handler).toHaveBeenCalledOnce();
+        });
+
+        it("émet ar-dialog-shown après l'ouverture", async () => {
+            el = await fixture('<ar-dialog></ar-dialog>');
+            const handler = vi.fn();
+            el.addEventListener('ar-dialog-shown', handler);
+            el.open = true;
+            await waitForUpdate(el);
+            expect(handler).toHaveBeenCalledOnce();
+        });
+
+        it("ar-dialog-show annulable empêche l'ouverture", async () => {
+            el = await fixture('<ar-dialog></ar-dialog>');
+            el.addEventListener('ar-dialog-show', (e) => e.preventDefault());
+            el.open = true;
+            await waitForUpdate(el);
+            expect(getDialogEl(el).open).toBe(false);
+        });
+
+        it('open=true deux fois ne double-appelle pas showModal', async () => {
+            el = await fixture('<ar-dialog></ar-dialog>');
+            el.open = true;
+            await waitForUpdate(el);
+            const spy = vi.spyOn(getDialogEl(el), 'showModal');
+            el.open = true;
+            await waitForUpdate(el);
+            expect(spy).not.toHaveBeenCalled();
+        });
+    });
+
+    // ── Fermeture ─────────────────────────────────────────────────────────────
+
+    describe('fermeture', () => {
+        beforeEach(async () => {
+            el = await fixture('<ar-dialog open></ar-dialog>');
+        });
+
+        it('ferme le <dialog> natif après animationend', async () => {
+            el.open = false;
+            await waitForUpdate(el);
+            fireAnimationEnd(el);
+            await waitForUpdate(el);
+            expect(getDialogEl(el).open).toBe(false);
+        });
+
+        it('restaure le scroll après fermeture', async () => {
+            el.open = false;
+            await waitForUpdate(el);
+            fireAnimationEnd(el);
+            await waitForUpdate(el);
+            expect(document.body.style.overflow).not.toBe('hidden');
+        });
+
+        it('émet ar-dialog-hide avant la fermeture', async () => {
+            const handler = vi.fn();
+            el.addEventListener('ar-dialog-hide', handler);
+            el.open = false;
+            await waitForUpdate(el);
+            expect(handler).toHaveBeenCalledOnce();
+        });
+
+        it('émet ar-dialog-hidden après la fermeture', async () => {
+            const handler = vi.fn();
+            el.addEventListener('ar-dialog-hidden', handler);
+            el.open = false;
+            await waitForUpdate(el);
+            fireAnimationEnd(el);
+            await waitForUpdate(el);
+            expect(handler).toHaveBeenCalledOnce();
+        });
+
+        it('ar-dialog-hide annulable maintient el.open=true et émet ar-dialog-hide-prevented', async () => {
+            const prevented = vi.fn();
+            el.addEventListener('ar-dialog-hide', (e) => e.preventDefault());
+            el.addEventListener('ar-dialog-hide-prevented', prevented);
+            el.open = false;
+            await waitForUpdate(el);
+            expect(el.open).toBe(true);
+            expect(prevented).toHaveBeenCalledOnce();
+        });
+
+        it('_isClosing bloque un double-appel à _close', async () => {
+            el.open = false;
+            await waitForUpdate(el);
+            const spy = vi.spyOn(getDialogEl(el), 'close');
+            // Tenter de refermer pendant que la fermeture est déjà en cours
+            el.open = false;
+            await waitForUpdate(el);
+            fireAnimationEnd(el);
+            await waitForUpdate(el);
+            // close() ne doit être appelé qu'une seule fois
+            expect(spy).toHaveBeenCalledOnce();
+        });
+
+        it('fermeture immédiate avec prefers-reduced-motion', async () => {
+            vi.spyOn(window, 'matchMedia').mockReturnValue({
+                matches: true,
+                addEventListener: vi.fn(),
+                removeEventListener: vi.fn(),
+            } as unknown as MediaQueryList);
+
+            el.open = false;
+            await waitForUpdate(el);
+            // Pas besoin d'animationend — fermeture synchrone
+            expect(getDialogEl(el).open).toBe(false);
+
+            vi.restoreAllMocks();
+        });
+
+        it('le fallback timeout déclenche _finishClose si animationend ne tire pas', async () => {
+            vi.useFakeTimers();
+            el.open = false;
+            await waitForUpdate(el);
+            expect(getDialogEl(el).open).toBe(true); // pas encore fermé
+            vi.advanceTimersByTime(600);
+            await waitForUpdate(el);
+            expect(getDialogEl(el).open).toBe(false);
+            vi.useRealTimers();
+        });
+    });
+
+    // ── data-ar-dismiss / data-ar-accept ──────────────────────────────────────
+
+    describe('dismiss / accept', () => {
+        beforeEach(async () => {
+            el = await fixture('<ar-dialog open></ar-dialog>');
+        });
+
+        it('clic sur data-ar-dismiss émet ar-dialog-dismissed et ferme', async () => {
+            const handler = vi.fn();
+            el.addEventListener('ar-dialog-dismissed', handler);
+            (requireShadow(el).querySelector('[data-ar-dismiss]') as HTMLElement).click();
+            await waitForUpdate(el);
+            expect(handler).toHaveBeenCalledOnce();
+        });
+
+        it('clic sur data-ar-accept émet ar-dialog-accepted', async () => {
+            // happy-dom ne propage pas les clicks slottés dans le shadow DOM.
+            // On simule data-ar-accept sur un élément shadow DOM (même code path que composedPath).
+            const handler = vi.fn();
+            el.addEventListener('ar-dialog-accepted', handler);
+            const body = requireShadow(el).querySelector('.dialog-body') as HTMLElement;
+            body.setAttribute('data-ar-accept', '');
+            body.click();
+            body.removeAttribute('data-ar-accept');
+            await waitForUpdate(el);
+            expect(handler).toHaveBeenCalledOnce();
+        });
+
+        it('ar-dialog-dismissed annulable émet ar-dialog-dismissed-prevented', async () => {
+            const prevented = vi.fn();
+            el.addEventListener('ar-dialog-dismissed', (e) => e.preventDefault());
+            el.addEventListener('ar-dialog-dismissed-prevented', prevented);
+            (requireShadow(el).querySelector('[data-ar-dismiss]') as HTMLElement).click();
+            await waitForUpdate(el);
+            expect(prevented).toHaveBeenCalledOnce();
+            expect(el.open).toBe(true);
+        });
+
+        it('ar-dialog-accepted annulable émet ar-dialog-accepted-prevented', async () => {
+            const prevented = vi.fn();
+            el.addEventListener('ar-dialog-accepted', (e) => e.preventDefault());
+            el.addEventListener('ar-dialog-accepted-prevented', prevented);
+            const body = requireShadow(el).querySelector('.dialog-body') as HTMLElement;
+            body.setAttribute('data-ar-accept', '');
+            body.click();
+            body.removeAttribute('data-ar-accept');
+            await waitForUpdate(el);
+            expect(prevented).toHaveBeenCalledOnce();
+            expect(el.open).toBe(true);
+        });
+    });
+
+    // ── Backdrop click ────────────────────────────────────────────────────────
+
+    describe('backdrop', () => {
+        beforeEach(async () => {
+            el = await fixture('<ar-dialog open></ar-dialog>');
+        });
+
+        it('pointerdown + pointerup sur le dialog (backdrop) ferme', async () => {
+            const dialogEl = getDialogEl(el);
+            dialogEl.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+            dialogEl.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+            await waitForUpdate(el);
+            // _isClosing est true (fermeture démarrée)
+            expect((el as unknown as { _isClosing: boolean })._isClosing).toBe(true);
+        });
+
+        it('pointerdown sur enfant + pointerup sur dialog (drag) ne ferme pas', async () => {
+            const dialogEl = getDialogEl(el);
+            const body = requireShadow(el).querySelector('.dialog-body') as Element;
+            body.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+            dialogEl.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+            await waitForUpdate(el);
+            expect((el as unknown as { _isClosing: boolean })._isClosing).toBe(false);
+        });
+
+        it('static-backdrop : backdrop click ne ferme pas', async () => {
+            el.staticBackdrop = true;
+            await waitForUpdate(el);
+            const dialogEl = getDialogEl(el);
+            dialogEl.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+            dialogEl.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+            await waitForUpdate(el);
+            expect((el as unknown as { _isClosing: boolean })._isClosing).toBe(false);
+        });
+    });
+
+    // ── Clavier ───────────────────────────────────────────────────────────────
+
+    describe('clavier', () => {
+        it('Escape ferme le dialog ouvert', async () => {
+            el = await fixture('<ar-dialog open></ar-dialog>');
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+            await waitForUpdate(el);
+            expect((el as unknown as { _isClosing: boolean })._isClosing).toBe(true);
+        });
+
+        it('Escape ignoré si dialog fermé', async () => {
+            el = await fixture('<ar-dialog></ar-dialog>');
+            const spy = vi.spyOn(getDialogEl(el), 'close');
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+            await waitForUpdate(el);
+            expect(spy).not.toHaveBeenCalled();
+        });
+
+        it('cancel natif sur le dialog est annulé (empêche fermeture native)', async () => {
+            el = await fixture('<ar-dialog open></ar-dialog>');
+            const event = new Event('cancel', { cancelable: true, bubbles: true });
+            getDialogEl(el).dispatchEvent(event);
+            expect(event.defaultPrevented).toBe(true);
+        });
+    });
+
+    // ── Scroll management ─────────────────────────────────────────────────────
+
+    describe('scroll', () => {
+        it("gèle le scroll à l'ouverture et le restaure à la fermeture", async () => {
+            el = await fixture('<ar-dialog></ar-dialog>');
+            el.open = true;
+            await waitForUpdate(el);
+            expect(document.body.style.overflow).toBe('hidden');
+
+            el.open = false;
+            await waitForUpdate(el);
+            fireAnimationEnd(el);
+            await waitForUpdate(el);
+            expect(document.body.style.overflow).not.toBe('hidden');
+        });
+    });
+
+    // ── Trigger externe ───────────────────────────────────────────────────────
+
+    describe('trigger externe data-ar-dialog-open', () => {
+        it('un bouton data-ar-dialog-open="id" ouvre le dialog correspondant', async () => {
+            el = await fixture('<ar-dialog id="test-dialog-ext"></ar-dialog>');
+            const btn = document.createElement('button');
+            btn.setAttribute('data-ar-dialog-open', 'test-dialog-ext');
+            document.body.appendChild(btn);
+
+            btn.click();
+            await waitForUpdate(el);
+            expect(el.open).toBe(true);
+
+            btn.remove();
+        });
+    });
 });

--- a/packages/core/src/components/dialog/dialog.test.ts
+++ b/packages/core/src/components/dialog/dialog.test.ts
@@ -9,11 +9,6 @@ function getDialogEl(el: ArDialog): HTMLDialogElement {
     return requireShadow(el).querySelector('dialog') as HTMLDialogElement;
 }
 
-/** Simule la fin de l'animation de fermeture. */
-function fireAnimationEnd(el: ArDialog): void {
-    getDialogEl(el).dispatchEvent(new Event('animationend'));
-}
-
 // ──────────────────────────────────────────────────────────────────────────────
 
 describe('ArDialog', () => {
@@ -77,6 +72,8 @@ describe('ArDialog', () => {
         it('mode est modal', () => expect(el.mode).toBe('modal'));
         it('placement est right', () => expect(el.placement).toBe('right'));
         it('size est md', () => expect(el.size).toBe('md'));
+        it('preventedMessage a sa valeur par défaut', () =>
+            expect(el.preventedMessage).toBe('Fermeture bloquée.'));
     });
 
     // ── Propriétés reflect ────────────────────────────────────────────────────
@@ -106,6 +103,11 @@ describe('ArDialog', () => {
             el = await fixture('<ar-dialog close-on-backdrop></ar-dialog>');
             expect(el.hasAttribute('close-on-backdrop')).toBe(true);
             expect(el.closeOnBackdrop).toBe(true);
+        });
+
+        it('prevented-message est lu depuis l’attribut', async () => {
+            el = await fixture('<ar-dialog prevented-message="Action refusée."></ar-dialog>');
+            expect(el.preventedMessage).toBe('Action refusée.');
         });
     });
 
@@ -211,6 +213,17 @@ describe('ArDialog', () => {
             await waitForUpdate(el);
             expect(spy).not.toHaveBeenCalled();
         });
+
+        it("ar-dialog-show expose l'id du composant dans detail", async () => {
+            el = await fixture('<ar-dialog id="dialog-events"></ar-dialog>');
+            let detailId: string | undefined;
+            el.addEventListener('ar-dialog-show', (event) => {
+                detailId = (event as CustomEvent<{ id?: string }>).detail.id;
+            });
+            el.open = true;
+            await waitForUpdate(el);
+            expect(detailId).toBe('dialog-events');
+        });
     });
 
     // ── Fermeture ─────────────────────────────────────────────────────────────
@@ -220,36 +233,10 @@ describe('ArDialog', () => {
             el = await fixture('<ar-dialog open></ar-dialog>');
         });
 
-        it('ferme le <dialog> natif après animationend', async () => {
-            el.open = false;
-            await waitForUpdate(el);
-            fireAnimationEnd(el);
-            await waitForUpdate(el);
-            expect(getDialogEl(el).open).toBe(false);
-        });
-
-        it('restaure le scroll après fermeture', async () => {
-            el.open = false;
-            await waitForUpdate(el);
-            fireAnimationEnd(el);
-            await waitForUpdate(el);
-            expect(document.body.style.overflow).not.toBe('hidden');
-        });
-
         it('émet ar-dialog-hide avant la fermeture', async () => {
             const handler = vi.fn();
             el.addEventListener('ar-dialog-hide', handler);
             el.open = false;
-            await waitForUpdate(el);
-            expect(handler).toHaveBeenCalledOnce();
-        });
-
-        it('émet ar-dialog-hidden après la fermeture', async () => {
-            const handler = vi.fn();
-            el.addEventListener('ar-dialog-hidden', handler);
-            el.open = false;
-            await waitForUpdate(el);
-            fireAnimationEnd(el);
             await waitForUpdate(el);
             expect(handler).toHaveBeenCalledOnce();
         });
@@ -262,19 +249,6 @@ describe('ArDialog', () => {
             await waitForUpdate(el);
             expect(el.open).toBe(true);
             expect(prevented).toHaveBeenCalledOnce();
-        });
-
-        it('_isClosing bloque un double-appel à _close', async () => {
-            el.open = false;
-            await waitForUpdate(el);
-            const spy = vi.spyOn(getDialogEl(el), 'close');
-            // Tenter de refermer pendant que la fermeture est déjà en cours
-            el.open = false;
-            await waitForUpdate(el);
-            fireAnimationEnd(el);
-            await waitForUpdate(el);
-            // close() ne doit être appelé qu'une seule fois
-            expect(spy).toHaveBeenCalledOnce();
         });
 
         it('fermeture immédiate avec prefers-reduced-motion', async () => {
@@ -301,6 +275,29 @@ describe('ArDialog', () => {
             await waitForUpdate(el);
             expect(getDialogEl(el).open).toBe(false);
             vi.useRealTimers();
+        });
+
+        it('restaure la valeur précédente de body.style.overflow à la fermeture', async () => {
+            el.remove();
+            document.body.style.overflow = 'clip';
+            el = await fixture('<ar-dialog open></ar-dialog>');
+
+            el.open = false;
+            await waitForUpdate(el);
+            await new Promise((resolve) => setTimeout(resolve, 550));
+            expect(document.body.style.overflow).toBe('clip');
+        });
+
+        it('réannonce le message par défaut si preventedMessage est vide', async () => {
+            el.preventedMessage = '   ';
+            const liveRegion = requireShadow(el).getElementById('dialog-status');
+
+            el.addEventListener('ar-dialog-hide', (e) => e.preventDefault());
+            el.open = false;
+            await waitForUpdate(el);
+            await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+
+            expect(liveRegion?.textContent).toBe('Fermeture bloquée.');
         });
     });
 
@@ -417,46 +414,26 @@ describe('ArDialog', () => {
             getDialogEl(el).dispatchEvent(event);
             expect(event.defaultPrevented).toBe(true);
         });
-    });
 
-    // ── Scroll management ─────────────────────────────────────────────────────
+        it('Escape ne ferme que le dialog au sommet quand plusieurs dialogs sont ouverts', async () => {
+            const first = await fixture<ArDialog>('<ar-dialog id="dialog-1" open></ar-dialog>');
+            const second = await fixture<ArDialog>('<ar-dialog id="dialog-2" open></ar-dialog>');
 
-    describe('scroll', () => {
-        it("gèle le scroll à l'ouverture et le restaure à la fermeture", async () => {
-            el = await fixture('<ar-dialog></ar-dialog>');
-            el.open = true;
-            await waitForUpdate(el);
-            expect(document.body.style.overflow).toBe('hidden');
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+            await waitForUpdate(first);
+            await waitForUpdate(second);
 
-            el.open = false;
-            await waitForUpdate(el);
-            fireAnimationEnd(el);
-            await waitForUpdate(el);
-            expect(document.body.style.overflow).not.toBe('hidden');
+            expect((first as unknown as { _isClosing: boolean })._isClosing).toBe(false);
+            expect((second as unknown as { _isClosing: boolean })._isClosing).toBe(true);
+
+            second.remove();
+            first.remove();
         });
     });
 
     // ── Gestion du focus ──────────────────────────────────────────────────────
 
     describe('gestion du focus', () => {
-        it("retourne le focus à l'élément déclencheur à la fermeture", async () => {
-            el = await fixture('<ar-dialog></ar-dialog>');
-            const trigger = document.createElement('button');
-            document.body.appendChild(trigger);
-            trigger.focus();
-
-            el.open = true;
-            await waitForUpdate(el);
-
-            el.open = false;
-            await waitForUpdate(el);
-            fireAnimationEnd(el);
-            await waitForUpdate(el);
-
-            expect(document.activeElement).toBe(trigger);
-            trigger.remove();
-        });
-
         it("déplace le focus sur le premier élément focalisable du contenu à l'ouverture", async () => {
             el = await fixture(`
                 <ar-dialog>
@@ -504,6 +481,19 @@ describe('ArDialog', () => {
             // Guard: le listener module-level est protégé par typeof
             // document !== 'undefined'
             expect(customElements.get('ar-dialog')).toBeDefined();
+        });
+
+        it("ignore un trigger data-ar-dialog-open si l'id ne correspond à aucun dialog", async () => {
+            el = await fixture('<ar-dialog id="dialog-existant"></ar-dialog>');
+            const btn = document.createElement('button');
+            btn.setAttribute('data-ar-dialog-open', 'dialog-introuvable');
+            document.body.appendChild(btn);
+
+            btn.click();
+            await waitForUpdate(el);
+
+            expect(el.open).toBe(false);
+            btn.remove();
         });
     });
 });

--- a/packages/core/src/components/dialog/dialog.test.ts
+++ b/packages/core/src/components/dialog/dialog.test.ts
@@ -435,6 +435,54 @@ describe('ArDialog', () => {
         });
     });
 
+    // ── Gestion du focus ──────────────────────────────────────────────────────
+
+    describe('gestion du focus', () => {
+        it("retourne le focus à l'élément déclencheur à la fermeture", async () => {
+            el = await fixture('<ar-dialog></ar-dialog>');
+            const trigger = document.createElement('button');
+            document.body.appendChild(trigger);
+            trigger.focus();
+
+            el.open = true;
+            await waitForUpdate(el);
+
+            el.open = false;
+            await waitForUpdate(el);
+            fireAnimationEnd(el);
+            await waitForUpdate(el);
+
+            expect(document.activeElement).toBe(trigger);
+            trigger.remove();
+        });
+
+        it("déplace le focus sur le premier élément focalisable du contenu à l'ouverture", async () => {
+            el = await fixture(`
+                <ar-dialog>
+                    <button id="first-btn">Premier</button>
+                </ar-dialog>
+            `);
+            const firstBtn = el.querySelector<HTMLButtonElement>('#first-btn');
+            if (!firstBtn) throw new Error('button#first-btn introuvable');
+            const focusSpy = vi.spyOn(firstBtn, 'focus');
+            el.open = true;
+            await waitForUpdate(el);
+            await waitForUpdate(el);
+            expect(focusSpy).toHaveBeenCalled();
+        });
+
+        it('déplace le focus sur le bouton fermer si aucun élément focalisable dans le slot', async () => {
+            el = await fixture('<ar-dialog><p>Texte</p></ar-dialog>');
+            const closeBtn = requireShadow(el).querySelector<HTMLElement>('[data-ar-dismiss]');
+            if (!closeBtn) throw new Error('[data-ar-dismiss] introuvable');
+            const focusSpy = vi.spyOn(closeBtn, 'focus');
+            el.open = true;
+            await waitForUpdate(el);
+            await waitForUpdate(el);
+            expect(focusSpy).toHaveBeenCalled();
+        });
+    });
+
     // ── Trigger externe ───────────────────────────────────────────────────────
 
     describe('trigger externe data-ar-dialog-open', () => {

--- a/packages/core/src/components/dialog/dialog.test.ts
+++ b/packages/core/src/components/dialog/dialog.test.ts
@@ -450,5 +450,11 @@ describe('ArDialog', () => {
 
             btn.remove();
         });
+
+        it('le module se charge sans erreur (guard SSR)', () => {
+            // Guard: le listener module-level est protégé par typeof
+            // document !== 'undefined'
+            expect(customElements.get('ar-dialog')).toBeDefined();
+        });
     });
 });

--- a/packages/core/src/components/dialog/dialog.test.ts
+++ b/packages/core/src/components/dialog/dialog.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { ArDialog } from './dialog.js';
+import { fixture, getPart } from '../../test-utils.js';
+// import { fixture, waitForUpdate, getPart, requirePart } from '../../test-utils.js';
+import './dialog.js';
+
+// ─── Aide-mémoire tests Lit ────────────────────────────────────────────────────
+//
+// fixture(html)          — monte un élément dans le DOM et attend le premier rendu
+// waitForUpdate(el)      — attend le prochain cycle de rendu après une mutation
+// getPart(el, 'name')    — retourne un part="name" du Shadow DOM (| null)
+//                          → utiliser pour les assertions .toBeNull() / .not.toBeNull()
+// requirePart(el, 'name')— idem, mais lance une erreur si absent
+//                          → utiliser quand on enchaîne .getAttribute, .classList, etc.
+//
+// ⚠ happy-dom ne sérialise pas les Text nodes dynamiques Lit en textContent.
+//   Tester le contenu textuel via la propriété JS (el.myProp) plutôt que textContent.
+//
+// ⚠ Les propriétés ARIA assignées via .ariaCurrent, .ariaExpanded, etc. (liaisons
+//   Lit) ne reflètent pas en attribut HTML dans happy-dom. Tester la propriété
+//   JS : (el as unknown as { ariaCurrent: string }).ariaCurrent.
+//
+// ─── Éléments à tester selon le type de composant ─────────────────────────────
+//
+// Composant standard (avec Shadow DOM) :
+//   - Rendu : shadowRoot non null, parts présents (getPart)
+//   - Valeurs par défaut : vérifier chaque propriété à l'état initial
+//   - Attributs reflect : el.prop = x → await waitForUpdate → el.getAttribute(...)
+//   - Comportement : interactions (clic, événements custom)
+//   - Accessibilité : role, aria-*, labels sr-only
+//
+// Sous-composant (sans Shadow DOM, createRenderRoot → this) :
+//   - shadowRoot est null
+//   - setRegistry() appelle registerItem / unregisterItem
+//   - disconnectedCallback() appelle unregisterItem
+//   - updated() appelle notifyItemChanged après le premier rendu seulement
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('ArDialog', () => {
+    let el: ArDialog;
+
+    afterEach(() => el?.remove());
+
+    // ── Rendu ─────────────────────────────────────────────────────────────────
+
+    describe('rendu', () => {
+        beforeEach(async () => {
+            el = await fixture('<ar-dialog></ar-dialog>');
+        });
+
+        it('monte un shadow DOM', () => {
+            expect(el.shadowRoot).not.toBeNull();
+        });
+
+        it('contient un élément racine avec part="dialog"', () => {
+            expect(getPart(el, 'dialog')).not.toBeNull();
+        });
+    });
+
+    // ── Valeurs par défaut ────────────────────────────────────────────────────
+
+    // describe('valeurs par défaut', () => { ... });
+
+    // ── Propriétés ────────────────────────────────────────────────────────────
+
+    // describe('propriétés', () => { ... });
+});

--- a/packages/core/src/components/dialog/dialog.test.ts
+++ b/packages/core/src/components/dialog/dialog.test.ts
@@ -72,7 +72,7 @@ describe('ArDialog', () => {
         });
 
         it('open est false', () => expect(el.open).toBe(false));
-        it('staticBackdrop est false', () => expect(el.staticBackdrop).toBe(false));
+        it('closeOnBackdrop est false', () => expect(el.closeOnBackdrop).toBe(false));
         it('label est vide', () => expect(el.label).toBe(''));
         it('mode est modal', () => expect(el.mode).toBe('modal'));
         it('placement est right', () => expect(el.placement).toBe('right'));
@@ -88,8 +88,8 @@ describe('ArDialog', () => {
         });
 
         it('mode reflète en attribut', async () => {
-            el = await fixture('<ar-dialog mode="panel"></ar-dialog>');
-            expect(el.getAttribute('mode')).toBe('panel');
+            el = await fixture('<ar-dialog mode="drawer"></ar-dialog>');
+            expect(el.getAttribute('mode')).toBe('drawer');
         });
 
         it('size reflète en attribut', async () => {
@@ -102,10 +102,10 @@ describe('ArDialog', () => {
             expect(el.getAttribute('placement')).toBe('left');
         });
 
-        it('static-backdrop reflète en attribut', async () => {
-            el = await fixture('<ar-dialog static-backdrop></ar-dialog>');
-            expect(el.hasAttribute('static-backdrop')).toBe(true);
-            expect(el.staticBackdrop).toBe(true);
+        it('close-on-backdrop reflète en attribut', async () => {
+            el = await fixture('<ar-dialog close-on-backdrop></ar-dialog>');
+            expect(el.hasAttribute('close-on-backdrop')).toBe(true);
+            expect(el.closeOnBackdrop).toBe(true);
         });
     });
 
@@ -363,29 +363,30 @@ describe('ArDialog', () => {
             el = await fixture('<ar-dialog open></ar-dialog>');
         });
 
-        it('pointerdown + pointerup sur le dialog (backdrop) ferme', async () => {
+        it('backdrop ne ferme pas par défaut', async () => {
             const dialogEl = getDialogEl(el);
             dialogEl.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
-            dialogEl.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
-            await waitForUpdate(el);
-            // _isClosing est true (fermeture démarrée)
-            expect((el as unknown as { _isClosing: boolean })._isClosing).toBe(true);
-        });
-
-        it('pointerdown sur enfant + pointerup sur dialog (drag) ne ferme pas', async () => {
-            const dialogEl = getDialogEl(el);
-            const body = requireShadow(el).querySelector('.dialog-body') as Element;
-            body.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
             dialogEl.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
             await waitForUpdate(el);
             expect((el as unknown as { _isClosing: boolean })._isClosing).toBe(false);
         });
 
-        it('static-backdrop : backdrop click ne ferme pas', async () => {
-            el.staticBackdrop = true;
+        it('close-on-backdrop : backdrop click ferme', async () => {
+            el.closeOnBackdrop = true;
             await waitForUpdate(el);
             const dialogEl = getDialogEl(el);
             dialogEl.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+            dialogEl.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+            await waitForUpdate(el);
+            expect((el as unknown as { _isClosing: boolean })._isClosing).toBe(true);
+        });
+
+        it('pointerdown sur enfant + pointerup sur dialog (drag) ne ferme pas', async () => {
+            el.closeOnBackdrop = true;
+            await waitForUpdate(el);
+            const dialogEl = getDialogEl(el);
+            const body = requireShadow(el).querySelector('.dialog-body') as Element;
+            body.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
             dialogEl.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
             await waitForUpdate(el);
             expect((el as unknown as { _isClosing: boolean })._isClosing).toBe(false);

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -26,7 +26,12 @@ export type ArDialogEvents =
     | 'ar-dialog-accepted-prevented';
 
 const arDialogLocks = new Set<ArDialog>();
+// Partagé entre instances pour restaurer fidèlement le overflow d'origine lors d'un empilement de dialogs.
 let _savedBodyOverflow: string | null = null;
+
+const prefersReducedMotion = (): boolean =>
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 const DEFAULT_DIALOG_LABEL = 'Dialogue';
 
 if (typeof document !== 'undefined') {
@@ -137,7 +142,8 @@ export class ArDialog extends LitElement {
      * @attr prevented-message
      * @default 'Fermeture bloquée.'
      */
-    @property({ attribute: 'prevented-message' }) preventedMessage = 'Fermeture bloquée.';
+    @property({ reflect: true, attribute: 'prevented-message' }) preventedMessage =
+        'Fermeture bloquée.';
 
     // ── Private state ──────────────────────────────────────────────────────────
 
@@ -240,9 +246,9 @@ export class ArDialog extends LitElement {
                         <span class="btn-content sr-only">Fermer</span>
                     </button>
                 </header>
-                <main part="body">
+                <div part="body">
                     <slot></slot>
-                </main>
+                </div>
                 ${this._slotController.test('footer')
                     ? html`<footer part="footer">
                           <slot name="footer"></slot>
@@ -345,7 +351,9 @@ export class ArDialog extends LitElement {
     };
 
     private _handleDialogCancel = (event: Event) => {
-        event.preventDefault(); // Empêche la fermeture automatique du <dialog> natif sur Escape
+        // Toujours annulé : la gestion Escape est déléguée à _handleDocumentKeyDown pour
+        // respecter la pile de dialogs (arDialogLocks) et les animations de fermeture.
+        event.preventDefault();
     };
 
     private _handleDialogPointerDown = (event: PointerEvent) => {
@@ -376,14 +384,10 @@ export class ArDialog extends LitElement {
         this.dialog?.showModal();
         this._freezeScroll();
 
-        const prefersReducedMotion =
-            typeof window.matchMedia === 'function' &&
-            window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-
-        if (!prefersReducedMotion) {
+        if (!prefersReducedMotion()) {
             this.dialog.classList.add('opening');
             const onOpenEnd = (e: AnimationEvent) => {
-                if (e.animationName && !e.animationName.startsWith('show')) return;
+                if (e.target !== this.dialog) return;
                 this.dialog.classList.remove('opening');
                 this.dialog.removeEventListener('animationend', onOpenEnd);
             };
@@ -417,15 +421,11 @@ export class ArDialog extends LitElement {
             return;
         }
 
-        const prefersReducedMotion =
-            typeof window.matchMedia === 'function' &&
-            window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-
         this._isClosing = true;
         this.dialog.classList.remove('opening', 'shake');
         this.dialog.classList.add('closing');
 
-        if (prefersReducedMotion) {
+        if (prefersReducedMotion()) {
             this._finishClose();
             return;
         }
@@ -451,11 +451,7 @@ export class ArDialog extends LitElement {
         void dialog.offsetWidth; // force reflow pour redémarrer l'animation si déjà en cours
         dialog.classList.add('shake');
 
-        const prefersReducedMotion =
-            typeof window.matchMedia === 'function' &&
-            window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-
-        if (prefersReducedMotion) {
+        if (prefersReducedMotion()) {
             setTimeout(() => dialog.classList.remove('shake'), 700);
         } else {
             const onShakeEnd = (e: AnimationEvent) => {

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -282,9 +282,10 @@ export class ArDialog extends LitElement {
     private _announce(): void {
         const el = this.shadowRoot?.getElementById('dialog-status');
         if (!el) return;
+        const message = this.preventedMessage.trim() || 'Fermeture bloquée.';
         el.textContent = '';
         requestAnimationFrame(() => {
-            el.textContent = this.preventedMessage;
+            el.textContent = message;
         });
     }
 

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -1,0 +1,355 @@
+import {
+    LitElement,
+    type TemplateResult,
+    html,
+    type CSSResultGroup,
+    type PropertyValues,
+} from 'lit';
+import { customElement, property, query, state } from 'lit/decorators.js';
+import utilitiesStyles from '../../styles/utilities.styles.js';
+import buttonStyles from '../../styles/components/button.styles.js';
+import styles from './dialog.styles.js';
+
+/** Evènements envoyés par le webcomposant FTModalSide */
+export type ArDialogEvents =
+    | 'ar-dialog-show'
+    | 'ar-dialog-shown'
+    | 'ar-dialog-hide'
+    | 'ar-dialog-hide-prevented'
+    | 'ar-dialog-hidden'
+    | 'ar-dialog-dismissed'
+    | 'ar-dialog-dismissed-prevented'
+    | 'ar-dialog-accepted'
+    | 'ar-dialog-accepted-prevented';
+
+const arDialogLocks = new Set();
+
+/**
+ * @summary Version améliorée du composant natif <dialog> avec affichage centré ou panel.
+ *
+ * @slot header
+ * @slot title
+ * @slot
+ * @slot footer
+ *
+ * @csspart base - L'élément racine du composant.
+ * @cssprop [--ar-dialog-size=auto] - Taille du composant.
+ *
+ * @event {CustomEvent} ar-dialog-change - Émis lors d'un changement.
+ */
+@customElement('ar-dialog')
+export class ArDialog extends LitElement {
+    static override styles: CSSResultGroup = [utilitiesStyles, buttonStyles, styles];
+
+    // Variables internes
+
+    // Références HTML
+    /** Elément HTML contenant la dialog */
+    @query('dialog', true)
+    dialog?: HTMLDialogElement;
+
+    /**
+     * Visibilité du composant.
+     * Quand l'attribut est présent le composant est visible.
+     * @attr open
+     * @default false
+     */
+    @property({ reflect: true, type: Boolean }) open: boolean = false;
+
+    /**
+     * Possibilité de fermer le composant en cliquant sur le backdrop.
+     * Si vrai, le composant ne se ferme pas quand l'utilisateur clique sur le fond grisé
+     *
+     * @attr staticBackdrop
+     * @default staticBackdrop
+     */
+    @property({ reflect: true, type: Boolean, attribute: 'static-backdrop' })
+    staticBackdrop: boolean = false;
+
+    /**
+     * Le label du composant dialog affiché dans le header.
+     * Pour utiliser du HTML, utiliser le slot `label`.
+     */
+    @property({ reflect: true }) label = '';
+
+    /**
+     * Mode d'affichage du composant.
+     *
+     * @attr mode
+     * @default dialog
+     */
+    @property({ reflect: true, type: String })
+    mode: 'modal' | 'panel' = 'modal';
+
+    /**
+     * Position du composant.
+     * Utilisé uniquement pour le mode 'panel'
+     *
+     * @attr mode
+     * @default dialog
+     */
+    @property({ reflect: true, type: String })
+    placement: 'left' | 'right' = 'right';
+
+    /**
+     * Largeur du composant.
+     *
+     * @attr mode
+     * @default size
+     */
+    @property({ reflect: true, type: String })
+    size: 'sm' | 'md' | 'lg' | 'xl' = 'md';
+
+    /** Valeur de la propriété de style overflow sur l'élément body à l'ouverture de la modale */
+    private _overflowOnClose: string | null = null;
+
+    private _pointerDownTarget: EventTarget | null = null;
+
+    @state() private _isClosing = false;
+
+    // ---------------------------------------------------------------------------
+    // Lifecycle
+    // ---------------------------------------------------------------------------
+
+    override disconnectedCallback(): void {
+        super.disconnectedCallback();
+        this.removeOpenListeners();
+        if (this.open) {
+            this._unfreezeScroll();
+        }
+    }
+
+    override firstUpdated(): void {
+        if (this.open && !this.dialog?.open) {
+            this._show();
+        }
+    }
+
+    override updated(changedProperties: PropertyValues<this>): void {
+        if (changedProperties.has('open')) {
+            if (this.open && !this.dialog?.open) {
+                this._show();
+            } else if (!this.open && this.dialog?.open) {
+                this._close();
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Render
+    // ---------------------------------------------------------------------------
+
+    override render(): TemplateResult {
+        return html`
+            <dialog
+                part="dialog"
+                aria-labelledby="dialog-heading"
+                aria-modal="true"
+                role="dialog"
+                ?inert=${!this.open || this._isClosing}
+                @cancel=${this._handleDialogCancel}
+                @click=${this._handleDialogClick}
+                @pointerdown=${this._handleDialogPointerDown}
+                @pointerup=${this._handleDialogPointerUp}
+            >
+                <div class="modal-dialog" role="document">
+                    <div class="dialog-content">
+                        <header part="header" class="dialog-header">
+                            <slot name="header">
+                                <h1 part="title" class="dialog-title" id="dialog-heading">
+                                    <slot name="label">${this.label}</slot>
+                                </h1>
+                                <button
+                                    id="ftdialog-close"
+                                    type="button"
+                                    class="btn btn-tertiary light close btn-ratio-square"
+                                    data-dismiss="dialog"
+                                    aria-describedby="dialog-heading"
+                                >
+                                    <span aria-hidden="true" class="icon icon-close"></span>
+                                    <span class="btn-content sr-only">Fermer la modale</span>
+                                </button>
+                            </slot>
+                        </header>
+                        <div part="body" class="dialog-body">
+                            <slot></slot>
+                        </div>
+                        <footer part="footer" class="dialog-footer">
+                            <slot name="footer"></slot>
+                        </footer>
+                    </div>
+                </div>
+            </dialog>
+        `;
+    }
+
+    /** Empêche le scroll sur le corps de page quand la modale est ouverte */
+    private _freezeScroll() {
+        arDialogLocks.add(this);
+
+        // On ajoute overflow hidden
+        if (arDialogLocks.size === 1 && document.body.style.overflow) {
+            // On fait un backup de l'overflow actuel
+            this._overflowOnClose = document.body.style.overflow;
+        }
+        document.body.style.overflow = 'hidden';
+    }
+
+    /** Remet le scroll sur le corps de page quand la modale est fermée */
+    private _unfreezeScroll() {
+        arDialogLocks.delete(this);
+        if (arDialogLocks.size > 0) return;
+
+        // On rétabli la valeur précédente si nécessaire
+        if (this._overflowOnClose) {
+            document.body.style.overflow = this._overflowOnClose;
+            this._overflowOnClose = null;
+        }
+        // Sinon on retire la clé
+        else {
+            document.body.style.removeProperty('overflow');
+        }
+    }
+
+    /**
+     * Emet l'évènement correspondant (ouverture, fermeture, ...)
+     * @param  name Nom de l'évènement à transmettre
+     * @emits Evènement du nom renseigné
+     */
+    private _emit(name: ArDialogEvents): CustomEvent {
+        const e = new CustomEvent(name, {
+            bubbles: true,
+            composed: true,
+            cancelable: true,
+            detail: { id: this.id },
+        });
+        this.dispatchEvent(e);
+        return e;
+    }
+
+    private addOpenListeners() {
+        document.addEventListener('keydown', this._handleDocumentKeyDown);
+    }
+
+    private removeOpenListeners() {
+        document.removeEventListener('keydown', this._handleDocumentKeyDown);
+    }
+
+    // ***** INTERACTIONS *****
+    /**
+     * Au click sur la modale, récupère quel élément a été cliqué et cache la modale selon le bouton.
+     * @param {MouseEvent} event Evènement du click
+     */
+    private _handleDialogClick = (event: MouseEvent) => {
+        const target = event.target as HTMLElement;
+        const dismissed = target.closest('[data-dismiss="dialog"]');
+        const accepted = target.closest('[data-accept="dialog"]');
+
+        if (dismissed || accepted) {
+            const e = this._emit(dismissed ? 'ar-dialog-dismissed' : 'ar-dialog-accepted');
+            if (e.defaultPrevented) {
+                const prevented = dismissed
+                    ? 'ar-dialog-dismissed-prevented'
+                    : 'ar-dialog-accepted-prevented';
+                this._emit(prevented);
+                return;
+            }
+
+            event.stopPropagation();
+            this._close();
+        }
+    };
+
+    /**
+     * À l'appui sur la touche escape, on ferme la modale
+     * @param {KeyboardEvent} event
+     */
+    private _handleDocumentKeyDown = (event: KeyboardEvent) => {
+        if (event.key === 'Escape' && this.open) {
+            event.preventDefault();
+            event.stopPropagation();
+            this._close();
+        }
+    };
+
+    /**
+     * Gestion de l'événement 'cancel' déclenché par le <dialog> lorsque la touche Esc est appuyée
+     * @param {Event} event
+     */
+    private _handleDialogCancel = (event: Event) => {
+        event.preventDefault(); // Empêche la fermeture automatique du dialog sur "Escape"
+    };
+
+    /**
+     * Au pointerdown sur la dialog, mémorise la cible pour comparaison au pointerup
+     * @param {PointerEvent} event
+     */
+    private _handleDialogPointerDown = (event: PointerEvent) => {
+        this._pointerDownTarget = event.target;
+    };
+
+    /**
+     * Au pointerup sur le backdrop, ferme la modale si le pointerdown était aussi sur le backdrop
+     * @param {PointerEvent} event
+     */
+    private _handleDialogPointerUp = (event: PointerEvent) => {
+        if (this.staticBackdrop) return;
+        if (this._pointerDownTarget === this.dialog && event.target === this.dialog) {
+            this._close();
+        }
+        this._pointerDownTarget = null;
+    };
+
+    // ***** API *****
+    /** Affiche la modale, fige le scroll et ajoute l'écoute du click */
+    private _show(): void {
+        const showEvent = this._emit('ar-dialog-show');
+        if (showEvent.defaultPrevented) {
+            return;
+        }
+
+        this.addOpenListeners();
+        this.dialog?.showModal();
+        this.open = true;
+        this._freezeScroll();
+
+        this._emit('ar-dialog-shown');
+    }
+
+    /** Cache la modale avec une animation, réactive le scroll et supprime l'écoute du click */
+    private _close(): void {
+        if (this._isClosing) return;
+        const ftModalHideEvent = this._emit('ar-dialog-hide');
+
+        // Si la fermeture est annulée
+        if (ftModalHideEvent.defaultPrevented) {
+            this.open = true;
+            this._emit('ar-dialog-hide-prevented');
+            return;
+        }
+
+        this._isClosing = true;
+
+        const prefersReducedMotion =
+            typeof window.matchMedia === 'function' &&
+            window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        const animationTiming = prefersReducedMotion ? 0 : 400;
+        this.dialog?.classList.add('closing');
+
+        setTimeout(() => {
+            this.dialog?.classList.remove('closing');
+            this.dialog?.close();
+            this._unfreezeScroll();
+            this.removeOpenListeners();
+            this._isClosing = false;
+            this.open = false;
+            this._emit('ar-dialog-hidden');
+        }, animationTiming);
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'ar-dialog': ArDialog;
+    }
+}

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -41,7 +41,7 @@ if (typeof document !== 'undefined') {
 }
 
 /**
- * @summary Version améliorée du composant natif <dialog> avec affichage centré ou panel.
+ * @summary Boîte de dialogue modale ou panneau latéral (drawer), accessible et animée.
  *
  * @slot label - Titre du dialog. Remplace la propriété `label` si du HTML est nécessaire.
  * @slot - Contenu principal du dialog.
@@ -52,6 +52,9 @@ if (typeof document !== 'undefined') {
  * @csspart title - Le titre du dialog.
  * @csspart body - La zone de contenu principale.
  * @csspart footer - La zone d'actions (absente du DOM si slot non utilisé).
+ *
+ * @cssprop [--width=500px (modal) ou 720px (drawer)] - Largeur du dialog. Prend le pas sur les tailles prédéfinies.
+ * @cssprop [--spacing=1.5rem] - Padding interne de la zone de contenu. Défaut : 1.5rem.
  *
  * @event {CustomEvent} ar-dialog-show - Émis avant l'ouverture. Annulable.
  * @event {CustomEvent} ar-dialog-shown - Émis après l'ouverture (après updateComplete).
@@ -71,20 +74,20 @@ export class ArDialog extends LitElement {
 
     /**
      * Visibilité du composant.
-     * Quand l'attribut est présent le composant est visible.
      * @attr open
      * @default false
      */
     @property({ reflect: true, type: Boolean }) open: boolean = false;
 
     /**
-     * Si vrai, un clic sur le backdrop ne ferme pas le dialog.
+     * Si présent, un clic sur le backdrop ferme le dialog.
+     * Par défaut, le backdrop est statique et ne déclenche pas la fermeture.
      *
-     * @attr static-backdrop
+     * @attr close-on-backdrop
      * @default false
      */
-    @property({ reflect: true, type: Boolean, attribute: 'static-backdrop' })
-    staticBackdrop: boolean = false;
+    @property({ reflect: true, type: Boolean, attribute: 'close-on-backdrop' })
+    closeOnBackdrop: boolean = false;
 
     /**
      * Titre affiché dans le header. Pour du HTML, utiliser `slot="label"`.
@@ -95,16 +98,16 @@ export class ArDialog extends LitElement {
     @property({ reflect: true }) label = '';
 
     /**
-     * Mode d'affichage : `modal` (centré avec backdrop) ou `panel` (latéral).
+     * Mode d'affichage : `modal` (centré avec backdrop) ou `drawer` (panneau latéral).
      *
      * @attr mode
      * @default 'modal'
      */
     @property({ reflect: true, type: String })
-    mode: 'modal' | 'panel' = 'modal';
+    mode: 'modal' | 'drawer' = 'modal';
 
     /**
-     * Côté d'affichage du panel. Sans effet en mode `modal`.
+     * Côté d'affichage du drawer. Sans effet en mode `modal`.
      *
      * @attr placement
      * @default 'right'
@@ -113,7 +116,8 @@ export class ArDialog extends LitElement {
     placement: 'left' | 'right' = 'right';
 
     /**
-     * Largeur du dialog. Les valeurs correspondent à des tailles CSS prédéfinies.
+     * Taille du dialog. Les valeurs correspondent à des largeurs CSS prédéfinies.
+     * Utilisez `--width` pour une valeur personnalisée.
      *
      * @attr size
      * @default 'md'
@@ -182,40 +186,48 @@ export class ArDialog extends LitElement {
         return html`
             <dialog
                 part="dialog"
+                role="dialog"
                 aria-labelledby="dialog-heading"
                 aria-modal="true"
-                role="dialog"
                 ?inert=${!this.open || this._isClosing}
                 @cancel=${this._handleDialogCancel}
                 @click=${this._handleDialogClick}
                 @pointerdown=${this._handleDialogPointerDown}
                 @pointerup=${this._handleDialogPointerUp}
             >
-                <div class="modal-dialog" role="document">
-                    <div class="dialog-content">
-                        <header part="header" class="dialog-header">
-                            <h1 part="title" class="dialog-title" id="dialog-heading">
-                                <slot name="label">${this.label}</slot>
-                            </h1>
-                            <button
-                                type="button"
-                                class="btn btn-tertiary light close btn-ratio-square"
-                                data-ar-dismiss
-                            >
-                                <span aria-hidden="true" class="icon icon-close"></span>
-                                <span class="btn-content sr-only">Fermer la modale</span>
-                            </button>
-                        </header>
-                        <div part="body" class="dialog-body">
-                            <slot></slot>
-                        </div>
-                        ${this._hasFooter
-                            ? html`<footer part="footer" class="dialog-footer">
-                                  <slot name="footer"></slot>
-                              </footer>`
-                            : nothing}
-                    </div>
+                <header part="header" class="dialog-header">
+                    <h1 part="title" class="dialog-title" id="dialog-heading">
+                        <slot name="label">${this.label}</slot>
+                    </h1>
+                    <button
+                        type="button"
+                        class="btn btn-tertiary light btn-ratio-square"
+                        data-ar-dismiss
+                    >
+                        <svg
+                            aria-hidden="true"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke-width="1.5"
+                            stroke="currentColor"
+                        >
+                            <path
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                d="M6 18 18 6M6 6l12 12"
+                            ></path>
+                        </svg>
+                        <span class="btn-content sr-only">Fermer</span>
+                    </button>
+                </header>
+                <div part="body" class="dialog-body" role="document">
+                    <slot></slot>
                 </div>
+                ${this._hasFooter
+                    ? html`<footer part="footer" class="dialog-footer">
+                          <slot name="footer"></slot>
+                      </footer>`
+                    : nothing}
             </dialog>
         `;
     }
@@ -286,6 +298,7 @@ export class ArDialog extends LitElement {
                     ? 'ar-dialog-dismissed-prevented'
                     : 'ar-dialog-accepted-prevented';
                 this._emit(prevented);
+                this._shake();
                 return;
             }
 
@@ -296,6 +309,9 @@ export class ArDialog extends LitElement {
 
     private _handleDocumentKeyDown = (event: KeyboardEvent) => {
         if (event.key === 'Escape' && this.open && !this._isClosing) {
+            // N'intercepte Escape que si ce dialog est au sommet de la pile (dialogs empilés)
+            const locks = [...arDialogLocks];
+            if (locks[locks.length - 1] !== this) return;
             event.preventDefault();
             event.stopPropagation();
             this._close();
@@ -311,7 +327,7 @@ export class ArDialog extends LitElement {
     };
 
     private _handleDialogPointerUp = (event: PointerEvent) => {
-        if (this.staticBackdrop) return;
+        if (!this.closeOnBackdrop) return;
         if (this._pointerDownTarget === this.dialog && event.target === this.dialog) {
             this._close();
         }
@@ -355,6 +371,7 @@ export class ArDialog extends LitElement {
         if (hideEvent.defaultPrevented) {
             this.open = true;
             this._emit('ar-dialog-hide-prevented');
+            this._shake();
             return;
         }
 
@@ -382,6 +399,13 @@ export class ArDialog extends LitElement {
             this._finishClose();
         };
         this.dialog.addEventListener('animationend', onEnd);
+    }
+
+    /** Animation de rejet — déclenche un shake sur le <dialog> natif pour signaler que la fermeture est bloquée. */
+    private _shake(): void {
+        this.dialog.classList.remove('shake');
+        void this.dialog.offsetWidth; // force reflow pour redémarrer l'animation si déjà en cours
+        this.dialog.classList.add('shake');
     }
 
     /** Finalise la fermeture : ferme le dialog natif, restaure l'état et émet ar-dialog-hidden. */

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -143,6 +143,14 @@ export class ArDialog extends LitElement {
     @property({ reflect: true, attribute: 'prevented-message' }) preventedMessage =
         'Fermeture bloquée.';
 
+    /**
+     * Label accessible du bouton de fermeture. À adapter pour la langue de l'interface.
+     *
+     * @attr close-label
+     * @default 'Fermer'
+     */
+    @property({ reflect: true, attribute: 'close-label' }) closeLabel = 'Fermer';
+
     // ── Private state ──────────────────────────────────────────────────────────
 
     @query('dialog', true)
@@ -210,6 +218,7 @@ export class ArDialog extends LitElement {
                 part="dialog"
                 role="dialog"
                 aria-labelledby="dialog-heading"
+                aria-describedby="dialog-body"
                 aria-modal="true"
                 ?inert=${!this.open || this._isClosing}
                 @cancel=${this._handleDialogCancel}
@@ -241,10 +250,10 @@ export class ArDialog extends LitElement {
                                 d="M6 18 18 6M6 6l12 12"
                             ></path>
                         </svg>
-                        <span class="btn-content sr-only">Fermer</span>
+                        <span class="btn-content sr-only">${this.closeLabel}</span>
                     </button>
                 </header>
-                <div part="body">
+                <div part="body" id="dialog-body">
                     <slot></slot>
                 </div>
                 ${this._slotController.test('footer')
@@ -309,6 +318,13 @@ export class ArDialog extends LitElement {
     // ── Interaction handlers ───────────────────────────────────────────────────
 
     private _handleDialogClick = (event: MouseEvent) => {
+        // Fallback backdrop close for Safari iOS (WebKit #267688 — pointerdown absent sur backdrop).
+        // Sur desktop, _handleDialogPointerUp déjà traité ; _close() est idempotent via _isClosing.
+        if (this.closeOnBackdrop && event.target === this.dialog) {
+            this._close();
+            return;
+        }
+
         const path = event.composedPath() as Element[];
         const stopAt = path.indexOf(this.dialog);
         const inner = stopAt >= 0 ? path.slice(0, stopAt) : path;
@@ -393,9 +409,12 @@ export class ArDialog extends LitElement {
         }
 
         this.updateComplete.then(() => {
-            const firstFocusable = this.querySelector<HTMLElement>(
-                'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-            );
+            const autoFocused = this.querySelector<HTMLElement>('[autofocus]');
+            const firstFocusable =
+                autoFocused ??
+                this.querySelector<HTMLElement>(
+                    'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+                );
             if (firstFocusable) {
                 firstFocusable.focus();
             } else {

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -26,17 +26,19 @@ export type ArDialogEvents =
 const arDialogLocks = new Set<ArDialog>();
 let _savedBodyOverflow: string | null = null;
 
-document.addEventListener(
-    'click',
-    (e: MouseEvent) => {
-        const trigger = (e.target as Element).closest('[data-ar-dialog-open]');
-        if (!trigger) return;
-        const id = trigger.getAttribute('data-ar-dialog-open');
-        const target = id ? (document.getElementById(id) as ArDialog | null) : null;
-        if (target?.tagName === 'AR-DIALOG') target.open = true;
-    },
-    { capture: true },
-);
+if (typeof document !== 'undefined') {
+    document.addEventListener(
+        'click',
+        (e: MouseEvent) => {
+            const trigger = (e.target as Element).closest('[data-ar-dialog-open]');
+            if (!trigger) return;
+            const id = trigger.getAttribute('data-ar-dialog-open');
+            const target = id ? (document.getElementById(id) as ArDialog | null) : null;
+            if (target?.tagName === 'AR-DIALOG') target.open = true;
+        },
+        { capture: true },
+    );
+}
 
 /**
  * @summary Version améliorée du composant natif <dialog> avec affichage centré ou panel.

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -196,7 +196,6 @@ export class ArDialog extends LitElement {
                                 type="button"
                                 class="btn btn-tertiary light close btn-ratio-square"
                                 data-ar-dismiss
-                                aria-describedby="dialog-heading"
                             >
                                 <span aria-hidden="true" class="icon icon-close"></span>
                                 <span class="btn-content sr-only">Fermer la modale</span>

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -10,7 +10,7 @@ import utilitiesStyles from '../../styles/utilities.styles.js';
 import buttonStyles from '../../styles/components/button.styles.js';
 import styles from './dialog.styles.js';
 
-/** Evènements envoyés par le webcomposant FTModalSide */
+/** Evènements envoyés par le webcomposant ArDialog */
 export type ArDialogEvents =
     | 'ar-dialog-show'
     | 'ar-dialog-shown'
@@ -22,7 +22,8 @@ export type ArDialogEvents =
     | 'ar-dialog-accepted'
     | 'ar-dialog-accepted-prevented';
 
-const arDialogLocks = new Set();
+const arDialogLocks = new Set<ArDialog>();
+let _savedBodyOverflow: string | null = null;
 
 /**
  * @summary Version améliorée du composant natif <dialog> avec affichage centré ou panel.
@@ -35,7 +36,15 @@ const arDialogLocks = new Set();
  * @csspart base - L'élément racine du composant.
  * @cssprop [--ar-dialog-size=auto] - Taille du composant.
  *
- * @event {CustomEvent} ar-dialog-change - Émis lors d'un changement.
+ * @event {CustomEvent} ar-dialog-show - Émis lorsque que le composant va s'afficher.
+ * @event {CustomEvent} ar-dialog-shown - Émis lorsque que le composant est affiché
+ * @event {CustomEvent} ar-dialog-hide - Émis lorsque que le composant va être masqué
+ * @event {CustomEvent} ar-dialog-hide-prevented - Émis lorsque que le masquage du composant a été interrompu
+ * @event {CustomEvent} ar-dialog-hidden - Émis lorsque que le composant est masqué
+ * @event {CustomEvent} ar-dialog-dismissed - Émis lorsque que le composant a été fermé
+ * @event {CustomEvent} ar-dialog-dismissed-prevented - Émis lorsque la fermeture du composant a été interrompue
+ * @event {CustomEvent} ar-dialog-accepted - Émis lorsque que le composant est fermé avec un bouton indiquant une acceptation
+ * @event {CustomEvent} ar-dialog-accepted-prevented - Émis lorsque que la fermeture via un bouton de confirmation a été interrompue
  */
 @customElement('ar-dialog')
 export class ArDialog extends LitElement {
@@ -46,7 +55,7 @@ export class ArDialog extends LitElement {
     // Références HTML
     /** Elément HTML contenant la dialog */
     @query('dialog', true)
-    dialog?: HTMLDialogElement;
+    dialog!: HTMLDialogElement;
 
     /**
      * Visibilité du composant.
@@ -61,7 +70,7 @@ export class ArDialog extends LitElement {
      * Si vrai, le composant ne se ferme pas quand l'utilisateur clique sur le fond grisé
      *
      * @attr staticBackdrop
-     * @default staticBackdrop
+     * @default false
      */
     @property({ reflect: true, type: Boolean, attribute: 'static-backdrop' })
     staticBackdrop: boolean = false;
@@ -69,6 +78,9 @@ export class ArDialog extends LitElement {
     /**
      * Le label du composant dialog affiché dans le header.
      * Pour utiliser du HTML, utiliser le slot `label`.
+     *
+     * @attr label
+     * @default ''
      */
     @property({ reflect: true }) label = '';
 
@@ -85,8 +97,8 @@ export class ArDialog extends LitElement {
      * Position du composant.
      * Utilisé uniquement pour le mode 'panel'
      *
-     * @attr mode
-     * @default dialog
+     * @attr placement
+     * @default 'right'
      */
     @property({ reflect: true, type: String })
     placement: 'left' | 'right' = 'right';
@@ -94,14 +106,11 @@ export class ArDialog extends LitElement {
     /**
      * Largeur du composant.
      *
-     * @attr mode
-     * @default size
+     * @attr size
+     * @default 'md'
      */
     @property({ reflect: true, type: String })
     size: 'sm' | 'md' | 'lg' | 'xl' = 'md';
-
-    /** Valeur de la propriété de style overflow sur l'élément body à l'ouverture de la modale */
-    private _overflowOnClose: string | null = null;
 
     private _pointerDownTarget: EventTarget | null = null;
 
@@ -113,7 +122,7 @@ export class ArDialog extends LitElement {
 
     override disconnectedCallback(): void {
         super.disconnectedCallback();
-        this.removeOpenListeners();
+        this._removeOpenListeners();
         if (this.open) {
             this._unfreezeScroll();
         }
@@ -160,7 +169,7 @@ export class ArDialog extends LitElement {
                                     <slot name="label">${this.label}</slot>
                                 </h1>
                                 <button
-                                    id="ftdialog-close"
+                                    id="ar-dialog-close"
                                     type="button"
                                     class="btn btn-tertiary light close btn-ratio-square"
                                     data-dismiss="dialog"
@@ -185,13 +194,10 @@ export class ArDialog extends LitElement {
 
     /** Empêche le scroll sur le corps de page quand la modale est ouverte */
     private _freezeScroll() {
-        arDialogLocks.add(this);
-
-        // On ajoute overflow hidden
-        if (arDialogLocks.size === 1 && document.body.style.overflow) {
-            // On fait un backup de l'overflow actuel
-            this._overflowOnClose = document.body.style.overflow;
+        if (arDialogLocks.size === 0) {
+            _savedBodyOverflow = document.body.style.overflow || null;
         }
+        arDialogLocks.add(this);
         document.body.style.overflow = 'hidden';
     }
 
@@ -200,15 +206,12 @@ export class ArDialog extends LitElement {
         arDialogLocks.delete(this);
         if (arDialogLocks.size > 0) return;
 
-        // On rétabli la valeur précédente si nécessaire
-        if (this._overflowOnClose) {
-            document.body.style.overflow = this._overflowOnClose;
-            this._overflowOnClose = null;
-        }
-        // Sinon on retire la clé
-        else {
+        if (_savedBodyOverflow) {
+            document.body.style.overflow = _savedBodyOverflow;
+        } else {
             document.body.style.removeProperty('overflow');
         }
+        _savedBodyOverflow = null;
     }
 
     /**
@@ -221,17 +224,17 @@ export class ArDialog extends LitElement {
             bubbles: true,
             composed: true,
             cancelable: true,
-            detail: { id: this.id },
+            detail: { id: this.id || undefined },
         });
         this.dispatchEvent(e);
         return e;
     }
 
-    private addOpenListeners() {
+    private _addOpenListeners() {
         document.addEventListener('keydown', this._handleDocumentKeyDown);
     }
 
-    private removeOpenListeners() {
+    private _removeOpenListeners() {
         document.removeEventListener('keydown', this._handleDocumentKeyDown);
     }
 
@@ -248,6 +251,7 @@ export class ArDialog extends LitElement {
         if (dismissed || accepted) {
             const e = this._emit(dismissed ? 'ar-dialog-dismissed' : 'ar-dialog-accepted');
             if (e.defaultPrevented) {
+                event.stopPropagation();
                 const prevented = dismissed
                     ? 'ar-dialog-dismissed-prevented'
                     : 'ar-dialog-accepted-prevented';
@@ -265,7 +269,7 @@ export class ArDialog extends LitElement {
      * @param {KeyboardEvent} event
      */
     private _handleDocumentKeyDown = (event: KeyboardEvent) => {
-        if (event.key === 'Escape' && this.open) {
+        if (event.key === 'Escape' && this.open && !this._isClosing) {
             event.preventDefault();
             event.stopPropagation();
             this._close();
@@ -308,21 +312,20 @@ export class ArDialog extends LitElement {
             return;
         }
 
-        this.addOpenListeners();
+        this._addOpenListeners();
         this.dialog?.showModal();
-        this.open = true;
         this._freezeScroll();
 
-        this._emit('ar-dialog-shown');
+        this.updateComplete.then(() => this._emit('ar-dialog-shown'));
     }
 
     /** Cache la modale avec une animation, réactive le scroll et supprime l'écoute du click */
     private _close(): void {
         if (this._isClosing) return;
-        const ftModalHideEvent = this._emit('ar-dialog-hide');
+        const hideEvent = this._emit('ar-dialog-hide');
 
         // Si la fermeture est annulée
-        if (ftModalHideEvent.defaultPrevented) {
+        if (hideEvent.defaultPrevented) {
             this.open = true;
             this._emit('ar-dialog-hide-prevented');
             return;
@@ -333,17 +336,18 @@ export class ArDialog extends LitElement {
         const prefersReducedMotion =
             typeof window.matchMedia === 'function' &&
             window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-        const animationTiming = prefersReducedMotion ? 0 : 400;
+        const duration = parseFloat(getComputedStyle(this.dialog).animationDuration) * 1000 || 0;
+        const animationTiming = prefersReducedMotion ? 0 : duration;
         this.dialog?.classList.add('closing');
 
         setTimeout(() => {
             this.dialog?.classList.remove('closing');
             this.dialog?.close();
             this._unfreezeScroll();
-            this.removeOpenListeners();
+            this._removeOpenListeners();
             this._isClosing = false;
             this.open = false;
-            this._emit('ar-dialog-hidden');
+            this.updateComplete.then(() => this._emit('ar-dialog-hidden'));
         }, animationTiming);
     }
 }

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -10,6 +10,8 @@ import { customElement, property, query, state } from 'lit/decorators.js';
 import utilitiesStyles from '../../styles/utilities.styles.js';
 import buttonStyles from '../../styles/components/button.styles.js';
 import styles from './dialog.styles.js';
+import { announceA11y } from '../../a11y/announce-a11y.js';
+import { HasSlotController } from '../../controllers/has-slot.controller.js';
 
 /** Evènements envoyés par le webcomposant ArDialog */
 export type ArDialogEvents =
@@ -25,6 +27,7 @@ export type ArDialogEvents =
 
 const arDialogLocks = new Set<ArDialog>();
 let _savedBodyOverflow: string | null = null;
+const DEFAULT_DIALOG_LABEL = 'Dialogue';
 
 if (typeof document !== 'undefined') {
     document.addEventListener(
@@ -145,30 +148,31 @@ export class ArDialog extends LitElement {
     /** Vrai pendant l'animation de fermeture — bloque les interactions et les double-appels. */
     @state() private _isClosing = false;
 
-    /** Vrai si au moins un enfant direct avec slot="footer" est présent. */
-    @state() private _hasFooter = false;
-
-    private _footerObserver?: MutationObserver;
-
     /** Élément qui avait le focus avant l'ouverture — pour le restaurer à la fermeture. */
     private _triggerElement: Element | null = null;
 
-    private _checkFooter(): void {
-        this._hasFooter = !!this.querySelector(':scope > [slot="footer"]');
+    private readonly _slotController = new HasSlotController(this, 'footer', 'label');
+    private _hasWarnedMissingLabel = false;
+
+    private _getHeadingLabel(): string {
+        return (this.label ?? '').trim() || DEFAULT_DIALOG_LABEL;
+    }
+
+    private _warnIfMissingLabel(): void {
+        if (this._hasWarnedMissingLabel) return;
+        if ((this.label ?? '').trim() || this._slotController.test('label')) return;
+
+        this._hasWarnedMissingLabel = true;
+        console.warn(
+            `[ar-dialog] Aucun libellé accessible fourni. Ajoutez la propriété "label" ou un enfant direct avec slot="label".`,
+            this,
+        );
     }
 
     // ── Lifecycle ──────────────────────────────────────────────────────────────
 
-    override connectedCallback(): void {
-        super.connectedCallback();
-        this._checkFooter();
-        this._footerObserver = new MutationObserver(() => this._checkFooter());
-        this._footerObserver.observe(this, { childList: true });
-    }
-
     override disconnectedCallback(): void {
         super.disconnectedCallback();
-        this._footerObserver?.disconnect();
         this._removeOpenListeners();
         if (this.open || this._isClosing) this._unfreezeScroll();
     }
@@ -180,6 +184,7 @@ export class ArDialog extends LitElement {
     }
 
     override updated(changedProperties: PropertyValues<this>): void {
+        this._warnIfMissingLabel();
         if (changedProperties.has('open')) {
             if (this.open && !this.dialog?.open) {
                 this._show();
@@ -192,6 +197,8 @@ export class ArDialog extends LitElement {
     // ── Render ─────────────────────────────────────────────────────────────────
 
     override render(): TemplateResult {
+        const headingLabel = this._getHeadingLabel();
+
         return html`
             <dialog
                 part="dialog"
@@ -204,9 +211,11 @@ export class ArDialog extends LitElement {
                 @pointerdown=${this._handleDialogPointerDown}
                 @pointerup=${this._handleDialogPointerUp}
             >
-                <header part="header" class="dialog-header">
-                    <h1 part="title" class="dialog-title" id="dialog-heading">
-                        <slot name="label">${this.label}</slot>
+                <header part="header">
+                    <h1 part="title" id="dialog-heading">
+                        ${this._slotController.test('label')
+                            ? html`<slot name="label"></slot>`
+                            : headingLabel}
                     </h1>
                     <button
                         type="button"
@@ -229,16 +238,15 @@ export class ArDialog extends LitElement {
                         <span class="btn-content sr-only">Fermer</span>
                     </button>
                 </header>
-                <div part="body" class="dialog-body" role="document">
+                <main part="body">
                     <slot></slot>
-                </div>
-                ${this._hasFooter
-                    ? html`<footer part="footer" class="dialog-footer">
+                </main>
+                ${this._slotController.test('footer')
+                    ? html`<footer part="footer">
                           <slot name="footer"></slot>
                       </footer>`
                     : nothing}
             </dialog>
-            <div aria-live="assertive" aria-atomic="true" class="sr-only" id="dialog-status"></div>
         `;
     }
 
@@ -280,13 +288,8 @@ export class ArDialog extends LitElement {
     }
 
     private _announce(): void {
-        const el = this.shadowRoot?.getElementById('dialog-status');
-        if (!el) return;
         const message = this.preventedMessage.trim() || 'Fermeture bloquée.';
-        el.textContent = '';
-        requestAnimationFrame(() => {
-            el.textContent = message;
-        });
+        announceA11y(message, 'assertive');
     }
 
     private _addOpenListeners() {
@@ -363,6 +366,7 @@ export class ArDialog extends LitElement {
         const showEvent = this._emit('ar-dialog-show');
         if (showEvent.defaultPrevented) {
             this._triggerElement = null;
+            this.open = false;
             return;
         }
 

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -57,7 +57,9 @@ if (typeof document !== 'undefined') {
  * @csspart footer - La zone d'actions (absente du DOM si slot non utilisé).
  *
  * @cssprop [--width=500px (modal) ou 720px (drawer)] - Largeur du dialog. Prend le pas sur les tailles prédéfinies.
- * @cssprop [--spacing=1.5rem] - Padding interne de la zone de contenu. Défaut : 1.5rem.
+ * @cssprop [--spacing=1.25rem] - Padding interne (block et inline) de la zone de contenu.
+ * @cssprop [--spacing-block] - Padding haut/bas. Prend le pas sur `--spacing` si défini.
+ * @cssprop [--spacing-inline] - Padding gauche/droite. Prend le pas sur `--spacing` si défini.
  *
  * @event {CustomEvent} ar-dialog-show - Émis avant l'ouverture. Annulable.
  * @event {CustomEvent} ar-dialog-shown - Émis après l'ouverture (après updateComplete).

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -137,6 +137,9 @@ export class ArDialog extends LitElement {
 
     private _footerObserver?: MutationObserver;
 
+    /** Élément qui avait le focus avant l'ouverture — pour le restaurer à la fermeture. */
+    private _triggerElement: Element | null = null;
+
     private _checkFooter(): void {
         this._hasFooter = !!this.querySelector(':scope > [slot="footer"]');
     }
@@ -319,8 +322,10 @@ export class ArDialog extends LitElement {
 
     /** Ouvre le dialog natif, gèle le scroll et enregistre le listener clavier. */
     private _show(): void {
+        this._triggerElement = document.activeElement;
         const showEvent = this._emit('ar-dialog-show');
         if (showEvent.defaultPrevented) {
+            this._triggerElement = null;
             return;
         }
 
@@ -328,7 +333,19 @@ export class ArDialog extends LitElement {
         this.dialog?.showModal();
         this._freezeScroll();
 
-        this.updateComplete.then(() => this._emit('ar-dialog-shown'));
+        this.updateComplete.then(() => {
+            const firstFocusable = this.querySelector<HTMLElement>(
+                'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+            );
+            if (firstFocusable) {
+                firstFocusable.focus();
+            } else {
+                (
+                    this.shadowRoot?.querySelector<HTMLElement>('[data-ar-dismiss]') ?? this.dialog
+                )?.focus();
+            }
+            this._emit('ar-dialog-shown');
+        });
     }
 
     /** Déclenche l'animation de fermeture et attend animationend avant de clore. */
@@ -375,6 +392,9 @@ export class ArDialog extends LitElement {
         this._removeOpenListeners();
         this._isClosing = false;
         this.open = false;
+        const trigger = this._triggerElement;
+        this._triggerElement = null;
+        (trigger as HTMLElement | null)?.focus?.();
         this.updateComplete.then(() => this._emit('ar-dialog-hidden'));
     }
 }

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -152,7 +152,7 @@ export class ArDialog extends LitElement {
         super.disconnectedCallback();
         this._footerObserver?.disconnect();
         this._removeOpenListeners();
-        if (this.open) this._unfreezeScroll();
+        if (this.open || this._isClosing) this._unfreezeScroll();
     }
 
     override firstUpdated(): void {
@@ -264,9 +264,15 @@ export class ArDialog extends LitElement {
     // ── Interaction handlers ───────────────────────────────────────────────────
 
     private _handleDialogClick = (event: MouseEvent) => {
-        const target = event.target as HTMLElement;
-        const dismissed = target.closest('[data-ar-dismiss]');
-        const accepted = target.closest('[data-ar-accept]');
+        const path = event.composedPath() as Element[];
+        const stopAt = path.indexOf(this.dialog);
+        const inner = stopAt >= 0 ? path.slice(0, stopAt) : path;
+        const dismissed = inner.find(
+            (n): n is HTMLElement => n instanceof HTMLElement && n.hasAttribute('data-ar-dismiss'),
+        );
+        const accepted = inner.find(
+            (n): n is HTMLElement => n instanceof HTMLElement && n.hasAttribute('data-ar-accept'),
+        );
 
         if (dismissed || accepted) {
             const e = this._emit(dismissed ? 'ar-dialog-dismissed' : 'ar-dialog-accepted');

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -12,6 +12,7 @@ import buttonStyles from '../../styles/components/button.styles.js';
 import styles from './dialog.styles.js';
 import { announceA11y } from '../../a11y/announce-a11y.js';
 import { HasSlotController } from '../../controllers/has-slot.controller.js';
+import { prefersReducedMotion } from '../../utils/media.js';
 
 /** Evènements envoyés par le webcomposant ArDialog */
 export type ArDialogEvents =
@@ -29,9 +30,6 @@ const arDialogLocks = new Set<ArDialog>();
 // Partagé entre instances pour restaurer fidèlement le overflow d'origine lors d'un empilement de dialogs.
 let _savedBodyOverflow: string | null = null;
 
-const prefersReducedMotion = (): boolean =>
-    typeof window.matchMedia === 'function' &&
-    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 const DEFAULT_DIALOG_LABEL = 'Dialogue';
 
 if (typeof document !== 'undefined') {

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -59,7 +59,7 @@ if (typeof document !== 'undefined') {
  * @event {CustomEvent} ar-dialog-show - Émis avant l'ouverture. Annulable.
  * @event {CustomEvent} ar-dialog-shown - Émis après l'ouverture (après updateComplete).
  * @event {CustomEvent} ar-dialog-hide - Émis avant la fermeture. Annulable.
- * @event {CustomEvent} ar-dialog-hide-prevented - Émis si ar-dialog-hide est annulé.
+ * @event {CustomEvent} ar-dialog-hide-prevented - Émis si ar-dialog-hide est annulé. Le composant secoue le dialog et annonce `prevented-message` aux lecteurs d'écran.
  * @event {CustomEvent} ar-dialog-hidden - Émis après la fermeture (après animation).
  * @event {CustomEvent} ar-dialog-dismissed - Émis lors d'un clic sur data-ar-dismiss. Annulable.
  * @event {CustomEvent} ar-dialog-dismissed-prevented - Émis si ar-dialog-dismissed est annulé.
@@ -124,6 +124,15 @@ export class ArDialog extends LitElement {
      */
     @property({ reflect: true, type: String })
     size: 'sm' | 'md' | 'lg' | 'xl' = 'md';
+
+    /**
+     * Message annoncé aux lecteurs d'écran quand une fermeture est bloquée
+     * (événements `ar-dialog-hide-prevented`, `ar-dialog-dismissed-prevented`, `ar-dialog-accepted-prevented`).
+     *
+     * @attr prevented-message
+     * @default 'Fermeture bloquée.'
+     */
+    @property({ attribute: 'prevented-message' }) preventedMessage = 'Fermeture bloquée.';
 
     // ── Private state ──────────────────────────────────────────────────────────
 
@@ -229,6 +238,7 @@ export class ArDialog extends LitElement {
                       </footer>`
                     : nothing}
             </dialog>
+            <div aria-live="assertive" aria-atomic="true" class="sr-only" id="dialog-status"></div>
         `;
     }
 
@@ -269,6 +279,15 @@ export class ArDialog extends LitElement {
         return e;
     }
 
+    private _announce(): void {
+        const el = this.shadowRoot?.getElementById('dialog-status');
+        if (!el) return;
+        el.textContent = '';
+        requestAnimationFrame(() => {
+            el.textContent = this.preventedMessage;
+        });
+    }
+
     private _addOpenListeners() {
         document.addEventListener('keydown', this._handleDocumentKeyDown);
     }
@@ -299,6 +318,7 @@ export class ArDialog extends LitElement {
                     : 'ar-dialog-accepted-prevented';
                 this._emit(prevented);
                 this._shake();
+                this._announce();
                 return;
             }
 
@@ -349,6 +369,20 @@ export class ArDialog extends LitElement {
         this.dialog?.showModal();
         this._freezeScroll();
 
+        const prefersReducedMotion =
+            typeof window.matchMedia === 'function' &&
+            window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+        if (!prefersReducedMotion) {
+            this.dialog.classList.add('opening');
+            const onOpenEnd = (e: AnimationEvent) => {
+                if (e.animationName && !e.animationName.startsWith('show')) return;
+                this.dialog.classList.remove('opening');
+                this.dialog.removeEventListener('animationend', onOpenEnd);
+            };
+            this.dialog.addEventListener('animationend', onOpenEnd);
+        }
+
         this.updateComplete.then(() => {
             const firstFocusable = this.querySelector<HTMLElement>(
                 'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
@@ -372,6 +406,7 @@ export class ArDialog extends LitElement {
             this.open = true;
             this._emit('ar-dialog-hide-prevented');
             this._shake();
+            this._announce();
             return;
         }
 
@@ -380,6 +415,7 @@ export class ArDialog extends LitElement {
             window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
         this._isClosing = true;
+        this.dialog.classList.remove('opening', 'shake');
         this.dialog.classList.add('closing');
 
         if (prefersReducedMotion) {
@@ -401,16 +437,32 @@ export class ArDialog extends LitElement {
         this.dialog.addEventListener('animationend', onEnd);
     }
 
-    /** Animation de rejet — déclenche un shake sur le <dialog> natif pour signaler que la fermeture est bloquée. */
+    /** Animation de rejet — déclenche un shake (ou outline si prefers-reduced-motion) pour signaler que la fermeture est bloquée. */
     private _shake(): void {
-        this.dialog.classList.remove('shake');
-        void this.dialog.offsetWidth; // force reflow pour redémarrer l'animation si déjà en cours
-        this.dialog.classList.add('shake');
+        const dialog = this.dialog;
+        dialog.classList.remove('shake');
+        void dialog.offsetWidth; // force reflow pour redémarrer l'animation si déjà en cours
+        dialog.classList.add('shake');
+
+        const prefersReducedMotion =
+            typeof window.matchMedia === 'function' &&
+            window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+        if (prefersReducedMotion) {
+            setTimeout(() => dialog.classList.remove('shake'), 700);
+        } else {
+            const onShakeEnd = (e: AnimationEvent) => {
+                if (e.animationName && e.animationName !== 'dialogShake') return;
+                dialog.classList.remove('shake');
+                dialog.removeEventListener('animationend', onShakeEnd);
+            };
+            dialog.addEventListener('animationend', onShakeEnd);
+        }
     }
 
     /** Finalise la fermeture : ferme le dialog natif, restaure l'état et émet ar-dialog-hidden. */
     private _finishClose(): void {
-        this.dialog.classList.remove('closing');
+        this.dialog.classList.remove('closing', 'opening', 'shake');
         this.dialog.close();
         this._unfreezeScroll();
         this._removeOpenListeners();

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -1,5 +1,6 @@
 import {
     LitElement,
+    nothing,
     type TemplateResult,
     html,
     type CSSResultGroup,
@@ -25,37 +26,46 @@ export type ArDialogEvents =
 const arDialogLocks = new Set<ArDialog>();
 let _savedBodyOverflow: string | null = null;
 
+document.addEventListener(
+    'click',
+    (e: MouseEvent) => {
+        const trigger = (e.target as Element).closest('[data-ar-dialog-open]');
+        if (!trigger) return;
+        const id = trigger.getAttribute('data-ar-dialog-open');
+        const target = id ? (document.getElementById(id) as ArDialog | null) : null;
+        if (target?.tagName === 'AR-DIALOG') target.open = true;
+    },
+    { capture: true },
+);
+
 /**
  * @summary Version améliorée du composant natif <dialog> avec affichage centré ou panel.
  *
- * @slot header
- * @slot title
- * @slot
- * @slot footer
+ * @slot label - Titre du dialog. Remplace la propriété `label` si du HTML est nécessaire.
+ * @slot - Contenu principal du dialog.
+ * @slot footer - Actions du dialog (boutons). Absent du DOM si non fourni.
  *
- * @csspart base - L'élément racine du composant.
- * @cssprop [--ar-dialog-size=auto] - Taille du composant.
+ * @csspart dialog - L'élément <dialog> racine.
+ * @csspart header - L'en-tête contenant le titre et le bouton de fermeture.
+ * @csspart title - Le titre du dialog.
+ * @csspart body - La zone de contenu principale.
+ * @csspart footer - La zone d'actions (absente du DOM si slot non utilisé).
  *
- * @event {CustomEvent} ar-dialog-show - Émis lorsque que le composant va s'afficher.
- * @event {CustomEvent} ar-dialog-shown - Émis lorsque que le composant est affiché
- * @event {CustomEvent} ar-dialog-hide - Émis lorsque que le composant va être masqué
- * @event {CustomEvent} ar-dialog-hide-prevented - Émis lorsque que le masquage du composant a été interrompu
- * @event {CustomEvent} ar-dialog-hidden - Émis lorsque que le composant est masqué
- * @event {CustomEvent} ar-dialog-dismissed - Émis lorsque que le composant a été fermé
- * @event {CustomEvent} ar-dialog-dismissed-prevented - Émis lorsque la fermeture du composant a été interrompue
- * @event {CustomEvent} ar-dialog-accepted - Émis lorsque que le composant est fermé avec un bouton indiquant une acceptation
- * @event {CustomEvent} ar-dialog-accepted-prevented - Émis lorsque que la fermeture via un bouton de confirmation a été interrompue
+ * @event {CustomEvent} ar-dialog-show - Émis avant l'ouverture. Annulable.
+ * @event {CustomEvent} ar-dialog-shown - Émis après l'ouverture (après updateComplete).
+ * @event {CustomEvent} ar-dialog-hide - Émis avant la fermeture. Annulable.
+ * @event {CustomEvent} ar-dialog-hide-prevented - Émis si ar-dialog-hide est annulé.
+ * @event {CustomEvent} ar-dialog-hidden - Émis après la fermeture (après animation).
+ * @event {CustomEvent} ar-dialog-dismissed - Émis lors d'un clic sur data-ar-dismiss. Annulable.
+ * @event {CustomEvent} ar-dialog-dismissed-prevented - Émis si ar-dialog-dismissed est annulé.
+ * @event {CustomEvent} ar-dialog-accepted - Émis lors d'un clic sur data-ar-accept. Annulable.
+ * @event {CustomEvent} ar-dialog-accepted-prevented - Émis si ar-dialog-accepted est annulé.
  */
 @customElement('ar-dialog')
 export class ArDialog extends LitElement {
     static override styles: CSSResultGroup = [utilitiesStyles, buttonStyles, styles];
 
-    // Variables internes
-
-    // Références HTML
-    /** Elément HTML contenant la dialog */
-    @query('dialog', true)
-    dialog!: HTMLDialogElement;
+    // ── Public properties ──────────────────────────────────────────────────────
 
     /**
      * Visibilité du composant.
@@ -66,18 +76,16 @@ export class ArDialog extends LitElement {
     @property({ reflect: true, type: Boolean }) open: boolean = false;
 
     /**
-     * Possibilité de fermer le composant en cliquant sur le backdrop.
-     * Si vrai, le composant ne se ferme pas quand l'utilisateur clique sur le fond grisé
+     * Si vrai, un clic sur le backdrop ne ferme pas le dialog.
      *
-     * @attr staticBackdrop
+     * @attr static-backdrop
      * @default false
      */
     @property({ reflect: true, type: Boolean, attribute: 'static-backdrop' })
     staticBackdrop: boolean = false;
 
     /**
-     * Le label du composant dialog affiché dans le header.
-     * Pour utiliser du HTML, utiliser le slot `label`.
+     * Titre affiché dans le header. Pour du HTML, utiliser `slot="label"`.
      *
      * @attr label
      * @default ''
@@ -85,17 +93,16 @@ export class ArDialog extends LitElement {
     @property({ reflect: true }) label = '';
 
     /**
-     * Mode d'affichage du composant.
+     * Mode d'affichage : `modal` (centré avec backdrop) ou `panel` (latéral).
      *
      * @attr mode
-     * @default dialog
+     * @default 'modal'
      */
     @property({ reflect: true, type: String })
     mode: 'modal' | 'panel' = 'modal';
 
     /**
-     * Position du composant.
-     * Utilisé uniquement pour le mode 'panel'
+     * Côté d'affichage du panel. Sans effet en mode `modal`.
      *
      * @attr placement
      * @default 'right'
@@ -104,7 +111,7 @@ export class ArDialog extends LitElement {
     placement: 'left' | 'right' = 'right';
 
     /**
-     * Largeur du composant.
+     * Largeur du dialog. Les valeurs correspondent à des tailles CSS prédéfinies.
      *
      * @attr size
      * @default 'md'
@@ -112,20 +119,40 @@ export class ArDialog extends LitElement {
     @property({ reflect: true, type: String })
     size: 'sm' | 'md' | 'lg' | 'xl' = 'md';
 
+    // ── Private state ──────────────────────────────────────────────────────────
+
+    @query('dialog', true)
+    dialog!: HTMLDialogElement;
+
+    /** Cible du dernier pointerdown, pour distinguer un vrai clic backdrop d'un drag. */
     private _pointerDownTarget: EventTarget | null = null;
 
+    /** Vrai pendant l'animation de fermeture — bloque les interactions et les double-appels. */
     @state() private _isClosing = false;
 
-    // ---------------------------------------------------------------------------
-    // Lifecycle
-    // ---------------------------------------------------------------------------
+    /** Vrai si au moins un enfant direct avec slot="footer" est présent. */
+    @state() private _hasFooter = false;
+
+    private _footerObserver?: MutationObserver;
+
+    private _checkFooter(): void {
+        this._hasFooter = !!this.querySelector(':scope > [slot="footer"]');
+    }
+
+    // ── Lifecycle ──────────────────────────────────────────────────────────────
+
+    override connectedCallback(): void {
+        super.connectedCallback();
+        this._checkFooter();
+        this._footerObserver = new MutationObserver(() => this._checkFooter());
+        this._footerObserver.observe(this, { childList: true });
+    }
 
     override disconnectedCallback(): void {
         super.disconnectedCallback();
+        this._footerObserver?.disconnect();
         this._removeOpenListeners();
-        if (this.open) {
-            this._unfreezeScroll();
-        }
+        if (this.open) this._unfreezeScroll();
     }
 
     override firstUpdated(): void {
@@ -144,9 +171,7 @@ export class ArDialog extends LitElement {
         }
     }
 
-    // ---------------------------------------------------------------------------
-    // Render
-    // ---------------------------------------------------------------------------
+    // ── Render ─────────────────────────────────────────────────────────────────
 
     override render(): TemplateResult {
         return html`
@@ -164,35 +189,36 @@ export class ArDialog extends LitElement {
                 <div class="modal-dialog" role="document">
                     <div class="dialog-content">
                         <header part="header" class="dialog-header">
-                            <slot name="header">
-                                <h1 part="title" class="dialog-title" id="dialog-heading">
-                                    <slot name="label">${this.label}</slot>
-                                </h1>
-                                <button
-                                    id="ar-dialog-close"
-                                    type="button"
-                                    class="btn btn-tertiary light close btn-ratio-square"
-                                    data-dismiss="dialog"
-                                    aria-describedby="dialog-heading"
-                                >
-                                    <span aria-hidden="true" class="icon icon-close"></span>
-                                    <span class="btn-content sr-only">Fermer la modale</span>
-                                </button>
-                            </slot>
+                            <h1 part="title" class="dialog-title" id="dialog-heading">
+                                <slot name="label">${this.label}</slot>
+                            </h1>
+                            <button
+                                type="button"
+                                class="btn btn-tertiary light close btn-ratio-square"
+                                data-ar-dismiss
+                                aria-describedby="dialog-heading"
+                            >
+                                <span aria-hidden="true" class="icon icon-close"></span>
+                                <span class="btn-content sr-only">Fermer la modale</span>
+                            </button>
                         </header>
                         <div part="body" class="dialog-body">
                             <slot></slot>
                         </div>
-                        <footer part="footer" class="dialog-footer">
-                            <slot name="footer"></slot>
-                        </footer>
+                        ${this._hasFooter
+                            ? html`<footer part="footer" class="dialog-footer">
+                                  <slot name="footer"></slot>
+                              </footer>`
+                            : nothing}
                     </div>
                 </div>
             </dialog>
         `;
     }
 
-    /** Empêche le scroll sur le corps de page quand la modale est ouverte */
+    // ── Scroll management ──────────────────────────────────────────────────────
+
+    /** Bloque le scroll du body. Le backup est partagé entre instances pour gérer les dialogs empilés. */
     private _freezeScroll() {
         if (arDialogLocks.size === 0) {
             _savedBodyOverflow = document.body.style.overflow || null;
@@ -201,7 +227,7 @@ export class ArDialog extends LitElement {
         document.body.style.overflow = 'hidden';
     }
 
-    /** Remet le scroll sur le corps de page quand la modale est fermée */
+    /** Restaure le scroll du body, seulement quand aucun autre dialog n'est ouvert. */
     private _unfreezeScroll() {
         arDialogLocks.delete(this);
         if (arDialogLocks.size > 0) return;
@@ -214,11 +240,8 @@ export class ArDialog extends LitElement {
         _savedBodyOverflow = null;
     }
 
-    /**
-     * Emet l'évènement correspondant (ouverture, fermeture, ...)
-     * @param  name Nom de l'évènement à transmettre
-     * @emits Evènement du nom renseigné
-     */
+    // ── Events ─────────────────────────────────────────────────────────────────
+
     private _emit(name: ArDialogEvents): CustomEvent {
         const e = new CustomEvent(name, {
             bubbles: true,
@@ -238,15 +261,12 @@ export class ArDialog extends LitElement {
         document.removeEventListener('keydown', this._handleDocumentKeyDown);
     }
 
-    // ***** INTERACTIONS *****
-    /**
-     * Au click sur la modale, récupère quel élément a été cliqué et cache la modale selon le bouton.
-     * @param {MouseEvent} event Evènement du click
-     */
+    // ── Interaction handlers ───────────────────────────────────────────────────
+
     private _handleDialogClick = (event: MouseEvent) => {
         const target = event.target as HTMLElement;
-        const dismissed = target.closest('[data-dismiss="dialog"]');
-        const accepted = target.closest('[data-accept="dialog"]');
+        const dismissed = target.closest('[data-ar-dismiss]');
+        const accepted = target.closest('[data-ar-accept]');
 
         if (dismissed || accepted) {
             const e = this._emit(dismissed ? 'ar-dialog-dismissed' : 'ar-dialog-accepted');
@@ -264,10 +284,6 @@ export class ArDialog extends LitElement {
         }
     };
 
-    /**
-     * À l'appui sur la touche escape, on ferme la modale
-     * @param {KeyboardEvent} event
-     */
     private _handleDocumentKeyDown = (event: KeyboardEvent) => {
         if (event.key === 'Escape' && this.open && !this._isClosing) {
             event.preventDefault();
@@ -276,26 +292,14 @@ export class ArDialog extends LitElement {
         }
     };
 
-    /**
-     * Gestion de l'événement 'cancel' déclenché par le <dialog> lorsque la touche Esc est appuyée
-     * @param {Event} event
-     */
     private _handleDialogCancel = (event: Event) => {
-        event.preventDefault(); // Empêche la fermeture automatique du dialog sur "Escape"
+        event.preventDefault(); // Empêche la fermeture automatique du <dialog> natif sur Escape
     };
 
-    /**
-     * Au pointerdown sur la dialog, mémorise la cible pour comparaison au pointerup
-     * @param {PointerEvent} event
-     */
     private _handleDialogPointerDown = (event: PointerEvent) => {
         this._pointerDownTarget = event.target;
     };
 
-    /**
-     * Au pointerup sur le backdrop, ferme la modale si le pointerdown était aussi sur le backdrop
-     * @param {PointerEvent} event
-     */
     private _handleDialogPointerUp = (event: PointerEvent) => {
         if (this.staticBackdrop) return;
         if (this._pointerDownTarget === this.dialog && event.target === this.dialog) {
@@ -304,8 +308,9 @@ export class ArDialog extends LitElement {
         this._pointerDownTarget = null;
     };
 
-    // ***** API *****
-    /** Affiche la modale, fige le scroll et ajoute l'écoute du click */
+    // ── Open / Close ───────────────────────────────────────────────────────────
+
+    /** Ouvre le dialog natif, gèle le scroll et enregistre le listener clavier. */
     private _show(): void {
         const showEvent = this._emit('ar-dialog-show');
         if (showEvent.defaultPrevented) {
@@ -319,36 +324,51 @@ export class ArDialog extends LitElement {
         this.updateComplete.then(() => this._emit('ar-dialog-shown'));
     }
 
-    /** Cache la modale avec une animation, réactive le scroll et supprime l'écoute du click */
+    /** Déclenche l'animation de fermeture et attend animationend avant de clore. */
     private _close(): void {
         if (this._isClosing) return;
         const hideEvent = this._emit('ar-dialog-hide');
-
-        // Si la fermeture est annulée
         if (hideEvent.defaultPrevented) {
             this.open = true;
             this._emit('ar-dialog-hide-prevented');
             return;
         }
 
-        this._isClosing = true;
-
         const prefersReducedMotion =
             typeof window.matchMedia === 'function' &&
             window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-        const duration = parseFloat(getComputedStyle(this.dialog).animationDuration) * 1000 || 0;
-        const animationTiming = prefersReducedMotion ? 0 : duration;
-        this.dialog?.classList.add('closing');
 
-        setTimeout(() => {
-            this.dialog?.classList.remove('closing');
-            this.dialog?.close();
-            this._unfreezeScroll();
-            this._removeOpenListeners();
-            this._isClosing = false;
-            this.open = false;
-            this.updateComplete.then(() => this._emit('ar-dialog-hidden'));
-        }, animationTiming);
+        this._isClosing = true;
+        this.dialog.classList.add('closing');
+
+        if (prefersReducedMotion) {
+            this._finishClose();
+            return;
+        }
+
+        const fallback = setTimeout(() => {
+            this.dialog.removeEventListener('animationend', onEnd);
+            this._finishClose();
+        }, 500);
+
+        const onEnd = (e: AnimationEvent) => {
+            if (e.target !== this.dialog) return;
+            clearTimeout(fallback);
+            this.dialog.removeEventListener('animationend', onEnd);
+            this._finishClose();
+        };
+        this.dialog.addEventListener('animationend', onEnd);
+    }
+
+    /** Finalise la fermeture : ferme le dialog natif, restaure l'état et émet ar-dialog-hidden. */
+    private _finishClose(): void {
+        this.dialog.classList.remove('closing');
+        this.dialog.close();
+        this._unfreezeScroll();
+        this._removeOpenListeners();
+        this._isClosing = false;
+        this.open = false;
+        this.updateComplete.then(() => this._emit('ar-dialog-hidden'));
     }
 }
 

--- a/packages/core/src/controllers/has-slot.controller.test.ts
+++ b/packages/core/src/controllers/has-slot.controller.test.ts
@@ -1,0 +1,109 @@
+import { LitElement, html } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { afterEach, describe, expect, it } from 'vitest';
+import { HasSlotController } from './has-slot.controller.js';
+import { fixture, waitForUpdate } from '../test-utils.js';
+
+// ── Fixture component ──────────────────────────────────────────────────────────
+
+@customElement('test-has-slot')
+class TestHasSlot extends LitElement {
+    readonly slots = new HasSlotController(this, '[default]', 'footer');
+
+    override render() {
+        return html`
+            ${this.slots.test('[default]') ? html`<span id="has-default">yes</span>` : ''}
+            ${this.slots.test('footer') ? html`<span id="has-footer">yes</span>` : ''}
+            <slot></slot>
+            <slot name="footer"></slot>
+        `;
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'test-has-slot': TestHasSlot;
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('HasSlotController', () => {
+    let el: TestHasSlot;
+
+    afterEach(() => {
+        el?.remove();
+    });
+
+    describe('slot par défaut', () => {
+        it('test("[default]") est false sans contenu', async () => {
+            el = await fixture('<test-has-slot></test-has-slot>');
+            expect(el.slots.test('[default]')).toBe(false);
+            expect(el.shadowRoot?.getElementById('has-default')).toBeNull();
+        });
+
+        it('test("[default]") est true avec un nœud texte non vide', async () => {
+            el = await fixture('<test-has-slot>Contenu texte</test-has-slot>');
+            expect(el.slots.test('[default]')).toBe(true);
+            expect(el.shadowRoot?.getElementById('has-default')).not.toBeNull();
+        });
+
+        it('test("[default]") est true avec un élément enfant sans slot', async () => {
+            el = await fixture('<test-has-slot><p>Paragraphe</p></test-has-slot>');
+            expect(el.slots.test('[default]')).toBe(true);
+        });
+
+        it('test("[default]") est false pour un nœud texte vide (espaces)', async () => {
+            el = await fixture('<test-has-slot>   </test-has-slot>');
+            expect(el.slots.test('[default]')).toBe(false);
+        });
+    });
+
+    describe('slot nommé', () => {
+        it('test("footer") est false sans slot footer', async () => {
+            el = await fixture('<test-has-slot></test-has-slot>');
+            expect(el.slots.test('footer')).toBe(false);
+            expect(el.shadowRoot?.getElementById('has-footer')).toBeNull();
+        });
+
+        it('test("footer") est true avec un enfant slot="footer"', async () => {
+            el = await fixture('<test-has-slot><button slot="footer">OK</button></test-has-slot>');
+            expect(el.slots.test('footer')).toBe(true);
+            expect(el.shadowRoot?.getElementById('has-footer')).not.toBeNull();
+        });
+
+        it('un élément avec un autre slot nommé ne déclenche pas footer', async () => {
+            el = await fixture('<test-has-slot><span slot="label">Titre</span></test-has-slot>');
+            expect(el.slots.test('footer')).toBe(false);
+        });
+    });
+
+    describe('réactivité slotchange', () => {
+        it('retire le slot footer : test("footer") devient false', async () => {
+            el = await fixture(
+                '<test-has-slot><button slot="footer" id="f">OK</button></test-has-slot>',
+            );
+            expect(el.slots.test('footer')).toBe(true);
+
+            (el.querySelector('#f') as Element).remove();
+            await waitForUpdate(el);
+
+            expect(el.slots.test('footer')).toBe(false);
+            expect(el.shadowRoot?.getElementById('has-footer')).toBeNull();
+        });
+    });
+
+    describe('cycle de vie', () => {
+        it('déconnexion puis reconnexion conserve la détection de slot', async () => {
+            el = await fixture('<test-has-slot><button slot="footer">OK</button></test-has-slot>');
+            expect(el.slots.test('footer')).toBe(true);
+
+            const parent = el.parentElement as HTMLElement;
+            parent.removeChild(el);
+            parent.appendChild(el);
+            await waitForUpdate(el);
+
+            expect(el.slots.test('footer')).toBe(true);
+        });
+    });
+});

--- a/packages/core/src/controllers/has-slot.controller.ts
+++ b/packages/core/src/controllers/has-slot.controller.ts
@@ -1,0 +1,53 @@
+import type { ReactiveController, ReactiveControllerHost } from 'lit';
+
+/** Reactive controller that detects slot presence, modelled after WebAwesome's HasSlotController. */
+export class HasSlotController implements ReactiveController {
+    private host: ReactiveControllerHost & Element;
+    private slotNames: string[];
+
+    constructor(host: ReactiveControllerHost & Element, ...slotNames: string[]) {
+        (this.host = host).addController(this);
+        this.slotNames = slotNames;
+    }
+
+    private hasDefaultSlot(): boolean {
+        if (!this.host.childNodes) return false;
+
+        return [...this.host.childNodes].some((node) => {
+            if (node.nodeType === Node.TEXT_NODE && (node.textContent ?? '').trim() !== '')
+                return true;
+            if (node.nodeType === Node.ELEMENT_NODE) {
+                const el = node as HTMLElement;
+                if (!el.hasAttribute('slot')) return true;
+            }
+            return false;
+        });
+    }
+
+    private hasNamedSlot(name: string): boolean {
+        return this.host.querySelector?.(`:scope > [slot="${name}"]`) !== null;
+    }
+
+    /** Returns true if the given slot has assigned content. Use `'[default]'` for the default slot. */
+    test(slotName: string): boolean {
+        return slotName === '[default]' ? this.hasDefaultSlot() : this.hasNamedSlot(slotName);
+    }
+
+    hostConnected(): void {
+        this.host.shadowRoot?.addEventListener('slotchange', this._handleSlotChange);
+    }
+
+    hostDisconnected(): void {
+        this.host.shadowRoot?.removeEventListener('slotchange', this._handleSlotChange);
+    }
+
+    private _handleSlotChange = (event: Event): void => {
+        const slot = event.target as HTMLSlotElement;
+        if (
+            (this.slotNames.includes('[default]') && !slot.name) ||
+            (slot.name && this.slotNames.includes(slot.name))
+        ) {
+            this.host.requestUpdate();
+        }
+    };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,7 @@
  *   import '@ariane-ui/core/components/alert/alert.js';
  */
 export { whenAllDefined } from './utils/when-all-defined.js';
+export { prefersReducedMotion } from './utils/media.js';
 export { HasSlotController } from './controllers/has-slot.controller.js';
 export { announceA11y } from './a11y/announce-a11y.js';
 export { ArAlert } from './components/alert/alert.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,8 @@
  *   import '@ariane-ui/core/components/alert/alert.js';
  */
 export { whenAllDefined } from './utils/when-all-defined.js';
+export { HasSlotController } from './controllers/has-slot.controller.js';
+export { announceA11y } from './a11y/announce-a11y.js';
 export { ArAlert } from './components/alert/alert.js';
 export { ArBreadcrumb } from './components/breadcrumb/breadcrumb.js';
 export { ArBreadcrumbItem } from './components/breadcrumb-item/breadcrumb-item.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,3 +13,4 @@ export { ArSpinner } from './components/spinner/spinner.js';
 export { ArPagination } from './components/pagination/pagination.js';
 export { ArStepper } from './components/stepper/stepper.js';
 export { ArStepperItem } from './components/stepper-item/stepper-item.js';
+export { ArDialog } from './components/dialog/dialog.js';

--- a/packages/core/src/styles/animations.styles.ts
+++ b/packages/core/src/styles/animations.styles.ts
@@ -1,58 +1,26 @@
 import { css } from 'lit';
 
 export default css`
-    @-webkit-keyframes spinnerRotate {
-        to {
-            -webkit-transform: rotate(1turn);
-            transform: rotate(1turn)
-        }
-    }
-
     @keyframes spinnerRotate {
         to {
-            -webkit-transform: rotate(1turn);
-            transform: rotate(1turn)
-        }
-    }
-
-    @-webkit-keyframes spinnerDash {
-        0% {
-            stroke-dasharray: 1,200;
-            stroke-dashoffset: 0
-        }
-
-        50% {
-            stroke-dasharray: 89,200;
-            stroke-dashoffset: -35px
-        }
-
-        to {
-            stroke-dasharray: 89,200;
-            stroke-dashoffset: -124px
+            transform: rotate(1turn);
         }
     }
 
     @keyframes spinnerDash {
         0% {
-            stroke-dasharray: 1,200;
-            stroke-dashoffset: 0
+            stroke-dasharray: 1, 200;
+            stroke-dashoffset: 0;
         }
 
         50% {
-            stroke-dasharray: 89,200;
-            stroke-dashoffset: -35px
+            stroke-dasharray: 89, 200;
+            stroke-dashoffset: -35px;
         }
 
         to {
-            stroke-dasharray: 89,200;
-            stroke-dashoffset: -124px
-        }
-    }
-
-    @-webkit-keyframes tabMaskFading {
-        to {
-            -webkit-mask-position: 0;
-            mask-position: 0
+            stroke-dasharray: 89, 200;
+            stroke-dashoffset: -124px;
         }
     }
 `;

--- a/packages/core/src/utils/media.ts
+++ b/packages/core/src/utils/media.ts
@@ -1,0 +1,4 @@
+/** Returns true if the user has requested reduced motion via OS/browser settings. */
+export const prefersReducedMotion = (): boolean =>
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;

--- a/packages/core/src/utils/media.ts
+++ b/packages/core/src/utils/media.ts
@@ -1,4 +1,5 @@
 /** Returns true if the user has requested reduced motion via OS/browser settings. */
 export const prefersReducedMotion = (): boolean =>
+    typeof window !== 'undefined' &&
     typeof window.matchMedia === 'function' &&
     window.matchMedia('(prefers-reduced-motion: reduce)').matches;


### PR DESCRIPTION
## Summary

- Ajoute le composant `<ar-dialog>` : boîte de dialogue modale ou panneau latéral (drawer), accessible et animée
- Ajoute l'utilitaire interne `announceA11y` pour les annonces `aria-live` partagées entre composants
- Ajoute `HasSlotController` pour la détection de slots (pattern WebAwesome)

## Composant `ar-dialog`

Wrapper Lit autour du `<dialog>` natif. Deux modes via `mode="modal"` (centré avec backdrop) et `mode="drawer"` (panneau latéral gauche ou droite).

**Comportements**
- Focus à l'ouverture : respect de `autofocus` sur les enfants, puis premier élément focalisable, puis bouton de fermeture ; restauration sur le déclencheur à la fermeture
- Scroll lock partagé entre instances pour les dialogs empilés ; `Escape` limité au dialog au sommet de la pile
- Événements annulables (`ar-dialog-show`, `ar-dialog-hide`, `ar-dialog-dismissed`, `ar-dialog-accepted`) avec shake visuel et annonce `aria-live` si la fermeture est bloquée
- Déclenchement déclaratif via `data-ar-dialog-open="id"`, fermeture via `data-ar-dismiss`, validation via `data-ar-accept`
- Fermeture au clic backdrop via `close-on-backdrop` (fallback `click` pour Safari iOS — WebKit #267688)
- Animations désactivées si `prefers-reduced-motion: reduce`
- Dark mode via tokens `--ar-color-*`
- SSR-safe (`typeof window !== 'undefined'` sur `prefersReducedMotion`)

**API**
- Props : `open`, `label`, `mode`, `placement`, `size`, `close-on-backdrop`, `prevented-message`, `close-label`
- Slots : `label` (titre HTML), défaut (contenu), `footer` (actions — absent du DOM si non utilisé)
- Parts : `dialog`, `header`, `title`, `body`, `footer`
- Custom properties : `--width`, `--spacing`, `--spacing-block`, `--spacing-inline`

**Accessibilité**
- `role="dialog"`, `aria-modal`, `aria-labelledby` + `aria-describedby` sur le `<dialog>` natif
- Label du bouton de fermeture localisable via `close-label` (défaut : `"Fermer"`)
- Avertissement console si ni `label` ni `slot="label"` ne sont fournis

**Compat navigateur**
- Safari 26 modal : `flex: 1 1 auto` sur le body (`flex-basis: auto` résout le `max-height` sur conteneur flex)
- Safari iOS backdrop : fallback `click` en complément des handlers `pointerdown`/`pointerup`
- Drawer : `max-height: 100dvh` pour overrider le défaut UA (`calc(100% - 6px - 2em)`)

## Test plan

- [x] `npm run test` — 314 tests Vitest
- [x] `npm run test:all` — 47 tests WTR browser (a11y inclus)
- [x] Vérification manuelle Safari (modal + drawer)