### PR TITLE
fix(a11y): retire aria-controls — non supporté cross-shadow-DOM

### DIFF
--- a/packages/core/src/components/dropdown/dropdown.a11y.test.ts
+++ b/packages/core/src/components/dropdown/dropdown.a11y.test.ts
@@ -43,10 +43,8 @@ describe('ar-dropdown — accessibilité', () => {
             expect(getTrigger(el).getAttribute('aria-haspopup')).to.equal('true');
         });
 
-        it('le trigger a aria-controls pointant vers le panel', () => {
-            const panel = getPanel(el);
-            const controls = getTrigger(el).getAttribute('aria-controls');
-            expect(controls).to.equal(panel.id);
+        it("le trigger n'a pas aria-controls (non supporté cross-shadow-DOM)", () => {
+            expect(getTrigger(el).hasAttribute('aria-controls')).to.equal(false);
         });
 
         it('aria-expanded="false" à l\'état fermé', () => {

--- a/packages/core/src/controllers/anchored.controller.browser.test.ts
+++ b/packages/core/src/controllers/anchored.controller.browser.test.ts
@@ -39,9 +39,9 @@ describe('AnchoredController', () => {
             expect(trigger.getAttribute('aria-haspopup')).to.equal('true');
         });
 
-        it("attach() pose aria-controls avec l'id du panel", async () => {
-            const { trigger, panel } = await setupAnchored({ popupMode: 'menu' });
-            expect(trigger.getAttribute('aria-controls')).to.equal(panel.id);
+        it('attach() ne pose pas aria-controls (non supporté cross-shadow-DOM)', async () => {
+            const { trigger } = await setupAnchored({ popupMode: 'menu' });
+            expect(trigger.hasAttribute('aria-controls')).to.equal(false);
         });
 
         it('attach() pose aria-expanded="false"', async () => {

--- a/packages/core/src/controllers/anchored.controller.ts
+++ b/packages/core/src/controllers/anchored.controller.ts
@@ -62,7 +62,6 @@ export class AnchoredController implements ReactiveController {
         this._popover.attach(trigger, panel);
         const haspopup = this._opts.popupMode === 'dialog' ? 'dialog' : 'true';
         trigger.setAttribute('aria-haspopup', haspopup);
-        trigger.setAttribute('aria-controls', panel.id);
         trigger.setAttribute('aria-expanded', 'false');
     }
 


### PR DESCRIPTION
Closes #69

## Résumé

- Supprime `trigger.setAttribute('aria-controls', panel.id)` dans `AnchoredController.attach()`
- `aria-controls` repose sur une résolution IDREF dans le même document tree — le shadow DOM crée une frontière opaque que les AT ne traversent pas
- `aria-expanded` + `aria-haspopup` restent en place et couvrent JAWS, NVDA, VoiceOver, Narrator sans référence IDREF

## Tests

- `AnchoredController` : test mis à jour pour vérifier l'**absence** d'`aria-controls`
- `ar-dropdown` a11y : idem

## Plan de vérification

- [x] `npm run test` — 401 tests Vitest passent
- [x] `npm run test:browser` — 117 tests WTR passent