### PR TITLE
feat(build): builds CDN dev/prod distincts + constante __DEV__

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -36,17 +36,19 @@ npm install
 
 ### `packages/core`
 
-| Commande                 | Description                       |
-| ------------------------ | --------------------------------- |
-| `npm run build:manifest` | Génère `custom-elements.json`     |
-| `npm run build:bundles`  | esbuild → `dist/` (npm) + `cdn/`  |
-| `npm run build:css`      | Thèmes CSS                        |
-| `npm run build:types`    | Déclarations TypeScript           |
-| `npm run test`           | Vitest, passe unique              |
-| `npm run test:watch`     | Vitest interactif                 |
-| `npm run test:coverage`  | Vitest avec rapport de couverture |
-| `npm run test:browser`   | @web/test-runner + Chromium       |
-| `npm run lint`           | ESLint                            |
+| Commande                     | Description                                      |
+| ---------------------------- | ------------------------------------------------ |
+| `npm run build:manifest`     | Génère `custom-elements.json`                    |
+| `npm run build:bundles`      | esbuild → `dist/` + `cdn/` dev + `cdn/*.prod.js` |
+| `npm run build:bundles:dev`  | npm + CDN dev uniquement (plus rapide en local)  |
+| `npm run build:bundles:prod` | npm + CDN prod uniquement                        |
+| `npm run build:css`          | Thèmes CSS                                       |
+| `npm run build:types`        | Déclarations TypeScript                          |
+| `npm run test`               | Vitest, passe unique                             |
+| `npm run test:watch`         | Vitest interactif                                |
+| `npm run test:coverage`      | Vitest avec rapport de couverture                |
+| `npm run test:browser`       | @web/test-runner + Chromium                      |
+| `npm run lint`               | ESLint                                           |
 
 ---
 
