### PR TITLE
fix(alert): prefers-reduced-motion — transition désactivée + fallback JS

### DIFF
--- a/packages/core/src/components/alert/alert.styles.ts
+++ b/packages/core/src/components/alert/alert.styles.ts
@@ -55,8 +55,16 @@ export default css`
     :host([hiding]) {
         opacity: 0;
         transform: scale(0.75);
-        transition: opacity, transform;
-        transition-duration: 0.33s;
+        transition:
+            opacity 0.33s,
+            transform 0.33s;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        :host([hiding]),
+        [part='close'] {
+            transition: none;
+        }
     }
 
     [part='close'] {

--- a/packages/core/src/components/alert/alert.ts
+++ b/packages/core/src/components/alert/alert.ts
@@ -1,6 +1,7 @@
 import { LitElement, type TemplateResult, html, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import styles from './alert.styles.js';
+import { prefersReducedMotion } from '../../utils/media.js';
 
 export function warn(name: string, message: string, error?: Error) {
     if (error) console.warn(`${name} - ${message}`, error);
@@ -174,7 +175,11 @@ export class ArAlert extends LitElement {
     }
 
     private _hide = (): void => {
-        this.hiding = this.canBeHidden;
+        if (!this.canBeHidden) return;
+        this.hiding = true;
+        if (prefersReducedMotion()) {
+            this._finishHide();
+        }
     };
 
     /** Supprime l'alerte du DOM et reporte le focus après la fin de la transition CSS */


### PR DESCRIPTION
## Summary

- `@media (prefers-reduced-motion: reduce)` : désactive la `transition` sur `:host([hiding])` et `[part='close']`
- JS : si `prefersReducedMotion()`, `_finishHide()` est appelé directement — sans ça, `transitionend` ne firerait jamais et l'alerte resterait dans le DOM indéfiniment
- Même pattern que `ar-dialog` : guard CSS + vérification JS dans la méthode de fermeture

## Test plan

- [x] `npm run test` — 314 tests Vitest
- [x] Vérification manuelle avec "Reduce motion" activé (macOS ou DevTools)