### PR TITLE
feat(stepper,breadcrumb): attribut open + part="trigger"

### DIFF
--- a/packages/core/src/components/breadcrumb/breadcrumb.test.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.test.ts
@@ -88,7 +88,7 @@ describe('ArBreadcrumb', () => {
                     <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
                 </ar-breadcrumb>
             `);
-            expect(getPart(el, 'dropdown')).toBeNull();
+            expect(getPart(el, 'trigger')).toBeNull();
         });
 
         it("affiche le bon nombre d'items", async () => {
@@ -171,14 +171,14 @@ describe('ArBreadcrumb', () => {
             ArBreadcrumb.mobileQuery = mockMediaQuery(true);
         });
 
-        it('affiche un part="dropdown" en mode mobile', async () => {
+        it('affiche un part="trigger" en mode mobile', async () => {
             el = await fixture(`
                 <ar-breadcrumb>
                     <ar-breadcrumb-item label="Accueil" href="/"></ar-breadcrumb-item>
                     <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
                 </ar-breadcrumb>
             `);
-            expect(getPart(el, 'dropdown')).not.toBeNull();
+            expect(getPart(el, 'trigger')).not.toBeNull();
         });
 
         it('ne rend pas de ol.breadcrumb-desktop en mode mobile', async () => {

--- a/packages/core/src/components/breadcrumb/breadcrumb.test.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.test.ts
@@ -296,6 +296,91 @@ describe('ArBreadcrumb', () => {
 
             expect(fired).toBe(true);
         });
+
+        it('open vaut false par défaut', async () => {
+            el = await fixture(`
+                <ar-breadcrumb>
+                    <ar-breadcrumb-item label="Accueil" href="/"></ar-breadcrumb-item>
+                    <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
+                </ar-breadcrumb>
+            `);
+            expect(el.open).toBe(false);
+            expect(el.hasAttribute('open')).toBe(false);
+        });
+
+        it('open est reflété comme attribut HTML après clic', async () => {
+            el = await fixture(`
+                <ar-breadcrumb>
+                    <ar-breadcrumb-item label="Accueil" href="/"></ar-breadcrumb-item>
+                    <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
+                </ar-breadcrumb>
+            `);
+            const btn = getShadow(el).querySelector('#breadcrumb-dropdown') as HTMLButtonElement;
+            btn.click();
+            await waitForUpdate(el);
+
+            expect(el.open).toBe(true);
+            expect(el.hasAttribute('open')).toBe(true);
+        });
+
+        it('open=true programmatique émet ar-breadcrumb-open', async () => {
+            el = await fixture(`
+                <ar-breadcrumb>
+                    <ar-breadcrumb-item label="Accueil" href="/"></ar-breadcrumb-item>
+                    <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
+                </ar-breadcrumb>
+            `);
+            const handler = vi.fn();
+            el.addEventListener('ar-breadcrumb-open', handler);
+
+            el.open = true;
+            await waitForUpdate(el);
+
+            expect(handler).toHaveBeenCalledOnce();
+        });
+
+        it('open=false programmatique émet ar-breadcrumb-close', async () => {
+            el = await fixture(`
+                <ar-breadcrumb>
+                    <ar-breadcrumb-item label="Accueil" href="/"></ar-breadcrumb-item>
+                    <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
+                </ar-breadcrumb>
+            `);
+            const btn = getShadow(el).querySelector('#breadcrumb-dropdown') as HTMLButtonElement;
+            btn.click();
+            await waitForUpdate(el);
+
+            const handler = vi.fn();
+            el.addEventListener('ar-breadcrumb-close', handler);
+            el.open = false;
+            await waitForUpdate(el);
+
+            expect(handler).toHaveBeenCalledOnce();
+        });
+    });
+
+    // ── Attribut open (desktop) ───────────────────────────────────────────────
+
+    describe('attribut open — mode desktop', () => {
+        beforeEach(() => {
+            ArBreadcrumb.mobileQuery = mockMediaQuery(false);
+        });
+
+        it("open=true n'émet pas d'événement en mode desktop", async () => {
+            el = await fixture(`
+                <ar-breadcrumb>
+                    <ar-breadcrumb-item label="Accueil" href="/"></ar-breadcrumb-item>
+                    <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
+                </ar-breadcrumb>
+            `);
+            const handler = vi.fn();
+            el.addEventListener('ar-breadcrumb-open', handler);
+
+            el.open = true;
+            await waitForUpdate(el);
+
+            expect(handler).not.toHaveBeenCalled();
+        });
     });
 
     // ── Mise à jour réactive ──────────────────────────────────────────────────

--- a/packages/core/src/components/breadcrumb/breadcrumb.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.ts
@@ -54,7 +54,7 @@ export class ArBreadcrumb extends LitElement {
      * Sans effet en mode desktop.
      * @attr open
      */
-    @property({ reflect: true, type: Boolean }) open = false;
+    @property({ reflect: true, type: Boolean }) open: boolean = false;
 
     @query('[part="trigger"]') private _dropdownTrigger?: HTMLButtonElement;
     @query('[part="panel"]') private _dropdownPanel?: HTMLElement;
@@ -79,7 +79,7 @@ export class ArBreadcrumb extends LitElement {
         },
     });
 
-    private readonly _anchoredCtrl = new AnchoredController(this, {
+    private readonly _popover = new AnchoredController(this, {
         lockScroll: false,
         popupMode: 'menu',
         placement: 'bottom-end',
@@ -115,6 +115,19 @@ export class ArBreadcrumb extends LitElement {
             void this.updateComplete.then(() => {
                 if (this.isConnected) this._attachDropdown();
             });
+        }
+        if (changed.has('open') && changed.get('open') !== undefined && this.isMobile) {
+            if (this.open) {
+                void this._popover.show();
+                this.dispatchEvent(
+                    new CustomEvent('ar-breadcrumb-open', { bubbles: true, composed: true }),
+                );
+            } else {
+                this._popover.hide();
+                this.dispatchEvent(
+                    new CustomEvent('ar-breadcrumb-close', { bubbles: true, composed: true }),
+                );
+            }
         }
     }
 
@@ -206,24 +219,16 @@ export class ArBreadcrumb extends LitElement {
 
     private _attachDropdown(): void {
         if (this._dropdownTrigger && this._dropdownPanel) {
-            this._anchoredCtrl.attach(this._dropdownTrigger, this._dropdownPanel);
+            this._popover.attach(this._dropdownTrigger, this._dropdownPanel);
         }
     }
 
     private _show(): void {
         this.open = true;
-        void this._anchoredCtrl.show();
-        this.dispatchEvent(
-            new CustomEvent('ar-breadcrumb-open', { bubbles: true, composed: true }),
-        );
     }
 
     private _hide(): void {
         this.open = false;
-        this._anchoredCtrl.hide();
-        this.dispatchEvent(
-            new CustomEvent('ar-breadcrumb-close', { bubbles: true, composed: true }),
-        );
     }
 
     private _handleMediaChange = (): void => {

--- a/packages/core/src/components/breadcrumb/breadcrumb.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.ts
@@ -6,7 +6,7 @@ import {
     nothing,
     type PropertyValues,
 } from 'lit';
-import { customElement, query, state } from 'lit/decorators.js';
+import { customElement, property, query, state } from 'lit/decorators.js';
 import { ContextProvider } from '@lit/context';
 import utilitiesStyles from '../../styles/utilities.styles.js';
 import panelStyles from '../../styles/shared/panel.styles.js';
@@ -30,7 +30,7 @@ import { AnchoredController } from '../../controllers/anchored.controller.js';
  * @csspart item       - Chaque `<li>` de la liste.
  * @csspart link       - Les `<a>` de navigation.
  * @csspart current    - Le `<span>` de la page courante (dernier élément, non cliquable).
- * @csspart dropdown   - Le conteneur du dropdown mobile.
+ * @csspart trigger    - Le bouton d'ouverture du panel mobile.
  * @csspart panel      - Le panel mobile flottant.
  *
  * @cssprop [--ar-breadcrumb-separator-color=var(--ar-color-neutral-80)] - Couleur du séparateur entre les items (desktop).
@@ -48,9 +48,15 @@ export class ArBreadcrumb extends LitElement {
     static mobileQuery: MediaQueryList = window.matchMedia('(max-width: 767px)');
 
     @state() private isMobile: boolean = ArBreadcrumb.mobileQuery.matches;
-    @state() private dropdownOpen: boolean = false;
 
-    @query('#breadcrumb-dropdown') private _dropdownTrigger?: HTMLButtonElement;
+    /**
+     * Contrôle programmatique du panel mobile. Reflété comme attribut HTML.
+     * Sans effet en mode desktop.
+     * @attr open
+     */
+    @property({ reflect: true, type: Boolean }) open = false;
+
+    @query('[part="trigger"]') private _dropdownTrigger?: HTMLButtonElement;
     @query('[part="panel"]') private _dropdownPanel?: HTMLElement;
 
     private _items = new Set<ArBreadcrumbItem>();
@@ -78,7 +84,7 @@ export class ArBreadcrumb extends LitElement {
         popupMode: 'menu',
         placement: 'bottom-end',
         onExternalClose: () => {
-            this.dropdownOpen = false;
+            this.open = false;
             this.dispatchEvent(
                 new CustomEvent('ar-breadcrumb-close', { bubbles: true, composed: true }),
             );
@@ -145,14 +151,15 @@ export class ArBreadcrumb extends LitElement {
             >
                 <p id="breadcrumb-label" class="sr-only">Vous êtes ici</p>
                 ${this.isMobile
-                    ? html`<div part="dropdown" class="breadcrumb-dropdown">
+                    ? html`<div class="breadcrumb-dropdown">
                           <a id="mobile-home-btn" class="btn btn-tertiary" href="${items[0]?.href}">
                               <span aria-hidden="true" class="icon icon-chevron-sm-l"></span>
                               <span class="btn-content">${items[0]?.label}</span>
                           </a>
                           <button
-                              @click=${this.dropdownOpen ? this._hide : this._show}
+                              @click=${this.open ? this._hide : this._show}
                               type="button"
+                              part="trigger"
                               class="btn btn-tertiary btn-ratio-square"
                               id="breadcrumb-dropdown"
                           >
@@ -204,7 +211,7 @@ export class ArBreadcrumb extends LitElement {
     }
 
     private _show(): void {
-        this.dropdownOpen = true;
+        this.open = true;
         void this._anchoredCtrl.show();
         this.dispatchEvent(
             new CustomEvent('ar-breadcrumb-open', { bubbles: true, composed: true }),
@@ -212,7 +219,7 @@ export class ArBreadcrumb extends LitElement {
     }
 
     private _hide(): void {
-        this.dropdownOpen = false;
+        this.open = false;
         this._anchoredCtrl.hide();
         this.dispatchEvent(
             new CustomEvent('ar-breadcrumb-close', { bubbles: true, composed: true }),

--- a/packages/core/src/components/stepper/stepper.browser.test.ts
+++ b/packages/core/src/components/stepper/stepper.browser.test.ts
@@ -20,8 +20,8 @@ function getPanel(el: ArStepper): HTMLElement {
 }
 
 function getTrigger(el: ArStepper): HTMLElement {
-    const btn = el.shadowRoot?.querySelector<HTMLElement>('.btn-stepper-mobile');
-    if (!btn) throw new Error('.btn-stepper-mobile introuvable');
+    const btn = el.shadowRoot?.querySelector<HTMLElement>('[part="trigger"]');
+    if (!btn) throw new Error('[part="trigger"] introuvable');
     return btn;
 }
 

--- a/packages/core/src/components/stepper/stepper.renderer.ts
+++ b/packages/core/src/components/stepper/stepper.renderer.ts
@@ -170,7 +170,8 @@ export function renderMobile(
         <div class="stepper-dropdown">
             <button
                 type="button"
-                class="btn btn-secondary btn-block btn-stepper-mobile"
+                part="trigger"
+                class="btn btn-secondary btn-block"
                 aria-controls="stepper-dropdown-menu"
                 @click=${ctx.onToggle}
             >

--- a/packages/core/src/components/stepper/stepper.styles.ts
+++ b/packages/core/src/components/stepper/stepper.styles.ts
@@ -15,6 +15,14 @@ export default css`
         gap: 0.25rem;
     }
 
+    [part='trigger'] {
+        padding: 0.5rem 0.75rem;
+        border-radius: 0.75rem;
+        justify-content: space-between;
+        line-height: normal;
+        text-align: left;
+    }
+
     [part='panel'] {
         padding: 0.75rem;
         min-width: var(--ar-stepper-panel-min-width, var(--ar-panel-min-width, 18rem));

--- a/packages/core/src/components/stepper/stepper.test.ts
+++ b/packages/core/src/components/stepper/stepper.test.ts
@@ -466,6 +466,55 @@ describe('ArStepper', () => {
         });
     });
 