@@ -243,12 +245,23 @@ describe('ArAlert a11y', () => {
 
 ## Build outputs
 
-| Répertoire                  | Usage                                        |
-| --------------------------- | -------------------------------------------- |
-| `dist/`                     | Bundle npm — Lit en peer dep, tree-shakeable |
-| `cdn/`                      | Bundle CDN — Lit bundlé, avec autoloader     |
-| `dist/custom-elements.json` | Manifest CEM — consommé par la doc           |
-| `dist/styles/themes/`       | Fichiers CSS de thème                        |
+| Répertoire                  | Usage                                                           |
+| --------------------------- | --------------------------------------------------------------- |
+| `dist/`                     | Bundle npm — Lit en dépendance externe, compatible tree-shaking |
+| `cdn/index.js`              | Bundle CDN dev — non minifié, avertissements actifs             |
+| `cdn/autoloader.js`         | Autoloader CDN dev                                              |
+| `cdn/index.prod.js`         | Bundle CDN prod — minifié, avertissements supprimés             |
+| `cdn/autoloader.prod.js`    | Autoloader CDN prod                                             |
+| `dist/custom-elements.json` | Manifest CEM — consommé par la doc                              |
+| `dist/styles/themes/`       | Fichiers CSS de thème                                           |
+
+### Constante `__DEV__`
+
+Les avertissements dans les composants sont conditionnels à `__DEV__` :
+
+- **CDN dev** : `__DEV__ = true` (injecté par esbuild) — avertissements visibles
+- **CDN prod** : `__DEV__ = false` — le code mort est supprimé par esbuild, aucun impact à l'exécution
+- **Bundle npm** : `__DEV__` est remplacé par `process.env.NODE_ENV !== "production"` via un banner — Vite et Webpack suppriment automatiquement le code mort lors du build de production du projet consommateur
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -27,16 +27,18 @@ Composants disponibles : `ar-alert`, `ar-breadcrumb`, `ar-pagination`,
 Ne charge chaque composant que lorsqu'il est utilisé dans la page. Aucun outil requis.
 
 ```html
-<script type="module" src="https://unpkg.com/@ariane-ui/core/cdn/autoloader.js"></script>
+<script type="module" src="https://unpkg.com/@ariane-ui/core/cdn/autoloader.prod.js"></script>
 <link rel="stylesheet" href="https://unpkg.com/@ariane-ui/core/themes/default.css" />
 ```
+
+> En développement local, remplacez `autoloader.prod.js` par `autoloader.js` pour obtenir des avertissements détaillés dans la console.
 
 ### Via CDN — Bundle complet
 
 Charge tous les composants en une seule requête.
 
 ```html
-<script type="module" src="https://unpkg.com/@ariane-ui/core/cdn/index.js"></script>
+<script type="module" src="https://unpkg.com/@ariane-ui/core/cdn/index.prod.js"></script>
 <link rel="stylesheet" href="https://unpkg.com/@ariane-ui/core/themes/default.css" />
 ```
 

--- a/apps/docs/src/pages/getting-started/quickstart.astro
+++ b/apps/docs/src/pages/getting-started/quickstart.astro
@@ -10,10 +10,13 @@ const tocEntries = [
     { id: 'npm',        label: 'Setup avancé (npm)', level: 1 as const },
 ];
 
-const codeAutoloader = `<script type="module" src="https://unpkg.com/@ariane-ui/core/cdn/autoloader.js"></scr` + `ipt>
+const codeAutoloader = `<script type="module" src="https://unpkg.com/@ariane-ui/core/cdn/autoloader.prod.js"></scr` + `ipt>
 <link rel="stylesheet" href="https://unpkg.com/@ariane-ui/core/themes/default.css" />`;
 
-const codeBundle = `<script type="module" src="https://unpkg.com/@ariane-ui/core/cdn/index.js"></scr` + `ipt>
+const codeAutoloaderDev = `<script type="module" src="https://unpkg.com/@ariane-ui/core/cdn/autoloader.js"></scr` + `ipt>
+<link rel="stylesheet" href="https://unpkg.com/@ariane-ui/core/themes/default.css" />`;
+
+const codeBundle = `<script type="module" src="https://unpkg.com/@ariane-ui/core/cdn/index.prod.js"></scr` + `ipt>
 <link rel="stylesheet" href="https://unpkg.com/@ariane-ui/core/themes/default.css" />`;
 
 const codeUsage = `<ar-alert version="success">
@@ -73,6 +76,10 @@ import '@ariane-ui/core/themes/default.css';`;
                 <p class="hint">
                     Les deux balises sont requises : le script enregistre les composants,
                     le CSS fournit le thème.
+                </p>
+                <p class="hint">
+                    En développement local, remplacez <code>autoloader.prod.js</code> par
+                    <code>autoloader.js</code> pour obtenir des avertissements détaillés dans la console.
                 </p>
                 <p>Les composants sont ensuite utilisables directement :</p>
                 <pre><code class="language-html" set:text={codeUsage} /></pre>

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   },
   "scripts": {
     "build": "turbo run build",
+    "build:bundles:dev": "turbo run build:bundles:dev",
+    "build:bundles:prod": "turbo run build:bundles:prod",
     "dev": "turbo run build:manifest && turbo run dev",
     "test": "turbo run test",
     "test:all": "turbo run test test:browser",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,7 +9,9 @@
       "default": "./dist/index.js"
     },
     "./cdn": "./cdn/index.js",
+    "./cdn.prod": "./cdn/index.prod.js",
     "./cdn/autoloader": "./cdn/autoloader.js",
+    "./cdn/autoloader.prod": "./cdn/autoloader.prod.js",
     "./themes/*": "./dist/styles/themes/*.css",
     "./custom-elements.json": "./dist/custom-elements.json",
     "./dist/*": "./dist/*"
@@ -24,6 +26,8 @@
     "build": "npm run build:manifest && npm run build:bundles && npm run build:css && npm run build:types",
     "build:manifest": "cem analyze --config cem.config.js",
     "build:bundles": "node scripts/build-bundles.js",
+    "build:bundles:dev": "node scripts/build-bundles.js --dev",
+    "build:bundles:prod": "node scripts/build-bundles.js --prod",
     "build:css": "node scripts/build-css.js",
     "build:types": "tsc --emitDeclarationOnly --declarationMap",
     "dev": "node scripts/build-bundles.js --watch & node scripts/build-css.js --watch",

--- a/packages/core/scripts/build-bundles.js
+++ b/packages/core/scripts/build-bundles.js
@@ -2,29 +2,26 @@
 /**
  * build-bundles.js
  *
- * Produit deux bundles distincts :
+ * Produit trois bundles distincts :
  *
- *  dist/   → bundle NPM : lit est "external", tree-shakeable, destiné aux bundlers (Vite, webpack).
- *            Les utilisateurs importent les composants individuellement ou via le barrel.
+ *  dist/          → bundle NPM : lit est "external", tree-shakeable, destiné aux bundlers
+ *                   (Vite, webpack). __DEV__ évalué à runtime via process.env.NODE_ENV.
  *
- *  cdn/    → bundle CDN : tout inclus (lit bundlé dedans), un seul fichier auto-contenu.
- *            Destiné à être chargé via <script type="module"> depuis un CDN.
+ *  cdn/           → bundle CDN dev : tout inclus (lit bundlé), non minifié, __DEV__ = true.
+ *                   Destiné au développement local via <script type="module">.
  *
- * Pourquoi deux cibles séparées ?
- * Le bundle npm suppose qu'un bundler en aval dédupliquera lit (et d'autres deps partagées).
- * Le bundle CDN ne peut pas faire cette supposition → tout est bundlé.
+ *  cdn/*.prod.js  → bundle CDN prod : tout inclus, minifié, __DEV__ = false (dead-code
+ *                   éliminé). Destiné à la production via un CDN.
+ *
+ * CLI flags :
+ *   --dev   → npm + CDN dev seulement
+ *   --prod  → npm + CDN prod seulement
+ *   --watch → npm + CDN dev en watch (prod inutile en watch)
+ *   (aucun) → npm + CDN dev + CDN prod (mode CI)
  */
 
 import esbuild from 'esbuild';
-import {
-    readdirSync,
-    mkdirSync,
-    copyFileSync,
-    rmSync,
-    existsSync,
-    readFileSync,
-    writeFileSync,
-} from 'fs';
+import { readdirSync, mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs';
 import { join, relative, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -32,6 +29,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
 const SRC = join(ROOT, 'src');
 const WATCH = process.argv.includes('--watch');
+const DEV_ONLY = process.argv.includes('--dev') || WATCH;
+const PROD_ONLY = process.argv.includes('--prod');
 
 // ─── Utilitaire : scan récursif de fichiers ───────────────────────────────────
 
@@ -77,6 +76,11 @@ const entryPoints = {
     ...Object.fromEntries(componentFiles.map((f) => [toEntryKey(f), f])),
 };
 
+const cdnEntryPoints = {
+    index: join(SRC, 'index.ts'),
+    autoloader: join(SRC, 'autoloader.ts'),
+};
+
 // ─── Options communes ─────────────────────────────────────────────────────────
 
 /** Dépendances runtime à externaliser dans le bundle npm (résolues par le bundler consommateur) */
@@ -94,7 +98,6 @@ const commonOptions = {
 
 // Préserver custom-elements.json pendant le clean : la doc Astro peut en avoir
 // besoin pendant que ce build tourne (race condition Turbo avec les tâches persistent).
-// Le manifest est regénéré juste après par build:manifest, pas par ce script.
 const manifestPath = join(ROOT, 'dist', 'custom-elements.json');
 let preservedManifest = null;
 if (existsSync(manifestPath)) {
@@ -109,7 +112,6 @@ for (const dir of ['dist', 'cdn']) {
     mkdirSync(target, { recursive: true });
 }
 
-// Restaure immédiatement le manifest pour que la doc ne tombe pas pendant le build
 if (preservedManifest !== null) {
     writeFileSync(manifestPath, preservedManifest, 'utf-8');
 }
@@ -121,11 +123,11 @@ async function buildNpm() {
         ...commonOptions,
         entryPoints,
         outdir: join(ROOT, 'dist'),
-        // lit reste external → dédupliqué par Vite/webpack côté consommateur
         external: EXTERNALS_NPM,
-        // Splitting permet de partager le code commun entre composants sans le dupliquer
         splitting: true,
         chunkNames: 'chunks/[name]-[hash]',
+        // esbuild define only accepts literals — __DEV__ is left to downstream bundlers.
+        // Vite / webpack will replace process.env.NODE_ENV at their own build step.
     };
 
     if (WATCH) {
@@ -138,21 +140,17 @@ async function buildNpm() {
     return esbuild.build(options);
 }
 
-// ─── Build CDN ────────────────────────────────────────────────────────────────
+// ─── Build CDN dev ────────────────────────────────────────────────────────────
 
-async function buildCdn() {
+async function buildCdnDev() {
     const options = {
         ...commonOptions,
-        entryPoints: {
-            index: join(SRC, 'index.ts'),
-            autoloader: join(SRC, 'autoloader.ts'),
-        },
+        entryPoints: cdnEntryPoints,
         outdir: join(ROOT, 'cdn'),
-        // Ici on ne met RIEN en external : tout est bundlé dans le fichier final
-        minify: !WATCH,
+        minify: false,
         splitting: true,
         chunkNames: 'chunks/[name]-[hash]',
-        metafile: true, // utile pour analyser le bundle (esbuild --analyze)
+        define: { __DEV__: 'true' },
     };
 
     if (WATCH) {
@@ -162,13 +160,32 @@ async function buildCdn() {
         return ctx;
     }
 
+    return esbuild.build(options);
+}
+
+// ─── Build CDN prod ───────────────────────────────────────────────────────────
+
+async function buildCdnProd() {
+    const options = {
+        ...commonOptions,
+        entryPoints: cdnEntryPoints,
+        outdir: join(ROOT, 'cdn'),
+        outExtension: { '.js': '.prod.js' },
+        minify: true,
+        splitting: true,
+        chunkNames: 'chunks/[name]-[hash]',
+        define: { __DEV__: 'false' },
+        metafile: true,
+    };
+
     const result = await esbuild.build(options);
 
-    // Afficher la taille du bundle CDN principal pour surveiller la régression
     if (result.metafile) {
-        const bytes = result.metafile.outputs['cdn/index.js']?.bytes ?? 0;
+        const outputs = result.metafile.outputs;
+        const key = Object.keys(outputs).find((k) => k.endsWith('index.prod.js'));
+        const bytes = key ? outputs[key].bytes : 0;
         const kb = (bytes / 1024).toFixed(1);
-        console.log(`\n✓ CDN bundle: ${kb} kB (minified)\n`);
+        console.log(`\n✓ CDN prod bundle: ${kb} kB (minified)\n`);
     }
 
     return result;
@@ -178,8 +195,6 @@ async function buildCdn() {
 
 function copyCemManifest() {
     const src = join(ROOT, 'dist', 'custom-elements.json');
-    // Le manifest est déjà dans dist/ grâce à cem analyze --outdir dist
-    // Cette étape existe au cas où le manifest serait ailleurs
     if (existsSync(src)) {
         console.log('✓ custom-elements.json already in dist/');
     }
@@ -190,7 +205,13 @@ function copyCemManifest() {
 async function main() {
     try {
         console.log('Building bundles...\n');
-        await Promise.all([buildNpm(), buildCdn()]);
+
+        const cdnBuilds = [];
+        if (!PROD_ONLY) cdnBuilds.push(buildCdnDev());
+        if (!DEV_ONLY) cdnBuilds.push(buildCdnProd());
+
+        await Promise.all([buildNpm(), ...cdnBuilds]);
+
         copyCemManifest();
         if (!WATCH) {
             console.log('✓ Build complete');

--- a/packages/core/scripts/build-bundles.js
+++ b/packages/core/scripts/build-bundles.js
@@ -5,7 +5,10 @@
  * Produit trois bundles distincts :
  *
  *  dist/          → bundle NPM : lit est "external", tree-shakeable, destiné aux bundlers
- *                   (Vite, webpack). __DEV__ évalué à runtime via process.env.NODE_ENV.
+ *                   (Vite, webpack). __DEV__ injecté via banner esbuild :
+ *                   `const __DEV__ = process.env.NODE_ENV !== "production";`
+ *                   Les bundlers consommateurs (Vite, webpack) remplacent process.env.NODE_ENV
+ *                   → dead-code elimination en prod, warnings actifs en dev.
  *
  *  cdn/           → bundle CDN dev : tout inclus (lit bundlé), non minifié, __DEV__ = true.
  *                   Destiné au développement local via <script type="module">.
@@ -126,8 +129,7 @@ async function buildNpm() {
         external: EXTERNALS_NPM,
         splitting: true,
         chunkNames: 'chunks/[name]-[hash]',
-        // esbuild define only accepts literals — __DEV__ is left to downstream bundlers.
-        // Vite / webpack will replace process.env.NODE_ENV at their own build step.
+        banner: { js: 'const __DEV__ = process.env.NODE_ENV !== "production";' },
     };
 
     if (WATCH) {

--- a/packages/core/src/env.d.ts
+++ b/packages/core/src/env.d.ts
@@ -1,0 +1,1 @@
+declare const __DEV__: boolean;

--- a/packages/core/src/utils/warn.ts
+++ b/packages/core/src/utils/warn.ts
@@ -1,0 +1,5 @@
+export function warn(tag: string, message: string): void {
+    if (__DEV__) {
+        console.warn(`[${tag}] ${message}`);
+    }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -11,6 +11,16 @@
       "inputs": ["src/**/*.ts", "scripts/build-bundles.js"],
       "outputs": ["dist/**", "cdn/**"]
     },
+    "build:bundles:dev": {
+      "dependsOn": ["build:manifest"],
+      "inputs": ["src/**/*.ts", "scripts/build-bundles.js"],
+      "outputs": ["dist/**", "cdn/**"]
+    },
+    "build:bundles:prod": {
+      "dependsOn": ["build:manifest"],
+      "inputs": ["src/**/*.ts", "scripts/build-bundles.js"],
+      "outputs": ["dist/**", "cdn/**"]
+    },
     "build:css": {
       "inputs": ["src/styles/**/*.css"],
       "outputs": ["dist/styles/**"]


### PR DESCRIPTION
## Résumé

- Introduce la constante `__DEV__` (remplacée statiquement par esbuild) pour réserver les warnings à l'environnement de développement (fondation pour issue #59)
- Scinde le build CDN en deux variantes : `cdn/index.js` (dev, non minifié) et `cdn/index.prod.js` (prod, minifié, dead-code éliminé) — convention Vue 3 avec suffix `.prod.js`
- Injecte `__DEV__` via `banner` dans le build npm (`const __DEV__ = process.env.NODE_ENV !== "production"`) pour que les bundlers consommateurs (Vite, Webpack) assurent la dead-code elimination côté utilisateur

## Nouveaux scripts

```bash
npm run build:bundles:dev   # npm + CDN dev uniquement (local)
npm run build:bundles:prod  # npm + CDN prod uniquement
npm run build:bundles       # les trois variantes (CI, comportement inchangé)
```

## Plan de test

- [x] `npm run build:bundles:dev` produit `cdn/index.js` et `cdn/autoloader.js` (non minifiés)
- [x] `npm run build:bundles:prod` produit `cdn/index.prod.js` et `cdn/autoloader.prod.js` (minifiés)
- [x] `npm run build:bundles` produit les quatre fichiers CDN + `dist/`
- [x] `dist/index.js` commence par `const __DEV__ = process.env.NODE_ENV !== "production";`
- [x] `grep __DEV__ cdn/index.prod.js` ne retourne rien (dead-code éliminé)
- [x] 360 tests passent

🤖 Generated with [Claude Code](https://claude.com/claude-code)