### PR TITLE
feat(components): migre les warn() vers l'utilitaire conditionnel __DEV__

### DIFF
--- a/packages/core/src/components/alert/alert.ts
+++ b/packages/core/src/components/alert/alert.ts
@@ -3,11 +3,6 @@ import { customElement, property } from 'lit/decorators.js';
 import styles from './alert.styles.js';
 import { prefersReducedMotion } from '../../utils/media.js';
 
-export function warn(name: string, message: string, error?: Error) {
-    if (error) console.warn(`${name} - ${message}`, error);
-    else console.warn(`${name} - ${message}`);
-}
-
 /** Objet de configuration d'un webcomposant ArAlert */
 export class ArAlertConfig {
     /** Permet de spécifier le type d'alerte */

--- a/packages/core/src/components/dialog/dialog.test.ts
+++ b/packages/core/src/components/dialog/dialog.test.ts
@@ -512,8 +512,7 @@ describe('ArDialog', () => {
             const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
             el = await fixture('<ar-dialog></ar-dialog>');
             expect(spy).toHaveBeenCalledWith(
-                expect.stringContaining('Aucun libellé accessible fourni'),
-                el,
+                expect.stringContaining('[ar-dialog] Aucun libellé accessible fourni'),
             );
         });
 
@@ -559,6 +558,49 @@ describe('ArDialog', () => {
 
             expect(el.open).toBe(false);
             btn.remove();
+        });
+    });
+
+    describe('warn() — label manquant et placement/modal', () => {
+        afterEach(() => {
+            vi.restoreAllMocks();
+        });
+
+        it("émet un warn si aucun label ni slot label n'est fourni", async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            await fixture('<ar-dialog open></ar-dialog>');
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('[ar-dialog]'));
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('label'));
+        });
+
+        it("n'émet pas de warn si label est fourni", async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            await fixture('<ar-dialog open label="Titre du dialog"></ar-dialog>');
+
+            expect(spy).not.toHaveBeenCalled();
+        });
+
+        it('émet un warn si placement est défini hors mode drawer', async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            await fixture('<ar-dialog label="Test" placement="left" mode="modal"></ar-dialog>');
+
+            const placementWarns = spy.mock.calls.filter((c) => String(c[0]).includes('placement'));
+            expect(placementWarns.length).toBeGreaterThan(0);
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('[ar-dialog]'));
+        });
+
+        it("n'émet pas de warn placement si mode est drawer", async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            await fixture('<ar-dialog label="Test" placement="left" mode="drawer"></ar-dialog>');
+
+            const placementWarns = spy.mock.calls.filter((c) => String(c[0]).includes('placement'));
+            expect(placementWarns).toHaveLength(0);
         });
     });
 });

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -14,6 +14,7 @@ import { announceA11y } from '../../a11y/announce-a11y.js';
 import { HasSlotController } from '../../controllers/has-slot.controller.js';
 import { prefersReducedMotion } from '../../utils/media.js';
 import { acquireScrollLock, releaseScrollLock } from '../../utils/scroll-lock.js';
+import { warn } from '../../utils/warn.js';
 
 /** Evènements envoyés par le webcomposant ArDialog */
 export type ArDialogEvents =
@@ -176,9 +177,9 @@ export class ArDialog extends LitElement {
         if ((this.label ?? '').trim() || this._slotController.test('label')) return;
 
         this._hasWarnedMissingLabel = true;
-        console.warn(
-            `[ar-dialog] Aucun libellé accessible fourni. Ajoutez la propriété "label" ou un enfant direct avec slot="label".`,
-            this,
+        warn(
+            'ar-dialog',
+            'Aucun libellé accessible fourni. Ajoutez la propriété "label" ou un enfant direct avec slot="label".',
         );
     }
 
@@ -198,6 +199,13 @@ export class ArDialog extends LitElement {
 
     override updated(changedProperties: PropertyValues<this>): void {
         this._warnIfMissingLabel();
+        if (
+            (changedProperties.has('placement') || changedProperties.has('mode')) &&
+            this.mode === 'modal' &&
+            this.placement !== 'right'
+        ) {
+            warn('ar-dialog', 'placement n\'a aucun effet en mode "modal".');
+        }
         if (changedProperties.has('open')) {
             if (this.open && !this.dialog?.open) {
                 this._show();

--- a/packages/core/src/components/dropdown/dropdown.test.ts
+++ b/packages/core/src/components/dropdown/dropdown.test.ts
@@ -316,4 +316,32 @@ describe('ArDropdown', () => {
             expect(hr.getAttribute('role')).toBe('separator');
         });
     });
+
+    describe('warn() — trigger introuvable', () => {
+        afterEach(() => {
+            vi.restoreAllMocks();
+        });
+
+        it('émet un warn si trigger pointe vers un ID inexistant (firstUpdated)', async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            el = await fixture('<ar-dropdown trigger="id-qui-nexiste-pas"></ar-dropdown>');
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('[ar-dropdown]'));
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('id-qui-nexiste-pas'));
+        });
+
+        it('émet un warn si trigger est mis à jour vers un ID inexistant', async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            el = await fixture<ArDropdown>('<ar-dropdown></ar-dropdown>');
+
+            el.trigger = 'id-inconnu';
+            await waitForUpdate(el);
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('[ar-dropdown]'));
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('id-inconnu'));
+        });
+    });
 });