+    // ── Attribut open ─────────────────────────────────────────────────────────
+
+    describe('attribut open', () => {
+        it('vaut false par défaut', async () => {
+            const el = await fixtureWithItems(`
+                <ar-stepper current-path="/a">
+                    <ar-stepper-item path="/a" label="A"></ar-stepper-item>
+                    <ar-stepper-item path="/b" label="B"></ar-stepper-item>
+                </ar-stepper>
+            `);
+            expect(el.open).toBe(false);
+            expect(el.hasAttribute('open')).toBe(false);
+        });
+
+        it('est reflété comme attribut HTML quand posé programmatiquement', async () => {
+            const el = await fixtureWithItems(`
+                <ar-stepper current-path="/a">
+                    <ar-stepper-item path="/a" label="A"></ar-stepper-item>
+                    <ar-stepper-item path="/b" label="B"></ar-stepper-item>
+                </ar-stepper>
+            `);
+            el.open = true;
+            await waitForUpdate(el);
+
+            expect(el.open).toBe(true);
+            expect(el.hasAttribute('open')).toBe(true);
+        });
+
+        it("open=true n'a pas d'effet en mode desktop", async () => {
+            vi.spyOn(window, 'matchMedia').mockReturnValue({
+                matches: true,
+                addEventListener: vi.fn(),
+                removeEventListener: vi.fn(),
+            } as unknown as MediaQueryList);
+
+            const el = await fixtureWithItems(`
+                <ar-stepper current-path="/a">
+                    <ar-stepper-item path="/a" label="A"></ar-stepper-item>
+                    <ar-stepper-item path="/b" label="B"></ar-stepper-item>
+                </ar-stepper>
+            `);
+            el.open = true;
+            await waitForUpdate(el);
+
+            expect(el.open).toBe(true);
+            expect(shadow(el).querySelector('[part="trigger"]')).toBeNull();
+        });
+    });
+
     // ── Annonces a11y ─────────────────────────────────────────────────────────
 
     describe('annonces a11y', () => {

--- a/packages/core/src/components/stepper/stepper.ts
+++ b/packages/core/src/components/stepper/stepper.ts
@@ -1,4 +1,10 @@
-import { LitElement, html, type TemplateResult, type CSSResultGroup } from 'lit';
+import {
+    LitElement,
+    html,
+    type TemplateResult,
+    type CSSResultGroup,
+    type PropertyValues,
+} from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { ContextProvider } from '@lit/context';
 
@@ -42,7 +48,7 @@ export interface ArStepperStepChangeDetail {
  * @csspart substep      - Une sous-étape.
  * @csspart step-link    - Le lien d'une étape.
  * @csspart dropdown     - Le conteneur dropdown.
- * @csspart dropdown-btn - Le bouton d'ouverture du dropdown.
+ * @csspart trigger      - Le bouton d'ouverture du panel mobile.
  * @csspart panel        - Le panel mobile flottant.
  *
  * @cssprop [--ar-stepper-panel-min-width=var(--ar-panel-min-width,18rem)]                    - Largeur min du panel mobile (cascade vers --ar-panel-min-width).
@@ -111,6 +117,14 @@ export class ArStepper extends LitElement {
     desktopFrom = 992;
 
     /**
+     * Contrôle programmatique du panel mobile. Reflété comme attribut HTML.
+     * Sans effet en mode desktop.
+     * @attr open
+     * @default false
+     */
+    @property({ reflect: true, type: Boolean }) open: boolean = false;
+
+    /**
      * Alignement de la liste d'étapes : `left` (défaut) ou `right`.
      * **Note** — l'alignement `right` ne s'applique qu'en mode desktop (rendu liste verticale).
      * En mode mobile (dropdown), les items restent alignés à gauche.
@@ -141,11 +155,16 @@ export class ArStepper extends LitElement {
 
     private readonly navigation = new NavigationTreeController(this);
     private readonly scrollFollow = new ScrollFollowController(this, () => this.getScrollTargets());
-    private readonly dropdown = new AnchoredController(this, {
+    private readonly _popover = new AnchoredController(this, {
         lockScroll: false,
         popupMode: 'menu',
+        onExternalClose: () => {
+            this.open = false;
+        },
     });
-    private readonly _onDropdownToggle = () => this.dropdown.toggle();
+    private readonly _onDropdownToggle = () => {
+        this.open = !this.open;
+    };
 
     // ── Registry / Context ───────────────────────────────────────────────────
 
@@ -201,19 +220,27 @@ export class ArStepper extends LitElement {
         super.disconnectedCallback();
     }
 
-    override updated(_changed: Map<PropertyKey, unknown>): void {
+    override updated(changed: PropertyValues<this>): void {
         if (!this._isDesktop && !this._dropdownAttached) {
             void this.updateComplete.then(() => {
                 this._dropdownAttached = this._attachDropdown();
             });
+        }
+        if (changed.has('open') && !this._isDesktop && this._dropdownAttached) {
+            if (this.open) {
+                void this._popover.show();
+            } else {
+                this._popover.hide();
+            }
         }
     }
 
     private _attachDropdown(): boolean {
         if (!this.isConnected) return false;
         if (this._dropdownTrigger && this._dropdownPanel) {
-            this.dropdown.hide(); // flush stale scroll-lock refs before re-attach
-            this.dropdown.attach(this._dropdownTrigger, this._dropdownPanel);
+            this._popover.hide(); // flush stale scroll-lock refs before re-attach
+            this._popover.attach(this._dropdownTrigger, this._dropdownPanel);
+            if (this.open) void this._popover.show();
             return true;
         }
         return false;
@@ -223,7 +250,7 @@ export class ArStepper extends LitElement {
 
     // willUpdate() s'exécute AVANT le rendu : les requestUpdate() déclenchés ici
     // (via setCurrentPath, setEnabled) sont mergés dans le cycle courant → 0 update parasite.
-    protected override willUpdate(changed: Map<PropertyKey, unknown>) {
+    protected override willUpdate(changed: PropertyValues<this>) {
         if (changed.has('currentPath') || this.navigation.tree.length) {
             this._currentStepIndex = this.computeCurrentStepIndex();
         }

--- a/packages/core/src/components/stepper/stepper.ts
+++ b/packages/core/src/components/stepper/stepper.ts
@@ -125,7 +125,7 @@ export class ArStepper extends LitElement {
     @state()
     private _isDesktop = false;
 
-    @query('.btn-stepper-mobile') private _dropdownTrigger?: HTMLElement;
+    @query('[part="trigger"]') private _dropdownTrigger?: HTMLElement;
     @query('[part="panel"]') private _dropdownPanel?: HTMLElement;
 
     private _originalParent: ParentNode | null = null;

--- a/packages/core/src/styles/components/button.styles.ts
+++ b/packages/core/src/styles/components/button.styles.ts
@@ -714,16 +714,6 @@ export default css`
         display: flex;
     }
 
-    .btn-stepper-mobile {
-        padding: 0.5rem 0.75rem;
-        border-radius: 0.75rem;
-        -webkit-box-pack: justify;
-        -ms-flex-pack: justify;
-        justify-content: space-between;
-        line-height: normal;
-        text-align: left;
-    }
-
     .btn-help,
     a.btn-help {
         margin-left: 0.25rem;


### PR DESCRIPTION
## Summary

- Expose `open` (`@property`, reflect) sur `ar-stepper` et `ar-breadcrumb` pour le contrôle programmatique du panel mobile — suit le pattern `ar-dialog` (`updated(PropertyValues<this>)` pilote le contrôleur, `_show/_hide` ne font que basculer la propriété)
- Ajoute `part="trigger"` sur le bouton d'ouverture mobile des deux composants ; migre le CSS de `.btn-stepper-mobile` vers `[part='trigger']` dans `stepper.styles.ts` (supprime les préfixes `-webkit-box-pack` / `-ms-flex-pack`)
- Supprime `part="dropdown"` de `ar-breadcrumb` (conteneur structurel interne sans valeur API publique)
<br>
- Renomme l'instance `AnchoredController` en `_popover` dans les trois composants qui l'utilisent (`ar-stepper`, `ar-breadcrumb`, `ar-dropdown`) pour uniformiser le nommage

## Test plan

- [x] 360 tests Vitest passent (`npm run test`)
- [x] Tests browser WTR (`npm run test:all`) — vérifier `stepper.browser.test.ts` et `breadcrumb.browser.test.ts`
- [x] Contrôle visuel : panel mobile stepper et breadcrumb s'ouvre/ferme via `el.open = true/false` en console
- [x] Vérifier `::part(trigger)` accessible depuis l'extérieur du shadow DOM pour le styling custom
