### PR TITLE
fix(stepper, dialog): évite les warnings Lit change-in-update

### DIFF
--- a/packages/core/src/components/dialog/dialog.test.ts
+++ b/packages/core/src/components/dialog/dialog.test.ts
@@ -194,6 +194,47 @@ describe('ArDialog', () => {
             expect(handler).toHaveBeenCalledOnce();
         });
 
+        it("ne déclenche pas de warning Lit 'change-in-update' lors d'un cycle open/close", async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            el = await fixture('<ar-dialog label="Titre" open></ar-dialog>');
+            await waitForUpdate(el);
+
+            el.open = false;
+            await waitForUpdate(el);
+            await new Promise((resolve) => setTimeout(resolve, 550));
+
+            expect(
+                spy.mock.calls
+                    .flat()
+                    .filter((value) => typeof value === 'string')
+                    .some((value) => value.includes('scheduled an update')),
+            ).toBe(false);
+
+            spy.mockRestore();
+        });
+
+        it("ne déclenche pas de warning Lit 'change-in-update' quand l'ouverture est annulée", async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            el = await fixture('<ar-dialog label="Titre"></ar-dialog>');
+            el.addEventListener('ar-dialog-show', (e) => e.preventDefault());
+            el.open = true;
+            await waitForUpdate(el);
+            await waitForUpdate(el);
+
+            expect(getDialogEl(el).open).toBe(false);
+            expect(el.open).toBe(false);
+            expect(
+                spy.mock.calls
+                    .flat()
+                    .filter((value) => typeof value === 'string')
+                    .some((value) => value.includes('scheduled an update')),
+            ).toBe(false);
+
+            spy.mockRestore();
+        });
+
         it("ar-dialog-show annulable empêche l'ouverture", async () => {
             el = await fixture('<ar-dialog></ar-dialog>');
             el.addEventListener('ar-dialog-show', (e) => e.preventDefault());

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -159,6 +159,9 @@ export class ArDialog extends LitElement {
     /** Cible du dernier pointerdown, pour distinguer un vrai clic backdrop d'un drag. */
     private _pointerDownTarget: EventTarget | null = null;
 
+    /** Évite de lancer la fermeture pendant le cycle `updated()` de Lit. */
+    private _closePending = false;
+
     /** Vrai pendant l'animation de fermeture — bloque les interactions et les double-appels. */
     @state() private _isClosing = false;
 
@@ -210,7 +213,7 @@ export class ArDialog extends LitElement {
             if (this.open && !this.dialog?.open) {
                 this._show();
             } else if (!this.open && this.dialog?.open) {
-                this._close();
+                this._scheduleClose();
             }
         }
     }
@@ -308,6 +311,18 @@ export class ArDialog extends LitElement {
         announceA11y(message, 'assertive');
     }
 
+    private _scheduleClose(): void {
+        if (this._closePending) return;
+        this._closePending = true;
+
+        void this.updateComplete.then(() => {
+            this._closePending = false;
+            if (this.isConnected && !this.open && this.dialog?.open) {
+                this._close();
+            }
+        });
+    }
+
     private _addOpenListeners() {
         document.addEventListener('keydown', this._handleDocumentKeyDown);
     }
@@ -390,7 +405,11 @@ export class ArDialog extends LitElement {
         const showEvent = this._emit('ar-dialog-show');
         if (showEvent.defaultPrevented) {
             this._triggerElement = null;
-            this.open = false;
+            void this.updateComplete.then(() => {
+                if (this.isConnected && this.open && !this.dialog?.open) {
+                    this.open = false;
+                }
+            });
             return;
         }
 

--- a/packages/core/src/components/stepper/stepper.test.ts
+++ b/packages/core/src/components/stepper/stepper.test.ts
@@ -590,4 +590,58 @@ describe('ArStepper', () => {
             expect(spy).toHaveBeenCalledWith(expect.stringContaining('conteneur-inexistant'));
         });
     });
+
+    describe('régressions change-in-update', () => {
+        afterEach(() => {
+            vi.restoreAllMocks();
+        });
+
+        it("ne déclenche pas de warning Lit 'change-in-update' lors de l'enregistrement des items", async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            await fixtureWithItems(`
+                <ar-stepper current-path="/a">
+                    <ar-stepper-item path="/a" label="A"></ar-stepper-item>
+                    <ar-stepper-item path="/b" label="B"></ar-stepper-item>
+                    <ar-stepper-item path="/c" label="C"></ar-stepper-item>
+                </ar-stepper>
+            `);
+
+            expect(
+                spy.mock.calls
+                    .flat()
+                    .filter((v) => typeof v === 'string')
+                    .some((v) => v.includes('scheduled an update')),
+            ).toBe(false);
+        });
+
+        it("ne déclenche pas de warning Lit 'change-in-update' lors du toggle open en mode mobile", async () => {
+            vi.spyOn(window, 'matchMedia').mockReturnValue({
+                matches: false,
+                addEventListener: vi.fn(),
+                removeEventListener: vi.fn(),
+            } as unknown as MediaQueryList);
+
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            const el = await fixtureWithItems(`
+                <ar-stepper current-path="/a">
+                    <ar-stepper-item path="/a" label="A"></ar-stepper-item>
+                    <ar-stepper-item path="/b" label="B"></ar-stepper-item>
+                </ar-stepper>
+            `);
+
+            el.open = true;
+            await waitForUpdate(el);
+            el.open = false;
+            await waitForUpdate(el);
+
+            expect(
+                spy.mock.calls
+                    .flat()
+                    .filter((v) => typeof v === 'string')
+                    .some((v) => v.includes('scheduled an update')),
+            ).toBe(false);
+        });
+    });
 });

