### PR TITLE
feat(docs): références WCAG inline dans la documentation des composants

### DIFF
--- a/.claude/skills/ariane-new-component/SKILL.md
+++ b/.claude/skills/ariane-new-component/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: ariane-new-component
+description: Conventions spécifiques au projet Ariane pour créer un nouveau composant — naming ar-*, structure fichiers, annotations CEM custom (@display, @parent, @ignore), test helpers maison. À utiliser quand on crée ou scaffold un nouveau composant ar-*.
+---
+
+# Créer un nouveau composant Ariane
+
+## Scaffold
+
+```bash
+npm run create ar-<nom>   # depuis la racine du monorepo
+```
+
+## Structure fichiers
+
+```
+components/<nom>/
+  <nom>.ts          # Classe LitElement, @customElement('ar-<nom>')
+  <nom>.styles.ts   # Styles Lit css`` tagged template
+  <nom>.test.ts     # Tests Vitest
+  # Composants complexes ajoutent :
+  <nom>.renderer.ts # Helpers de rendu (desktop/mobile)
+  <nom>.utils.ts    # Fonctions utilitaires pures
+```
+
+## Naming
+
+| Élément | Convention | Exemple |
+|---|---|---|
+| Tag HTML | `ar-<name>` | `ar-stepper` |
+| Classe | `Ar<Name>` | `ArStepper` |
+| Événements | `ar-<event>` | `ar-step-change` |
+| CSS custom properties | `--ar-<component>-<prop>` | `--ar-stepper-gap` |
+| CSS parts | `part="base"`, `part="label"`, etc. | |
+
+## Annotations JSDoc CEM
+
+Les annotations standard (`@slot`, `@csspart`, `@cssprop`, `@event`, `@summary`) sont connues. Annotations spécifiques au projet :
+
+| Annotation | Effet |
+|---|---|
+| `@display demo` | Page doc : exemples + playground + API (défaut) |
+| `@display docs` | Page doc : API uniquement, pas de playground |
+| `@parent ar-<tag>` | Marque comme sous-composant — nav et home page le lisent via CEM `x-parent` |
+| `@ignore` | Exclut un membre des contrôles playground |
+
+## Test helpers (boilerplate maison)
+
+Copier en tête de chaque `.test.ts` — évite les non-null assertions bloquées par `lint-staged --max-warnings=0` :
+
+```typescript
+async function fixture<T extends HTMLElement>(html: string): Promise<T> {
+    const template = document.createElement('template');
+    template.innerHTML = html.trim();
+    const el = template.content.firstElementChild as T;
+    document.body.appendChild(el);
+    await (el as any).updateComplete;
+    await (el as any).updateComplete;
+    return el;
+}
+
+async function waitForUpdate(el: HTMLElement): Promise<void> {
+    await (el as any).updateComplete;
+    await (el as any).updateComplete;
+}
+
+function getPart(el: Element, name: string): Element | null {
+    return el.shadowRoot?.querySelector(`[part="${name}"]`) ?? null;
+}
+```
+
+Le double `await updateComplete` est intentionnel — absorbe les cycles déclenchés par `queueMicrotask`.
+
+## Export
+
+Ajouter dans `packages/core/src/index.ts` :
+
+```typescript
+export * from './components/<nom>/<nom>.js';
+```
+
+## Accessibilité
+
+Avant d'implémenter un composant, identifier les critères WCAG applicables au pattern UI. Documenter dans le plan d'implémentation :
+
+- Le pattern ARIA attendu (rôle, états, propriétés ARIA)
+- Les critères WCAG couverts automatiquement par le composant
+- Les responsabilités laissées à l'auteur de la page
+
+Critères courants par pattern :
+
+| Pattern UI                                | Critères WCAG clés                            |
+| ----------------------------------------- | --------------------------------------------- |
+| Disclosure / toggle (dropdown, accordion) | 4.1.2 `aria-expanded`, 2.1.1 keyboard         |
+| Navigation landmark                       | 1.3.1 `role="navigation"` + `aria-labelledby` |
+| Live region / status                      | 4.1.3 status messages                         |
+| Dialog / modal                            | 2.1.2 no keyboard trap                        |
+| Item courant (breadcrumb, stepper)        | 2.4.8 `aria-current`                          |
+| Contenu au survol / focus                 | 1.4.13 hover/focus persistence                |
+| Composant interactif avec état            | 4.1.2 name, role, value                       |
+
+La page "Understanding" correspondante est linkable via le composant `WcagRef` dans la doc (voir skill `ariane-write-docs`).

--- a/.claude/skills/ariane-write-docs/SKILL.md
+++ b/.claude/skills/ariane-write-docs/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: ariane-write-docs
+description: Architecture du site de documentation Ariane utilisation Astro 6 et conventions MDX — fichiers clés apps/docs/, frontmatter schema, mapping types CEM vers contrôles playground. À utiliser quand on écrit ou modifie une page de documentation composant.
+---
+
+# Documentation Ariane (`apps/docs/`)
+
+## Fichiers clés
+
+| Fichier                                | Rôle                                                                               |
+| -------------------------------------- | ---------------------------------------------------------------------------------- |
+| `src/pages/components/[slug].astro`    | Route dynamique — résout HTML playground, appelle `buildControls()`, construit TOC |
+| `src/components/Playground.astro`      | Variantes + playground + ComponentApi ; charge `public/js/playground.js`           |
+| `src/components/ComponentApi.astro`    | Tables API depuis le CEM ; swatches couleur sur les CSS custom property defaults   |
+| `src/components/TableOfContents.astro` | TOC sticky colonne droite ; reçoit `entries[]` via props                           |
+| `src/components/SiteNav.astro`         | Nav gauche ; auto-généré depuis le CEM avec hiérarchie parent/enfant               |
+| `src/layouts/Layout.astro`             | Grille 3 colonnes (`260px 1fr 220px`) quand `showToc={true}`                       |
+| `src/content/config.ts`                | Schéma Zod du frontmatter MDX                                                      |
+| `public/js/playground.js`              | Boutons copier + manipulation live des attributs via `setAttribute`                |
+| `src/utils/cem-types.ts`               | Types CEM + helpers `getCustomElements`, `buildControls`                           |
+| `src/utils/parse-tokens.ts`            | Parse `default.css`, catégorise les CSS custom properties                          |
+| `src/utils/tag-name.ts`                | `getSlug()`, `getPrefix()`, `groupByPrefix()`                                      |
+
+## MDX frontmatter schema
+
+```yaml
+tagName: ar-alert # requis
+title: Alerte # requis
+description: … # optionnel
+playgroundTemplate: default # optionnel — variante initiale du playground (défaut : première)
+variants:
+    - name: default
+      label: Par défaut
+      description: …
+      html: '<ar-alert variant="info">Message.</ar-alert>'
+```
+
+## Sous-composants
+
+`@parent ar-<tag>` en JSDoc uniquement — pas de champ MDX. Le CEM `x-parent` est lu directement par la nav et la home page.
+
+## Mapping CEM type → contrôle playground
+
+Défini dans `src/utils/cem-types.ts` → `buildControls()` :
+
+| Type CEM                         | Contrôle                                               |
+| -------------------------------- | ------------------------------------------------------ |
+| `'a' \| 'b' \| …`                | `<select>`                                             |
+| `'a' \| 'b' \| undefined`        | `<select>` + option "Par défaut" (value="") en premier |
+| `boolean`                        | `<input type="checkbox">`                              |
+| `number` / `number \| undefined` | `<input type="number">`                                |
+| autre                            | `<input type="text">`                                  |
+
+## Références WCAG
+
+La section "Pris en charge automatiquement" de chaque composant doit référencer les critères WCAG implémentés via le composant `WcagRef`.
+
+### Import
+
+Ajouter après le frontmatter de chaque fichier MDX qui utilise des références WCAG :
+
+```mdx
+import WcagRef from '../../components/WcagRef.astro';
+```
+
+### Usage inline
+
+Placer `<WcagRef>` directement dans la bullet qui décrit le comportement couvert. Une référence par comportement distinct.
+
+```mdx
+- `role="alert"` conforme
+    <WcagRef
+        criterion="4.1.3"
+        summary="Status Messages : les messages de statut doivent être annoncés aux technologies d'assistance sans déplacer le focus."
+    />
+```
+
+### Props
+
+| Prop        | Type     | Exemple                   |
+| ----------- | -------- | ------------------------- |
+| `criterion` | `string` | `"4.1.2"`                 |
+| `summary`   | `string` | `"Name, Role, Value : …"` |
+
+Le composant (`apps/docs/src/components/WcagRef.astro`) génère l'ID automatiquement et construit l'URL vers la page "Understanding" WCAG 2.2. `ar-tooltip` est disponible globalement via le layout — aucun import supplémentaire n'est nécessaire.
+
+### Critères déjà mappés
+
+Voir la table `slugs` dans `WcagRef.astro` pour la liste des critères supportés : 1.3.1, 1.4.13, 2.1.1, 2.1.2, 2.4.8, 3.2.2, 4.1.2, 4.1.3.

