### PR TITLE
refactor(dropdown): renomme l'attribut trigger → for

### DIFF
--- a/apps/docs/src/content/components/ar-dropdown.mdx
+++ b/apps/docs/src/content/components/ar-dropdown.mdx
@@ -66,10 +66,10 @@ variants:
           </ar-dropdown>
     - name: external-trigger
       label: Trigger externe
-      description: "L'attribut `trigger` accepte l'ID d'un élément déclencheur situé en dehors du composant. Utile pour les boutons dans une barre d'outils ou une autre zone de la page."
+      description: "L'attribut `for` accepte l'ID d'un élément déclencheur situé en dehors du composant. Utile pour les boutons dans une barre d'outils ou une autre zone de la page."
       html: |
           <button class="btn btn-secondary" id="ar-doc-ext-trigger">Trigger externe ▾</button>
-          <ar-dropdown trigger="ar-doc-ext-trigger">
+          <ar-dropdown for="ar-doc-ext-trigger">
               <ar-dropdown-item><button>Modifier</button></ar-dropdown-item>
               <ar-dropdown-item><button>Dupliquer</button></ar-dropdown-item>
               <ar-dropdown-item><button>Supprimer</button></ar-dropdown-item>
@@ -101,7 +101,7 @@ variants:
 
 ### Pris en charge automatiquement
 