--- a/packages/core/src/components/stepper/stepper.ts
+++ b/packages/core/src/components/stepper/stepper.ts
@@ -228,10 +228,15 @@ export class ArStepper extends LitElement {
             });
         }
         if (changed.has('open') && !this._isDesktop && this._dropdownAttached) {
+            // Différer évite que Popover.requestUpdate() déclenche le warning Lit "change-in-update".
             if (this.open) {
-                void this._popover.show();
+                void this.updateComplete.then(() => {
+                    if (this.isConnected) void this._popover.show();
+                });
             } else {
-                this._popover.hide();
+                void this.updateComplete.then(() => {
+                    if (this.isConnected) this._popover.hide();
+                });
             }
         }
     }
@@ -307,18 +312,19 @@ export class ArStepper extends LitElement {
     private _rebuildPending = false;
 
     /**
-     * Déclenche une reconstruction de l'arbre au prochain microtask.
-     * Le debounce via `_rebuildPending` évite N rebuilds pour N items qui s'enregistrent
-     * en même temps au premier rendu.
+     * Déclenche une reconstruction de l'arbre après le cycle de rendu courant.
+     * Le debounce via `_rebuildPending` évite N rebuilds pour N items simultanés.
+     * `updateComplete.then` garantit que le rebuild est hors du cycle Lit actif.
      */
     private rebuildTree(): void {
         if (this._rebuildPending) return;
         this._rebuildPending = true;
 
-        queueMicrotask(() => {
+        void this.updateComplete.then(() => {
             this._rebuildPending = false;
             this.navigation.buildFromItems(Array.from(this.items));
             this.scrollFollow.refresh();
+            this.requestUpdate();
         });
     }
 

--- a/packages/core/src/controllers/navigation-tree.controller.test.ts
+++ b/packages/core/src/controllers/navigation-tree.controller.test.ts
@@ -71,11 +71,11 @@ describe('NavigationTreeController', () => {
         expect(ctrl.tree.map((n) => n.path)).toEqual(['/a', '/b', '/c']);
     });
 
-    it('buildFromItems() appelle requestUpdate', () => {
+    it('buildFromItems() ne déclenche pas requestUpdate (responsabilité du caller)', () => {
         const host = makeHost();
         const ctrl = new NavigationTreeController(host);
         ctrl.buildFromItems([makeItem('/a')]);
-        expect(host.requestUpdate).toHaveBeenCalledTimes(1);
+        expect(host.requestUpdate).not.toHaveBeenCalled();
     });
 
     it('setCurrentPath() met à jour le chemin courant et appelle requestUpdate', () => {
@@ -86,7 +86,7 @@ describe('NavigationTreeController', () => {
         ctrl.setCurrentPath('/b');
 
         expect(ctrl.currentNode?.path).toBe('/b');
-        expect(host.requestUpdate).toHaveBeenCalledTimes(2); // buildFromItems + setCurrentPath
+        expect(host.requestUpdate).toHaveBeenCalledTimes(1); // setCurrentPath seulement
     });
 
     it('setCurrentPath() ne fait rien si le path est identique', () => {

--- a/packages/core/src/controllers/navigation-tree.controller.ts
+++ b/packages/core/src/controllers/navigation-tree.controller.ts
@@ -86,8 +86,6 @@ export class NavigationTreeController implements ReactiveController {
         this.buildOrdered();
 
         computeNavigationStates(this.ordered, this.currentPath);
-
-        this.host.requestUpdate();
     }
 
     setCurrentPath(path: string) {


### PR DESCRIPTION
## Résumé

Correction de deux warnings Lit `change-in-update` sur `ar-stepper` et `ar-dialog`.

Ces warnings apparaissaient quand un composant planifiait une nouvelle mise à jour pendant ou juste après son propre cycle `updated()`. Le comportement restait fonctionnel, mais Lit signale ce pattern comme inefficace et fragile.

---

## Contexte

Le premier correctif concernait `ar-stepper` : certaines synchronisations liées au popover mobile et à l'arbre de navigation pouvaient déclencher des `requestUpdate()` pendant le cycle de rendu actif.

Un pattern similaire existait ensuite dans `ar-dialog` :
- `updated()` appelait `_close()` directement quand `open` passait à `false`
- `_close()` posait immédiatement l'état réactif `_isClosing`
- `_show()` pouvait aussi remettre `open = false` immédiatement si l'événement `ar-dialog-show` était annulé

Ces deux chemins pouvaient donc provoquer le warning Lit `change-in-update`.

---

## Ce qui a été corrigé

### `ar-stepper`

- Diffère les interactions avec le popover mobile après `updateComplete`
- Évite les `requestUpdate()` parasites pendant le cycle de rendu courant
- Ajuste les tests du contrôleur de navigation pour refléter que le rebuild est piloté par l'appelant

### `ar-dialog`

- Remplace l'appel direct à `_close()` depuis `updated()` par une fermeture différée via `_scheduleClose()`
- Garde l'ouverture synchrone pour préserver le timing de `ar-dialog-shown`
- Diffère le rollback `open = false` quand `ar-dialog-show` est annulé
- Ajoute des tests de non-régression pour les deux chemins sensibles :
  - cycle `open -> close`
  - ouverture annulée via `event.preventDefault()`

---

## Tests

- [x] `npm run test --workspace @ariane-ui/core -- dialog.test.ts` — 66 tests verts
- [x] `npm run test:browser --workspace @ariane-ui/core -- --files src/components/dialog/dialog.browser.test.ts` — 9 tests verts
- [x] Vérifier que les logs browser ne contiennent plus le warning Lit `scheduled an update`
- [x] Vérifier que l'ouverture annulée garde le `<dialog>` natif fermé et remet `open` à `false`
- [x] Vérifier que la fermeture animée de `ar-dialog` continue d'émettre `ar-dialog-hidden`

---

## Plan de test manuel

- [x] Ouvrir un `ar-stepper` en mode mobile et ouvrir / fermer le panel plusieurs fois
- [x] Vérifier qu'aucun warning Lit `change-in-update` n'apparaît pour `ar-stepper`
- [x] Ouvrir puis fermer un `ar-dialog` standard
- [x] Vérifier qu'aucun warning Lit `change-in-update` n'apparaît pour `ar-dialog`
- [x] Tester un listener qui annule `ar-dialog-show` avec `event.preventDefault()`
- [x] Vérifier que le dialog ne s'ouvre pas et que `open` revient bien à `false`