--- a/packages/core/src/components/dropdown/dropdown.ts
+++ b/packages/core/src/components/dropdown/dropdown.ts
@@ -2,6 +2,7 @@ import { LitElement, html, type TemplateResult, type PropertyValues } from 'lit'
 import { customElement, property, query } from 'lit/decorators.js';
 import { AnchoredController } from '../../controllers/anchored.controller.js';
 import type { ArDropdownItem } from '../dropdown-item/dropdown-item.js';
+import { warn } from '../../utils/warn.js';
 import panelStyles from '../../styles/shared/panel.styles.js';
 import styles from './dropdown.styles.js';
 
@@ -89,9 +90,6 @@ export class ArDropdown extends LitElement {
 
     override firstUpdated(): void {
         const trigger = this._resolvedTrigger;
-        if (this.trigger && !trigger) {
-            console.warn(`[ar-dropdown] Aucun élément trouvé avec l'id "${this.trigger}".`);
-        }
         if (trigger && this._panel) {
             this._popover.attach(trigger, this._panel);
             if (this.trigger) {
@@ -120,7 +118,7 @@ export class ArDropdown extends LitElement {
             this._externalTrigger = null;
             const newTrigger = this._resolvedTrigger;
             if (this.trigger && !newTrigger) {
-                console.warn(`[ar-dropdown] Aucun élément trouvé avec l'id "${this.trigger}".`);
+                warn('ar-dropdown', `Aucun élément trouvé avec l'id "${this.trigger}".`);
             }
             if (newTrigger && this._panel) {
                 this._popover.attach(newTrigger, this._panel);

--- a/packages/core/src/components/pagination/pagination.test.ts
+++ b/packages/core/src/components/pagination/pagination.test.ts
@@ -322,4 +322,45 @@ describe('ArPagination', () => {
             );
         });
     });
+
+    describe('warn() — bornes numériques', () => {
+        afterEach(() => {
+            vi.restoreAllMocks();
+        });
+
+        it('émet un warn si total < 1', async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            await fixture('<ar-pagination total="0"></ar-pagination>');
+
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('[ar-pagination]'));
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('total'));
+        });
+
+        it('émet un warn si current < 1', async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            await fixture('<ar-pagination current="0" total="5"></ar-pagination>');
+
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('[ar-pagination]'));
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('current'));
+        });
+
+        it('émet un warn si current > total', async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            await fixture('<ar-pagination current="10" total="5"></ar-pagination>');
+
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('[ar-pagination]'));
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('current'));
+        });
+
+        it("n'émet pas de warn pour des valeurs valides", async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            await fixture('<ar-pagination current="3" total="10"></ar-pagination>');
+
+            expect(spy).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/packages/core/src/components/pagination/pagination.ts
+++ b/packages/core/src/components/pagination/pagination.ts
@@ -6,6 +6,7 @@ import buttonStyles from '../../styles/components/button.styles.js';
 import styles from './pagination.styles.js';
 import { mrPaginationUtils } from './pagination.utils.js';
 import { announceA11y } from '../../a11y/announce-a11y.js';
+import { warn } from '../../utils/warn.js';
 
 /** Objet de configuration d'un webcomposant ArPagination */
 export class ArPaginationConfig {
@@ -75,6 +76,22 @@ export class ArPagination extends LitElement {
      */
     @property({ reflect: true, type: String, useDefault: true })
     variant: 'light' | 'dark' = ArPagination.DEFAULT_VARIANT;
+
+    override updated(changed: Map<string, unknown>): void {
+        if (changed.has('total') && this.total < 1) {
+            warn('ar-pagination', `total doit être ≥ 1. Valeur reçue : ${this.total}.`);
+        }
+        if (changed.has('current') || changed.has('total')) {
+            if (this.current < 1) {
+                warn('ar-pagination', `current doit être ≥ 1. Valeur reçue : ${this.current}.`);
+            } else if (this.current > this.total) {
+                warn(
+                    'ar-pagination',
+                    `current (${this.current}) est supérieur à total (${this.total}).`,
+                );
+            }
+        }
+    }
 
     override render(): TemplateResult {
         const isNextDisabled = this.current >= this.total;

--- a/packages/core/src/components/progressbar/progressbar.test.ts
+++ b/packages/core/src/components/progressbar/progressbar.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ArProgressbar } from './progressbar.js';
 import { fixture, waitForUpdate, getPart, requirePart } from '../../test-utils.js';
 import './progressbar.js';
@@ -135,6 +135,40 @@ describe('ArProgressbar', () => {
         it('aria-valuenow est clampé à 100 si percent > 100', async () => {
             el = await fixture('<ar-progressbar percent="999"></ar-progressbar>');
             expect(requirePart(el, 'bar').getAttribute('aria-valuenow')).toBe('100');
+        });
+    });
+
+    describe('warn() — percent hors bornes', () => {
+        afterEach(() => {
+            vi.restoreAllMocks();
+        });
+
+        it('émet un warn si percent > 100', async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            await fixture('<ar-progressbar percent="150"></ar-progressbar>');
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('[ar-progressbar]'));
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('150'));
+        });
+
+        it('émet un warn si percent < 0', async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            await fixture('<ar-progressbar percent="-10"></ar-progressbar>');
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('[ar-progressbar]'));
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('-10'));
+        });
+
+        it("n'émet pas de warn pour une valeur valide", async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            await fixture('<ar-progressbar percent="50"></ar-progressbar>');
+
+            expect(spy).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/core/src/components/progressbar/progressbar.ts
+++ b/packages/core/src/components/progressbar/progressbar.ts
@@ -2,6 +2,7 @@ import { LitElement, type TemplateResult, html, type CSSResultGroup } from 'lit'
 import { customElement, property } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import utilitiesStyles from '../../styles/utilities.styles.js';
+import { warn } from '../../utils/warn.js';
 import styles from './progressbar.styles.js';
 
 /** Objet de configuration d'un webcomposant ArProgressbar */
@@ -43,6 +44,19 @@ export class ArProgressbar extends LitElement {
      */
     @property({ reflect: true, useDefault: true, type: Number })
     percent = 0;
+
+    override updated(changed: Map<string, unknown>): void {
+        if (changed.has('percent')) {
+            if (isNaN(this.percent)) {
+                warn('ar-progressbar', `percent est NaN — vérifiez l'attribut HTML fourni.`);
+            } else if (this.percent < 0 || this.percent > 100) {
+                warn(
+                    'ar-progressbar',
+                    `percent doit être compris entre 0 et 100. Valeur reçue : ${this.percent}. Elle sera bornée automatiquement.`,
+                );
+            }
+        }
+    }
 
     override render(): TemplateResult {
         // Clamp défensif : même si la propriété est bornée, une valeur HTML arbitraire peut passer

--- a/packages/core/src/components/spinner/spinner.test.ts
+++ b/packages/core/src/components/spinner/spinner.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ArSpinner } from './spinner.js';
 import { fixture, waitForUpdate, getPart, requirePart } from '../../test-utils.js';
 import './spinner.js';
@@ -163,6 +163,40 @@ describe('ArSpinner', () => {
         it('le SVG a focusable="false"', async () => {
             el = await fixture('<ar-spinner></ar-spinner>');
             expect(requirePart(el, 'spinner').getAttribute('focusable')).toBe('false');
+        });
+    });
+
+    describe('warn() — labels ARIA vides', () => {
+        afterEach(() => {
+            vi.restoreAllMocks();
+        });
+
+        it('émet un warn si loading-label est vidé', async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            await fixture('<ar-spinner loading-label=""></ar-spinner>');
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('[ar-spinner]'));
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('loading-label'));
+        });
+
+        it('émet un warn si done-label est vidé', async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            await fixture('<ar-spinner done-label=""></ar-spinner>');
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('[ar-spinner]'));
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('done-label'));
+        });
+
+        it("n'émet pas de warn avec les labels par défaut", async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            await fixture('<ar-spinner></ar-spinner>');
+
+            expect(spy).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/core/src/components/spinner/spinner.ts
+++ b/packages/core/src/components/spinner/spinner.ts
@@ -3,6 +3,7 @@ import { customElement, property } from 'lit/decorators.js';
 import utilitiesStyles from '../../styles/utilities.styles.js';
 import animationsStyles from '../../styles/animations.styles.js';
 import styles from './spinner.styles.js';
+import { warn } from '../../utils/warn.js';
 
 /**
  * @summary Indicateur de chargement accessible avec états "en cours" et "terminé".
@@ -52,6 +53,21 @@ export class ArSpinner extends LitElement {
 
     @property({ reflect: true, type: String, useDefault: true })
     size: 'xs' | 'sm' | 'lg' | undefined = undefined;
+
+    override updated(changed: Map<string, unknown>): void {
+        if (changed.has('loadingLabel') && !this.loadingLabel.trim()) {
+            warn(
+                'ar-spinner',
+                "loading-label est vide — le spinner ne sera pas annoncé aux lecteurs d'écran.",
+            );
+        }
+        if (changed.has('doneLabel') && !this.doneLabel.trim()) {
+            warn(
+                'ar-spinner',
+                "done-label est vide — l'état terminé ne sera pas annoncé aux lecteurs d'écran.",
+            );
+        }
+    }
 
     override render(): TemplateResult {
         return html` <svg

--- a/packages/core/src/components/stepper/stepper.test.ts
+++ b/packages/core/src/components/stepper/stepper.test.ts
@@ -571,4 +571,23 @@ describe('ArStepper', () => {
             );
         });
     });
+
+    describe('warn() — desktop-target introuvable', () => {
+        afterEach(() => {
+            vi.restoreAllMocks();
+        });
+
+        it('émet un warn si desktop-target pointe vers un ID inexistant', async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            const el = await fixture<ArStepper>(
+                '<ar-stepper desktop-target="conteneur-inexistant"></ar-stepper>',
+            );
+            (el as unknown as Record<string, () => void>)['_teleportToTarget']?.();
+
+            expect(spy).toHaveBeenCalled();
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('[ar-stepper]'));
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('conteneur-inexistant'));
+        });
+    });
 });

--- a/packages/core/src/components/stepper/stepper.ts
+++ b/packages/core/src/components/stepper/stepper.ts
@@ -21,6 +21,7 @@ import { ScrollFollowController } from '../../controllers/scroll-follow.controll
 import { AnchoredController } from '../../controllers/anchored.controller.js';
 import { renderDesktop, renderMobile } from './stepper.renderer.js';
 import { type ArStepperItem } from '../stepper-item/stepper-item.js';
+import { warn } from '../../utils/warn.js';
 
 /** Détail de l'événement émis lors d'un changement d'étape */
 export interface ArStepperStepChangeDetail {
@@ -381,7 +382,7 @@ export class ArStepper extends LitElement {
         if (!this.desktopTarget) return;
         const target = document.getElementById(this.desktopTarget);
         if (!target) {
-            console.warn(`[ar-stepper] desktop target "${this.desktopTarget}" not found`);
+            warn('ar-stepper', `desktop-target "${this.desktopTarget}" introuvable.`);
             return;
         }
         if (this.parentNode !== target) {

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+    define: {
+        __DEV__: 'true',
+    },
     test: {
         // happy-dom : supporte Shadow DOM, Custom Elements Registry, adoptedStyleSheets.
         // Plus léger et ~3x plus rapide que jsdom, contrairement à @web/test-runner

--- a/packages/core/web-test-runner.config.js
+++ b/packages/core/web-test-runner.config.js
@@ -15,7 +15,9 @@ export default {
     // experimentalDecorators + useDefineForClassFields, requis par les décorateurs Lit.
     // Le plugin ne résout pas "extends" quand il lit tsconfigRaw, donc tsconfig.json
     // (qui étend tsconfig.base.json) ne suffit pas.
-    plugins: [esbuildPlugin({ ts: true, tsconfig: './tsconfig.wtr.json' })],
+    plugins: [
+        esbuildPlugin({ ts: true, tsconfig: './tsconfig.wtr.json', define: { __DEV__: 'true' } }),
+    ],
 
     nodeResolve: true,
 };


### PR DESCRIPTION
## Résumé

- Injecte `__DEV__ = true` dans `vitest.config.ts` pour permettre les tests des branches `warn()`
- Migre les `console.warn` nus existants vers `warn(tag, message)` protégé par `__DEV__` : `ar-alert` (fonction locale supprimée), `ar-dropdown` (×2), `ar-stepper`, `ar-dialog`
- Ajoute des warnings utiles : `ar-progressbar` (percent hors [0,100]), `ar-pagination` (current/total hors bornes), `ar-spinner` (labels ARIA vides), `ar-dialog` (placement en mode modal)
- Couvre chaque nouveau warn par un test Vitest (anti-régression)
- +17 tests — 377 au total (vs 360 avant)

Closes #59

## Plan de test

- [x] `npm run test` — tous les tests passent
- [x] `grep -rn "console\.warn" packages/core/src/components` — aucun résultat dans le code de production
- [x] Vérifier en mode dev (CDN) que les warns apparaissent bien en console
- [x] Vérifier en mode prod que les warns sont supprimés (esbuild tree-shake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)