-- Le trigger reçoit `aria-haspopup="true"`, `aria-controls` (pointant vers le panel) et `aria-expanded` synchronisé à l'état ouvert/fermé.
+- Le trigger reçoit `aria-haspopup="true"` et `aria-expanded` synchronisé à l'état ouvert/fermé.
 - En mode menu (présence d'`ar-dropdown-item`), le panel reçoit `role="menu"` et chaque enfant focusable reçoit `role="menuitem"`.
 - Navigation clavier complète : `↑` `↓` `Home` `End` pour déplacer le focus, `Escape` et `Tab` pour fermer.
 - Retour du focus sur le trigger à la fermeture.

--- a/docs/superpowers/plans/2026-05-05-ar-dropdown-for-attribute.md
+++ b/docs/superpowers/plans/2026-05-05-ar-dropdown-for-attribute.md
@@ -1,0 +1,549 @@
+# ar-dropdown : renommage `trigger` → `for` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Renommer l'attribut `trigger` en `for` sur `ar-dropdown` pour aligner l'API avec `ar-tooltip`, et ajouter un avertissement `__DEV__` quand `for` et `slot="trigger"` sont définis simultanément.
+
+**Architecture:** Renommage de propriété Lit pur + ajout d'un `warn()` dans `_handleTriggerSlotChange`. Les deux mécanismes de résolution du trigger (slot et attribut `for`) sont conservés — `for` garde la priorité sur le slot.
+
+**Tech Stack:** Lit 3, TypeScript, Vitest (tests unitaires), @web/test-runner (tests browser)
+
+---
+
+## Fichiers concernés
+
+| Fichier                                                          | Action                                              |
+| ---------------------------------------------------------------- | --------------------------------------------------- |
+| `packages/core/src/components/dropdown/dropdown.ts`              | Modifier — renommage + warn conflit                 |
+| `packages/core/src/components/dropdown/dropdown.test.ts`         | Modifier — renommage + nouveau test warn            |
+| `packages/core/src/components/dropdown/dropdown.browser.test.ts` | Aucun changement nécessaire                         |
+| `packages/core/src/components/dropdown/dropdown.a11y.test.ts`    | Aucun changement nécessaire                         |
+| `apps/docs/src/content/components/ar-dropdown.mdx`               | Modifier — variante external-trigger + section a11y |
+| `custom-elements.json`                                           | Régénérer via `npm run build:manifest`              |
+
+---
+
+## Task 1 : RED — mettre à jour les tests pour `for`
+
+**Files:**
+
+- Modify: `packages/core/src/components/dropdown/dropdown.test.ts`
+
+- [ ] **Étape 1 : Mettre à jour les tests dans `dropdown.test.ts`**
+
+Appliquer les remplacements suivants dans `packages/core/src/components/dropdown/dropdown.test.ts` :
+
+**Section "valeurs par défaut" (ligne ~51) :**
+
+```ts
+// AVANT
+it('trigger=""', () => expect(el.trigger).toBe(''));
+
+// APRÈS
+it('for=""', () => expect(el.for).toBe(''));
+```
+
+**Section "attributs reflect" (lignes ~98-102) :**
+
+```ts
+// AVANT
+it('trigger reflète en attribut', async () => {
+    el.trigger = 'mon-btn';
+    await waitForUpdate(el);
+    expect(el.getAttribute('trigger')).toBe('mon-btn');
+});
+
+// APRÈS
+it('for reflète en attribut', async () => {
+    el.for = 'mon-btn';
+    await waitForUpdate(el);
+    expect(el.getAttribute('for')).toBe('mon-btn');
+});
+```
+
+**Section "trigger externe" — describe title et tous les fixtures (lignes ~219-262) :**
+
+```ts
+// AVANT
+describe('trigger externe', () => {
+    ...
+    it('pose aria-haspopup et aria-expanded sur le trigger externe', async () => {
+        el = await fixture('<ar-dropdown trigger="test-ext-trigger"></ar-dropdown>');
+        ...
+    });
+
+    it('le clic sur le trigger externe ouvre le dropdown', async () => {
+        el = await fixture('<ar-dropdown trigger="test-ext-trigger"></ar-dropdown>');
+        ...
+    });
+
+    it('le slot trigger est ignoré quand trigger est défini', async () => {
+        el = await fixture(`
+            <ar-dropdown trigger="test-ext-trigger">
+                <button slot="trigger" id="slot-btn">Slot</button>
+            </ar-dropdown>
+        `);
+        ...
+    });
+
+    it("affiche un warn si l'ID est introuvable", async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        el = await fixture('<ar-dropdown trigger="id-qui-nexiste-pas"></ar-dropdown>');
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('id-qui-nexiste-pas'));
+        warnSpy.mockRestore();
+    });
+});
+
+// APRÈS
+describe('for — trigger externe', () => {
+    ...
+    it('pose aria-haspopup et aria-expanded sur le trigger externe', async () => {
+        el = await fixture('<ar-dropdown for="test-ext-trigger"></ar-dropdown>');
+        ...
+    });
+
+    it('le clic sur le trigger externe ouvre le dropdown', async () => {
+        el = await fixture('<ar-dropdown for="test-ext-trigger"></ar-dropdown>');
+        ...
+    });
+
+    it('le slot trigger est ignoré quand for est défini', async () => {
+        el = await fixture(`
+            <ar-dropdown for="test-ext-trigger">
+                <button slot="trigger" id="slot-btn">Slot</button>
+            </ar-dropdown>
+        `);
+        ...
+    });
+
+    it("affiche un warn si l'ID est introuvable", async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        el = await fixture('<ar-dropdown for="id-qui-nexiste-pas"></ar-dropdown>');
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('id-qui-nexiste-pas'));
+        warnSpy.mockRestore();
+    });
+});
+```
+
+**Section "warn() — trigger introuvable" (lignes ~320-346) :**
+
+```ts
+// AVANT
+describe('warn() — trigger introuvable', () => {
+    ...
+    it('émet un warn si trigger pointe vers un ID inexistant (firstUpdated)', async () => {
+        const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        el = await fixture('<ar-dropdown trigger="id-qui-nexiste-pas"></ar-dropdown>');
+        expect(spy).toHaveBeenCalledOnce();
+        expect(spy).toHaveBeenCalledWith(expect.stringContaining('[ar-dropdown]'));
+        expect(spy).toHaveBeenCalledWith(expect.stringContaining('id-qui-nexiste-pas'));
+    });
+
+    it('émet un warn si trigger est mis à jour vers un ID inexistant', async () => {
+        const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        el = await fixture<ArDropdown>('<ar-dropdown></ar-dropdown>');
+        el.trigger = 'id-inconnu';
+        await waitForUpdate(el);
+        expect(spy).toHaveBeenCalledOnce();
+        expect(spy).toHaveBeenCalledWith(expect.stringContaining('[ar-dropdown]'));
+        expect(spy).toHaveBeenCalledWith(expect.stringContaining('id-inconnu'));
+    });
+});
+
+// APRÈS
+describe('warn() — for introuvable', () => {
+    ...
+    it('émet un warn si for pointe vers un ID inexistant (firstUpdated)', async () => {
+        const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        el = await fixture('<ar-dropdown for="id-qui-nexiste-pas"></ar-dropdown>');
+        expect(spy).toHaveBeenCalledOnce();
+        expect(spy).toHaveBeenCalledWith(expect.stringContaining('[ar-dropdown]'));
+        expect(spy).toHaveBeenCalledWith(expect.stringContaining('id-qui-nexiste-pas'));
+    });
+
+    it('émet un warn si for est mis à jour vers un ID inexistant', async () => {
+        const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        el = await fixture<ArDropdown>('<ar-dropdown></ar-dropdown>');
+        el.for = 'id-inconnu';
+        await waitForUpdate(el);
+        expect(spy).toHaveBeenCalledOnce();
+        expect(spy).toHaveBeenCalledWith(expect.stringContaining('[ar-dropdown]'));
+        expect(spy).toHaveBeenCalledWith(expect.stringContaining('id-inconnu'));
+    });
+});
+```
+
+- [ ] **Étape 2 : Vérifier que les tests échouent**
+
+```bash
+npm run test
+```
+
+Résultat attendu : plusieurs tests échouent — `el.for` vaut `undefined` (propriété pas encore renommée dans l'implémentation), et les fixtures `for="..."` ne sont pas reconnues par Lit.
+
+---
+
+## Task 2 : GREEN — renommer la propriété dans `dropdown.ts`
+
+**Files:**
+
+- Modify: `packages/core/src/components/dropdown/dropdown.ts`
+
+- [ ] **Étape 1 : Renommer la propriété et toutes ses références**
+
+Dans `packages/core/src/components/dropdown/dropdown.ts`, apporter les modifications suivantes :
+
+**JSDoc `@slot` (ligne ~27) :**
+
+```ts
+// AVANT
+ * @slot trigger  - Le bouton déclencheur (ignoré si `trigger` est défini).
+
+// APRÈS
+ * @slot trigger  - Le bouton déclencheur (ignoré si `for` est défini).
+```
+
+**Propriété (ligne ~75) :**
+
+```ts
+// AVANT
+    @property({ reflect: true }) trigger = '';
+
+// APRÈS
+    @property({ reflect: true }) for = '';
+```
+
+**`firstUpdated` (lignes ~91-101) :**
+
+```ts
+// AVANT
+    override firstUpdated(): void {
+        const trigger = this._resolvedTrigger;
+        if (trigger && this._panel) {
+            this._popover.attach(trigger, this._panel);
+            if (this.trigger) {
+                trigger.addEventListener('click', this._handleTriggerClick);
+                this._externalTrigger = trigger;
+            }
+        }
+        if (this.open) this._show();
+    }
+
+// APRÈS
+    override firstUpdated(): void {
+        const trigger = this._resolvedTrigger;
+        if (trigger && this._panel) {
+            this._popover.attach(trigger, this._panel);
+            if (this.for) {
+                trigger.addEventListener('click', this._handleTriggerClick);
+                this._externalTrigger = trigger;
+            }
+        }
+        if (this.open) this._show();
+    }
+```
+
+**`updated` — bloc `changed.has('trigger')` (lignes ~116-130) :**
+
+```ts
+// AVANT
+if (changed.has('trigger')) {
+    this._externalTrigger?.removeEventListener('click', this._handleTriggerClick);
+    this._externalTrigger = null;
+    const newTrigger = this._resolvedTrigger;
+    if (this.trigger && !newTrigger) {
+        warn('ar-dropdown', `Aucun élément trouvé avec l'id "${this.trigger}".`);
+    }
+    if (newTrigger && this._panel) {
+        this._popover.attach(newTrigger, this._panel);
+        if (this.trigger) {
+            newTrigger.addEventListener('click', this._handleTriggerClick);
+            this._externalTrigger = newTrigger;
+        }
+    }
+}
+
+// APRÈS
+if (changed.has('for')) {
+    this._externalTrigger?.removeEventListener('click', this._handleTriggerClick);
+    this._externalTrigger = null;
+    const newTrigger = this._resolvedTrigger;
+    if (this.for && !newTrigger) {
+        warn('ar-dropdown', `Aucun élément trouvé avec l'id "${this.for}".`);
+    }
+    if (newTrigger && this._panel) {
+        this._popover.attach(newTrigger, this._panel);
+        if (this.for) {
+            newTrigger.addEventListener('click', this._handleTriggerClick);
+            this._externalTrigger = newTrigger;
+        }
+    }
+}
+```
+
+**`_resolvedTrigger` (lignes ~153-159) :**
+
+```ts
+// AVANT
+    private get _resolvedTrigger(): HTMLElement | null {
+        if (this.trigger) {
+            return document.getElementById(this.trigger);
+        }
+        const slot = this.shadowRoot?.querySelector<HTMLSlotElement>('slot[name="trigger"]');
+        return (slot?.assignedElements({ flatten: true })[0] as HTMLElement | undefined) ?? null;
+    }
+
+// APRÈS
+    private get _resolvedTrigger(): HTMLElement | null {
+        if (this.for) {
+            return document.getElementById(this.for);
+        }
+        const slot = this.shadowRoot?.querySelector<HTMLSlotElement>('slot[name="trigger"]');
+        return (slot?.assignedElements({ flatten: true })[0] as HTMLElement | undefined) ?? null;
+    }
+```
+
+**`_handleTriggerSlotChange` (lignes ~161-167) :**
+
+```ts
+// AVANT
+    private _handleTriggerSlotChange(): void {
+        if (this.trigger) return;
+        const trigger = this._resolvedTrigger;
+        if (!trigger || !this._panel) return;
+        this._popover.attach(trigger, this._panel);
+        trigger.addEventListener('click', this._handleTriggerClick);
+    }
+
+// APRÈS
+    private _handleTriggerSlotChange(): void {
+        if (this.for) return;
+        const trigger = this._resolvedTrigger;
+        if (!trigger || !this._panel) return;
+        this._popover.attach(trigger, this._panel);
+        trigger.addEventListener('click', this._handleTriggerClick);
+    }
+```
+
+- [ ] **Étape 2 : Vérifier que les tests passent**
+
+```bash
+npm run test
+```
+
+Résultat attendu :
+
+```
+Test Files  21 passed (21)
+Tests  401 passed (401)
+```
+
+- [ ] **Étape 3 : Commit**
+
+```bash
+git add packages/core/src/components/dropdown/dropdown.ts \
+        packages/core/src/components/dropdown/dropdown.test.ts
+git commit -m "refactor(dropdown): renomme l'attribut trigger → for"
+```
+
+---
+
+## Task 3 : RED — test du warn de conflit `for` + slot
+
+**Files:**
+
+- Modify: `packages/core/src/components/dropdown/dropdown.test.ts`
+
+- [ ] **Étape 1 : Ajouter le test de conflit dans la section `warn()`**
+
+Dans `dropdown.test.ts`, dans le describe `'warn() — for introuvable'`, ajouter un troisième test **après** les deux tests existants :
+
+```ts
+it('émet un warn si for et slot="trigger" sont tous les deux définis', async () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const conflictBtn = document.createElement('button');
+    conflictBtn.id = 'conflict-warn-btn';
+    document.body.appendChild(conflictBtn);
+
+    el = await fixture(`
+        <ar-dropdown for="conflict-warn-btn">
+            <button slot="trigger">Slot trigger</button>
+        </ar-dropdown>
+    `);
+
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('[ar-dropdown]'));
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('for'));
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('priorité'));
+
+    conflictBtn.remove();
+    spy.mockRestore();
+});
+```
+
+- [ ] **Étape 2 : Vérifier que le test échoue**
+
+```bash
+npm run test -- --reporter=verbose 2>&1 | grep -A5 "conflit\|conflict"
+```
+
+Résultat attendu : le test échoue car `spy` n'a pas encore été appelé avec ce message.
+
+---
+
+## Task 4 : GREEN — implémenter le warn de conflit
+
+**Files:**
+
+- Modify: `packages/core/src/components/dropdown/dropdown.ts`
+
+- [ ] **Étape 1 : Ajouter le warn dans `_handleTriggerSlotChange`**
+
+Dans `dropdown.ts`, remplacer `_handleTriggerSlotChange` par :
+
+```ts
+    private _handleTriggerSlotChange(): void {
+        if (this.for) {
+            const slot = this.shadowRoot?.querySelector<HTMLSlotElement>('slot[name="trigger"]');
+            if (slot?.assignedElements({ flatten: true }).length) {
+                warn(
+                    'ar-dropdown',
+                    'for et slot="trigger" sont tous les deux définis — for prend la priorité.',
+                );
+            }
+            return;
+        }
+        const trigger = this._resolvedTrigger;
+        if (!trigger || !this._panel) return;
+        this._popover.attach(trigger, this._panel);
+        trigger.addEventListener('click', this._handleTriggerClick);
+    }
+```
+
+- [ ] **Étape 2 : Vérifier que tous les tests passent**
+
+```bash
+npm run test
+```
+
+Résultat attendu :
+
+```
+Test Files  21 passed (21)
+Tests  402 passed (402)
+```
+
+(+1 par rapport à avant : le nouveau test de conflit)
+
+- [ ] **Étape 3 : Vérifier les tests browser**
+
+```bash
+npm run test:browser 2>&1 | tail -5
+```
+
+Résultat attendu : `117 passed, 0 failed`
+
+- [ ] **Étape 4 : Commit**
+
+```bash
+git add packages/core/src/components/dropdown/dropdown.ts \
+        packages/core/src/components/dropdown/dropdown.test.ts
+git commit -m "feat(dropdown): warn __DEV__ quand for et slot=\"trigger\" sont tous les deux définis"
+```
+
+---
+
+## Task 5 : Mettre à jour la documentation
+
+**Files:**
+
+- Modify: `apps/docs/src/content/components/ar-dropdown.mdx`
+
+- [ ] **Étape 1 : Mettre à jour la variante `external-trigger`**
+
+Dans `apps/docs/src/content/components/ar-dropdown.mdx`, localiser la section `name: external-trigger` (vers la ligne 67) et remplacer :
+
+```yaml
+- name: external-trigger
+  label: Trigger externe
+  description: "L'attribut `trigger` accepte l'ID d'un élément déclencheur situé en dehors du composant. Utile pour les boutons dans une barre d'outils ou une autre zone de la page."
+  html: |
+      <button class="btn btn-secondary" id="ar-doc-ext-trigger">Trigger externe ▾</button>
+      <ar-dropdown trigger="ar-doc-ext-trigger">
+          <ar-dropdown-item><button>Modifier</button></ar-dropdown-item>
+          <ar-dropdown-item><button>Dupliquer</button></ar-dropdown-item>
+          <ar-dropdown-item><button>Supprimer</button></ar-dropdown-item>
+      </ar-dropdown>
+```
+
+par :
+
+```yaml
+- name: external-trigger
+  label: Trigger externe
+  description: "L'attribut `for` accepte l'ID d'un élément déclencheur situé en dehors du composant. Utile pour les boutons dans une barre d'outils ou une autre zone de la page."
+  html: |
+      <button class="btn btn-secondary" id="ar-doc-ext-trigger">Trigger externe ▾</button>
+      <ar-dropdown for="ar-doc-ext-trigger">
+          <ar-dropdown-item><button>Modifier</button></ar-dropdown-item>
+          <ar-dropdown-item><button>Dupliquer</button></ar-dropdown-item>
+          <ar-dropdown-item><button>Supprimer</button></ar-dropdown-item>
+      </ar-dropdown>
+```
+
+- [ ] **Étape 2 : Mettre à jour la section accessibilité**
+
+Localiser la ligne (vers la ligne 104) :
+
+```markdown
+- Le trigger reçoit `aria-haspopup="true"`, `aria-controls` (pointant vers le panel) et `aria-expanded` synchronisé à l'état ouvert/fermé.
+```
+
+et remplacer par :
+
+```markdown
+- Le trigger reçoit `aria-haspopup="true"` et `aria-expanded` synchronisé à l'état ouvert/fermé.
+```
+
+- [ ] **Étape 3 : Commit**
+
+```bash
+git add apps/docs/src/content/components/ar-dropdown.mdx
+git commit -m "docs(dropdown): attribut trigger → for dans la doc et les démos"
+```
+
+---
+
+## Task 6 : Régénérer le manifest
+
+**Files:**
+
+- Modify: `custom-elements.json`
+
+- [ ] **Étape 1 : Régénérer**
+
+```bash
+npm run build:manifest
+```
+
+- [ ] **Étape 2 : Vérifier que `for` apparaît dans le manifest**
+
+```bash
+grep -A3 '"name": "for"' custom-elements.json | head -10
+```
+
+Résultat attendu : entrée `for` avec `"type": { "text": "string" }` et `"default": ""`.
+
+Vérifier aussi que `trigger` n'apparaît plus :
+
+```bash
+grep '"name": "trigger"' custom-elements.json
+```
+
+Résultat attendu : aucune sortie.
+
+- [ ] **Étape 3 : Commit**
+
+```bash
+git add custom-elements.json
+git commit -m "chore(manifest): régénère custom-elements.json après renommage trigger → for"
+```

--- a/docs/superpowers/specs/2026-05-05-ar-dropdown-for-attribute.md
+++ b/docs/superpowers/specs/2026-05-05-ar-dropdown-for-attribute.md
@@ -1,0 +1,108 @@
+# ar-dropdown : renommage `trigger` → `for`
+
+**Date :** 2026-05-05
+**Issue :** backlog — cohérence API avec `ar-tooltip`
+**Scope :** `packages/core` uniquement
+
+---
+
+## Contexte
+
+`ar-dropdown` expose deux mécanismes pour résoudre son trigger :
+
+1. `slot="trigger"` — trigger slotté, vit à l'intérieur du composant (cas courant)
+2. attribut `trigger="btn-id"` — trigger externe par ID (cas toolbar, composant parent)
+
+`ar-tooltip` utilise `for="btn-id"` pour le même mécanisme d'ID externe. Le renommage aligne les deux composants sur la même convention, cohérente avec `<label for>`.
+
+Les deux cas d'usage sont conservés : le slot pour le cas "trigger créé pour le dropdown", `for` pour le cas "trigger préexistant". La complexité de gestion est déjà en place.
+
+---
+
+## Décisions
+
+### `trigger` → `for`
+
+L'attribut `trigger` est renommé `for` dans `ar-dropdown`. Même comportement, même priorité : si `for` est défini, il prend la priorité sur le slot.
+
+On est en alpha — pas de période de dépréciation, pas d'alias.
+
+### Slot `"trigger"` conservé
+
+Le slot `slot="trigger"` reste le mécanisme principal pour le cas courant. Le retirer forcerait un ID sur chaque trigger, ce qui est du bruit pour la majorité des usages.
+
+### `warn()` sur conflit
+
+Si `for` est défini **et** qu'un élément est assigné au slot `"trigger"`, un avertissement `__DEV__` est émis :
+
+```
+[ar-dropdown] for et slot="trigger" sont tous les deux définis — for prend la priorité.
+```
+
+Aligné avec l'infra `warn()` existante (`src/utils/warn.ts`).
+
+---
+
+## Changements
+
+### `packages/core/src/components/dropdown/dropdown.ts`
+
+- `@property trigger` → `@property for` (même options : `reflect: true`)
+- `this.trigger` → `this.for` partout
+- `changed.has('trigger')` → `changed.has('for')`
+- Warn ID introuvable : `"l'id \"${this.trigger}\""` → `"l'id \"${this.for}\""`
+- `_resolvedTrigger` : ajouter le warn conflit quand `this.for` est défini et slot non vide
+- JSDoc `@slot trigger` : mettre à jour la mention de `trigger` → `for`
+
+### `packages/core/src/components/dropdown/dropdown.test.ts`
+
+- Renommer les occurrences de l'attribut `trigger` → `for`
+- Ajouter un test : warn émis quand `for` + slot `"trigger"` sont tous les deux actifs
+
+### `packages/core/src/components/dropdown/dropdown.browser.test.ts`
+
+- Renommer les occurrences de l'attribut `trigger` → `for`
+
+### `packages/core/src/components/dropdown/dropdown.a11y.test.ts`
+
+- Renommer les occurrences de l'attribut `trigger` → `for`
+
+### `apps/docs/src/content/components/ar-dropdown.mdx`
+
+- Variante `external-trigger` : `trigger="ar-doc-ext-trigger"` → `for="ar-doc-ext-trigger"`
+- Description de la variante : mettre à jour la mention de l'attribut
+- Section accessibilité : retirer la mention de `aria-controls` (supprimé en #69)
+
+### `custom-elements.json`
+
+- Régénérer via `npm run build:manifest`
+
+---
+
+## Comportement résolu inchangé
+
+| Cas              | `for`  | Slot    | Trigger résolu                                          |
+| ---------------- | ------ | ------- | ------------------------------------------------------- |
+| Slot uniquement  | vide   | présent | premier élément du slot                                 |
+| `for` uniquement | défini | vide    | `document.getElementById(for)` — warn si ID introuvable |
+| Les deux         | défini | présent | `document.getElementById(for)` + warn conflit           |
+| Aucun            | vide   | vide    | `null` — silencieux                                     |
+
+---
+
+## Tests à écrire / mettre à jour
+
+| Fichier                    | Action                                                 |
+| -------------------------- | ------------------------------------------------------ |
+| `dropdown.test.ts`         | renommer `trigger` → `for` ; ajouter test warn conflit |
+| `dropdown.browser.test.ts` | renommer `trigger` → `for`                             |
+| `dropdown.a11y.test.ts`    | renommer `trigger` → `for`                             |
+
+---
+
+## Hors scope
+
+- Renommer le slot `"trigger"` (conservé tel quel)
+- Modifier `ar-dropdown-item`
+- Modifier `AnchoredController`
+- Changelog, release notes (gérés à la prochaine release)

--- a/packages/core/src/components/dropdown/dropdown.test.ts
+++ b/packages/core/src/components/dropdown/dropdown.test.ts
@@ -48,7 +48,7 @@ describe('ArDropdown', () => {
         it('noScrollLock=false', () => expect(el.noScrollLock).toBe(false));
         it('distance=4', () => expect(el.distance).toBe(4));
         it('offset=0', () => expect(el.offset).toBe(0));
-        it('trigger=""', () => expect(el.trigger).toBe(''));
+        it('for=""', () => expect(el.for).toBe(''));
     });
 
     // ── Attributs reflect ─────────────────────────────────────────────────────
@@ -95,10 +95,10 @@ describe('ArDropdown', () => {
             expect(el.getAttribute('offset')).toBe('8');
         });
 
-        it('trigger reflète en attribut', async () => {
-            el.trigger = 'mon-btn';
+        it('for reflète en attribut', async () => {
+            el.for = 'mon-btn';
             await waitForUpdate(el);
-            expect(el.getAttribute('trigger')).toBe('mon-btn');
+            expect(el.getAttribute('for')).toBe('mon-btn');
         });
     });
 
@@ -217,7 +217,7 @@ describe('ArDropdown', () => {
 
     // ── Trigger externe ───────────────────────────────────────────────────────
 
-    describe('trigger externe', () => {
+    describe('for — trigger externe', () => {
         let externalBtn: HTMLButtonElement;
 
         beforeEach(() => {
@@ -229,13 +229,13 @@ describe('ArDropdown', () => {
         afterEach(() => externalBtn.remove());
 
         it('pose aria-haspopup et aria-expanded sur le trigger externe', async () => {
-            el = await fixture('<ar-dropdown trigger="test-ext-trigger"></ar-dropdown>');
+            el = await fixture('<ar-dropdown for="test-ext-trigger"></ar-dropdown>');
             expect(externalBtn.getAttribute('aria-haspopup')).toBe('true');
             expect(externalBtn.getAttribute('aria-expanded')).toBe('false');
         });
 
         it('le clic sur le trigger externe ouvre le dropdown', async () => {
-            el = await fixture('<ar-dropdown trigger="test-ext-trigger"></ar-dropdown>');
+            el = await fixture('<ar-dropdown for="test-ext-trigger"></ar-dropdown>');
             mockPanelPopover(el);
 
             externalBtn.click();
@@ -244,9 +244,9 @@ describe('ArDropdown', () => {
             expect(el.open).toBe(true);
         });
 
-        it('le slot trigger est ignoré quand trigger est défini', async () => {
+        it('le slot trigger est ignoré quand for est défini', async () => {
             el = await fixture(`
