### PR TITLE
fix(spinner): reduced-motion, transform-box SVG, suppression préfixes webkit

### DIFF
--- a/packages/core/src/components/spinner/spinner.styles.ts
+++ b/packages/core/src/components/spinner/spinner.styles.ts
@@ -17,30 +17,29 @@ export default css`
     .spinner {
         width: 56px;
         height: 56px;
-        -webkit-animation: spinnerRotate 2s linear infinite;
         animation: spinnerRotate 2s linear infinite;
-        -webkit-transform-origin: center center;
+        transform-box: fill-box;
         transform-origin: center center;
     }
 
     .spinner-path {
         stroke-width: 4;
+        stroke-dasharray: 1, 200;
         stroke-dashoffset: 0;
         stroke-linecap: round;
         stroke: var(--ar-spinner-stroke-color, currentColor);
-        -webkit-animation: spinnerDash 1.5s ease-in-out infinite;
         animation: spinnerDash 1.5s ease-in-out infinite;
     }
 
-    @media (prefers-reduced-motion: no-preference) {
-        .spinner-path {
-            stroke-dasharray: 1, 200;
-        }
-    }
-
     @media (prefers-reduced-motion: reduce) {
+        .spinner {
+            animation: spinnerPulse 1.5s ease-in-out infinite;
+        }
+
         .spinner-path {
+            animation: none;
             stroke-dasharray: 89, 200;
+            stroke-dashoffset: -35px;
         }
     }
 

--- a/packages/core/src/styles/animations.styles.ts
+++ b/packages/core/src/styles/animations.styles.ts
@@ -23,4 +23,14 @@ export default css`
             stroke-dashoffset: -124px;
         }
     }
+
+    @keyframes spinnerPulse {
+        0%,
+        100% {
+            opacity: 1;
+        }
+        50% {
+            opacity: 0.35;
+        }
+    }
 `;


### PR DESCRIPTION
## Summary

- `prefers-reduced-motion`: stoppe la rotation et `spinnerDash`, remplace par `spinnerPulse` (opacité 1→0.35→1) pour conserver le signal d'activité ; arc figé à mi-course
- `transform-box: fill-box` sur `.spinner` pour que `transform-origin: center center` soit calculé sur le bounding box SVG et non le viewport
- Suppression des préfixes `-webkit-animation` et `-webkit-transform-origin`
- `stroke-dasharray: 1, 200` sorti du bloc `@media (no-preference)` — valeur de départ directe sur `.spinner-path`

## Test plan

- [x] `npm run test` — 314 tests Vitest
- [ ] Vérification manuelle `prefers-reduced-motion: reduce` (OS setting ou DevTools)