--- a/apps/docs/src/components/WcagRef.astro
+++ b/apps/docs/src/components/WcagRef.astro
@@ -1,0 +1,31 @@
+---
+interface Props {
+    criterion: string;
+    summary: string;
+}
+
+const { criterion, summary } = Astro.props;
+
+const slugs: Record<string, string> = {
+    '1.3.1': 'info-and-relationships',
+    '1.4.13': 'content-on-hover-or-focus',
+    '2.1.1': 'keyboard',
+    '2.1.2': 'no-keyboard-trap',
+    '2.4.8': 'location',
+    '3.2.2': 'on-input',
+    '4.1.2': 'name-role-value',
+    '4.1.3': 'status-messages',
+};
+
+const id = `wcag-${criterion.replace(/\./g, '-')}`;
+const slug = slugs[criterion] ?? criterion.replace(/\./g, '-');
+const href = `https://www.w3.org/WAI/WCAG22/Understanding/${slug}/`;
+---
+
+<a
+    {id}
+    {href}
+    target="_blank"
+    rel="noopener"
+    style="cursor:help; text-decoration:underline dotted;"
+>WCAG {criterion}</a><ar-tooltip for={id}>{summary}</ar-tooltip>

--- a/apps/docs/src/components/WcagRef.astro
+++ b/apps/docs/src/components/WcagRef.astro
@@ -19,7 +19,7 @@ const slugs: Record<string, string> = {
 
 const id = `wcag-${criterion.replace(/\./g, '-')}`;
 const slug = slugs[criterion] ?? criterion.replace(/\./g, '-');
-const href = `https://www.w3.org/WAI/WCAG22/Understanding/${slug}/`;
+const href = `https://www.w3.org/WAI/WCAG22/Understanding/${slug}`;
 ---
 
 <a

--- a/apps/docs/src/components/WcagRef.astro
+++ b/apps/docs/src/components/WcagRef.astro
@@ -28,4 +28,4 @@ const href = `https://www.w3.org/WAI/WCAG22/Understanding/${slug}`;
     target="_blank"
     rel="noopener"
     style="cursor:help; text-decoration:underline dotted;"
->WCAG {criterion}</a><ar-tooltip for={id}>{summary}</ar-tooltip>
+>WCAG {criterion}<span class="sr-only"> (ouvre dans un nouvel onglet)</span></a><ar-tooltip for={id}>{summary}</ar-tooltip>

--- a/apps/docs/src/components/WcagRef.astro
+++ b/apps/docs/src/components/WcagRef.astro
@@ -28,4 +28,4 @@ const href = `https://www.w3.org/WAI/WCAG22/Understanding/${slug}`;
     target="_blank"
     rel="noopener"
     style="cursor:help; text-decoration:underline dotted;"
->WCAG {criterion}<span class="sr-only"> (ouvre dans un nouvel onglet)</span></a><ar-tooltip for={id}>{summary}</ar-tooltip>
+>WCAG {criterion} <span aria-hidden="true">↗</span><span class="sr-only"> (ouvre dans un nouvel onglet)</span></a><ar-tooltip for={id}>{summary}</ar-tooltip>

--- a/apps/docs/src/content/components/ar-alert.mdx
+++ b/apps/docs/src/content/components/ar-alert.mdx
@@ -34,12 +34,18 @@ variants:
           </div>
 ---
 
+import WcagRef from '../../components/WcagRef.astro';
+
 ## Accessibilité
 
 ### Pris en charge automatiquement
 
 - `role="alert"` (interruption immédiate) ou `role="status"` (annonce polie) posé sur
-  l'hôte selon le variant — `info` → `status`, tous les autres → `alert`.
+  l'hôte selon le variant — `info` → `status`, tous les autres → `alert` — conforme
+    <WcagRef
+        criterion="4.1.3"
+        summary="Status Messages : les messages de statut doivent être annoncés aux technologies d'assistance sans déplacer le focus."
+    />
 - L'icône est masquée aux lecteurs d'écran (`aria-hidden`). L'information de sévérité
   est portée par le `role`, pas par l'icône.
 - Une icône par défaut est fournie pour chaque variant. Elle peut être remplacée via le

--- a/apps/docs/src/content/components/ar-breadcrumb.mdx
+++ b/apps/docs/src/content/components/ar-breadcrumb.mdx
@@ -23,14 +23,21 @@ variants:
           </ar-breadcrumb>
 ---
 
+import WcagRef from '../../components/WcagRef.astro';
+
 ## Accessibilité
 
 ### Pris en charge automatiquement
 
 - `role="navigation"` et `aria-labelledby` posés sur le conteneur — la région est identifiable
-  par les lecteurs d'écran sans configuration supplémentaire.
+  par les lecteurs d'écran sans configuration supplémentaire
+  (<WcagRef criterion="1.3.1" summary="Info and Relationships : les relations et structures visuelles doivent être déterminables par programmation ou disponibles en texte." />).
 - Le dernier item est automatiquement rendu comme texte (pas de lien), quel que soit son
-  attribut `href`. `aria-current="page"` lui est appliqué automatiquement.
+  attribut `href`. `aria-current="page"` lui est appliqué automatiquement — conforme
+    <WcagRef
+        criterion="2.4.8"
+        summary="Location : l'utilisateur doit pouvoir situer sa position dans un ensemble de pages."
+    />
 - Les icônes de séparation sont masquées aux lecteurs d'écran (`aria-hidden`).
 - En mobile, le bouton "dropdown" expose son état via `aria-expanded`. Son label est vocalisé
   via une classe `.sr-only` — accessible sans être visible.

--- a/apps/docs/src/content/components/ar-dialog.mdx
+++ b/apps/docs/src/content/components/ar-dialog.mdx
@@ -87,15 +87,25 @@ variants:
           </script>
 ---
 
+import WcagRef from '../../components/WcagRef.astro';
+
 ## Accessibilité
 
 ### Pris en charge automatiquement
 
 - Élément `<dialog>` natif avec `role="dialog"`, `aria-labelledby`, `aria-describedby` et `aria-modal`.
-- Le focus est déplacé à l'ouverture sur l'élément portant `autofocus`, ou à défaut sur le premier élément focalisable, ou sur le bouton de fermeture si aucun n'est présent.
+- Le focus est déplacé à l'ouverture sur l'élément portant `autofocus`, ou à défaut sur le premier élément focalisable, ou sur le bouton de fermeture si aucun n'est présent — conforme
+    <WcagRef
+        criterion="2.1.2"
+        summary="No Keyboard Trap : le focus clavier peut toujours quitter un composant via les touches standard (Escape, Tab)."
+    />
 - Le focus est restauré sur l'élément déclencheur à la fermeture.
 - Le scroll du `<body>` est bloqué à l'ouverture et restauré à la fermeture, y compris avec plusieurs dialogs empilés.
-- La touche Escape passe par `ar-dialog-hide` : la fermeture peut donc être interceptée avec `event.preventDefault()`.
+- La touche Escape passe par `ar-dialog-hide` : la fermeture peut donc être interceptée avec `event.preventDefault()` — comportement prévisible conforme
+    <WcagRef
+        criterion="3.2.2"
+        summary="On Input : modifier un composant UI ne doit pas provoquer de changement de contexte inattendu sans en avertir l'utilisateur au préalable."
+    />
 - Quand une fermeture est bloquée, le composant secoue visuellement le dialog et annonce automatiquement `prevented-message` via la zone d'annonce globale de la librairie.
 - Les animations sont désactivées si `prefers-reduced-motion: reduce` est actif.
 

--- a/apps/docs/src/content/components/ar-dropdown.mdx
+++ b/apps/docs/src/content/components/ar-dropdown.mdx
@@ -97,13 +97,23 @@ variants:
           </p>
 ---
 
+import WcagRef from '../../components/WcagRef.astro';
+
 ## Accessibilité
 
 ### Pris en charge automatiquement
 
-- Le trigger reçoit `aria-haspopup="true"` et `aria-expanded` synchronisé à l'état ouvert/fermé.
+- Le trigger reçoit `aria-haspopup="true"` et `aria-expanded` synchronisé à l'état ouvert/fermé —
+    <WcagRef
+        criterion="4.1.2"
+        summary="Name, Role, Value : tout composant UI doit exposer son nom, rôle et valeur (états inclus) aux technologies d'assistance."
+    />
 - En mode menu (présence d'`ar-dropdown-item`), le panel reçoit `role="menu"` et chaque enfant focusable reçoit `role="menuitem"`.
-- Navigation clavier complète : `↑` `↓` `Home` `End` pour déplacer le focus, `Escape` et `Tab` pour fermer.
+- Navigation clavier complète : `↑` `↓` `Home` `End` pour déplacer le focus, `Escape` et `Tab` pour fermer —
+    <WcagRef
+        criterion="2.1.1"
+        summary="Keyboard : toutes les fonctionnalités doivent être accessibles au clavier sans temporisation spécifique."
+    />
 - Retour du focus sur le trigger à la fermeture.
 - Light-dismiss natif (`popover="auto"`) : un clic hors du panel ferme automatiquement.
 - Les animations sont désactivées si `prefers-reduced-motion: reduce` est actif.

--- a/apps/docs/src/content/components/ar-pagination.mdx
+++ b/apps/docs/src/content/components/ar-pagination.mdx
@@ -25,13 +25,19 @@ variants:
           <ar-pagination current="18" total="20"></ar-pagination>
 ---
 
+import WcagRef from '../../components/WcagRef.astro';
+
 ## Accessibilité
 
 ### Pris en charge automatiquement
 
 - `role="navigation"` et `aria-labelledby` posés sur le conteneur — la région est annoncée
   par les lecteurs d'écran comme zone de navigation.
-- Les boutons "précédent" et "suivant" ont `aria-disabled` synchronisé avec leur état désactivé.
+- Les boutons "précédent" et "suivant" ont `aria-disabled` synchronisé avec leur état désactivé —
+    <WcagRef
+        criterion="4.1.2"
+        summary="Name, Role, Value : tout composant UI doit exposer son nom, rôle et valeur (états inclus) aux technologies d'assistance."
+    />
 - Les séparateurs et points de suspension sont masqués aux lecteurs d'écran (`aria-hidden`).
 
 ### À la charge de l'auteur

--- a/apps/docs/src/content/components/ar-progressbar.mdx
+++ b/apps/docs/src/content/components/ar-progressbar.mdx
@@ -21,12 +21,15 @@ variants:
           </ar-progressbar>
 ---
 
+import WcagRef from '../../components/WcagRef.astro';
+
 ## Accessibilité
 
 ### Pris en charge automatiquement
 
 - `role="progressbar"`, `aria-valuenow`, `aria-valuemin` et `aria-valuemax` posés sur la barre —
-  la progression est vocalisée automatiquement par les lecteurs d'écran.
+  la progression est vocalisée automatiquement par les lecteurs d'écran
+  (<WcagRef criterion="4.1.2" summary="Name, Role, Value : tout composant UI doit exposer son nom, rôle et valeur (états inclus) aux technologies d'assistance." />).
 - La valeur de `aria-labelledby` pointe sur le label slotté, pas sur un texte invisible —
   le contexte de la progression est toujours visible et vocalisé simultanément.
 

--- a/apps/docs/src/content/components/ar-spinner.mdx
+++ b/apps/docs/src/content/components/ar-spinner.mdx
@@ -33,13 +33,19 @@ variants:
           <ar-spinner size="lg"></ar-spinner>
 ---
 
+import WcagRef from '../../components/WcagRef.astro';
+
 ## Accessibilité
 
 ### Pris en charge automatiquement
 
 - L'animation SVG est masquée aux lecteurs d'écran (`aria-hidden`). Un `<div role="alert">`
   invisible annonce les changements d'état — le passage "en cours → terminé" est vocalisé
-  sans intervention supplémentaire.
+  sans intervention supplémentaire — conforme
+    <WcagRef
+        criterion="4.1.3"
+        summary="Status Messages : les messages de statut doivent être annoncés aux technologies d'assistance sans déplacer le focus."
+    />
 - Les labels "en cours" (`loading-label`) et "terminé" (`done-label`) ont des valeurs par
   défaut raisonnables utilisées si non fournis.
 

--- a/apps/docs/src/content/components/ar-stepper.mdx
+++ b/apps/docs/src/content/components/ar-stepper.mdx
@@ -67,12 +67,15 @@ variants:
           </ar-stepper>
 ---
 
+import WcagRef from '../../components/WcagRef.astro';
+
 ## Accessibilité
 
 ### Pris en charge automatiquement
 
 - `role="navigation"` et `aria-labelledby` posés sur le conteneur — la région est annoncée
-  et identifiable par les lecteurs d'écran.
+  et identifiable par les lecteurs d'écran
+  (<WcagRef criterion="1.3.1" summary="Info and Relationships : les relations et structures visuelles doivent être déterminables par programmation ou disponibles en texte." />).
 - L'état courant (`current-path`) est reflété visuellement et structurellement — les items
   actifs, complétés et désactivés sont distingués.
 

--- a/apps/docs/src/content/components/ar-tooltip.mdx
+++ b/apps/docs/src/content/components/ar-tooltip.mdx
@@ -66,13 +66,20 @@ variants:
           <ar-tooltip for="tt-disabled" disabled>Ce texte ne s'affichera pas</ar-tooltip>
 ---
 
+import WcagRef from '../../components/WcagRef.astro';
+
 ## Accessibilité
 
 ### Pris en charge automatiquement
 
 - Le trigger reçoit `aria-describedby` pointant vers l'élément `<ar-tooltip>` lui-même (light DOM). Les IDREF ne franchissent pas la frontière shadow DOM — référencer la bulle interne rendrait la description invisible aux lecteurs d'écran. L'hôte étant toujours présent dans le DOM, la description est disponible dès le focus, même quand la bulle est visuellement fermée.
 - La bulle porte `role="tooltip"` et `popover="manual"`.
-- **WCAG 1.4.13 — Content on Hover or Focus :** déplacer le pointeur du trigger vers la bulle annule le timer de fermeture ; la bulle reste ouverte tant que le pointeur y séjourne.
+- <WcagRef
+      criterion="1.4.13"
+      summary="Content on Hover or Focus : le contenu affiché au survol ou au focus doit être persistant, escamotable et consultable au pointeur."
+  />
+  : déplacer le pointeur du trigger vers la bulle annule le timer de fermeture ; la bulle reste
+  ouverte tant que le pointeur y séjourne.
 - La touche `Escape` ferme immédiatement le tooltip sans déplacer le focus.
 - Les animations sont désactivées si `prefers-reduced-motion: reduce` est actif.
 

--- a/apps/docs/src/layouts/Layout.astro
+++ b/apps/docs/src/layouts/Layout.astro
@@ -56,9 +56,7 @@ const {
         <script type="module" src="/cdn/index.js"></script>
         <script src="/js/playground.js" is:inline></script>
 
-        <style>
-            *, *::before, *::after { box-sizing: border-box; }
-
+        <style is:global>
             .sr-only {
                 position: absolute;
                 width: 1px;
@@ -70,6 +68,9 @@ const {
                 white-space: nowrap;
                 border-width: 0;
             }
+        </style>
+        <style>
+            *, *::before, *::after { box-sizing: border-box; }
 
             .alpha-banner {
                 position:        relative;

--- a/apps/docs/src/layouts/Layout.astro
+++ b/apps/docs/src/layouts/Layout.astro
@@ -59,6 +59,18 @@ const {
         <style>
             *, *::before, *::after { box-sizing: border-box; }
 
+            .sr-only {
+                position: absolute;
+                width: 1px;
+                height: 1px;
+                padding: 0;
+                margin: -1px;
+                overflow: hidden;
+                clip: rect(0, 0, 0, 0);
+                white-space: nowrap;
+                border-width: 0;
+            }
+
             .alpha-banner {
                 position:        relative;
                 z-index:         200;

--- a/docs/superpowers/plans/2026-05-06-wcag-references.md
+++ b/docs/superpowers/plans/2026-05-06-wcag-references.md
@@ -1,0 +1,701 @@
+# Références WCAG inline — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ajouter un composant Astro `WcagRef` qui rend un lien + tooltip WCAG, puis l'insérer inline dans la section Accessibilité de chaque page de composant.
+
+**Architecture:** Un seul composant `WcagRef.astro` dans `apps/docs/src/components/` reçoit un numéro de critère et un résumé, génère l'ID, construit l'URL WCAG 2.2, et rend un `<a>` + `<ar-tooltip>` côte à côte. Chaque fichier MDX qui en a besoin l'importe explicitement après son frontmatter.
+
+**Tech Stack:** Astro 5 (composant `.astro`), MDX (content collections), `ar-tooltip` (web component Ariane)
+
+---
+
+## Fichiers
+
+| Action   | Chemin                                                                                |
+| -------- | ------------------------------------------------------------------------------------- |
+| Créer    | `apps/docs/src/components/WcagRef.astro`                                              |
+| Modifier | `apps/docs/src/content/components/ar-alert.mdx`                                       |
+| Modifier | `apps/docs/src/content/components/ar-breadcrumb.mdx`                                  |
+| Modifier | `apps/docs/src/content/components/ar-dialog.mdx`                                      |
+| Modifier | `apps/docs/src/content/components/ar-dropdown.mdx`                                    |
+| Modifier | `apps/docs/src/content/components/ar-pagination.mdx`                                  |
+| Modifier | `apps/docs/src/content/components/ar-progressbar.mdx`                                 |
+| Modifier | `apps/docs/src/content/components/ar-spinner.mdx`                                     |
+| Modifier | `apps/docs/src/content/components/ar-stepper.mdx`                                     |
+| Modifier | `apps/docs/src/content/components/ar-tooltip.mdx`                                     |
+| Modifier | `/Users/jon/Code/Active_projects/ariane/.claude/skills/ariane-new-component/SKILL.md` |
+| Modifier | `/Users/jon/Code/Active_projects/ariane/.claude/skills/ariane-write-docs/SKILL.md`    |
+
+---
+
+## Task 1 : Composant `WcagRef.astro`
+
+**Files:**
+
+- Create: `apps/docs/src/components/WcagRef.astro`
+
+- [ ] **Step 1 : Créer le composant**
+
+Créer `apps/docs/src/components/WcagRef.astro` avec ce contenu exact :
+
+```astro
+---
+interface Props {
+    criterion: string;
+    summary: string;
+}
+
+const { criterion, summary } = Astro.props;
+
+const slugs: Record<string, string> = {
+    '1.3.1': 'info-and-relationships',
+    '1.4.13': 'content-on-hover-or-focus',
+    '2.1.1': 'keyboard',
+    '2.1.2': 'no-keyboard-trap',
+    '2.4.8': 'location',
+    '3.2.2': 'on-input',
+    '4.1.2': 'name-role-value',
+    '4.1.3': 'status-messages',
+};
+
+const id = `wcag-${criterion.replace(/\./g, '-')}`;
+const slug = slugs[criterion] ?? criterion.replace(/\./g, '-');
+const href = `https://www.w3.org/WAI/WCAG22/Understanding/${slug}/`;
+---
+
+<a
+    {id}
+    {href}
+    target="_blank"
+    rel="noopener"
+    style="cursor:help; text-decoration:underline dotted;"
+>WCAG {criterion}</a><ar-tooltip for={id}>{summary}</ar-tooltip>
+```
+
+> **Note `ar-tooltip` :** `<ar-tooltip>` est un custom element Ariane. Il n'y a pas d'import Astro à écrire — le layout `Layout.astro` charge déjà `/cdn/index.js` qui enregistre tous les composants Ariane globalement sur chaque page. `WcagRef.astro` peut utiliser `<ar-tooltip>` directement dans son template sans script supplémentaire.
+
+> **Note rendu :** Pas d'espace entre `</a>` et `<ar-tooltip>` — évite un espace visible entre le lien et le tooltip dans le rendu HTML.
+
+- [ ] **Step 2 : Vérifier que le dev server démarre sans erreur**
+
+```bash
+npm run dev
+```
+
+Attendu : compilation sans erreur TypeScript ni Astro. Ouvrir n'importe quelle page composant pour confirmer qu'aucune régression n'est introduite.
+
+- [ ] **Step 3 : Commiter**
+
+```bash
+git add apps/docs/src/components/WcagRef.astro
+git commit -m "feat(docs): composant WcagRef — lien + tooltip pour critères WCAG"
+```
+
+---
+
+## Task 2 : `ar-alert` — critère 4.1.3
+
+**Files:**
+
+- Modify: `apps/docs/src/content/components/ar-alert.mdx`
+
+**Critère :** 4.1.3 Status Messages — les messages de statut doivent être annoncés aux technologies d'assistance sans déplacer le focus.
+
+- [ ] **Step 1 : Ajouter l'import après le frontmatter**
+
+Dans `ar-alert.mdx`, après la ligne `---` qui clôt le frontmatter (ligne ~35), ajouter :
+
+```mdx
+import WcagRef from '../../components/WcagRef.astro';
+```
+
+Le fichier commence ainsi :
+
+```mdx
+---
+tagName: ar-alert
+...
+---
+
+import WcagRef from '../../components/WcagRef.astro';
+
+## Accessibilité
+```
+
+- [ ] **Step 2 : Insérer la référence dans la bullet `role="alert"`**
+
+Remplacer la première bullet de "Pris en charge automatiquement" :
+
+**Avant :**
+
+```mdx
+- `role="alert"` (interruption immédiate) ou `role="status"` (annonce polie) posé sur
+  l'hôte selon le variant — `info` → `status`, tous les autres → `alert`.
+```
+
+**Après :**
+
+```mdx
+- `role="alert"` (interruption immédiate) ou `role="status"` (annonce polie) posé sur
+  l'hôte selon le variant — `info` → `status`, tous les autres → `alert` — conforme
+    <WcagRef
+        criterion="4.1.3"
+        summary="Status Messages : les messages de statut doivent être annoncés aux technologies d'assistance sans déplacer le focus."
+    />
+```
+
+- [ ] **Step 3 : Vérifier visuellement**
+
+Ouvrir `http://localhost:4321/components/alert` dans le navigateur. Vérifier :
+
+- Le texte « WCAG 4.1.3 » apparaît en fin de bullet avec underline pointillé.
+- Au survol ou focus : tooltip « Status Messages : … » visible.
+- Le lien s'ouvre dans un nouvel onglet vers `https://www.w3.org/WAI/WCAG22/Understanding/status-messages/`.
+
+- [ ] **Step 4 : Commiter**
+
+```bash
+git add apps/docs/src/content/components/ar-alert.mdx
+git commit -m "docs(alert): référence WCAG 4.1.3 inline dans la section accessibilité"
+```
+
+---
+
+## Task 3 : `ar-breadcrumb` — critères 1.3.1 et 2.4.8
+
+**Files:**
+
+- Modify: `apps/docs/src/content/components/ar-breadcrumb.mdx`
+
+- [ ] **Step 1 : Ajouter l'import**
+
+Après le frontmatter de `ar-breadcrumb.mdx` :
+
+```mdx
+import WcagRef from '../../components/WcagRef.astro';
+```
+
+- [ ] **Step 2 : Insérer 1.3.1 dans la bullet `role="navigation"`**
+
+**Avant :**
+
+```mdx
+- `role="navigation"` et `aria-labelledby` posés sur le conteneur — la région est identifiable
+  par les lecteurs d'écran sans configuration supplémentaire.
+```
+
+**Après :**
+
+```mdx
+- `role="navigation"` et `aria-labelledby` posés sur le conteneur — la région est identifiable
+  par les lecteurs d'écran sans configuration supplémentaire
+  (<WcagRef criterion="1.3.1" summary="Info and Relationships : les relations et structures visuelles doivent être déterminables par programmation ou disponibles en texte." />).
+```
+
+- [ ] **Step 3 : Insérer 2.4.8 dans la bullet `aria-current`**
+
+**Avant :**
+
+```mdx
+- Le dernier item est automatiquement rendu comme texte (pas de lien), quel que soit son
+  attribut `href`. `aria-current="page"` lui est appliqué automatiquement.
+```
+
+**Après :**
+
+```mdx
+- Le dernier item est automatiquement rendu comme texte (pas de lien), quel que soit son
+  attribut `href`. `aria-current="page"` lui est appliqué automatiquement — conforme
+    <WcagRef
+        criterion="2.4.8"
+        summary="Location : l'utilisateur doit pouvoir situer sa position dans un ensemble de pages."
+    />
+```
+
+- [ ] **Step 4 : Vérifier visuellement**
+
+Ouvrir `http://localhost:4321/components/breadcrumb`. Vérifier les deux références WCAG (1.3.1 et 2.4.8) avec tooltip et lien corrects.
+
+- [ ] **Step 5 : Commiter**
+
+```bash
+git add apps/docs/src/content/components/ar-breadcrumb.mdx
+git commit -m "docs(breadcrumb): références WCAG 1.3.1 et 2.4.8 inline"
+```
+
+---
+
+## Task 4 : `ar-dialog` — critères 2.1.2 et 3.2.2
+
+**Files:**
+
+- Modify: `apps/docs/src/content/components/ar-dialog.mdx`
+
+- [ ] **Step 1 : Ajouter l'import**
+
+Après le frontmatter de `ar-dialog.mdx` :
+
+```mdx
+import WcagRef from '../../components/WcagRef.astro';
+```
+
+- [ ] **Step 2 : Insérer 2.1.2 dans la bullet focus trap**
+
+**Avant :**
+
+```mdx
+- Le focus est déplacé à l'ouverture sur l'élément portant `autofocus`, ou à défaut sur le premier élément focalisable, ou sur le bouton de fermeture si aucun n'est présent.
+```
+
+**Après :**
+
+```mdx
+- Le focus est déplacé à l'ouverture sur l'élément portant `autofocus`, ou à défaut sur le premier élément focalisable, ou sur le bouton de fermeture si aucun n'est présent — conforme
+    <WcagRef
+        criterion="2.1.2"
+        summary="No Keyboard Trap : le focus clavier peut toujours quitter un composant via les touches standard (Escape, Tab)."
+    />
+```
+
+- [ ] **Step 3 : Insérer 3.2.2 dans la bullet Escape**
+
+**Avant :**
+
+```mdx
+- La touche Escape passe par `ar-dialog-hide` : la fermeture peut donc être interceptée avec `event.preventDefault()`.
+```
+
+**Après :**
+
+```mdx
+- La touche Escape passe par `ar-dialog-hide` : la fermeture peut donc être interceptée avec `event.preventDefault()` — comportement prévisible conforme
+    <WcagRef
+        criterion="3.2.2"
+        summary="On Input : modifier un composant UI ne doit pas provoquer de changement de contexte inattendu sans en avertir l'utilisateur au préalable."
+    />
+```
+
+- [ ] **Step 4 : Vérifier visuellement**
+
+Ouvrir `http://localhost:4321/components/dialog`. Vérifier les deux références WCAG.
+
+- [ ] **Step 5 : Commiter**
+
+```bash
+git add apps/docs/src/content/components/ar-dialog.mdx
+git commit -m "docs(dialog): références WCAG 2.1.2 et 3.2.2 inline"
+```
+
+---
+
+## Task 5 : `ar-dropdown` — critères 4.1.2 et 2.1.1
+
+**Files:**
+
+- Modify: `apps/docs/src/content/components/ar-dropdown.mdx`
+
+- [ ] **Step 1 : Ajouter l'import**
+
+Après le frontmatter de `ar-dropdown.mdx` :
+
+```mdx
+import WcagRef from '../../components/WcagRef.astro';
+```
+
+- [ ] **Step 2 : Insérer 4.1.2 dans la bullet `aria-haspopup`**
+
+**Avant :**
+
+```mdx
+- Le trigger reçoit `aria-haspopup="true"` et `aria-expanded` synchronisé à l'état ouvert/fermé.
+```
+
+**Après :**
+
+```mdx
+- Le trigger reçoit `aria-haspopup="true"` et `aria-expanded` synchronisé à l'état ouvert/fermé —
+    <WcagRef
+        criterion="4.1.2"
+        summary="Name, Role, Value : tout composant UI doit exposer son nom, rôle et valeur (états inclus) aux technologies d'assistance."
+    />
+```
+
+- [ ] **Step 3 : Insérer 2.1.1 dans la bullet navigation clavier**
+
+**Avant :**
+
+```mdx
+- Navigation clavier complète : `↑` `↓` `Home` `End` pour déplacer le focus, `Escape` et `Tab` pour fermer.
+```
+
+**Après :**
+
+```mdx
+- Navigation clavier complète : `↑` `↓` `Home` `End` pour déplacer le focus, `Escape` et `Tab` pour fermer —
+    <WcagRef
+        criterion="2.1.1"
+        summary="Keyboard : toutes les fonctionnalités doivent être accessibles au clavier sans temporisation spécifique."
+    />
+```
+
+- [ ] **Step 4 : Vérifier visuellement**
+
+Ouvrir `http://localhost:4321/components/dropdown`. Vérifier les deux références WCAG.
+
+- [ ] **Step 5 : Commiter**
+
+```bash
+git add apps/docs/src/content/components/ar-dropdown.mdx
+git commit -m "docs(dropdown): références WCAG 4.1.2 et 2.1.1 inline"
+```
+
+---
+
+## Task 6 : `ar-pagination` — critère 4.1.2
+
+**Files:**
+
+- Modify: `apps/docs/src/content/components/ar-pagination.mdx`
+
+- [ ] **Step 1 : Ajouter l'import**
+
+Après le frontmatter de `ar-pagination.mdx` :
+
+```mdx
+import WcagRef from '../../components/WcagRef.astro';
+```
+
+- [ ] **Step 2 : Insérer 4.1.2 dans la bullet `aria-disabled`**
+
+**Avant :**
+
+```mdx
+- Les boutons "précédent" et "suivant" ont `aria-disabled` synchronisé avec leur état désactivé.
+```
+
+**Après :**
+
+```mdx
+- Les boutons "précédent" et "suivant" ont `aria-disabled` synchronisé avec leur état désactivé —
+    <WcagRef
+        criterion="4.1.2"
+        summary="Name, Role, Value : tout composant UI doit exposer son nom, rôle et valeur (états inclus) aux technologies d'assistance."
+    />
+```
+
+- [ ] **Step 3 : Vérifier visuellement**
+
+Ouvrir `http://localhost:4321/components/pagination`. Vérifier la référence WCAG 4.1.2.
+
+- [ ] **Step 4 : Commiter**
+
+```bash
+git add apps/docs/src/content/components/ar-pagination.mdx
+git commit -m "docs(pagination): référence WCAG 4.1.2 inline"
+```
+
+---
+
+## Task 7 : `ar-progressbar` — critère 4.1.2
+
+**Files:**
+
+- Modify: `apps/docs/src/content/components/ar-progressbar.mdx`
+
+- [ ] **Step 1 : Ajouter l'import**
+
+Après le frontmatter de `ar-progressbar.mdx` :
+
+```mdx
+import WcagRef from '../../components/WcagRef.astro';
+```
+
+- [ ] **Step 2 : Insérer 4.1.2 dans la bullet `role="progressbar"`**
+
+**Avant :**
+
+```mdx
+- `role="progressbar"`, `aria-valuenow`, `aria-valuemin` et `aria-valuemax` posés sur la barre —
+  la progression est vocalisée automatiquement par les lecteurs d'écran.
+```
+
+**Après :**
+
+```mdx
+- `role="progressbar"`, `aria-valuenow`, `aria-valuemin` et `aria-valuemax` posés sur la barre —
+  la progression est vocalisée automatiquement par les lecteurs d'écran
+  (<WcagRef criterion="4.1.2" summary="Name, Role, Value : tout composant UI doit exposer son nom, rôle et valeur (états inclus) aux technologies d'assistance." />).
+```
+
+- [ ] **Step 3 : Vérifier visuellement**
+
+Ouvrir `http://localhost:4321/components/progressbar`. Vérifier la référence WCAG 4.1.2.
+
+- [ ] **Step 4 : Commiter**
+
+```bash
+git add apps/docs/src/content/components/ar-progressbar.mdx
+git commit -m "docs(progressbar): référence WCAG 4.1.2 inline"
+```
+
+---
+
+## Task 8 : `ar-spinner` — critère 4.1.3
+
+**Files:**
+
+- Modify: `apps/docs/src/content/components/ar-spinner.mdx`
+
+- [ ] **Step 1 : Ajouter l'import**
+
+Après le frontmatter de `ar-spinner.mdx` :
+
+```mdx
+import WcagRef from '../../components/WcagRef.astro';
+```
+
+- [ ] **Step 2 : Insérer 4.1.3 dans la bullet `role="alert"`**
+
+**Avant :**
+
+```mdx
+- L'animation SVG est masquée aux lecteurs d'écran (`aria-hidden`). Un `<div role="alert">`
+  invisible annonce les changements d'état — le passage "en cours → terminé" est vocalisé
+  sans intervention supplémentaire.
+```
+
+**Après :**
+
+```mdx
+- L'animation SVG est masquée aux lecteurs d'écran (`aria-hidden`). Un `<div role="alert">`
+  invisible annonce les changements d'état — le passage "en cours → terminé" est vocalisé
+  sans intervention supplémentaire — conforme
+    <WcagRef
+        criterion="4.1.3"
+        summary="Status Messages : les messages de statut doivent être annoncés aux technologies d'assistance sans déplacer le focus."
+    />
+```
+
+- [ ] **Step 3 : Vérifier visuellement**
+
+Ouvrir `http://localhost:4321/components/spinner`. Vérifier la référence WCAG 4.1.3.
+
+- [ ] **Step 4 : Commiter**
+
+```bash
+git add apps/docs/src/content/components/ar-spinner.mdx
+git commit -m "docs(spinner): référence WCAG 4.1.3 inline"
+```
+
+---
+
+## Task 9 : `ar-stepper` — critère 1.3.1
+
+**Files:**
+
+- Modify: `apps/docs/src/content/components/ar-stepper.mdx`
+
+- [ ] **Step 1 : Ajouter l'import**
+
+Après le frontmatter de `ar-stepper.mdx` :
+
+```mdx
+import WcagRef from '../../components/WcagRef.astro';
+```
+
+- [ ] **Step 2 : Insérer 1.3.1 dans la bullet `role="navigation"`**
+
+**Avant :**
+
+```mdx
+- `role="navigation"` et `aria-labelledby` posés sur le conteneur — la région est annoncée
+  et identifiable par les lecteurs d'écran.
+```
+
+**Après :**
+
+```mdx
+- `role="navigation"` et `aria-labelledby` posés sur le conteneur — la région est annoncée
+  et identifiable par les lecteurs d'écran
+  (<WcagRef criterion="1.3.1" summary="Info and Relationships : les relations et structures visuelles doivent être déterminables par programmation ou disponibles en texte." />).
+```
+
+- [ ] **Step 3 : Vérifier visuellement**
+
+Ouvrir `http://localhost:4321/components/stepper`. Vérifier la référence WCAG 1.3.1.
+
+- [ ] **Step 4 : Commiter**
+
+```bash
+git add apps/docs/src/content/components/ar-stepper.mdx
+git commit -m "docs(stepper): référence WCAG 1.3.1 inline"
+```
+
+---
+
+## Task 10 : `ar-tooltip` — migration de la référence 1.4.13 vers `WcagRef`
+
+**Files:**
+
+- Modify: `apps/docs/src/content/components/ar-tooltip.mdx`
+
+La référence WCAG 1.4.13 existe déjà dans ce fichier, en deux endroits : une fois dans le frontmatter (description) et une fois dans la section Accessibilité sous forme de bullet. On migre uniquement la bullet narrative vers `WcagRef`. La description du frontmatter et les références dans les variants HTML sont laissées telles quelles (elles ne sont pas du MDX narratif).
+
+- [ ] **Step 1 : Ajouter l'import**
+
+Après le frontmatter de `ar-tooltip.mdx` (après la ligne `---` de fermeture) :
+
+```mdx
+import WcagRef from '../../components/WcagRef.astro';
+```
+
+- [ ] **Step 2 : Remplacer la bullet WCAG 1.4.13 dans la section Accessibilité**
+
+**Avant (ligne ~75) :**
+
+```mdx
+- **WCAG 1.4.13 — Content on Hover or Focus :** déplacer le pointeur du trigger vers la bulle annule le timer de fermeture ; la bulle reste ouverte tant que le pointeur y séjourne.
+```
+
+**Après :**
+
+```mdx
+- <WcagRef
+      criterion="1.4.13"
+      summary="Content on Hover or Focus : le contenu affiché au survol ou au focus doit être persistant, escamotable et consultable au pointeur."
+  />
+  : déplacer le pointeur du trigger vers la bulle annule le timer de fermeture ; la bulle reste
+  ouverte tant que le pointeur y séjourne.
+```
+
+- [ ] **Step 3 : Vérifier visuellement**
+
+Ouvrir `http://localhost:4321/components/tooltip`. Vérifier :
+
+- La bullet 1.4.13 affiche le lien WCAG + tooltip.
+- Les autres occurrences de "WCAG 1.4.13" dans les variants HTML (démo abbr, description des délais) sont inchangées.
+
+- [ ] **Step 4 : Commiter**
+
+```bash
+git add apps/docs/src/content/components/ar-tooltip.mdx
+git commit -m "docs(tooltip): migration référence WCAG 1.4.13 vers WcagRef"
+```
+
+---
+
+## Task 11 : Mettre à jour le skill `ariane-new-component`
+
+**Files:**
+
+- Modify: `.claude/skills/ariane-new-component/SKILL.md`
+
+Ajouter une section **Accessibilité** à la fin du fichier. Cette section guide la réflexion sur les critères WCAG lors de la conception d'un nouveau composant.
+
+- [ ] **Step 1 : Ajouter la section à la fin du fichier**
+
+Ouvrir `.claude/skills/ariane-new-component/SKILL.md` et ajouter après la section `## Export` :
+
+```markdown
+## Accessibilité
+
+Avant d'implémenter un composant, identifier les critères WCAG applicables au pattern UI. Documenter dans le plan d'implémentation :
+
+- Le pattern ARIA attendu (rôle, états, propriétés ARIA)
+- Les critères WCAG couverts automatiquement par le composant
+- Les responsabilités laissées à l'auteur de la page
+
+Critères courants par pattern :
+
+| Pattern UI                                | Critères WCAG clés                            |
+| ----------------------------------------- | --------------------------------------------- |
+| Disclosure / toggle (dropdown, accordion) | 4.1.2 `aria-expanded`, 2.1.1 keyboard         |
+| Navigation landmark                       | 1.3.1 `role="navigation"` + `aria-labelledby` |
+| Live region / status                      | 4.1.3 status messages                         |
+| Dialog / modal                            | 2.1.2 no keyboard trap                        |
+| Item courant (breadcrumb, stepper)        | 2.4.8 `aria-current`                          |
+| Contenu au survol / focus                 | 1.4.13 hover/focus persistence                |
+| Composant interactif avec état            | 4.1.2 name, role, value                       |
+
+La page "Understanding" correspondante est linkable via le composant `WcagRef` dans la doc (voir skill `ariane-write-docs`).
+```
+
+- [ ] **Step 2 : Commiter**
+
+```bash
+git add .claude/skills/ariane-new-component/SKILL.md
+git commit -m "docs(skills): section accessibilité WCAG dans ariane-new-component"
+```
+
+---
+
+## Task 12 : Mettre à jour le skill `ariane-write-docs`
+
+**Files:**
+
+- Modify: `.claude/skills/ariane-write-docs/SKILL.md`
+
+Ajouter une section **Références WCAG** qui explique comment utiliser `WcagRef` dans les fichiers MDX de composants.
+
+- [ ] **Step 1 : Ajouter la section à la fin du fichier**
+
+Ouvrir `.claude/skills/ariane-write-docs/SKILL.md` et ajouter après la dernière section existante :
+
+````markdown
+## Références WCAG
+
+La section "Pris en charge automatiquement" de chaque composant doit référencer les critères WCAG implémentés via le composant `WcagRef`.
+
+### Import
+
+Ajouter après le frontmatter de chaque fichier MDX qui utilise des références WCAG :
+
+```mdx
+import WcagRef from '../../components/WcagRef.astro';
+```
+
+### Usage inline
+
+Placer `<WcagRef>` directement dans la bullet qui décrit le comportement couvert. Une référence par comportement distinct.
+
+```mdx
+- `role="alert"` conforme
+    <WcagRef
+        criterion="4.1.3"
+        summary="Status Messages : les messages de statut doivent être annoncés aux technologies d'assistance sans déplacer le focus."
+    />
+```
+
+### Props
+
+| Prop        | Type     | Exemple                   |
+| ----------- | -------- | ------------------------- |
+| `criterion` | `string` | `"4.1.2"`                 |
+| `summary`   | `string` | `"Name, Role, Value : …"` |
+
+Le composant (`apps/docs/src/components/WcagRef.astro`) génère l'ID automatiquement et construit l'URL vers la page "Understanding" WCAG 2.2. `ar-tooltip` est disponible globalement via le layout — aucun import supplémentaire n'est nécessaire.
+
+### Critères déjà mappés
+
+Voir la table `slugs` dans `WcagRef.astro` pour la liste des critères supportés : 1.3.1, 1.4.13, 2.1.1, 2.1.2, 2.4.8, 3.2.2, 4.1.2, 4.1.3.
+````
+
+- [ ] **Step 2 : Commiter**
+
+```bash
+git add .claude/skills/ariane-write-docs/SKILL.md
+git commit -m "docs(skills): instructions WcagRef dans ariane-write-docs"
+```
+
+---
+
+## Vérification finale
+
+- [ ] Lancer `npm run build` depuis la racine du monorepo et vérifier qu'il n'y a aucune erreur TypeScript ni Astro.
+
+```bash
+npm run build
+```
+
+Attendu : build complet sans erreur. Toute erreur TypeScript sur `WcagRef.astro` (props manquants, mauvais types) sera signalée ici.

--- a/docs/superpowers/specs/2026-05-05-wcag-references-design.md
+++ b/docs/superpowers/specs/2026-05-05-wcag-references-design.md
@@ -1,0 +1,100 @@
+# Design : Références WCAG inline dans la doc des composants
+
+**Date :** 2026-05-05  
+**Statut :** approuvé
+
+---
+
+## Objectif
+
+Référencer les critères WCAG pertinents directement dans la section Accessibilité de chaque page de composant, sous forme de liens interactifs avec tooltip explicatif — sans alourdir la structure existante.
+
+---
+
+## Composant `WcagRef.astro`
+
+### Localisation
+
+`apps/docs/src/components/WcagRef.astro`
+
+### Props
+
+| Prop        | Type     | Description                                     |
+| ----------- | -------- | ----------------------------------------------- |
+| `criterion` | `string` | Numéro du critère WCAG, ex. `"4.1.2"`           |
+| `summary`   | `string` | Texte court résumant le critère pour le tooltip |
+
+### Comportement
+
+- **ID de l'`ar-tooltip`** : dérivé du critère → `wcag-${criterion.replace(/\./g, '-')}` (ex. `wcag-4-1-2`). Unicité garantie par critère ; pas de collision entre pages.
+- **Lien** : cible la page "Understanding" du W3C WAI (WCAG 2.2). Ouverture `target="_blank" rel="noopener"`.
+- **Texte du lien** : `WCAG ${criterion}`.
+- **Style** : underline pointillé + `cursor: help`, cohérent avec le pattern `<abbr>` déjà utilisé sur la page de démo du tooltip.
+
+### Rendu HTML
+
+```html
+<a
+    href="https://www.w3.org/WAI/WCAG22/Understanding/name-role-value/"
+    id="wcag-4-1-2"
+    target="_blank"
+    rel="noopener"
+    style="cursor:help; text-decoration:underline dotted;"
+>
+    WCAG 4.1.2
+</a>
+<ar-tooltip for="wcag-4-1-2">
+    Name, Role, Value : tout composant UI doit exposer son nom, rôle et valeur aux technologies
+    d'assistance.
+</ar-tooltip>
+```
+
+---
+
+## Intégration dans les MDX
+
+Import explicite en tête de chaque fichier `.mdx` qui en a besoin :
+
+```mdx
+import WcagRef from '../../components/WcagRef.astro';
+```
+
+Usage inline dans les bullets existantes, au bout de la phrase qui décrit le comportement concerné. Pas de nouvelle sous-section ni de tableau.
+
+**Règle :** une référence par comportement distinct. Si une bullet décrit plusieurs choses, on ne cite que le critère qui s'y applique directement.
+
+---
+
+## Mapping critères ↔ composants
+
+| Composant        | Critère | Page Understanding          | Justification                                  |
+| ---------------- | ------- | --------------------------- | ---------------------------------------------- |
+| `ar-alert`       | 4.1.3   | `status-messages`           | `role="alert"` / `role="status"`               |
+| `ar-breadcrumb`  | 1.3.1   | `info-and-relationships`    | `role="navigation"` + `aria-labelledby`        |
+| `ar-breadcrumb`  | 2.4.8   | `location`                  | `aria-current="page"` sur l'item courant       |
+| `ar-dialog`      | 2.1.2   | `no-keyboard-trap`          | Focus trap à l'ouverture                       |
+| `ar-dialog`      | 3.2.2   | `on-input`                  | Fermeture prévisible via Escape                |
+| `ar-dropdown`    | 4.1.2   | `name-role-value`           | `aria-haspopup` + `aria-expanded`              |
+| `ar-dropdown`    | 2.1.1   | `keyboard`                  | Navigation `↑↓ Home End Escape Tab`            |
+| `ar-pagination`  | 4.1.2   | `name-role-value`           | `aria-disabled` synchronisé                    |
+| `ar-progressbar` | 4.1.2   | `name-role-value`           | `role="progressbar"` + `aria-valuenow/min/max` |
+| `ar-spinner`     | 4.1.3   | `status-messages`           | `role="alert"` sur l'annonce d'état            |
+| `ar-stepper`     | 1.3.1   | `info-and-relationships`    | `role="navigation"` + structure sémantique     |
+| `ar-tooltip`     | 1.4.13  | `content-on-hover-or-focus` | _(déjà présent, à migrer vers WcagRef)_        |
+
+---
+
+## URLs WCAG
+
+Format : `https://www.w3.org/WAI/WCAG22/Understanding/<slug>/`
+
+Tous les critères du mapping utilisent WCAG 2.2 (superset de 2.1 — pas de fallback nécessaire).
+
+---
+
+## Ce qui n'est pas dans ce scope
+
+- Modifier la structure des sections Accessibilité existantes.
+- Ajouter des critères AAA.
+- Couvrir exhaustivement tous les critères applicables — l'objectif est d'éclairer les comportements clés, pas de produire un audit WCAG.
+- Modifier `packages/core` (les tokens `--doc-*` restent dans `apps/docs/`).


### PR DESCRIPTION
## Summary

- Nouveau composant `WcagRef.astro` — génère un lien WCAG 2.2 + tooltip `<ar-tooltip>` à partir d'un critère et d'un résumé
- Références WCAG inline ajoutées dans la section Accessibilité de 9 pages composant (alert, breadcrumb, dialog, dropdown, pagination, progressbar, spinner, stepper, tooltip)
- Skills `ariane-new-component` et `ariane-write-docs` mis à jour avec les conventions d'usage de `WcagRef`

## Test Plan

- [x] Build docs sans erreur TypeScript ni Astro : `npm run build`
- [x] Sur chaque page composant modifiée : vérifier que le lien « WCAG X.X.X » apparaît en fin de bullet avec underline pointillé
- [x] Au survol ou focus : tooltip visible avec le résumé du critère
- [x] Le lien s'ouvre dans un nouvel onglet vers la page Understanding WCAG 2.2 correcte

🤖 Generated with [Claude Code](https://claude.com/claude-code)