-                <ar-dropdown trigger="test-ext-trigger">
+                <ar-dropdown for="test-ext-trigger">
                     <button slot="trigger" id="slot-btn">Slot</button>
                 </ar-dropdown>
             `);
@@ -256,7 +256,7 @@ describe('ArDropdown', () => {
 
         it("affiche un warn si l'ID est introuvable", async () => {
             const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-            el = await fixture('<ar-dropdown trigger="id-qui-nexiste-pas"></ar-dropdown>');
+            el = await fixture('<ar-dropdown for="id-qui-nexiste-pas"></ar-dropdown>');
             expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('id-qui-nexiste-pas'));
             warnSpy.mockRestore();
         });
@@ -317,26 +317,26 @@ describe('ArDropdown', () => {
         });
     });
 
-    describe('warn() — trigger introuvable', () => {
+    describe('warn() — for introuvable', () => {
         afterEach(() => {
             vi.restoreAllMocks();
         });
 
-        it('émet un warn si trigger pointe vers un ID inexistant (firstUpdated)', async () => {
+        it('émet un warn si for pointe vers un ID inexistant (firstUpdated)', async () => {
             const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-            el = await fixture('<ar-dropdown trigger="id-qui-nexiste-pas"></ar-dropdown>');
+            el = await fixture('<ar-dropdown for="id-qui-nexiste-pas"></ar-dropdown>');
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith(expect.stringContaining('[ar-dropdown]'));
             expect(spy).toHaveBeenCalledWith(expect.stringContaining('id-qui-nexiste-pas'));
         });
 
-        it('émet un warn si trigger est mis à jour vers un ID inexistant', async () => {
+        it('émet un warn si for est mis à jour vers un ID inexistant', async () => {
             const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
             el = await fixture<ArDropdown>('<ar-dropdown></ar-dropdown>');
 
-            el.trigger = 'id-inconnu';
+            el.for = 'id-inconnu';
             await waitForUpdate(el);
 
             expect(spy).toHaveBeenCalledOnce();

--- a/packages/core/src/components/dropdown/dropdown.test.ts
+++ b/packages/core/src/components/dropdown/dropdown.test.ts
@@ -343,5 +343,25 @@ describe('ArDropdown', () => {
             expect(spy).toHaveBeenCalledWith(expect.stringContaining('[ar-dropdown]'));
             expect(spy).toHaveBeenCalledWith(expect.stringContaining('id-inconnu'));
         });
+
+        it('émet un warn si for et slot="trigger" sont tous les deux définis', async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            const conflictBtn = document.createElement('button');
+            conflictBtn.id = 'conflict-warn-btn';
+            document.body.appendChild(conflictBtn);
+
+            el = await fixture(`
+                <ar-dropdown for="conflict-warn-btn">
+                    <button slot="trigger">Slot trigger</button>
+                </ar-dropdown>
+            `);
+
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('[ar-dropdown]'));
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('for'));
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('priorité'));
+
+            conflictBtn.remove();
+            spy.mockRestore();
+        });
     });
 });

--- a/packages/core/src/components/dropdown/dropdown.ts
+++ b/packages/core/src/components/dropdown/dropdown.ts
@@ -89,6 +89,15 @@ export class ArDropdown extends LitElement {
     private readonly _uniqueId = Math.random().toString(36).slice(2, 9);
 
     override firstUpdated(): void {
+        if (this.for) {
+            const slot = this.shadowRoot?.querySelector<HTMLSlotElement>('slot[name="trigger"]');
+            if (slot?.assignedElements({ flatten: true }).length) {
+                warn(
+                    'ar-dropdown',
+                    'for et slot="trigger" sont tous les deux définis — for prend la priorité.',
+                );
+            }
+        }
         const trigger = this._resolvedTrigger;
         if (trigger && this._panel) {
             this._popover.attach(trigger, this._panel);
@@ -159,7 +168,16 @@ export class ArDropdown extends LitElement {
     }
 
     private _handleTriggerSlotChange(): void {
-        if (this.for) return;
+        if (this.for) {
+            const slot = this.shadowRoot?.querySelector<HTMLSlotElement>('slot[name="trigger"]');
+            if (slot?.assignedElements({ flatten: true }).length) {
+                warn(
+                    'ar-dropdown',
+                    'for et slot="trigger" sont tous les deux définis — for prend la priorité.',
+                );
+            }
+            return;
+        }
         const trigger = this._resolvedTrigger;
         if (!trigger || !this._panel) return;
         this._popover.attach(trigger, this._panel);

--- a/packages/core/src/components/dropdown/dropdown.ts
+++ b/packages/core/src/components/dropdown/dropdown.ts
@@ -24,7 +24,7 @@ export type ArDropdownPlacement =
  * @summary Mécanisme de disclosure accessible basé sur l'API popover native.
  * @display demo
  *
- * @slot trigger  - Le bouton déclencheur (ignoré si `trigger` est défini).
+ * @slot trigger  - Le bouton déclencheur (ignoré si `for` est défini).
  * @slot          - Contenu du panel (libre ou ar-dropdown-item pour le mode menu).
  *
  * @csspart panel - Le panel flottant.
@@ -72,7 +72,7 @@ export class ArDropdown extends LitElement {
      * ID d'un élément déclencheur externe (light DOM). Quand défini, le slot
      * `trigger` est ignoré.
      */
-    @property({ reflect: true }) trigger = '';
+    @property({ reflect: true }) for = '';
 
     @query('[part="panel"]') private _panel!: HTMLElement;
 
@@ -92,7 +92,7 @@ export class ArDropdown extends LitElement {
         const trigger = this._resolvedTrigger;
         if (trigger && this._panel) {
             this._popover.attach(trigger, this._panel);
-            if (this.trigger) {
+            if (this.for) {
                 trigger.addEventListener('click', this._handleTriggerClick);
                 this._externalTrigger = trigger;
             }
@@ -113,16 +113,16 @@ export class ArDropdown extends LitElement {
         if (changed.has('offset')) {
             this._popover.setOffset(this.offset);
         }
-        if (changed.has('trigger')) {
+        if (changed.has('for')) {
             this._externalTrigger?.removeEventListener('click', this._handleTriggerClick);
             this._externalTrigger = null;
             const newTrigger = this._resolvedTrigger;
-            if (this.trigger && !newTrigger) {
-                warn('ar-dropdown', `Aucun élément trouvé avec l'id "${this.trigger}".`);
+            if (this.for && !newTrigger) {
+                warn('ar-dropdown', `Aucun élément trouvé avec l'id "${this.for}".`);
             }
             if (newTrigger && this._panel) {
                 this._popover.attach(newTrigger, this._panel);
-                if (this.trigger) {
+                if (this.for) {
                     newTrigger.addEventListener('click', this._handleTriggerClick);
                     this._externalTrigger = newTrigger;
                 }
@@ -151,15 +151,15 @@ export class ArDropdown extends LitElement {
     }
 
     private get _resolvedTrigger(): HTMLElement | null {
-        if (this.trigger) {
-            return document.getElementById(this.trigger);
+        if (this.for) {
+            return document.getElementById(this.for);
         }
         const slot = this.shadowRoot?.querySelector<HTMLSlotElement>('slot[name="trigger"]');
         return (slot?.assignedElements({ flatten: true })[0] as HTMLElement | undefined) ?? null;
     }
 
     private _handleTriggerSlotChange(): void {
-        if (this.trigger) return;
+        if (this.for) return;
         const trigger = this._resolvedTrigger;
         if (!trigger || !this._panel) return;
         this._popover.attach(trigger, this._panel);


### PR DESCRIPTION
## Résumé

- Renomme l'attribut `trigger` en `for` sur `ar-dropdown` — aligne l'API avec `ar-tooltip` et le pattern natif `<label for>`
- Conserve les deux mécanismes : `slot="trigger"` (cas courant) et `for="id"` (trigger externe)
- Ajoute un `warn()` `__DEV__` quand `for` et `slot="trigger"` sont définis simultanément
- Met à jour la variante `external-trigger` et la section accessibilité dans la doc (retire la mention de `aria-controls`, supprimé en #69)

## Tests

- Vitest : 402 tests, tous verts (+1 nouveau test warn conflit)
- WTR : 117 tests, tous verts

## Plan de vérification

- [x] `npm run test` — 402 tests Vitest passent
- [x] `npm run test:browser` — 117 tests WTR passent
- [x] Tester la démo `external-trigger` dans la doc (`for=` fonctionne)
- [x] Tester la démo `slot="trigger"` standard (inchangée)