### PR TITLE
feat(tab-group): ar-tab-group, ar-tab, ar-tab-panel — WAI-ARIA Tabs

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -84,6 +84,8 @@ jobs:
 
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
+        env:
+          DEBIAN_FRONTEND: noninteractive
 
       - name: Browser tests
         run: npm run test:browser --workspace=packages/core

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -64,7 +64,7 @@ jobs:
 
   browser:
     name: Browser Tests (core)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout
@@ -82,10 +82,13 @@ jobs:
       - name: Build core
         run: npm run build --workspace=packages/core
 
-      - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
+      - name: Install Playwright system deps
+        run: npx playwright install-deps chromium
         env:
           DEBIAN_FRONTEND: noninteractive
+
+      - name: Install Playwright Chromium
+        run: npx playwright install chromium
 
       - name: Browser tests
         run: npm run test:browser --workspace=packages/core

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -82,13 +82,5 @@ jobs:
       - name: Build core
         run: npm run build --workspace=packages/core
 
-      - name: Install Playwright system deps
-        run: npx playwright install-deps chromium
-        env:
-          DEBIAN_FRONTEND: noninteractive
-
-      - name: Install Playwright Chromium
-        run: npx playwright install chromium
-
       - name: Browser tests
         run: npm run test:browser --workspace=packages/core

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,11 @@ Web components library pour patterns UI accessibles, Lit 3 + TypeScript. Monorep
 - Conventional Commits (commitlint + Husky)
 - CSS tokens `--doc-*` (`apps/docs/`) ne forcent jamais un ajout dans `packages/core`
 
+## Philosophie de conception
+
+- **Mobile-first** : toute décision d'API, de comportement ou de style part du cas mobile. Le desktop est une amélioration progressive, pas le point de départ. Avant d'ajouter une option, se demander si le comportement par défaut couvre déjà le cas mobile sans configuration.
+- **Headless** : aucun fallback cosmétique dans les composants (`var(--token)` sans valeur par défaut). Toutes les valeurs de design vont dans `themes/default.css`. Les fallbacks structurels (0px pour des compensations de layout) sont acceptables.
+
 ## Common Commands
 
 ```bash

--- a/apps/docs/src/content/components/ar-tab-group.mdx
+++ b/apps/docs/src/content/components/ar-tab-group.mdx
@@ -12,9 +12,9 @@ variants:
               <ar-tab panel="intro">Introduction</ar-tab>
               <ar-tab panel="usage">Utilisation</ar-tab>
               <ar-tab panel="api">API</ar-tab>
-              <ar-tab-panel name="intro">Contenu de l'onglet Introduction.</ar-tab-panel>
-              <ar-tab-panel name="usage">Contenu de l'onglet Utilisation.</ar-tab-panel>
-              <ar-tab-panel name="api">Contenu de l'onglet API.</ar-tab-panel>
+              <ar-tab-panel name="intro" style="padding: 0.75rem 1rem">Contenu de l'onglet Introduction.</ar-tab-panel>
+              <ar-tab-panel name="usage" style="padding: 0.75rem 1rem">Contenu de l'onglet Utilisation.</ar-tab-panel>
+              <ar-tab-panel name="api" style="padding: 0.75rem 1rem">Contenu de l'onglet API.</ar-tab-panel>
           </ar-tab-group>
     - name: active
       label: Onglet initial
@@ -24,9 +24,9 @@ variants:
               <ar-tab panel="intro">Introduction</ar-tab>
               <ar-tab panel="usage">Utilisation</ar-tab>
               <ar-tab panel="api">API</ar-tab>
-              <ar-tab-panel name="intro">Introduction.</ar-tab-panel>
-              <ar-tab-panel name="usage">Cet onglet est actif par défaut.</ar-tab-panel>
-              <ar-tab-panel name="api">API.</ar-tab-panel>
+              <ar-tab-panel name="intro" style="padding: 0.75rem 1rem">Introduction.</ar-tab-panel>
+              <ar-tab-panel name="usage" style="padding: 0.75rem 1rem">Cet onglet est actif par défaut.</ar-tab-panel>
+              <ar-tab-panel name="api" style="padding: 0.75rem 1rem">API.</ar-tab-panel>
           </ar-tab-group>
     - name: disabled
       label: Onglet désactivé
@@ -36,9 +36,9 @@ variants:
               <ar-tab panel="a">Actif</ar-tab>
               <ar-tab panel="b" disabled>Désactivé</ar-tab>
               <ar-tab panel="c">Actif aussi</ar-tab>
-              <ar-tab-panel name="a">Panel A.</ar-tab-panel>
-              <ar-tab-panel name="b">Panel B (inaccessible).</ar-tab-panel>
-              <ar-tab-panel name="c">Panel C.</ar-tab-panel>
+              <ar-tab-panel name="a" style="padding: 0.75rem 1rem">Panel A.</ar-tab-panel>
+              <ar-tab-panel name="b" style="padding: 0.75rem 1rem">Panel B (inaccessible).</ar-tab-panel>
+              <ar-tab-panel name="c" style="padding: 0.75rem 1rem">Panel C.</ar-tab-panel>
           </ar-tab-group>
     - name: manual-activation
       label: Activation manuelle
@@ -48,9 +48,9 @@ variants:
               <ar-tab panel="a">Tab A</ar-tab>
               <ar-tab panel="b">Tab B</ar-tab>
               <ar-tab panel="c">Tab C</ar-tab>
-              <ar-tab-panel name="a">Panel A.</ar-tab-panel>
-              <ar-tab-panel name="b">Panel B.</ar-tab-panel>
-              <ar-tab-panel name="c">Panel C.</ar-tab-panel>
+              <ar-tab-panel name="a" style="padding: 0.75rem 1rem">Panel A.</ar-tab-panel>
+              <ar-tab-panel name="b" style="padding: 0.75rem 1rem">Panel B.</ar-tab-panel>
+              <ar-tab-panel name="c" style="padding: 0.75rem 1rem">Panel C.</ar-tab-panel>
           </ar-tab-group>
     - name: scroll-hints
       label: Scroll hints
@@ -79,10 +79,10 @@ variants:
                   <ar-tab panel="b">Deuxième onglet</ar-tab>
                   <ar-tab panel="c">Troisième onglet</ar-tab>
                   <ar-tab panel="d">Quatrième onglet</ar-tab>
-                  <ar-tab-panel name="a">Panel A.</ar-tab-panel>
-                  <ar-tab-panel name="b">Panel B.</ar-tab-panel>
-                  <ar-tab-panel name="c">Panel C.</ar-tab-panel>
-                  <ar-tab-panel name="d">Panel D.</ar-tab-panel>
+                  <ar-tab-panel name="a" style="padding: 0.75rem 1rem">Panel A.</ar-tab-panel>
+                  <ar-tab-panel name="b" style="padding: 0.75rem 1rem">Panel B.</ar-tab-panel>
+                  <ar-tab-panel name="c" style="padding: 0.75rem 1rem">Panel C.</ar-tab-panel>
+                  <ar-tab-panel name="d" style="padding: 0.75rem 1rem">Panel D.</ar-tab-panel>
               </ar-tab-group>
           </div>
     - name: styled
@@ -99,27 +99,30 @@ variants:
                   --ar-tab-border-radius: 9999px;
               }
           </style>
-          <p style="margin-bottom: 0.5rem; font-weight: 500;">Top border</p>
-          <div class="demo-top" style="margin-bottom: 1.5rem;">
-              <ar-tab-group>
-                  <ar-tab panel="a">Premier</ar-tab>
-                  <ar-tab panel="b">Deuxième</ar-tab>
-                  <ar-tab panel="c">Troisième</ar-tab>
-                  <ar-tab-panel name="a">Panel A.</ar-tab-panel>
-                  <ar-tab-panel name="b">Panel B.</ar-tab-panel>
-                  <ar-tab-panel name="c">Panel C.</ar-tab-panel>
-              </ar-tab-group>
-          </div>
-          <p style="margin-bottom: 0.5rem; font-weight: 500;">Pill</p>
-          <div class="demo-pill">
-              <ar-tab-group>
-                  <ar-tab panel="a">Premier</ar-tab>
-                  <ar-tab panel="b">Deuxième</ar-tab>
-                  <ar-tab panel="c">Troisième</ar-tab>
-                  <ar-tab-panel name="a">Panel A.</ar-tab-panel>
-                  <ar-tab-panel name="b">Panel B.</ar-tab-panel>
-                  <ar-tab-panel name="c">Panel C.</ar-tab-panel>
-              </ar-tab-group>
+          <div style="display: flex; flex-direction: column; width: 100%;">
+              <p style="margin: 0 0 1.25rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: var(--doc-text-muted, #6b7280);">Top border</p>
+              <div class="demo-top">
+                  <ar-tab-group>
+                      <ar-tab panel="a">Premier</ar-tab>
+                      <ar-tab panel="b">Deuxième</ar-tab>
+                      <ar-tab panel="c">Troisième</ar-tab>
+                      <ar-tab-panel name="a" style="padding: 0.75rem 1rem">Panel A.</ar-tab-panel>
+                      <ar-tab-panel name="b" style="padding: 0.75rem 1rem">Panel B.</ar-tab-panel>
+                      <ar-tab-panel name="c" style="padding: 0.75rem 1rem">Panel C.</ar-tab-panel>
+                  </ar-tab-group>
+              </div>
+              <hr style="margin: 1.5rem 0; border: none; border-top: 1px solid var(--doc-border, #e5e7eb);" />
+              <p style="margin: 0 0 1.25rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: var(--doc-text-muted, #6b7280);">Pill</p>
+              <div class="demo-pill">
+                  <ar-tab-group>
+                      <ar-tab panel="a">Premier</ar-tab>
+                      <ar-tab panel="b">Deuxième</ar-tab>
+                      <ar-tab panel="c">Troisième</ar-tab>
+                      <ar-tab-panel name="a" style="padding: 0.75rem 1rem">Panel A.</ar-tab-panel>
+                      <ar-tab-panel name="b" style="padding: 0.75rem 1rem">Panel B.</ar-tab-panel>
+                      <ar-tab-panel name="c" style="padding: 0.75rem 1rem">Panel C.</ar-tab-panel>
+                  </ar-tab-group>
+              </div>
           </div>
 ---
 

--- a/apps/docs/src/content/components/ar-tab-group.mdx
+++ b/apps/docs/src/content/components/ar-tab-group.mdx
@@ -52,9 +52,71 @@ variants:
               <ar-tab-panel name="b" style="padding: 0.75rem 1rem">Panel B.</ar-tab-panel>
               <ar-tab-panel name="c" style="padding: 0.75rem 1rem">Panel C.</ar-tab-panel>
           </ar-tab-group>
+    - name: scroll-buttons
+      label: Boutons de scroll
+      description: La méthode publique `scrollNav(direction, amount?)` permet de piloter facilement le défilement de la tablist sans accéder au shadow DOM. Dans l'exemple suivante, les boutons sont affichés/masqués via CSS `:has()` en fonction des classes `has-overflow-start` / `has-overflow-end`.
+      html: |
+          <style>
+            .demo-scroll-nav {
+                max-width: 350px;
+                position: relative;
+            }
+            .demo-scroll-nav button {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                width: 2rem;
+                height: 2rem;
+                border: none;
+                border-radius: 0.375rem;
+                background: var(--doc-bg);
+                color: var(--ar-tab-active-color);
+                cursor: pointer;
+                font-size: 1rem;
+                transition: opacity 0.15s;
+                position: absolute;
+                top: .5rem;
+
+                &:hover {
+                    background-color: var(--ar-tab-hover-bg);
+                }
+            }
+
+            .demo-scroll-nav .btn-start {
+                left: -1rem;
+            }
+
+            .demo-scroll-nav .btn-end {
+                right: -2.3rem;
+            }
+
+            .demo-scroll-nav:not(:has(ar-tab-group.has-overflow-start)) .btn-start,
+            .demo-scroll-nav:not(:has(ar-tab-group.has-overflow-end)) .btn-end {
+                opacity: 0.3;
+                pointer-events: none;
+            }
+          </style>
+          <div class="demo-scroll-nav">
+            <button class="btn-start" onclick="this.parentElement.querySelector('ar-tab-group').scrollNav('start')" aria-label="Défiler vers le début">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5"><path fill-rule="evenodd" d="M11.78 5.22a.75.75 0 0 1 0 1.06L8.06 10l3.72 3.72a.75.75 0 1 1-1.06 1.06l-4.25-4.25a.75.75 0 0 1 0-1.06l4.25-4.25a.75.75 0 0 1 1.06 0Z" clip-rule="evenodd" /></svg>
+            </button>
+            <ar-tab-group>
+                <ar-tab panel="a">Premier onglet</ar-tab>
+                <ar-tab panel="b">Deuxième onglet</ar-tab>
+                <ar-tab panel="c">Troisième onglet</ar-tab>
+                <ar-tab panel="d">Quatrième onglet</ar-tab>
+                <ar-tab-panel name="a" style="padding: 0.75rem 1rem">Panel A.</ar-tab-panel>
+                <ar-tab-panel name="b" style="padding: 0.75rem 1rem">Panel B.</ar-tab-panel>
+                <ar-tab-panel name="c" style="padding: 0.75rem 1rem">Panel C.</ar-tab-panel>
+                <ar-tab-panel name="d" style="padding: 0.75rem 1rem">Panel D.</ar-tab-panel>
+            </ar-tab-group>
+            <button class="btn-end" onclick="this.parentElement.querySelector('ar-tab-group').scrollNav('end')" aria-label="Défiler vers la fin">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5"><path fill-rule="evenodd" d="M8.22 5.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06-1.06L11.94 10 8.22 6.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" /></svg>
+            </button>
+          </div>
     - name: scroll-hints
       label: Scroll hints
-      description: L'attribut `scroll-hints` ajoute les classes `has-overflow-start` et `has-overflow-end` sur l'hôte quand du contenu est masqué de chaque côté. La démo ci-dessous branche un `mask-image` CSS sur ces classes pour signaler l'overflow en temps réel.
+      description: Les classes `has-overflow-start` et `has-overflow-end` sont posées automatiquement sur l'hôte. La démo ci-dessous branche un `mask-image` CSS sur ces classes pour signaler l'overflow en temps réel — aucun attribut requis.
       html: |
           <style>
               .demo-scroll ar-tab-group.has-overflow-start:not(.has-overflow-end)::part(nav) {
@@ -74,7 +136,7 @@ variants:
               }
           </style>
           <div class="demo-scroll" style="max-width: 300px;">
-              <ar-tab-group scroll-hints>
+              <ar-tab-group>
                   <ar-tab panel="a">Premier onglet</ar-tab>
                   <ar-tab panel="b">Deuxième onglet</ar-tab>
                   <ar-tab panel="c">Troisième onglet</ar-tab>
@@ -163,7 +225,8 @@ Le tablist utilise un scroll horizontal natif (`overflow-x: auto`). Les onglets 
 
 **Recommandations pour votre design system :**
 
-- Utilisez `scroll-hints` et branchez un `mask-image` CSS sur les classes `has-overflow-start` / `has-overflow-end` de l'hôte pour signaler visuellement l'overflow aux utilisateurs souris (voir la variante _Scroll hints_).
+- Branchez un `mask-image` CSS sur les classes `has-overflow-start` / `has-overflow-end` de l'hôte pour signaler visuellement l'overflow aux utilisateurs souris — ces classes sont posées automatiquement (voir la variante _Scroll hints_).
+- Pour ajouter des boutons de navigation, appelez `scrollNav('start' | 'end', amount?)` — la méthode scrolle `[part="nav"]` sans avoir à percer le shadow DOM (voir la démo _Boutons de scroll_ ci-dessous).
 - Si une scrollbar visible est souhaitée, stylez `ar-tab-group::part(nav)::-webkit-scrollbar` et `scrollbar-width`.
 
 ### À la charge de l'auteur

--- a/apps/docs/src/content/components/ar-tab-group.mdx
+++ b/apps/docs/src/content/components/ar-tab-group.mdx
@@ -95,7 +95,7 @@ variants:
               }
               .demo-pill ar-tab {
                   --ar-tab-active-shadow: none;
-                  --ar-tab-active-bg: var(--ar-color-interactive-subtle, #eaecfb);
+                  --ar-tab-active-bg: var(--ar-color-interactive-subtle, #f4f5ff);
                   --ar-tab-border-radius: 9999px;
               }
           </style>

--- a/apps/docs/src/content/components/ar-tab-group.mdx
+++ b/apps/docs/src/content/components/ar-tab-group.mdx
@@ -1,0 +1,120 @@
+---
+tagName: ar-tab-group
+title: Tab Group
+description: Groupe d'onglets accessibles — pattern WAI-ARIA Tabs complet avec roving tabindex et gestion du scroll horizontal.
+playgroundTemplate: default
+variants:
+    - name: default
+      label: Par défaut
+      description: Déclarer les onglets avec `<ar-tab panel="nom">` et les panneaux avec `<ar-tab-panel name="nom">`. L'association se fait par correspondance du nom.
+      html: |
+          <ar-tab-group>
+              <ar-tab panel="intro">Introduction</ar-tab>
+              <ar-tab panel="usage">Utilisation</ar-tab>
+              <ar-tab panel="api">API</ar-tab>
+              <ar-tab-panel name="intro">Contenu de l'onglet Introduction.</ar-tab-panel>
+              <ar-tab-panel name="usage">Contenu de l'onglet Utilisation.</ar-tab-panel>
+              <ar-tab-panel name="api">Contenu de l'onglet API.</ar-tab-panel>
+          </ar-tab-group>
+    - name: active
+      label: Onglet initial
+      description: Utilisez l'attribut `active` pour définir l'onglet ouvert par défaut.
+      html: |
+          <ar-tab-group active="usage">
+              <ar-tab panel="intro">Introduction</ar-tab>
+              <ar-tab panel="usage">Utilisation</ar-tab>
+              <ar-tab panel="api">API</ar-tab>
+              <ar-tab-panel name="intro">Introduction.</ar-tab-panel>
+              <ar-tab-panel name="usage">Cet onglet est actif par défaut.</ar-tab-panel>
+              <ar-tab-panel name="api">API.</ar-tab-panel>
+          </ar-tab-group>
+    - name: disabled
+      label: Onglet désactivé
+      description: L'attribut `disabled` sur un `<ar-tab>` rend l'onglet non sélectionnable et l'exclut de la navigation clavier.
+      html: |
+          <ar-tab-group>
+              <ar-tab panel="a">Actif</ar-tab>
+              <ar-tab panel="b" disabled>Désactivé</ar-tab>
+              <ar-tab panel="c">Actif aussi</ar-tab>
+              <ar-tab-panel name="a">Panel A.</ar-tab-panel>
+              <ar-tab-panel name="b">Panel B (inaccessible).</ar-tab-panel>
+              <ar-tab-panel name="c">Panel C.</ar-tab-panel>
+          </ar-tab-group>
+    - name: manual-activation
+      label: Activation manuelle
+      description: Avec `manual-activation`, les flèches déplacent le focus sans changer l'onglet actif — il faut appuyer sur Entrée ou Espace pour confirmer. Utile quand le contenu du panel est coûteux à charger.
+      html: |
+          <ar-tab-group manual-activation>
+              <ar-tab panel="a">Tab A</ar-tab>
+              <ar-tab panel="b">Tab B</ar-tab>
+              <ar-tab panel="c">Tab C</ar-tab>
+              <ar-tab-panel name="a">Panel A.</ar-tab-panel>
+              <ar-tab-panel name="b">Panel B.</ar-tab-panel>
+              <ar-tab-panel name="c">Panel C.</ar-tab-panel>
+          </ar-tab-group>
+    - name: scroll-hints
+      label: Scroll hints
+      description: L'attribut `scroll-hints` ajoute les classes `has-overflow-start` et `has-overflow-end` sur `part="nav"` quand du contenu est masqué de chaque côté. La demo ci-dessous utilise un `mask-image` CSS pour signaler l'overflow.
+      html: |
+          <style>
+              .demo-scroll ar-tab-group::part(nav) {
+                  --mask-start: linear-gradient(to right, transparent 0, black 3rem);
+                  --mask-end: linear-gradient(to left, transparent 0, black 3rem);
+                  mask-image: var(--mask-start-active, none), var(--mask-end-active, none);
+              }
+              .demo-scroll ar-tab-group::part(nav).has-overflow-start {
+                  --mask-start-active: var(--mask-start);
+              }
+              .demo-scroll ar-tab-group::part(nav).has-overflow-end {
+                  --mask-end-active: var(--mask-end);
+              }
+          </style>
+          <div class="demo-scroll" style="max-width: 300px;">
+              <ar-tab-group scroll-hints>
+                  <ar-tab panel="a">Premier onglet</ar-tab>
+                  <ar-tab panel="b">Deuxième onglet</ar-tab>
+                  <ar-tab panel="c">Troisième onglet</ar-tab>
+                  <ar-tab panel="d">Quatrième onglet</ar-tab>
+                  <ar-tab-panel name="a">Panel A.</ar-tab-panel>
+                  <ar-tab-panel name="b">Panel B.</ar-tab-panel>
+                  <ar-tab-panel name="c">Panel C.</ar-tab-panel>
+                  <ar-tab-panel name="d">Panel D.</ar-tab-panel>
+              </ar-tab-group>
+          </div>
+---
+
+import WcagRef from '../../components/WcagRef.astro';
+
+## Accessibilité
+
+### Pris en charge automatiquement
+
+- Le tablist reçoit `role="tablist"`, chaque onglet `role="tab"` et chaque panneau `role="tabpanel"`.
+- Les associations `aria-controls` (onglet → panneau) et `aria-labelledby` (panneau → onglet) sont calculées et posées automatiquement sur les hôtes en light DOM — les IDREF restent dans le même arbre et sont lisibles par les technologies d'assistance.
+- <WcagRef
+      criterion="2.1.1"
+      summary="Keyboard : toutes les fonctionnalités doivent être accessibles au clavier."
+  />
+  : navigation ←/→ entre les onglets, `Home`/`End` pour le premier/dernier, `Tab` pour atteindre le
+  panneau actif.
+- L'onglet actif a `tabindex="0"`, les inactifs `tabindex="-1"` (roving tabindex).
+- Les panneaux inactifs ont l'attribut `hidden` natif — exclus du flux de tabulation et invisibles aux lecteurs d'écran.
+
+### Scroll horizontal et overflow
+
+<WcagRef
+    criterion="1.4.10"
+    summary="Reflow : le contenu doit être accessible à 320px de large sans scroll horizontal."
+/>
+
+Le tablist utilise un scroll horizontal natif (`overflow-x: auto`). Les onglets restent toujours accessibles au clavier via les flèches (l'onglet actif est automatiquement ramené dans le viewport). Cette approche s'appuie sur l'exception WCAG 1.4.10 pour les éléments de navigation à mise en page bidimensionnelle.
+
+**Recommandations pour votre design system :**
+
+- Utilisez `scroll-hints` et branchez un `mask-image` CSS sur `.has-overflow-end` / `.has-overflow-start` pour signaler visuellement l'overflow aux utilisateurs souris (voir la variante _Scroll hints_).
+- Si une scrollbar visible est souhaitée, stylez `ar-tab-group::part(nav)::-webkit-scrollbar` et `scrollbar-width`.
+
+### À la charge de l'auteur
+
+- **Nommer le tablist** : si la page contient plusieurs `ar-tab-group`, ajoutez l'attribut `label` sur chacun — il devient l'`aria-label` du tablist, permettant aux lecteurs d'écran de les distinguer.
+- **Libellés des onglets** : le texte visible de l'onglet est son nom accessible. Évitez les onglets avec des icônes seules sans texte alternatif (`aria-label` sur `ar-tab`).

--- a/apps/docs/src/content/components/ar-tab-group.mdx
+++ b/apps/docs/src/content/components/ar-tab-group.mdx
@@ -90,12 +90,21 @@ variants:
       description: Les tokens `--ar-tab-*` permettent de changer le style de l'indicateur actif sans modifier le composant. Exemple — indicateur en haut (top border) et style pill.
       html: |
           <style>
+              .demo-top ar-tab-group {
+                  --ar-tab-group-border-top-width: 1px;
+                  --ar-tab-group-border-bottom-width: 0;
+              }
               .demo-top ar-tab {
                   --ar-tab-active-shadow: inset 0 3px 0 var(--ar-tab-indicator-color);
               }
+
+              .demo-pill ar-tab-group {
+                --ar-tab-group-border-top-width: 0;
+                --ar-tab-group-border-bottom-width: 0;
+              }
               .demo-pill ar-tab {
                   --ar-tab-active-shadow: none;
-                  --ar-tab-active-bg: var(--ar-color-interactive-subtle, #f4f5ff);
+                  --ar-tab-active-bg: var(--ar-color-interactive-subtle);
                   --ar-tab-border-radius: 9999px;
               }
           </style>

--- a/apps/docs/src/content/components/ar-tab-group.mdx
+++ b/apps/docs/src/content/components/ar-tab-group.mdx
@@ -85,6 +85,42 @@ variants:
                   <ar-tab-panel name="d">Panel D.</ar-tab-panel>
               </ar-tab-group>
           </div>
+    - name: styled
+      label: Avec thème personnalisé
+      description: Les tokens `--ar-tab-*` permettent de changer le style de l'indicateur actif sans modifier le composant. Exemple — indicateur en haut (top border) et style pill.
+      html: |
+          <style>
+              .demo-top ar-tab {
+                  --ar-tab-active-shadow: inset 0 3px 0 var(--ar-tab-indicator-color);
+              }
+              .demo-pill ar-tab {
+                  --ar-tab-active-shadow: none;
+                  --ar-tab-active-bg: var(--ar-color-interactive-subtle, #eaecfb);
+                  --ar-tab-border-radius: 9999px;
+              }
+          </style>
+          <p style="margin-bottom: 0.5rem; font-weight: 500;">Top border</p>
+          <div class="demo-top" style="margin-bottom: 1.5rem;">
+              <ar-tab-group>
+                  <ar-tab panel="a">Premier</ar-tab>
+                  <ar-tab panel="b">Deuxième</ar-tab>
+                  <ar-tab panel="c">Troisième</ar-tab>
+                  <ar-tab-panel name="a">Panel A.</ar-tab-panel>
+                  <ar-tab-panel name="b">Panel B.</ar-tab-panel>
+                  <ar-tab-panel name="c">Panel C.</ar-tab-panel>
+              </ar-tab-group>
+          </div>
+          <p style="margin-bottom: 0.5rem; font-weight: 500;">Pill</p>
+          <div class="demo-pill">
+              <ar-tab-group>
+                  <ar-tab panel="a">Premier</ar-tab>
+                  <ar-tab panel="b">Deuxième</ar-tab>
+                  <ar-tab panel="c">Troisième</ar-tab>
+                  <ar-tab-panel name="a">Panel A.</ar-tab-panel>
+                  <ar-tab-panel name="b">Panel B.</ar-tab-panel>
+                  <ar-tab-panel name="c">Panel C.</ar-tab-panel>
+              </ar-tab-group>
+          </div>
 ---
 
 import WcagRef from '../../components/WcagRef.astro';

--- a/apps/docs/src/content/components/ar-tab-group.mdx
+++ b/apps/docs/src/content/components/ar-tab-group.mdx
@@ -54,19 +54,23 @@ variants:
           </ar-tab-group>
     - name: scroll-hints
       label: Scroll hints
-      description: L'attribut `scroll-hints` ajoute les classes `has-overflow-start` et `has-overflow-end` sur `part="nav"` quand du contenu est masqué de chaque côté. La demo ci-dessous utilise un `mask-image` CSS pour signaler l'overflow.
+      description: L'attribut `scroll-hints` ajoute les classes `has-overflow-start` et `has-overflow-end` sur l'hôte quand du contenu est masqué de chaque côté. La démo ci-dessous branche un `mask-image` CSS sur ces classes pour signaler l'overflow en temps réel.
       html: |
           <style>
-              .demo-scroll ar-tab-group::part(nav) {
-                  --mask-start: linear-gradient(to right, transparent 0, black 3rem);
-                  --mask-end: linear-gradient(to left, transparent 0, black 3rem);
-                  mask-image: var(--mask-start-active, none), var(--mask-end-active, none);
+              .demo-scroll ar-tab-group.has-overflow-start:not(.has-overflow-end)::part(nav) {
+                  mask-image: linear-gradient(to right, transparent, black 3rem);
               }
-              .demo-scroll ar-tab-group::part(nav).has-overflow-start {
-                  --mask-start-active: var(--mask-start);
+              .demo-scroll ar-tab-group.has-overflow-end:not(.has-overflow-start)::part(nav) {
+                  mask-image: linear-gradient(to left, transparent, black 3rem);
               }
-              .demo-scroll ar-tab-group::part(nav).has-overflow-end {
-                  --mask-end-active: var(--mask-end);
+              .demo-scroll ar-tab-group.has-overflow-start.has-overflow-end::part(nav) {
+                  mask-image: linear-gradient(
+                      to right,
+                      transparent,
+                      black 3rem,
+                      black calc(100% - 3rem),
+                      transparent
+                  );
               }
           </style>
           <div class="demo-scroll" style="max-width: 300px;">
@@ -111,7 +115,7 @@ Le tablist utilise un scroll horizontal natif (`overflow-x: auto`). Les onglets 
 
 **Recommandations pour votre design system :**
 
-- Utilisez `scroll-hints` et branchez un `mask-image` CSS sur `.has-overflow-end` / `.has-overflow-start` pour signaler visuellement l'overflow aux utilisateurs souris (voir la variante _Scroll hints_).
+- Utilisez `scroll-hints` et branchez un `mask-image` CSS sur les classes `has-overflow-start` / `has-overflow-end` de l'hôte pour signaler visuellement l'overflow aux utilisateurs souris (voir la variante _Scroll hints_).
 - Si une scrollbar visible est souhaitée, stylez `ar-tab-group::part(nav)::-webkit-scrollbar` et `scrollbar-width`.
 
 ### À la charge de l'auteur

--- a/apps/docs/src/content/components/ar-tab-panel.mdx
+++ b/apps/docs/src/content/components/ar-tab-panel.mdx
@@ -1,12 +1,7 @@
 ---
 tagName: ar-tab-panel
-title: TabPanel
-description: Description du composant ar-tab-panel.
-variants:
-    - name: Par défaut
-      description: Rendu par défaut du composant.
-      html: |
-          <ar-tab-panel></ar-tab-panel>
+title: Tab Panel
+description: Panneau de contenu pour ar-tab-group. Pose automatiquement role="tabpanel", tabindex et aria-labelledby sur son hôte via le registry de ar-tab-group.
 ---
 
-Documentation narrative du composant `ar-tab-panel`.
+Sous-composant de [`ar-tab-group`](/components/ar-tab-group). À utiliser exclusivement comme enfant direct de `ar-tab-group`.

--- a/apps/docs/src/content/components/ar-tab-panel.mdx
+++ b/apps/docs/src/content/components/ar-tab-panel.mdx
@@ -1,0 +1,12 @@
+---
+tagName: ar-tab-panel
+title: TabPanel
+description: Description du composant ar-tab-panel.
+variants:
+    - name: Par défaut
+      description: Rendu par défaut du composant.
+      html: |
+          <ar-tab-panel></ar-tab-panel>
+---
+
+Documentation narrative du composant `ar-tab-panel`.

--- a/apps/docs/src/content/components/ar-tab.mdx
+++ b/apps/docs/src/content/components/ar-tab.mdx
@@ -1,12 +1,7 @@
 ---
 tagName: ar-tab
 title: Tab
-description: Description du composant ar-tab.
-variants:
-    - name: Par défaut
-      description: Rendu par défaut du composant.
-      html: |
-          <ar-tab></ar-tab>
+description: Onglet déclencheur pour ar-tab-group. Pose automatiquement role="tab", tabindex et aria-controls sur son hôte via le registry de ar-tab-group.
 ---
 
-Documentation narrative du composant `ar-tab`.
+Sous-composant de [`ar-tab-group`](/components/ar-tab-group). À utiliser exclusivement comme enfant direct de `ar-tab-group`.

--- a/apps/docs/src/content/components/ar-tab.mdx
+++ b/apps/docs/src/content/components/ar-tab.mdx
@@ -1,0 +1,12 @@
+---
+tagName: ar-tab
+title: Tab
+description: Description du composant ar-tab.
+variants:
+    - name: Par défaut
+      description: Rendu par défaut du composant.
+      html: |
+          <ar-tab></ar-tab>
+---
+
+Documentation narrative du composant `ar-tab`.

--- a/apps/docs/src/pages/getting-started/utilisation.astro
+++ b/apps/docs/src/pages/getting-started/utilisation.astro
@@ -5,6 +5,7 @@ import TableOfContents from '../../components/TableOfContents.astro';
 const tocEntries = [
     { id: 'composants',       label: 'Utiliser les composants', level: 1 as const },
     { id: 'chargement',       label: 'Attendre le chargement',  level: 1 as const },
+    { id: 'headless',         label: 'Modèle headless',         level: 1 as const },
     { id: 'personnalisation', label: 'Personnalisation CSS',    level: 1 as const },
     { id: 'tokens',           label: 'Design Tokens',           level: 1 as const },
 ];
@@ -91,6 +92,27 @@ const codeTokens = `:root {
                 <p>Via CDN (sans import) :</p>
                 <pre><code class="language-js" set:text={codeWhenAllDefinedCdn} /></pre>
             </section>
+        </section>
+
+        <section id="headless" class="main-section">
+            <div>
+                <h3 class="section-title">Modèle headless</h3>
+                <p>
+                    Ariane est une librairie <strong>headless</strong> : les composants ne portent
+                    aucun style visuel par défaut. Couleurs, espacements et typographie proviennent
+                    exclusivement du fichier de thème chargé séparément.
+                </p>
+                <p>
+                    Sans thème, les composants fonctionnent (accessibilité, interactions, slots)
+                    mais leur rendu visuel est indéfini. C'est intentionnel — Ariane est une
+                    fondation sur laquelle construire un design system, pas un kit d'UI clé en main.
+                </p>
+                <p>
+                    Les exemples de cette documentation utilisent <code>themes/default.css</code>.
+                    Vous pouvez le remplacer par votre propre thème en définissant les tokens CSS
+                    de chaque composant sur <code>:root</code>.
+                </p>
+            </div>
         </section>
 
         <section id="personnalisation" class="main-section">

--- a/docs/decisions/ADR-004-philosophie-style-composants.md
+++ b/docs/decisions/ADR-004-philosophie-style-composants.md
@@ -1,0 +1,88 @@
+# ADR-004 : Philosophie de style des composants
+
+**Statut :** Adopté  
+**Date :** 2026-05-08
+
+## Contexte
+
+Ariane se positionne comme une fondation pour construire un design system, pas comme un
+design system prêt à l'emploi. La question du niveau de style à embarquer dans les
+composants n'avait pas été tranchée formellement. En pratique, certains composants
+(dropdown, breadcrumb, stepper) embarquaient des styles visuels complets, tandis que
+d'autres (ar-tab-group) restaient quasi headless. Cette incohérence rendait les attentes
+des intégrateurs floues.
+
+La revue du composant ar-tab-group (PR #73) a mis en évidence la nécessité de formaliser
+cette décision.
+
+### Repères dans l'écosystème
+
+- **Lion (ING)** — headless radical, zéro style visuel, fondation pure. Trop bas niveau
+  pour Ariane : les intégrateurs doivent tout styler de zéro, y compris les signaux a11y.
+- **Web Awesome / Shoelace** — styles complets, CSS custom properties, `::part()`. Prêt
+  à l'emploi mais trop opinionné : impose une identité visuelle que les design systems
+  construits sur Ariane devront surcharger intégralement.
+- **Spectrum (Adobe), Clarity (VMware)** — styles complets portés par des tokens de design
+  system. Modèle adapté à un design system maison, pas à une fondation générique.
+
+Ariane vise la voie intermédiaire : fournir les styles qui ne devraient pas être
+modifiés (structure, accessibilité) et exposer le reste via des tokens CSS et des `::part()`.
+
+## Décision
+
+Les styles d'un composant Ariane sont répartis en trois couches.
+
+### Couche 1 — Styles internes fixes
+
+Styles embarqués dans le Shadow DOM et non exposés à la customisation. Ils garantissent
+le bon fonctionnement structurel et les signaux d'accessibilité obligatoires.
+
+Exemples : `display`, `overflow`, `position` pour le layout ; présence de l'indicateur
+actif sur un tab ; traitement visuel `[aria-disabled]` ; outline de focus.
+
+Ces styles ne sont pas surchargeables via des tokens. Si un intégrateur doit les modifier,
+c'est un signal que le composant doit évoluer.
+
+### Couche 2 — Tokens CSS `--ar-*`
+
+Les propriétés visuelles légitimement variables (couleur, padding, typographie, taille de
+l'indicateur, etc.) sont exposées sous forme de CSS custom properties préfixées `--ar-`.
+
+Les tokens sont déclarés avec une valeur par défaut fonctionnelle dans le Shadow DOM :
+
+```css
+color: var(--ar-tab-color, currentColor);
+```
+
+Ils constituent le contrat de personnalisation principal pour les consommateurs qui
+construisent un thème. Un fichier `default.css` au niveau du package fournit des valeurs
+de thème de base.
+
+### Couche 3 — `::part()` stratégiques
+
+Des attributs `part` sont posés sur les éléments internes clés pour permettre un accès
+direct au Shadow DOM via CSS externe, au-delà de ce que couvrent les tokens.
+
+Les parts sont documentés sur chaque composant (`@csspart` en JSDoc). Ils sont choisis
+avec parcimonie : uniquement les éléments sur lesquels un intégrateur aura légitimement
+besoin d'intervenir (fond, bordure, typographie avancée, états hover/focus custom).
+
+## Règle de tri
+
+| Nature du style                             | Couche         |
+| ------------------------------------------- | -------------- |
+| Layout structurel (`display`, `overflow`…)  | Interne fixe   |
+| Signal a11y obligatoire (indicator, focus…) | Interne fixe   |
+| Couleur, padding, typographie, espacement   | Token `--ar-*` |
+| Accès direct à un élément interne           | `::part()`     |
+
+## Conséquences
+
+- Les composants existants (dropdown, breadcrumb, stepper) devront être auditées pour
+  vérifier que leurs styles respectent ce découpage. Les styles visuels non exposés via
+  token sont à migrer progressivement.
+- Chaque nouveau composant doit documenter ses tokens (`@cssprop`) et ses parts
+  (`@csspart`) dans le JSDoc, qui alimente le Custom Elements Manifest et la doc générée.
+- Les styles de démo dans `apps/docs/` peuvent aller au-delà des tokens pour illustrer
+  des cas d'usage (ex. scroll hints avec `mask-image`), mais ne doivent jamais être
+  confondus avec le style du composant.

--- a/docs/superpowers/plans/2026-05-07-ar-tab-group.md
+++ b/docs/superpowers/plans/2026-05-07-ar-tab-group.md
@@ -1,0 +1,1783 @@
+# ar-tab-group Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implémenter le pattern WAI-ARIA Tabs complet via trois éléments coopérants (`ar-tab-group`, `ar-tab`, `ar-tab-panel`) avec roving tabindex, association tab↔panel par nom, scroll horizontal et scroll-hints.
+
+**Architecture:** `ar-tab-group` fournit un `ContextProvider` (`@lit/context`) exposant un registry. `ar-tab` et `ar-tab-panel` sont des `ContextConsumer` qui s'enregistrent au `connectedCallback`. `ar-tab-group` orchestre tout : pose les attributs ARIA sur les hosts light DOM, gère le roving tabindex et le clavier.
+
+**Tech Stack:** Lit 3, TypeScript, `@lit/context`, Vitest (tests unitaires), `@web/test-runner` + `@open-wc/testing` (tests browser).
+
+---
+
+## Structure des fichiers
+
+| Fichier                                                            | Action                     | Responsabilité                                                   |
+| ------------------------------------------------------------------ | -------------------------- | ---------------------------------------------------------------- |
+| `packages/core/src/context/tabs.context.ts`                        | Créer                      | Interface `TabGroupRegistry` + clé de contexte                   |
+| `packages/core/src/components/tab/tab.ts`                          | Créer (scaffold)           | `ar-tab` : props, consumer, ARIA sur host, click                 |
+| `packages/core/src/components/tab/tab.styles.ts`                   | Créer (scaffold)           | Styles ar-tab                                                    |
+| `packages/core/src/components/tab/tab.test.ts`                     | Créer (scaffold)           | Tests unitaires ar-tab (Vitest)                                  |
+| `packages/core/src/components/tab-panel/tab-panel.ts`              | Créer (scaffold)           | `ar-tab-panel` : props, consumer, ARIA sur host                  |
+| `packages/core/src/components/tab-panel/tab-panel.styles.ts`       | Créer (scaffold)           | Styles ar-tab-panel                                              |
+| `packages/core/src/components/tab-panel/tab-panel.test.ts`         | Créer (scaffold)           | Tests unitaires ar-tab-panel (Vitest)                            |
+| `packages/core/src/components/tab-group/tab-group.ts`              | Modifier (scaffold existe) | `ar-tab-group` : provider, registry, ARIA, clavier, scroll-hints |
+| `packages/core/src/components/tab-group/tab-group.styles.ts`       | Modifier (scaffold existe) | Styles ar-tab-group                                              |
+| `packages/core/src/components/tab-group/tab-group.test.ts`         | Modifier (scaffold existe) | Tests unitaires intégration (Vitest)                             |
+| `packages/core/src/components/tab-group/tab-group.browser.test.ts` | Créer                      | Tests browser clavier + scroll-hints (WTR)                       |
+| `packages/core/src/components/tab-group/tab-group.a11y.test.ts`    | Créer                      | Tests ARIA accessibilité (WTR)                                   |
+| `packages/core/src/index.ts`                                       | Modifier                   | Ajouter exports ArTab, ArTabPanel                                |
+| `packages/core/src/autoloader.ts`                                  | Modifier                   | Ajouter ar-tab, ar-tab-panel                                     |
+| `apps/docs/src/content/components/ar-tab-group.mdx`                | Modifier (scaffold existe) | Documentation complète avec variantes                            |
+| `apps/docs/src/content/components/ar-tab.mdx`                      | Créer (scaffold crée)      | Doc sous-composant ar-tab                                        |
+| `apps/docs/src/content/components/ar-tab-panel.mdx`                | Créer (scaffold crée)      | Doc sous-composant ar-tab-panel                                  |
+
+---
+
+## Task 0 : Créer la branche de travail
+
+- [ ] **Step 1 : Créer la branche depuis dev**
+
+```bash
+git checkout dev && git checkout -b feat/ar-tab-group
+```
+
+---
+
+## Task 1 : Scaffold ar-tab, ar-tab-panel + tabs.context.ts
+
+**Files:**
+
+- Create: `packages/core/src/context/tabs.context.ts`
+- Create: `packages/core/src/components/tab/` (via scaffold)
+- Create: `packages/core/src/components/tab-panel/` (via scaffold)
+- Modify: `packages/core/src/index.ts` (scaffold met à jour automatiquement)
+- Modify: `packages/core/src/autoloader.ts` (scaffold met à jour automatiquement)
+
+- [ ] **Step 1 : Lancer le scaffold pour ar-tab**
+
+Depuis la racine du repo :
+
+```bash
+npm run create ar-tab
+```
+
+Résultat attendu :
+
+```
+✓ src/components/tab/tab.ts
+✓ src/components/tab/tab.styles.ts
+✓ src/components/tab/tab.test.ts
+✓ apps/docs/src/content/components/ar-tab.mdx
+✓ src/index.ts mis à jour
+✓ src/autoloader.ts mis à jour
+```
+
+- [ ] **Step 2 : Lancer le scaffold pour ar-tab-panel**
+
+```bash
+npm run create ar-tab-panel
+```
+
+Résultat attendu :
+
+```
+✓ src/components/tab-panel/tab-panel.ts
+✓ src/components/tab-panel/tab-panel.styles.ts
+✓ src/components/tab-panel/tab-panel.test.ts
+✓ apps/docs/src/content/components/ar-tab-panel.mdx
+✓ src/index.ts mis à jour
+✓ src/autoloader.ts mis à jour
+```
+
+- [ ] **Step 3 : Créer tabs.context.ts**
+
+```typescript
+// packages/core/src/context/tabs.context.ts
+import { createContext } from '@lit/context';
+import type { ArTab } from '../components/tab/tab.js';
+import type { ArTabPanel } from '../components/tab-panel/tab-panel.js';
+
+export interface TabGroupRegistry {
+    registerTab(tab: ArTab): void;
+    unregisterTab(tab: ArTab): void;
+    registerPanel(panel: ArTabPanel): void;
+    unregisterPanel(panel: ArTabPanel): void;
+    activate(name: string): void;
+}
+
+export const tabGroupContext = createContext<TabGroupRegistry>(Symbol('ar-tab-group'));
+```
+
+- [ ] **Step 4 : Vérifier les exports dans index.ts**
+
+Ouvrir `packages/core/src/index.ts` et vérifier que ces trois lignes sont présentes (le scaffold les ajoute automatiquement) :
+
+```typescript
+export { ArTabGroup } from './components/tab-group/tab-group.js';
+export { ArTab } from './components/tab/tab.js';
+export { ArTabPanel } from './components/tab-panel/tab-panel.js';
+```
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add packages/core/src/context/tabs.context.ts \
+        packages/core/src/components/tab/ \
+        packages/core/src/components/tab-panel/ \
+        packages/core/src/index.ts \
+        packages/core/src/autoloader.ts \
+        apps/docs/src/content/components/ar-tab.mdx \
+        apps/docs/src/content/components/ar-tab-panel.mdx
+git commit -m "feat(tab-group): scaffold ar-tab, ar-tab-panel + tabs.context"
+```
+
+---
+
+## Task 2 : ar-tab — tests unitaires + implémentation
+
+**Files:**
+
+- Modify: `packages/core/src/components/tab/tab.ts`
+- Modify: `packages/core/src/components/tab/tab.test.ts`
+
+- [ ] **Step 1 : Écrire les tests unitaires ar-tab**
+
+Remplacer le contenu de `packages/core/src/components/tab/tab.test.ts` :
+
+```typescript
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fixture, waitForUpdate, getPart } from '../../test-utils.js';
+import type { ArTab } from './tab.js';
+import './tab.js';
+
+describe('ArTab', () => {
+    let el: ArTab;
+    afterEach(() => el?.remove());
+
+    describe('rendu', () => {
+        it('monte un shadow DOM avec un slot', async () => {
+            el = await fixture('<ar-tab panel="a">Tab A</ar-tab>');
+            expect(el.shadowRoot).not.toBeNull();
+            expect(el.shadowRoot?.querySelector('slot')).not.toBeNull();
+        });
+    });
+
+    describe('valeurs par défaut', () => {
+        it('panel vaut chaîne vide', async () => {
+            el = await fixture('<ar-tab>Tab</ar-tab>');
+            expect(el.panel).toBe('');
+        });
+
+        it('disabled vaut false', async () => {
+            el = await fixture('<ar-tab panel="a">Tab A</ar-tab>');
+            expect(el.disabled).toBe(false);
+        });
+    });
+
+    describe('attribut panel', () => {
+        it("lit panel depuis l'attribut HTML", async () => {
+            el = await fixture('<ar-tab panel="intro">Tab</ar-tab>');
+            expect(el.panel).toBe('intro');
+        });
+
+        it('reflète panel en attribut', async () => {
+            el = await fixture('<ar-tab panel="intro">Tab</ar-tab>');
+            el.panel = 'usage';
+            await waitForUpdate(el);
+            expect(el.getAttribute('panel')).toBe('usage');
+        });
+    });
+
+    describe('disabled', () => {
+        it('reflète disabled en attribut', async () => {
+            el = await fixture('<ar-tab panel="a">Tab</ar-tab>');
+            el.disabled = true;
+            await waitForUpdate(el);
+            expect(el.hasAttribute('disabled')).toBe(true);
+        });
+
+        it('ne déclenche pas activate si disabled', async () => {
+            el = await fixture('<ar-tab panel="a" disabled>Tab</ar-tab>');
+            const spy = vi.fn();
+            (el as any)._registry = { activate: spy, registerTab: vi.fn(), unregisterTab: vi.fn() };
+            el.click();
+            expect(spy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('click', () => {
+        it('appelle registry.activate(panel) au clic', async () => {
+            el = await fixture('<ar-tab panel="test">Tab</ar-tab>');
+            const activate = vi.fn();
+            (el as any)._registry = { activate, registerTab: vi.fn(), unregisterTab: vi.fn() };
+            el.click();
+            expect(activate).toHaveBeenCalledWith('test');
+        });
+    });
+});
+```
+
+- [ ] **Step 2 : Lancer les tests — vérifier l'échec**
+
+```bash
+cd packages/core && npm run test -- --reporter=verbose tab/tab.test.ts
+```
+
+Attendu : FAIL — le scaffold génère un stub minimal ; les tests de `panel`, `disabled`, `click` et ARIA échouent car l'implémentation réelle n'est pas encore écrite.
+
+- [ ] **Step 3 : Implémenter ar-tab**
+
+Remplacer `packages/core/src/components/tab/tab.ts` :
+
+```typescript
+import { LitElement, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { ContextConsumer } from '@lit/context';
+import { tabGroupContext, type TabGroupRegistry } from '../../context/tabs.context.js';
+import styles from './tab.styles.js';
+
+/**
+ * @summary Onglet déclencheur pour ar-tab-group.
+ * @parent ar-tab-group
+ * @display docs
+ *
+ * @slot - Libellé de l'onglet.
+ *
+ * @csspart base - Wrapper du slot.
+ */
+@customElement('ar-tab')
+export class ArTab extends LitElement {
+    static override styles = [styles];
+
+    /** Nom du ar-tab-panel associé. Requis. */
+    @property({ reflect: true }) panel = '';
+
+    /** Désactive l'onglet — non sélectionnable, ignoré au clavier. */
+    @property({ reflect: true, type: Boolean }) disabled = false;
+
+    _registry?: TabGroupRegistry;
+
+    protected readonly _consumer = new ContextConsumer(this, {
+        context: tabGroupContext,
+        subscribe: true,
+        callback: (registry) => this._setRegistry(registry),
+    });
+
+    private _setRegistry(registry: TabGroupRegistry): void {
+        if (this._registry) {
+            this._registry.unregisterTab(this);
+        }
+        this._registry = registry;
+        registry.registerTab(this);
+    }
+
+    override connectedCallback(): void {
+        super.connectedCallback();
+        this.addEventListener('click', this._handleClick);
+    }
+
+    override disconnectedCallback(): void {
+        this._registry?.unregisterTab(this);
+        this._registry = undefined;
+        this.removeEventListener('click', this._handleClick);
+        super.disconnectedCallback();
+    }
+
+    private _handleClick = (): void => {
+        if (!this.disabled) {
+            this._registry?.activate(this.panel);
+        }
+    };
+
+    override render() {
+        return html`<div part="base"><slot></slot></div>`;
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'ar-tab': ArTab;
+    }
+}
+```
+
+- [ ] **Step 4 : Relancer les tests — vérifier le passage**
+
+```bash
+cd packages/core && npm run test -- --reporter=verbose tab/tab.test.ts
+```
+
+Attendu : PASS (6 tests).
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add packages/core/src/components/tab/
+git commit -m "feat(tab-group): ar-tab — implémentation et tests unitaires"
+```
+
+---
+
+## Task 3 : ar-tab-panel — tests unitaires + implémentation
+
+**Files:**
+
+- Modify: `packages/core/src/components/tab-panel/tab-panel.ts`
+- Modify: `packages/core/src/components/tab-panel/tab-panel.test.ts`
+
+- [ ] **Step 1 : Écrire les tests unitaires ar-tab-panel**
+
+Remplacer `packages/core/src/components/tab-panel/tab-panel.test.ts` :
+
+```typescript
+import { afterEach, describe, expect, it } from 'vitest';
+import { fixture, waitForUpdate } from '../../test-utils.js';
+import type { ArTabPanel } from './tab-panel.js';
+import './tab-panel.js';
+
+describe('ArTabPanel', () => {
+    let el: ArTabPanel;
+    afterEach(() => el?.remove());
+
+    describe('rendu', () => {
+        it('monte un shadow DOM avec un slot', async () => {
+            el = await fixture('<ar-tab-panel name="a">Contenu</ar-tab-panel>');
+            expect(el.shadowRoot).not.toBeNull();
+            expect(el.shadowRoot?.querySelector('slot')).not.toBeNull();
+        });
+    });
+
+    describe('valeurs par défaut', () => {
+        it('name vaut chaîne vide', async () => {
+            el = await fixture('<ar-tab-panel>Contenu</ar-tab-panel>');
+            expect(el.name).toBe('');
+        });
+    });
+
+    describe('attribut name', () => {
+        it("lit name depuis l'attribut HTML", async () => {
+            el = await fixture('<ar-tab-panel name="intro">Contenu</ar-tab-panel>');
+            expect(el.name).toBe('intro');
+        });
+
+        it('reflète name en attribut', async () => {
+            el = await fixture('<ar-tab-panel name="intro">Contenu</ar-tab-panel>');
+            el.name = 'usage';
+            await waitForUpdate(el);
+            expect(el.getAttribute('name')).toBe('usage');
+        });
+    });
+});
+```
+
+- [ ] **Step 2 : Lancer les tests — vérifier l'échec**
+
+```bash
+cd packages/core && npm run test -- --reporter=verbose tab-panel/tab-panel.test.ts
+```
+
+Attendu : FAIL — le scaffold génère un stub minimal ; les tests de `name` et de reflect échouent car l'implémentation réelle n'est pas encore écrite.
+
+- [ ] **Step 3 : Implémenter ar-tab-panel**
+
+Remplacer `packages/core/src/components/tab-panel/tab-panel.ts` :
+
+```typescript
+import { LitElement, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { ContextConsumer } from '@lit/context';
+import { tabGroupContext, type TabGroupRegistry } from '../../context/tabs.context.js';
+import styles from './tab-panel.styles.js';
+
+/**
+ * @summary Panneau de contenu pour ar-tab-group.
+ * @parent ar-tab-group
+ * @display docs
+ *
+ * @slot - Contenu du panel.
+ *
+ * @csspart base - Wrapper du slot.
+ */
+@customElement('ar-tab-panel')
+export class ArTabPanel extends LitElement {
+    static override styles = [styles];
+
+    /** Nom correspondant à l'attribut `panel` du ar-tab associé. Requis. */
+    @property({ reflect: true }) name = '';
+
+    private _registry?: TabGroupRegistry;
+
+    protected readonly _consumer = new ContextConsumer(this, {
+        context: tabGroupContext,
+        subscribe: true,
+        callback: (registry) => this._setRegistry(registry),
+    });
+
+    private _setRegistry(registry: TabGroupRegistry): void {
+        if (this._registry) {
+            this._registry.unregisterPanel(this);
+        }
+        this._registry = registry;
+        registry.registerPanel(this);
+    }
+
+    override disconnectedCallback(): void {
+        this._registry?.unregisterPanel(this);
+        this._registry = undefined;
+        super.disconnectedCallback();
+    }
+
+    override render() {
+        return html`<div part="base"><slot></slot></div>`;
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'ar-tab-panel': ArTabPanel;
+    }
+}
+```
+
+- [ ] **Step 4 : Relancer les tests — vérifier le passage**
+
+```bash
+cd packages/core && npm run test -- --reporter=verbose tab-panel/tab-panel.test.ts
+```
+
+Attendu : PASS (4 tests).
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add packages/core/src/components/tab-panel/
+git commit -m "feat(tab-group): ar-tab-panel — implémentation et tests unitaires"
+```
+
+---
+
+## Task 4 : ar-tab-group — registry, ARIA, show/hide
+
+**Files:**
+
+- Modify: `packages/core/src/components/tab-group/tab-group.ts`
+- Modify: `packages/core/src/components/tab-group/tab-group.test.ts`
+
+- [ ] **Step 1 : Écrire les tests unitaires ar-tab-group (registry + ARIA)**
+
+Remplacer `packages/core/src/components/tab-group/tab-group.test.ts` :
+
+```typescript
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fixture, waitForUpdate, getPart } from '../../test-utils.js';
+import type { ArTabGroup } from './tab-group.js';
+import './tab-group.js';
+import '../tab/tab.js';
+import '../tab-panel/tab-panel.js';
+
+const DEFAULT_HTML = `
+    <ar-tab-group>
+        <ar-tab panel="a">Tab A</ar-tab>
+        <ar-tab panel="b">Tab B</ar-tab>
+        <ar-tab-panel name="a">Panel A</ar-tab-panel>
+        <ar-tab-panel name="b">Panel B</ar-tab-panel>
+    </ar-tab-group>
+`;
+
+describe('ArTabGroup', () => {
+    let el: ArTabGroup;
+    afterEach(() => el?.remove());
+
+    // ── Rendu ───────────────────────────────────────────────────────────────
+
+    describe('rendu', () => {
+        beforeEach(async () => {
+            el = await fixture('<ar-tab-group></ar-tab-group>');
+        });
+
+        it('monte un shadow DOM', () => {
+            expect(el.shadowRoot).not.toBeNull();
+        });
+
+        it('contient part="base"', () => {
+            expect(getPart(el, 'base')).not.toBeNull();
+        });
+
+        it('contient part="nav"', () => {
+            expect(getPart(el, 'nav')).not.toBeNull();
+        });
+
+        it('contient part="tabs" avec role="tablist"', () => {
+            expect(getPart(el, 'tabs')?.getAttribute('role')).toBe('tablist');
+        });
+    });
+
+    // ── Valeurs par défaut ─────────────────────────────────────────────────
+
+    describe('valeurs par défaut', () => {
+        beforeEach(async () => {
+            el = await fixture('<ar-tab-group></ar-tab-group>');
+        });
+
+        it('active vaut chaîne vide', () => expect(el.active).toBe(''));
+        it('label vaut chaîne vide', () => expect(el.label).toBe(''));
+        it('manualActivation vaut false', () => expect(el.manualActivation).toBe(false));
+        it('scrollHints vaut false', () => expect(el.scrollHints).toBe(false));
+    });
+
+    // ── Onglet actif par défaut ────────────────────────────────────────────
+
+    describe('onglet actif par défaut', () => {
+        it('active le premier onglet non-disabled si active est absent', async () => {
+            el = await fixture(DEFAULT_HTML);
+            await waitForUpdate(el);
+            const tabA = el.querySelector<HTMLElement>('ar-tab[panel="a"]')!;
+            expect(tabA.getAttribute('aria-selected')).toBe('true');
+            expect(tabA.getAttribute('tabindex')).toBe('0');
+        });
+
+        it('masque le panel inactif avec hidden', async () => {
+            el = await fixture(DEFAULT_HTML);
+            await waitForUpdate(el);
+            const panelB = el.querySelector<HTMLElement>('ar-tab-panel[name="b"]')!;
+            expect(panelB.hasAttribute('hidden')).toBe(true);
+        });
+
+        it('affiche le panel actif sans hidden', async () => {
+            el = await fixture(DEFAULT_HTML);
+            await waitForUpdate(el);
+            const panelA = el.querySelector<HTMLElement>('ar-tab-panel[name="a"]')!;
+            expect(panelA.hasAttribute('hidden')).toBe(false);
+        });
+    });
+
+    // ── Attribut active ────────────────────────────────────────────────────
+
+    describe('attribut active', () => {
+        it('active le bon onglet selon active="b"', async () => {
+            el = await fixture(`
+                <ar-tab-group active="b">
+                    <ar-tab panel="a">Tab A</ar-tab>
+                    <ar-tab panel="b">Tab B</ar-tab>
+                    <ar-tab-panel name="a">Panel A</ar-tab-panel>
+                    <ar-tab-panel name="b">Panel B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            await waitForUpdate(el);
+            const tabB = el.querySelector<HTMLElement>('ar-tab[panel="b"]')!;
+            expect(tabB.getAttribute('aria-selected')).toBe('true');
+        });
+
+        it("changer active programmatiquement met à jour l'ARIA", async () => {
+            el = await fixture(DEFAULT_HTML);
+            await waitForUpdate(el);
+            el.active = 'b';
+            await waitForUpdate(el);
+            const tabB = el.querySelector<HTMLElement>('ar-tab[panel="b"]')!;
+            expect(tabB.getAttribute('aria-selected')).toBe('true');
+            const panelB = el.querySelector<HTMLElement>('ar-tab-panel[name="b"]')!;
+            expect(panelB.hasAttribute('hidden')).toBe(false);
+        });
+    });
+
+    // ── ARIA IDs et associations ───────────────────────────────────────────
+
+    describe('ARIA — IDs et associations', () => {
+        beforeEach(async () => {
+            el = await fixture(DEFAULT_HTML);
+            await waitForUpdate(el);
+        });
+
+        it('chaque ar-tab a role="tab"', () => {
+            el.querySelectorAll('ar-tab').forEach((tab) => {
+                expect(tab.getAttribute('role')).toBe('tab');
+            });
+        });
+
+        it('chaque ar-tab-panel a role="tabpanel"', () => {
+            el.querySelectorAll('ar-tab-panel').forEach((panel) => {
+                expect(panel.getAttribute('role')).toBe('tabpanel');
+            });
+        });
+
+        it("aria-controls sur ar-tab pointe vers l'ID du panel correspondant", () => {
+            const tabA = el.querySelector<HTMLElement>('ar-tab[panel="a"]')!;
+            const panelA = el.querySelector<HTMLElement>('ar-tab-panel[name="a"]')!;
+            expect(tabA.getAttribute('aria-controls')).toBe(panelA.id);
+        });
+
+        it("aria-labelledby sur ar-tab-panel pointe vers l'ID du tab correspondant", () => {
+            const tabA = el.querySelector<HTMLElement>('ar-tab[panel="a"]')!;
+            const panelA = el.querySelector<HTMLElement>('ar-tab-panel[name="a"]')!;
+            expect(panelA.getAttribute('aria-labelledby')).toBe(tabA.id);
+        });
+
+        it('chaque ar-tab-panel a tabindex="0"', () => {
+            el.querySelectorAll('ar-tab-panel').forEach((panel) => {
+                expect(panel.getAttribute('tabindex')).toBe('0');
+            });
+        });
+    });
+
+    // ── label ──────────────────────────────────────────────────────────────
+
+    describe('attribut label', () => {
+        it('pose aria-label sur le tablist', async () => {
+            el = await fixture(`
+                <ar-tab-group label="Navigation principale">
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            expect(getPart(el, 'tabs')?.getAttribute('aria-label')).toBe('Navigation principale');
+        });
+    });
+
+    // ── disabled ───────────────────────────────────────────────────────────
+
+    describe('ar-tab disabled', () => {
+        it('pose aria-disabled="true" sur l\'onglet désactivé', async () => {
+            el = await fixture(`
+                <ar-tab-group>
+                    <ar-tab panel="a" disabled>Tab A</ar-tab>
+                    <ar-tab panel="b">Tab B</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            await waitForUpdate(el);
+            const tabA = el.querySelector<HTMLElement>('ar-tab[panel="a"]')!;
+            expect(tabA.getAttribute('aria-disabled')).toBe('true');
+        });
+
+        it('saute le premier onglet si disabled et active le suivant', async () => {
+            el = await fixture(`
+                <ar-tab-group>
+                    <ar-tab panel="a" disabled>Tab A</ar-tab>
+                    <ar-tab panel="b">Tab B</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            await waitForUpdate(el);
+            const tabB = el.querySelector<HTMLElement>('ar-tab[panel="b"]')!;
+            expect(tabB.getAttribute('aria-selected')).toBe('true');
+        });
+    });
+
+    // ── Événement ─────────────────────────────────────────────────────────
+
+    describe('événement ar-tab-group-change', () => {
+        it('émet ar-tab-group-change avec { active } au clic', async () => {
+            el = await fixture(DEFAULT_HTML);
+            await waitForUpdate(el);
+            const events: CustomEvent[] = [];
+            el.addEventListener('ar-tab-group-change', (e) => events.push(e as CustomEvent));
+            const tabB = el.querySelector<HTMLElement>('ar-tab[panel="b"]')!;
+            tabB.click();
+            await waitForUpdate(el);
+            expect(events.length).toBe(1);
+            expect(events[0].detail).toEqual({ active: 'b' });
+        });
+    });
+
+    // ── warn() ─────────────────────────────────────────────────────────────
+
+    describe('warn() — panel orphelin', () => {
+        it("affiche un warn si panel d'un ar-tab n'a pas de ar-tab-panel correspondant", async () => {
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            el = await fixture(`
+                <ar-tab-group>
+                    <ar-tab panel="orphan">Tab</ar-tab>
+                </ar-tab-group>
+            `);
+            await waitForUpdate(el);
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('orphan'));
+            warnSpy.mockRestore();
+        });
+    });
+
+    // ── slot="tab" automatique ─────────────────────────────────────────────
+
+    describe('slot="tab" automatique', () => {
+        it('pose slot="tab" sur chaque ar-tab enregistré', async () => {
+            el = await fixture(DEFAULT_HTML);
+            await waitForUpdate(el);
+            el.querySelectorAll('ar-tab').forEach((tab) => {
+                expect(tab.getAttribute('slot')).toBe('tab');
+            });
+        });
+    });
+});
+```
+
+- [ ] **Step 2 : Lancer les tests — vérifier l'échec**
+
+```bash
+cd packages/core && npm run test -- --reporter=verbose tab-group/tab-group.test.ts
+```
+
+Attendu : FAIL — les tests d'ARIA et d'onglet actif échouent.
+
+- [ ] **Step 3 : Implémenter ar-tab-group (core)**
+
+Remplacer `packages/core/src/components/tab-group/tab-group.ts` :
+
+```typescript
+import { LitElement, html, nothing, type PropertyValues } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { ContextProvider } from '@lit/context';
+import { tabGroupContext, type TabGroupRegistry } from '../../context/tabs.context.js';
+import type { ArTab } from '../tab/tab.js';
+import type { ArTabPanel } from '../tab-panel/tab-panel.js';
+import { warn } from '../../utils/warn.js';
+import styles from './tab-group.styles.js';
+
+/**
+ * @summary Groupe d'onglets accessibles — pattern WAI-ARIA Tabs complet.
+ * @display demo
+ *
+ * @slot - ar-tab et ar-tab-panel enfants.
+ *
+ * @csspart base - Conteneur racine.
+ * @csspart nav  - Zone scrollable (overflow-x: auto).
+ * @csspart tabs - div[role="tablist"].
+ *
+ * @cssprop [--ar-tab-group-gap=0] - Espacement entre tablist et panels.
+ *
+ * @event {CustomEvent<{ active: string }>} ar-tab-group-change - Émis quand l'onglet actif change.
+ */
+@customElement('ar-tab-group')
+export class ArTabGroup extends LitElement {
+    static override styles = [styles];
+
+    /** Nom de l'onglet actif. Si absent, le premier onglet non-disabled s'active. */
+    @property({ reflect: true }) active = '';
+
+    /** aria-label sur le tablist — recommandé si plusieurs ar-tab-group sur la page. */
+    @property({ reflect: true }) label = '';
+
+    /** Active le mode manuel : les flèches déplacent le focus sans activer l'onglet. */
+    @property({ attribute: 'manual-activation', reflect: true, type: Boolean })
+    manualActivation = false;
+
+    /** Active les classes has-overflow-start / has-overflow-end sur part="nav". */
+    @property({ attribute: 'scroll-hints', reflect: true, type: Boolean })
+    scrollHints = false;
+
+    private _tabs: ArTab[] = [];
+    private _panels: ArTabPanel[] = [];
+    private readonly _prefix = Math.random().toString(36).slice(2, 9);
+    private _resizeObserver?: ResizeObserver;
+    private _scrollHintsUnlisten?: () => void;
+
+    private readonly _registry: TabGroupRegistry = {
+        registerTab: (tab: ArTab) => {
+            if (!this._tabs.includes(tab)) {
+                this._tabs.push(tab);
+                this._tabs.sort((a, b) =>
+                    a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1,
+                );
+            }
+            tab.setAttribute('slot', 'tab');
+            this._syncAll();
+        },
+        unregisterTab: (tab: ArTab) => {
+            this._tabs = this._tabs.filter((t) => t !== tab);
+            this._syncAll();
+        },
+        registerPanel: (panel: ArTabPanel) => {
+            if (!this._panels.includes(panel)) {
+                this._panels.push(panel);
+            }
+            this._syncAll();
+        },
+        unregisterPanel: (panel: ArTabPanel) => {
+            this._panels = this._panels.filter((p) => p !== panel);
+            this._syncAll();
+        },
+        activate: (name: string) => {
+            if (this.active === name) return;
+            this.active = name;
+            this._syncAll();
+            this._scrollActiveTabIntoView();
+            this._emit('ar-tab-group-change', { active: name });
+        },
+    };
+
+    protected readonly _provider = new ContextProvider(this, {
+        context: tabGroupContext,
+        initialValue: this._registry,
+    });
+
+    override updated(changed: PropertyValues<this>): void {
+        if (changed.has('active')) {
+            this._syncAll();
+            this._scrollActiveTabIntoView();
+        }
+        if (changed.has('label')) {
+            const tablist = this.shadowRoot?.querySelector('[part="tabs"]');
+            if (tablist) {
+                if (this.label) tablist.setAttribute('aria-label', this.label);
+                else tablist.removeAttribute('aria-label');
+            }
+        }
+        if (changed.has('scrollHints')) {
+            this._setupScrollHints();
+        }
+    }
+
+    override connectedCallback(): void {
+        super.connectedCallback();
+        this.addEventListener('keydown', this._handleKeyDown);
+    }
+
+    override disconnectedCallback(): void {
+        super.disconnectedCallback();
+        this.removeEventListener('keydown', this._handleKeyDown);
+        this._resizeObserver?.disconnect();
+        this._scrollHintsUnlisten?.();
+    }
+
+    override render() {
+        return html`
+            <div part="base">
+                <div part="nav">
+                    <div part="tabs" role="tablist" aria-label=${this.label || nothing}>
+                        <slot name="tab"></slot>
+                    </div>
+                </div>
+                <slot></slot>
+            </div>
+        `;
+    }
+
+    private get _effectiveActive(): string {
+        const found = this._tabs.find((t) => t.panel === this.active && !t.disabled);
+        if (found) return this.active;
+        return this._tabs.find((t) => !t.disabled)?.panel ?? '';
+    }
+
+    private _syncAll(): void {
+        const active = this._effectiveActive;
+        const pfx = this._prefix;
+
+        this._tabs.forEach((tab) => {
+            const isActive = tab.panel === active;
+            tab.setAttribute('role', 'tab');
+            tab.id = `${pfx}-tab-${tab.panel}`;
+            tab.setAttribute('aria-controls', `${pfx}-panel-${tab.panel}`);
+            tab.setAttribute('aria-selected', String(isActive));
+            tab.setAttribute('tabindex', isActive ? '0' : '-1');
+            if (tab.disabled) {
+                tab.setAttribute('aria-disabled', 'true');
+            } else {
+                tab.removeAttribute('aria-disabled');
+            }
+            if (tab.panel && !this._panels.find((p) => p.name === tab.panel)) {
+                warn('ar-tab-group', `Aucun ar-tab-panel avec name="${tab.panel}" trouvé.`);
+            }
+        });
+
+        this._panels.forEach((panel) => {
+            const isActive = panel.name === active;
+            panel.setAttribute('role', 'tabpanel');
+            panel.id = `${pfx}-panel-${panel.name}`;
+            panel.setAttribute('aria-labelledby', `${pfx}-tab-${panel.name}`);
+            panel.setAttribute('tabindex', '0');
+            if (isActive) {
+                panel.removeAttribute('hidden');
+            } else {
+                panel.setAttribute('hidden', '');
+            }
+        });
+    }
+
+    private _scrollActiveTabIntoView(): void {
+        const active = this._effectiveActive;
+        const tab = this._tabs.find((t) => t.panel === active);
+        tab?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+    }
+
+    private _emit(name: string, detail: unknown): void {
+        this.dispatchEvent(new CustomEvent(name, { detail, bubbles: true, composed: true }));
+    }
+
+    private _handleKeyDown = (e: KeyboardEvent): void => {
+        const target = e.composedPath()[0] as Element;
+        if (!this._tabs.some((t) => t === target)) return;
+
+        const enabledTabs = this._tabs.filter((t) => !t.disabled);
+        const currentIdx = enabledTabs.findIndex((t) => t === target);
+
+        switch (e.key) {
+            case 'ArrowLeft':
+            case 'ArrowRight': {
+                e.preventDefault();
+                const dir = e.key === 'ArrowLeft' ? -1 : 1;
+                const newIdx = (currentIdx + dir + enabledTabs.length) % enabledTabs.length;
+                this._moveFocusTo(enabledTabs[newIdx]);
+                if (!this.manualActivation) {
+                    this._registry.activate(enabledTabs[newIdx].panel);
+                }
+                break;
+            }
+            case 'Home':
+                e.preventDefault();
+                this._moveFocusTo(enabledTabs[0]);
+                if (!this.manualActivation) this._registry.activate(enabledTabs[0].panel);
+                break;
+            case 'End':
+                e.preventDefault();
+                this._moveFocusTo(enabledTabs[enabledTabs.length - 1]);
+                if (!this.manualActivation)
+                    this._registry.activate(enabledTabs[enabledTabs.length - 1].panel);
+                break;
+            case 'Enter':
+            case ' ': // Espace — WAI-ARIA Tabs: Enter ET Space activent en mode manuel
+                if (this.manualActivation) {
+                    e.preventDefault();
+                    const tab = this._tabs.find((t) => t === target);
+                    if (tab) this._registry.activate(tab.panel);
+                }
+                break;
+        }
+    };
+
+    private _moveFocusTo(tab: ArTab): void {
+        this._tabs.forEach((t) => t.setAttribute('tabindex', '-1'));
+        tab.setAttribute('tabindex', '0');
+        tab.focus();
+    }
+
+    private _setupScrollHints(): void {
+        this._resizeObserver?.disconnect();
+        this._scrollHintsUnlisten?.();
+        this._scrollHintsUnlisten = undefined;
+
+        const nav = this.shadowRoot?.querySelector<HTMLElement>('[part="nav"]');
+        if (!nav || !this.scrollHints) return;
+
+        const update = () => {
+            nav.classList.toggle('has-overflow-start', nav.scrollLeft > 0);
+            nav.classList.toggle(
+                'has-overflow-end',
+                nav.scrollLeft + nav.clientWidth < nav.scrollWidth,
+            );
+        };
+
+        this._resizeObserver = new ResizeObserver(update);
+        this._resizeObserver.observe(nav);
+        nav.addEventListener('scroll', update, { passive: true });
+        this._scrollHintsUnlisten = () => nav.removeEventListener('scroll', update);
+        update();
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'ar-tab-group': ArTabGroup;
+    }
+}
+```
+
+- [ ] **Step 4 : Relancer les tests — vérifier le passage**
+
+```bash
+cd packages/core && npm run test -- --reporter=verbose tab-group/tab-group.test.ts
+```
+
+Attendu : PASS (tous les tests tab-group).
+
+- [ ] **Step 5 : Lancer l'ensemble des tests pour détecter les régressions**
+
+```bash
+cd packages/core && npm run test
+```
+
+Attendu : tous les tests passent.
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git add packages/core/src/components/tab-group/
+git commit -m "feat(tab-group): ar-tab-group — registry, ARIA, clavier"
+```
+
+---
+
+## Task 5 : Styles minimaux (tab-group, tab, tab-panel)
+
+**Files:**
+
+- Modify: `packages/core/src/components/tab-group/tab-group.styles.ts`
+- Modify: `packages/core/src/components/tab/tab.styles.ts`
+- Modify: `packages/core/src/components/tab-panel/tab-panel.styles.ts`
+
+> Les styles sont fonctionnels (layout, overflow, focus) sans imposer de design visuel — le design system complétera via `::part()`.
+
+- [ ] **Step 1 : Écrire tab-group.styles.ts**
+
+```typescript
+// packages/core/src/components/tab-group/tab-group.styles.ts
+import { css } from 'lit';
+
+export default css`
+    :host {
+        display: block;
+    }
+
+    [part='base'] {
+        display: flex;
+        flex-direction: column;
+        gap: var(--ar-tab-group-gap, 0);
+    }
+
+    [part='nav'] {
+        overflow-x: auto;
+        /* Masque la scrollbar native — le design system la styline via ::part(nav) */
+        scrollbar-width: none;
+    }
+
+    [part='nav']::-webkit-scrollbar {
+        display: none;
+    }
+
+    [part='tabs'] {
+        display: flex;
+        flex-direction: row;
+    }
+`;
+```
+
+- [ ] **Step 2 : Écrire tab.styles.ts**
+
+```typescript
+// packages/core/src/components/tab/tab.styles.ts
+import { css } from 'lit';
+
+export default css`
+    :host {
+        display: inline-flex;
+        cursor: pointer;
+        white-space: nowrap;
+        user-select: none;
+    }
+
+    :host([disabled]) {
+        cursor: not-allowed;
+        opacity: 0.5;
+    }
+
+    :host(:focus-visible) {
+        outline: 2px solid currentColor;
+        outline-offset: -2px;
+    }
+`;
+```
+
+- [ ] **Step 3 : Écrire tab-panel.styles.ts**
+
+```typescript
+// packages/core/src/components/tab-panel/tab-panel.styles.ts
+import { css } from 'lit';
+
+export default css`
+    :host {
+        display: block;
+    }
+
+    :host([hidden]) {
+        display: none;
+    }
+`;
+```
+
+- [ ] **Step 4 : Vérifier les tests**
+
+```bash
+cd packages/core && npm run test
+```
+
+Attendu : tous les tests passent.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add packages/core/src/components/tab-group/tab-group.styles.ts \
+        packages/core/src/components/tab/tab.styles.ts \
+        packages/core/src/components/tab-panel/tab-panel.styles.ts
+git commit -m "feat(tab-group): styles fonctionnels tab-group, tab, tab-panel"
+```
+
+---
+
+## Task 6 : Tests browser — clavier, scroll-hints, accessibilité
+
+**Files:**
+
+- Create: `packages/core/src/components/tab-group/tab-group.browser.test.ts`
+- Create: `packages/core/src/components/tab-group/tab-group.a11y.test.ts`
+
+- [ ] **Step 1 : Écrire tab-group.browser.test.ts**
+
+```typescript
+/// <reference types="mocha" />
+/**
+ * tab-group.browser.test.ts
+ *
+ * Tests nécessitant un vrai navigateur (Chromium via @web/test-runner) :
+ *   - Navigation clavier (flèches, Home, End, Enter/Space)
+ *   - Activation automatique vs manuelle
+ *   - scroll-hints (has-overflow-start / has-overflow-end)
+ *   - scrollIntoView au changement d'onglet
+ */
+import { fixture, html, expect, aTimeout } from '@open-wc/testing';
+import type { ArTabGroup } from './tab-group.js';
+import './tab-group.js';
+import '../tab/tab.js';
+import '../tab-panel/tab-panel.js';
+
+function getTab(el: ArTabGroup, panel: string): HTMLElement {
+    const tab = el.querySelector<HTMLElement>(`ar-tab[panel="${panel}"]`);
+    if (!tab) throw new Error(`ar-tab[panel="${panel}"] introuvable`);
+    return tab;
+}
+
+function getNav(el: ArTabGroup): HTMLElement {
+    const nav = el.shadowRoot?.querySelector<HTMLElement>('[part="nav"]');
+    if (!nav) throw new Error('[part="nav"] introuvable');
+    return nav;
+}
+
+describe('ar-tab-group — browser', () => {
+    // ── Activation par clic ────────────────────────────────────────────────
+
+    describe('activation par clic', () => {
+        it('affiche le panel correspondant et masque les autres', async () => {
+            const wrapper = await fixture<HTMLElement>(html`
+                <ar-tab-group>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab panel="b">B</ar-tab>
+                    <ar-tab-panel name="a">Panel A</ar-tab-panel>
+                    <ar-tab-panel name="b">Panel B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            const el = wrapper.querySelector<ArTabGroup>('ar-tab-group')!;
+            getTab(el, 'b').click();
+            await el.updateComplete;
+            expect(el.querySelector('ar-tab-panel[name="b"]')!.hasAttribute('hidden')).to.equal(
+                false,
+            );
+            expect(el.querySelector('ar-tab-panel[name="a"]')!.hasAttribute('hidden')).to.equal(
+                true,
+            );
+        });
+
+        it('émet ar-tab-group-change avec { active }', async () => {
+            const wrapper = await fixture<HTMLElement>(html`
+                <ar-tab-group>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab panel="b">B</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            const el = wrapper.querySelector<ArTabGroup>('ar-tab-group')!;
+            const events: CustomEvent[] = [];
+            el.addEventListener('ar-tab-group-change', (e) => events.push(e as CustomEvent));
+            getTab(el, 'b').click();
+            await el.updateComplete;
+            expect(events[0].detail.active).to.equal('b');
+        });
+    });
+
+    // ── Navigation clavier — activation automatique ────────────────────────
+
+    describe('navigation clavier — mode automatique', () => {
+        it('ArrowRight active le tab suivant', async () => {
+            const wrapper = await fixture<HTMLElement>(html`
+                <ar-tab-group>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab panel="b">B</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            const el = wrapper.querySelector<ArTabGroup>('ar-tab-group')!;
+            getTab(el, 'a').focus();
+            getTab(el, 'a').dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, composed: true }),
+            );
+            await el.updateComplete;
+            expect(el.active).to.equal('b');
+            expect(getTab(el, 'b').getAttribute('aria-selected')).to.equal('true');
+        });
+
+        it('ArrowLeft active le tab précédent (wrap)', async () => {
+            const wrapper = await fixture<HTMLElement>(html`
+                <ar-tab-group>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab panel="b">B</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            const el = wrapper.querySelector<ArTabGroup>('ar-tab-group')!;
+            getTab(el, 'a').focus();
+            getTab(el, 'a').dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true, composed: true }),
+            );
+            await el.updateComplete;
+            expect(el.active).to.equal('b');
+        });
+
+        it('Home active le premier tab', async () => {
+            const wrapper = await fixture<HTMLElement>(html`
+                <ar-tab-group active="b">
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab panel="b">B</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            const el = wrapper.querySelector<ArTabGroup>('ar-tab-group')!;
+            getTab(el, 'b').focus();
+            getTab(el, 'b').dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'Home', bubbles: true, composed: true }),
+            );
+            await el.updateComplete;
+            expect(el.active).to.equal('a');
+        });
+
+        it('End active le dernier tab', async () => {
+            const wrapper = await fixture<HTMLElement>(html`
+                <ar-tab-group>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab panel="b">B</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            const el = wrapper.querySelector<ArTabGroup>('ar-tab-group')!;
+            getTab(el, 'a').focus();
+            getTab(el, 'a').dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'End', bubbles: true, composed: true }),
+            );
+            await el.updateComplete;
+            expect(el.active).to.equal('b');
+        });
+    });
+
+    // ── Navigation clavier — activation manuelle ───────────────────────────
+
+    describe('navigation clavier — manual-activation', () => {
+        it('ArrowRight déplace le focus sans changer active', async () => {
+            const wrapper = await fixture<HTMLElement>(html`
+                <ar-tab-group manual-activation>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab panel="b">B</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            const el = wrapper.querySelector<ArTabGroup>('ar-tab-group')!;
+            getTab(el, 'a').focus();
+            getTab(el, 'a').dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, composed: true }),
+            );
+            await el.updateComplete;
+            expect(el.active).to.equal('a');
+            expect(document.activeElement).to.equal(getTab(el, 'b'));
+        });
+
+        it('Enter sur le tab focusé active le panel', async () => {
+            const wrapper = await fixture<HTMLElement>(html`
+                <ar-tab-group manual-activation>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab panel="b">B</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            const el = wrapper.querySelector<ArTabGroup>('ar-tab-group')!;
+            getTab(el, 'a').focus();
+            getTab(el, 'a').dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, composed: true }),
+            );
+            await el.updateComplete;
+            getTab(el, 'b').dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, composed: true }),
+            );
+            await el.updateComplete;
+            expect(el.active).to.equal('b');
+        });
+    });
+
+    // ── scroll-hints ───────────────────────────────────────────────────────
+
+    describe('scroll-hints', () => {
+        it('ajoute has-overflow-end quand le contenu déborde', async () => {
+            const wrapper = await fixture<HTMLElement>(html`
+                <div style="width: 100px; overflow: hidden;">
+                    <ar-tab-group scroll-hints>
+                        <ar-tab panel="a" style="min-width:60px">A</ar-tab>
+                        <ar-tab panel="b" style="min-width:60px">B</ar-tab>
+                        <ar-tab panel="c" style="min-width:60px">C</ar-tab>
+                        <ar-tab-panel name="a">A</ar-tab-panel>
+                        <ar-tab-panel name="b">B</ar-tab-panel>
+                        <ar-tab-panel name="c">C</ar-tab-panel>
+                    </ar-tab-group>
+                </div>
+            `);
+            const el = wrapper.querySelector<ArTabGroup>('ar-tab-group')!;
+            await aTimeout(50);
+            const nav = getNav(el);
+            expect(nav.classList.contains('has-overflow-end')).to.equal(true);
+        });
+
+        it("n'ajoute pas has-overflow-start si scroll à 0", async () => {
+            const wrapper = await fixture<HTMLElement>(html`
+                <div style="width: 100px; overflow: hidden;">
+                    <ar-tab-group scroll-hints>
+                        <ar-tab panel="a" style="min-width:60px">A</ar-tab>
+                        <ar-tab panel="b" style="min-width:60px">B</ar-tab>
+                        <ar-tab panel="c" style="min-width:60px">C</ar-tab>
+                        <ar-tab-panel name="a">A</ar-tab-panel>
+                        <ar-tab-panel name="b">B</ar-tab-panel>
+                        <ar-tab-panel name="c">C</ar-tab-panel>
+                    </ar-tab-group>
+                </div>
+            `);
+            const el = wrapper.querySelector<ArTabGroup>('ar-tab-group')!;
+            await aTimeout(50);
+            const nav = getNav(el);
+            expect(nav.classList.contains('has-overflow-start')).to.equal(false);
+        });
+    });
+});
+```
+
+- [ ] **Step 2 : Écrire tab-group.a11y.test.ts**
+
+```typescript
+/// <reference types="mocha" />
+/**
+ * tab-group.a11y.test.ts
+ *
+ * Tests d'accessibilité structurels — WAI-ARIA Tabs pattern.
+ */
+import { fixture, html, expect } from '@open-wc/testing';
+import type { ArTabGroup } from './tab-group.js';
+import './tab-group.js';
+import '../tab/tab.js';
+import '../tab-panel/tab-panel.js';
+
+describe('ar-tab-group — accessibilité', () => {
+    // ── Rôles ARIA ─────────────────────────────────────────────────────────
+
+    describe('rôles ARIA', () => {
+        it('le tablist a role="tablist"', async () => {
+            const wrapper = await fixture<HTMLElement>(html`
+                <ar-tab-group>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            const el = wrapper.querySelector<ArTabGroup>('ar-tab-group')!;
+            const tablist = el.shadowRoot?.querySelector('[part="tabs"]');
+            expect(tablist?.getAttribute('role')).to.equal('tablist');
+        });
+
+        it('chaque ar-tab a role="tab"', async () => {
+            const wrapper = await fixture<HTMLElement>(html`
+                <ar-tab-group>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab panel="b">B</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            const el = wrapper.querySelector<ArTabGroup>('ar-tab-group')!;
+            el.querySelectorAll('ar-tab').forEach((tab) => {
+                expect(tab.getAttribute('role')).to.equal('tab');
+            });
+        });
+
+        it('chaque ar-tab-panel a role="tabpanel"', async () => {
+            const wrapper = await fixture<HTMLElement>(html`
+                <ar-tab-group>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            const el = wrapper.querySelector<ArTabGroup>('ar-tab-group')!;
+            expect(el.querySelector('ar-tab-panel')!.getAttribute('role')).to.equal('tabpanel');
+        });
+    });
+
+    // ── Associations ARIA ──────────────────────────────────────────────────
+
+    describe('associations ARIA (light DOM → light DOM)', () => {
+        it("aria-controls du tab pointe vers l'ID du panel (même arbre)", async () => {
+            const wrapper = await fixture<HTMLElement>(html`
+                <ar-tab-group>
+                    <ar-tab panel="intro">Intro</ar-tab>
+                    <ar-tab-panel name="intro">Contenu</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            const el = wrapper.querySelector<ArTabGroup>('ar-tab-group')!;
+            const tab = el.querySelector<HTMLElement>('ar-tab[panel="intro"]')!;
+            const panel = el.querySelector<HTMLElement>('ar-tab-panel[name="intro"]')!;
+            expect(tab.getAttribute('aria-controls')).to.equal(panel.id);
+            // Vérifie que l'ID référencé est bien résolvable dans le light DOM
+            expect(document.getElementById(panel.id)).to.equal(panel);
+        });
+
+        it("aria-labelledby du panel pointe vers l'ID du tab (même arbre)", async () => {
+            const wrapper = await fixture<HTMLElement>(html`
+                <ar-tab-group>
+                    <ar-tab panel="intro">Intro</ar-tab>
+                    <ar-tab-panel name="intro">Contenu</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            const el = wrapper.querySelector<ArTabGroup>('ar-tab-group')!;
+            const tab = el.querySelector<HTMLElement>('ar-tab[panel="intro"]')!;
+            const panel = el.querySelector<HTMLElement>('ar-tab-panel[name="intro"]')!;
+            expect(panel.getAttribute('aria-labelledby')).to.equal(tab.id);
+            expect(document.getElementById(tab.id)).to.equal(tab);
+        });
+    });
+
+    // ── État sélectionné ───────────────────────────────────────────────────
+
+    describe('état sélectionné', () => {
+        it('le tab actif a aria-selected="true"', async () => {
+            const wrapper = await fixture<HTMLElement>(html`
+                <ar-tab-group>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            const el = wrapper.querySelector<ArTabGroup>('ar-tab-group')!;
+            expect(el.querySelector('ar-tab')!.getAttribute('aria-selected')).to.equal('true');
+        });
+
+        it('les tabs inactifs ont aria-selected="false"', async () => {
+            const wrapper = await fixture<HTMLElement>(html`
+                <ar-tab-group>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab panel="b">B</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            const el = wrapper.querySelector<ArTabGroup>('ar-tab-group')!;
+            expect(el.querySelector('ar-tab[panel="b"]')!.getAttribute('aria-selected')).to.equal(
+                'false',
+            );
+        });
+    });
+
+    // ── Panneau masqué ─────────────────────────────────────────────────────
+
+    describe('panneau masqué', () => {
+        it("le panel inactif a l'attribut hidden", async () => {
+            const wrapper = await fixture<HTMLElement>(html`
+                <ar-tab-group>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab panel="b">B</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            const el = wrapper.querySelector<ArTabGroup>('ar-tab-group')!;
+            expect(el.querySelector('ar-tab-panel[name="b"]')!.hasAttribute('hidden')).to.equal(
+                true,
+            );
+        });
+
+        it("le panel actif n'a pas l'attribut hidden", async () => {
+            const wrapper = await fixture<HTMLElement>(html`
+                <ar-tab-group>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            const el = wrapper.querySelector<ArTabGroup>('ar-tab-group')!;
+            expect(el.querySelector('ar-tab-panel[name="a"]')!.hasAttribute('hidden')).to.equal(
+                false,
+            );
+        });
+    });
+
+    // ── Roving tabindex ────────────────────────────────────────────────────
+
+    describe('roving tabindex', () => {
+        it('le tab actif a tabindex="0", les inactifs tabindex="-1"', async () => {
+            const wrapper = await fixture<HTMLElement>(html`
+                <ar-tab-group>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab panel="b">B</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            const el = wrapper.querySelector<ArTabGroup>('ar-tab-group')!;
+            expect(el.querySelector('ar-tab[panel="a"]')!.getAttribute('tabindex')).to.equal('0');
+            expect(el.querySelector('ar-tab[panel="b"]')!.getAttribute('tabindex')).to.equal('-1');
+        });
+    });
+});
+```
+
+- [ ] **Step 3 : Lancer les tests browser**
+
+```bash
+cd packages/core && npm run test:browser
+```
+
+Attendu : tous les tests browser passent.
+
+- [ ] **Step 4 : Commit**
+
+```bash
+git add packages/core/src/components/tab-group/tab-group.browser.test.ts \
+        packages/core/src/components/tab-group/tab-group.a11y.test.ts
+git commit -m "test(tab-group): tests browser clavier, scroll-hints et accessibilité"
+```
+
+---
+
+## Task 7 : Documentation MDX
+
+**Files:**
+
+- Modify: `apps/docs/src/content/components/ar-tab-group.mdx`
+- Modify: `apps/docs/src/content/components/ar-tab.mdx`
+- Modify: `apps/docs/src/content/components/ar-tab-panel.mdx`
+
+- [ ] **Step 1 : Écrire ar-tab-group.mdx**
+
+Remplacer `apps/docs/src/content/components/ar-tab-group.mdx` :
+
+```mdx
+---
+tagName: ar-tab-group
+title: Tab Group
+description: Groupe d'onglets accessibles — pattern WAI-ARIA Tabs complet avec roving tabindex et gestion du scroll horizontal.
+playgroundTemplate: default
+variants:
+    - name: default
+      label: Par défaut
+      description: Déclarer les onglets avec `<ar-tab panel="nom">` et les panneaux avec `<ar-tab-panel name="nom">`. L'association se fait par correspondance du nom.
+      html: |
+          <ar-tab-group>
+              <ar-tab panel="intro">Introduction</ar-tab>
+              <ar-tab panel="usage">Utilisation</ar-tab>
+              <ar-tab panel="api">API</ar-tab>
+              <ar-tab-panel name="intro">Contenu de l'onglet Introduction.</ar-tab-panel>
+              <ar-tab-panel name="usage">Contenu de l'onglet Utilisation.</ar-tab-panel>
+              <ar-tab-panel name="api">Contenu de l'onglet API.</ar-tab-panel>
+          </ar-tab-group>
+    - name: active
+      label: Onglet initial
+      description: Utilisez l'attribut `active` pour définir l'onglet ouvert par défaut.
+      html: |
+          <ar-tab-group active="usage">
+              <ar-tab panel="intro">Introduction</ar-tab>
+              <ar-tab panel="usage">Utilisation</ar-tab>
+              <ar-tab panel="api">API</ar-tab>
+              <ar-tab-panel name="intro">Introduction.</ar-tab-panel>
+              <ar-tab-panel name="usage">Cet onglet est actif par défaut.</ar-tab-panel>
+              <ar-tab-panel name="api">API.</ar-tab-panel>
+          </ar-tab-group>
+    - name: disabled
+      label: Onglet désactivé
+      description: L'attribut `disabled` sur un `<ar-tab>` rend l'onglet non sélectionnable et l'exclut de la navigation clavier.
+      html: |
+          <ar-tab-group>
+              <ar-tab panel="a">Actif</ar-tab>
+              <ar-tab panel="b" disabled>Désactivé</ar-tab>
+              <ar-tab panel="c">Actif aussi</ar-tab>
+              <ar-tab-panel name="a">Panel A.</ar-tab-panel>
+              <ar-tab-panel name="b">Panel B (inaccessible).</ar-tab-panel>
+              <ar-tab-panel name="c">Panel C.</ar-tab-panel>
+          </ar-tab-group>
+    - name: manual-activation
+      label: Activation manuelle
+      description: Avec `manual-activation`, les flèches déplacent le focus sans changer l'onglet actif — il faut appuyer sur Entrée ou Espace pour confirmer. Utile quand le contenu du panel est coûteux à charger.
+      html: |
+          <ar-tab-group manual-activation>
+              <ar-tab panel="a">Tab A</ar-tab>
+              <ar-tab panel="b">Tab B</ar-tab>
+              <ar-tab panel="c">Tab C</ar-tab>
+              <ar-tab-panel name="a">Panel A.</ar-tab-panel>
+              <ar-tab-panel name="b">Panel B.</ar-tab-panel>
+              <ar-tab-panel name="c">Panel C.</ar-tab-panel>
+          </ar-tab-group>
+    - name: scroll-hints
+      label: Scroll hints
+      description: L'attribut `scroll-hints` ajoute les classes `has-overflow-start` et `has-overflow-end` sur `part="nav"` quand du contenu est masqué de chaque côté. La demo ci-dessous utilise un `mask-image` CSS pour signaler l'overflow.
+      html: |
+          <style>
+              .demo-scroll ar-tab-group::part(nav) {
+                  --mask-start: linear-gradient(to right, transparent 0, black 3rem);
+                  --mask-end: linear-gradient(to left, transparent 0, black 3rem);
+                  mask-image: var(--mask-start-active, none), var(--mask-end-active, none);
+              }
+              .demo-scroll ar-tab-group::part(nav).has-overflow-start {
+                  --mask-start-active: var(--mask-start);
+              }
+              .demo-scroll ar-tab-group::part(nav).has-overflow-end {
+                  --mask-end-active: var(--mask-end);
+              }
+          </style>
+          <div class="demo-scroll" style="max-width: 300px;">
+              <ar-tab-group scroll-hints>
+                  <ar-tab panel="a">Premier onglet</ar-tab>
+                  <ar-tab panel="b">Deuxième onglet</ar-tab>
+                  <ar-tab panel="c">Troisième onglet</ar-tab>
+                  <ar-tab panel="d">Quatrième onglet</ar-tab>
+                  <ar-tab-panel name="a">Panel A.</ar-tab-panel>
+                  <ar-tab-panel name="b">Panel B.</ar-tab-panel>
+                  <ar-tab-panel name="c">Panel C.</ar-tab-panel>
+                  <ar-tab-panel name="d">Panel D.</ar-tab-panel>
+              </ar-tab-group>
+          </div>
+---
+
+import WcagRef from '../../components/WcagRef.astro';
+
+## Accessibilité
+
+### Pris en charge automatiquement
+
+- Le tablist reçoit `role="tablist"`, chaque onglet `role="tab"` et chaque panneau `role="tabpanel"`.
+- Les associations `aria-controls` (onglet → panneau) et `aria-labelledby` (panneau → onglet) sont calculées et posées automatiquement sur les hôtes en light DOM — les IDREF restent dans le même arbre et sont lisibles par les technologies d'assistance.
+- <WcagRef
+      criterion="2.1.1"
+      summary="Keyboard : toutes les fonctionnalités doivent être accessibles au clavier."
+  />
+  : navigation ←/→ entre les onglets, `Home`/`End` pour le premier/dernier, `Tab` pour atteindre le
+  panneau actif.
+- L'onglet actif a `tabindex="0"`, les inactifs `tabindex="-1"` (roving tabindex).
+- Les panneaux inactifs ont l'attribut `hidden` natif — exclus du flux de tabulation et invisibles aux lecteurs d'écran.
+
+### Scroll horizontal et overflow
+
+<WcagRef
+    criterion="1.4.10"
+    summary="Reflow : le contenu doit être accessible à 320px de large sans scroll horizontal."
+/>
+
+Le tablist utilise un scroll horizontal natif (`overflow-x: auto`). Les onglets restent toujours accessibles au clavier via les flèches (l'onglet actif est automatiquement ramené dans le viewport). Cette approche s'appuie sur l'exception WCAG 1.4.10 pour les éléments de navigation à mise en page bidimensionnelle.
+
+**Recommandations pour votre design system :**
+
+- Utilisez `scroll-hints` et branchez un `mask-image` CSS sur `.has-overflow-end` / `.has-overflow-start` pour signaler visuellement l'overflow aux utilisateurs souris (voir la variante _Scroll hints_).
+- Si une scrollbar visible est souhaitée, stylez `ar-tab-group::part(nav)::-webkit-scrollbar` et `scrollbar-width`.
+
+### À la charge de l'auteur
+
+- **Nommer le tablist** : si la page contient plusieurs `ar-tab-group`, ajoutez l'attribut `label` sur chacun — il devient l'`aria-label` du tablist, permettant aux lecteurs d'écran de les distinguer.
+- **Libellés des onglets** : le texte visible de l'onglet est son nom accessible. Évitez les onglets avec des icônes seules sans texte alternatif (`aria-label` sur `ar-tab`).
+```
+
+- [ ] **Step 2 : Mettre à jour ar-tab.mdx**
+
+Remplacer `apps/docs/src/content/components/ar-tab.mdx` :
+
+```mdx
+---
+tagName: ar-tab
+title: Tab
+description: Onglet déclencheur pour ar-tab-group. Pose automatiquement role="tab", tabindex et aria-controls sur son hôte via le registry de ar-tab-group.
+---
+
+Sous-composant de [`ar-tab-group`](/components/ar-tab-group). À utiliser exclusivement comme enfant direct de `ar-tab-group`.
+```
+
+- [ ] **Step 3 : Mettre à jour ar-tab-panel.mdx**
+
+Remplacer `apps/docs/src/content/components/ar-tab-panel.mdx` :
+
+```mdx
+---
+tagName: ar-tab-panel
+title: Tab Panel
+description: Panneau de contenu pour ar-tab-group. Pose automatiquement role="tabpanel", tabindex et aria-labelledby sur son hôte via le registry de ar-tab-group.
+---
+
+Sous-composant de [`ar-tab-group`](/components/ar-tab-group). À utiliser exclusivement comme enfant direct de `ar-tab-group`.
+```
+
+- [ ] **Step 4 : Vérifier la compilation du site de documentation**
+
+```bash
+cd apps/docs && npm run build 2>&1 | tail -20
+```
+
+Attendu : build sans erreur.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add apps/docs/src/content/components/ar-tab-group.mdx \
+        apps/docs/src/content/components/ar-tab.mdx \
+        apps/docs/src/content/components/ar-tab-panel.mdx
+git commit -m "docs(tab-group): documentation MDX — variantes, accessibilité, scroll"
+```
+
+---
+
+## Task 8 : Branche et PR
+
+- [ ] **Step 1 : Vérifier que tous les tests passent**
+
+```bash
+npm run test:all
+```
+
+Attendu : tous les tests Vitest + WTR passent.
+
+- [ ] **Step 2 : Vérifier les exports dans index.ts**
+
+```bash
+grep -n 'ArTab\|ArTabGroup\|ArTabPanel' packages/core/src/index.ts
+```
+
+Attendu : les trois classes sont exportées.
+
+- [ ] **Step 3 : Pousser la branche**
+
+```bash
+git push -u origin feat/ar-tab-group
+```
+
+- [ ] **Step 4 : Créer la PR vers dev**
+
+```bash
+gh pr create \
+  --base dev \
+  --title "feat(tab-group): ar-tab-group, ar-tab, ar-tab-panel — WAI-ARIA Tabs" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Implémente le pattern WAI-ARIA Tabs complet via trois éléments : `ar-tab-group`, `ar-tab`, `ar-tab-panel`
+- Communication via `@lit/context` registry — ARIA (role, IDs, aria-controls, aria-labelledby) posé sur les hôtes light DOM
+- Roving tabindex, navigation clavier ←/→ Home/End, activation automatique et manuelle (`manual-activation`)
+- Scroll horizontal avec `scrollIntoView` + mécanisme `scroll-hints` (classes CSS dynamiques)
+
+## Test plan
+
+- [ ] `npm run test` — tous les tests Vitest passent
+- [ ] `npm run test:all` — tests WTR browser + a11y passent
+- [ ] Tester manuellement la navigation clavier dans le navigateur
+- [ ] Vérifier la démo scroll-hints dans la doc
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/docs/superpowers/plans/2026-05-08-ar-tab-group-style.md
+++ b/docs/superpowers/plans/2026-05-08-ar-tab-group-style.md
@@ -1,0 +1,384 @@
+# ar-tab-group Style Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Appliquer l'ADR-004 sur ar-tab / ar-tab-group / ar-tab-panel — styles internes fixes, tokens CSS `--ar-tab-*`, thème par défaut.
+
+**Architecture:** Trois couches par composant : (1) styles structurels/a11y non-surchargeables dans le Shadow DOM, (2) tokens `--ar-tab-*` déclarés avec fallback no-op dans les styles du composant, composés par le thème pour produire un rendu underline par défaut, (3) `::part()` déjà en place, aucun ajout. Le thème `default.css` expose les tokens ergonomiques (`--ar-tab-indicator-color`, `--ar-tab-indicator-width`) et compose `--ar-tab-active-shadow` à partir de ceux-ci.
+
+**Tech Stack:** Lit 3, TypeScript, CSS custom properties, `default.css` sous `@layer ariane.theme`
+
+**Spec de référence :** `docs/superpowers/specs/2026-05-08-ar-tab-group-style-design.md`
+**ADR :** `docs/decisions/ADR-004-philosophie-style-composants.md`
+
+---
+
+## Fichiers concernés
+
+| Fichier                                                      | Action                               |
+| ------------------------------------------------------------ | ------------------------------------ |
+| `packages/core/src/components/tab/tab.styles.ts`             | Modifier — appliquer tous les tokens |
+| `packages/core/src/components/tab-group/tab-group.styles.ts` | Modifier — ajouter séparateur        |
+| `packages/core/src/components/tab/tab.ts`                    | Modifier — ajouter `@cssprop` JSDoc  |
+| `packages/core/src/components/tab-group/tab-group.ts`        | Modifier — ajouter `@cssprop` JSDoc  |
+| `packages/core/src/styles/themes/default.css`                | Modifier — section `/* tab */`       |
+| `apps/docs/src/content/components/ar-tab-group.mdx`          | Modifier — variante démo styling     |
+
+---
+
+## Task 1 : Styles `ar-tab` — tab.styles.ts
+
+**Files:**
+
+- Modify: `packages/core/src/components/tab/tab.styles.ts`
+
+- [ ] **Remplacer le contenu de `tab.styles.ts` par les styles complets**
+
+```typescript
+import { css } from 'lit';
+
+export default css`
+    :host {
+        display: inline-flex;
+        cursor: pointer;
+        white-space: nowrap;
+        user-select: none;
+        border-radius: var(--ar-tab-border-radius, 0);
+        font-weight: var(--ar-tab-font-weight, inherit);
+    }
+
+    [part='base'] {
+        display: flex;
+        align-items: center;
+        color: var(--ar-tab-color, inherit);
+        background: var(--ar-tab-bg, transparent);
+        padding: var(--ar-tab-padding-y, 0.5rem) var(--ar-tab-padding-x, 1rem);
+        border-radius: inherit;
+    }
+
+    :host(:hover:not([disabled])) [part='base'] {
+        color: var(--ar-tab-hover-color, inherit);
+        background: var(--ar-tab-hover-bg, transparent);
+    }
+
+    :host([aria-selected='true']) [part='base'] {
+        color: var(--ar-tab-active-color, inherit);
+        background: var(--ar-tab-active-bg, transparent);
+        box-shadow: var(--ar-tab-active-shadow, none);
+    }
+
+    :host([disabled]) {
+        cursor: not-allowed;
+        opacity: var(--ar-tab-disabled-opacity, 0.5);
+    }
+
+    :host(:focus-visible) {
+        outline: 2px solid var(--ar-focus-ring-color, currentColor);
+        outline-offset: var(--ar-focus-ring-offset, 2px);
+    }
+`;
+```
+
+Note : `color`, `background` et `box-shadow` sont sur `[part="base"]` et non sur `:host` pour qu'ils soient accessibles et surchargeables via `ar-tab::part(base)`. `border-radius` est sur `:host` et hérité par `[part="base"]` via `border-radius: inherit`.
+
+- [ ] **Vérifier que les tests passent**
+
+```bash
+npm run test
+```
+
+Résultat attendu : `438 passed` (ou plus si des tests ont été ajoutés).
+
+- [ ] **Commit**
+
+```bash
+git add packages/core/src/components/tab/tab.styles.ts
+git commit -m "feat(tab): styles tokens — default, hover, actif, disabled, focus"
+```
+
+---
+
+## Task 2 : Styles `ar-tab-group` — séparateur tablist/panels
+
+**Files:**
+
+- Modify: `packages/core/src/components/tab-group/tab-group.styles.ts`
+
+- [ ] **Ajouter le séparateur sur `[part='nav']` dans `tab-group.styles.ts`**
+
+Contenu complet du fichier après modification :
+
+```typescript
+import { css } from 'lit';
+
+export default css`
+    :host {
+        display: block;
+    }
+
+    [part='base'] {
+        display: flex;
+        flex-direction: column;
+        gap: var(--ar-tab-group-gap, 0);
+    }
+
+    [part='nav'] {
+        overflow-x: auto;
+        scrollbar-width: none;
+        border-bottom: var(--ar-tab-group-border-width, 0) solid
+            var(--ar-tab-group-border-color, transparent);
+    }
+
+    [part='nav']::-webkit-scrollbar {
+        display: none;
+    }
+
+    [part='tabs'] {
+        display: flex;
+        flex-direction: row;
+    }
+`;
+```
+
+- [ ] **Vérifier que les tests passent**
+
+```bash
+npm run test
+```
+
+Résultat attendu : même nombre de tests passants qu'à la Task 1.
+
+- [ ] **Commit**
+
+```bash
+git add packages/core/src/components/tab-group/tab-group.styles.ts
+git commit -m "feat(tab-group): token séparateur --ar-tab-group-border-*"
+```
+
+---
+
+## Task 3 : JSDoc `@cssprop` — tab.ts et tab-group.ts
+
+**Files:**
+
+- Modify: `packages/core/src/components/tab/tab.ts`
+- Modify: `packages/core/src/components/tab-group/tab-group.ts`
+
+- [ ] **Ajouter les `@cssprop` dans le JSDoc de `ArTab` (tab.ts)**
+
+Remplacer le bloc JSDoc du composant (lignes 8–15 environ) par :
+
+```typescript
+/**
+ * @summary Onglet déclencheur pour ar-tab-group.
+ * @parent ar-tab-group
+ * @display docs
+ *
+ * @slot - Libellé de l'onglet.
+ *
+ * @csspart base - Wrapper du slot — couleur, fond, padding, box-shadow actif.
+ *
+ * @cssprop [--ar-tab-color=inherit] - Couleur du texte (état par défaut).
+ * @cssprop [--ar-tab-bg=transparent] - Fond (état par défaut).
+ * @cssprop [--ar-tab-padding-x=1rem] - Padding horizontal.
+ * @cssprop [--ar-tab-padding-y=0.5rem] - Padding vertical.
+ * @cssprop [--ar-tab-border-radius=0] - Rayon de bordure (utile pour le style pill).
+ * @cssprop [--ar-tab-font-weight=inherit] - Graisse du texte.
+ * @cssprop [--ar-tab-hover-color=inherit] - Couleur du texte au survol.
+ * @cssprop [--ar-tab-hover-bg=transparent] - Fond au survol.
+ * @cssprop [--ar-tab-active-color=inherit] - Couleur du texte quand l'onglet est actif.
+ * @cssprop [--ar-tab-active-bg=transparent] - Fond quand l'onglet est actif.
+ * @cssprop [--ar-tab-active-shadow=none] - box-shadow complet sur part="base" quand actif. Le thème par défaut le compose depuis --ar-tab-indicator-color et --ar-tab-indicator-width.
+ * @cssprop [--ar-tab-indicator-color=currentColor] - Couleur de l'indicateur actif (utilisé par le thème pour composer --ar-tab-active-shadow).
+ * @cssprop [--ar-tab-indicator-width=2px] - Épaisseur de l'indicateur actif (utilisé par le thème pour composer --ar-tab-active-shadow).
+ * @cssprop [--ar-tab-disabled-opacity=0.5] - Opacité de l'onglet désactivé.
+ */
+```
+
+- [ ] **Ajouter les `@cssprop` dans le JSDoc de `ArTabGroup` (tab-group.ts)**
+
+Remplacer le bloc JSDoc du composant (lignes 11–23 environ) par :
+
+```typescript
+/**
+ * @summary Groupe d'onglets accessibles — pattern WAI-ARIA Tabs complet.
+ * @display demo
+ *
+ * @slot - ar-tab et ar-tab-panel enfants.
+ *
+ * @csspart base - Conteneur racine.
+ * @csspart nav  - Zone scrollable (overflow-x: auto).
+ * @csspart tabs - div[role="tablist"].
+ *
+ * @cssprop [--ar-tab-group-gap=0] - Espacement entre tablist et panels.
+ * @cssprop [--ar-tab-group-border-width=0] - Épaisseur du trait séparateur sous la tablist. Mettre à 1px pour l'activer.
+ * @cssprop [--ar-tab-group-border-color=transparent] - Couleur du trait séparateur sous la tablist.
+ *
+ * @event {CustomEvent<{ active: string }>} ar-tab-group-change - Émis quand l'onglet actif change.
+ */
+```
+
+- [ ] **Régénérer le Custom Elements Manifest**
+
+```bash
+npm run build:manifest
+```
+
+Résultat attendu : `custom-elements.json` mis à jour sans erreur.
+
+- [ ] **Vérifier que les tests passent**
+
+```bash
+npm run test
+```
+
+- [ ] **Commit**
+
+```bash
+git add packages/core/src/components/tab/tab.ts packages/core/src/components/tab-group/tab-group.ts
+git commit -m "docs(tab,tab-group): @cssprop JSDoc pour tous les tokens"
+```
+
+---
+
+## Task 4 : Thème — section `ar-tab` dans `default.css`
+
+**Files:**
+
+- Modify: `packages/core/src/styles/themes/default.css`
+
+- [ ] **Ajouter la section tab à la fin de la section `6. TOKENS COMPOSANTS`**
+
+Juste avant la ligne `}` fermant `:root {` (après la dernière entrée, `--ar-table-padding-x: 1rem;`), ajouter :
+
+```css
+/* tab */
+--ar-tab-color: var(--ar-color-text-muted);
+--ar-tab-bg: transparent;
+--ar-tab-padding-x: 1rem;
+--ar-tab-padding-y: 0.5rem;
+--ar-tab-border-radius: 0;
+--ar-tab-font-weight: var(--ar-font-weight-normal);
+
+--ar-tab-hover-color: var(--ar-color-text);
+--ar-tab-hover-bg: transparent;
+
+--ar-tab-active-color: var(--ar-color-interactive);
+--ar-tab-active-bg: transparent;
+--ar-tab-indicator-color: var(--ar-color-interactive);
+--ar-tab-indicator-width: 2px;
+--ar-tab-active-shadow: inset 0 calc(-1 * var(--ar-tab-indicator-width)) 0
+    var(--ar-tab-indicator-color);
+
+--ar-tab-disabled-opacity: 0.5;
+
+--ar-tab-group-border-color: var(--ar-color-border);
+--ar-tab-group-border-width: 0;
+```
+
+Aucune surcharge dark mode nécessaire : tous ces tokens référencent des tokens sémantiques (`--ar-color-interactive`, `--ar-color-text-muted`, `--ar-color-border`) qui sont déjà surchargés dans `:root[data-theme='dark']` et `@media (prefers-color-scheme: dark)`.
+
+- [ ] **Vérifier que les tests passent**
+
+```bash
+npm run test
+```
+
+- [ ] **Commit**
+
+```bash
+git add packages/core/src/styles/themes/default.css
+git commit -m "feat(theme): tokens ar-tab — underline par défaut via --ar-tab-active-shadow"
+```
+
+---
+
+## Task 5 : Documentation MDX — variante styling
+
+**Files:**
+
+- Modify: `apps/docs/src/content/components/ar-tab-group.mdx`
+
+- [ ] **Ajouter une variante `styled` dans le frontmatter**
+
+Dans la liste `variants:`, après la variante `scroll-hints` existante, ajouter :
+
+```yaml
+- name: styled
+  label: Avec thème personnalisé
+  description: Les tokens `--ar-tab-*` permettent de changer le style de l'indicateur actif sans modifier le composant. Exemple — indicateur en haut (top border) et style pill.
+  html: |
+      <style>
+          .demo-top ar-tab {
+              --ar-tab-active-shadow: inset 0 3px 0 var(--ar-tab-indicator-color);
+          }
+          .demo-pill ar-tab {
+              --ar-tab-active-shadow: none;
+              --ar-tab-active-bg: var(--ar-color-interactive-subtle, #eaecfb);
+              --ar-tab-border-radius: 9999px;
+          }
+      </style>
+      <p style="margin-bottom: 0.5rem; font-weight: 500;">Top border</p>
+      <div class="demo-top" style="margin-bottom: 1.5rem;">
+          <ar-tab-group>
+              <ar-tab panel="a">Premier</ar-tab>
+              <ar-tab panel="b">Deuxième</ar-tab>
+              <ar-tab panel="c">Troisième</ar-tab>
+              <ar-tab-panel name="a">Panel A.</ar-tab-panel>
+              <ar-tab-panel name="b">Panel B.</ar-tab-panel>
+              <ar-tab-panel name="c">Panel C.</ar-tab-panel>
+          </ar-tab-group>
+      </div>
+      <p style="margin-bottom: 0.5rem; font-weight: 500;">Pill</p>
+      <div class="demo-pill">
+          <ar-tab-group>
+              <ar-tab panel="a">Premier</ar-tab>
+              <ar-tab panel="b">Deuxième</ar-tab>
+              <ar-tab panel="c">Troisième</ar-tab>
+              <ar-tab-panel name="a">Panel A.</ar-tab-panel>
+              <ar-tab-panel name="b">Panel B.</ar-tab-panel>
+              <ar-tab-panel name="c">Panel C.</ar-tab-panel>
+          </ar-tab-group>
+      </div>
+```
+
+- [ ] **Vérifier que le build docs ne produit pas d'erreur**
+
+```bash
+npm run build --workspace=apps/docs 2>&1 | tail -20
+```
+
+Résultat attendu : build terminé sans erreur.
+
+- [ ] **Commit**
+
+```bash
+git add apps/docs/src/content/components/ar-tab-group.mdx
+git commit -m "docs(tab-group): variante styling — top border et pill via tokens"
+```
+
+---
+
+## Task 6 : Vérification finale et push
+
+- [ ] **Lancer la suite de tests complète**
+
+```bash
+npm run test:all
+```
+
+Résultat attendu : tous les tests Vitest + WTR passent, aucune régression.
+
+- [ ] **Vérifier les tokens dans le Custom Elements Manifest**
+
+```bash
+npm run build:manifest && grep -A 5 '"--ar-tab-color"' packages/core/custom-elements.json
+```
+
+Résultat attendu : le token apparaît avec sa description dans le JSON généré.
+
+- [ ] **Push**
+
+```bash
+git push
+```

--- a/docs/superpowers/specs/2026-05-07-ar-tab-group-design.md
+++ b/docs/superpowers/specs/2026-05-07-ar-tab-group-design.md
@@ -1,0 +1,321 @@
+---
+date: 2026-05-07
+status: approved
+---
+
+# ar-tab-group — Design spec
+
+## Contexte
+
+`ar-tab-group` implémente le pattern **WAI-ARIA Tabs** complet : un groupe d'onglets accessibles avec roving tabindex, association automatique tab ↔ panel par nom, et gestion de l'overflow horizontal.
+
+Trois éléments coopèrent via `@lit/context` :
+
+- `ar-tab-group` — conteneur, fournit le registry, orchestre l'ARIA et le clavier
+- `ar-tab` — onglet déclencheur, s'enregistre dans le registry
+- `ar-tab-panel` — panneau de contenu, s'enregistre dans le registry
+
+Référence de conformité : **WCAG 2.2 AA**.
+
+---
+
+## API publique
+
+### `ar-tab-group`
+
+#### Attributs
+
+| Attribut            | Type      | Défaut  | Description                                                                       |
+| ------------------- | --------- | ------- | --------------------------------------------------------------------------------- |
+| `active`            | `string`  | `''`    | Nom de l'onglet actif. Si absent, le premier onglet non-disabled s'active.        |
+| `label`             | `string`  | `''`    | `aria-label` sur le tablist — recommandé si plusieurs `ar-tab-group` sur la page. |
+| `manual-activation` | `boolean` | `false` | Les flèches déplacent le focus sans activer l'onglet — Enter/Space requis.        |
+| `scroll-hints`      | `boolean` | `false` | Active les classes `has-overflow-start` / `has-overflow-end` sur `part="nav"`.    |
+
+#### Événements
+
+| Événement             | Détail               | Annulable |
+| --------------------- | -------------------- | --------- |
+| `ar-tab-group-change` | `{ active: string }` | non       |
+
+#### CSS Parts
+
+| Part   | Élément                                              |
+| ------ | ---------------------------------------------------- |
+| `base` | Conteneur racine                                     |
+| `nav`  | Zone scrollable (overflow-x: auto, scroll-hints ici) |
+| `tabs` | `div[role="tablist"]`                                |
+
+#### CSS custom properties
+
+| Propriété            | Défaut | Description                        |
+| -------------------- | ------ | ---------------------------------- |
+| `--ar-tab-group-gap` | `0`    | Espacement entre tablist et panels |
+
+---
+
+### `ar-tab`
+
+#### Attributs
+
+| Attribut   | Type      | Défaut  | Description                                   |
+| ---------- | --------- | ------- | --------------------------------------------- |
+| `panel`    | `string`  | requis  | Nom du `ar-tab-panel` associé.                |
+| `disabled` | `boolean` | `false` | Onglet non sélectionnable, ignoré au clavier. |
+
+#### CSS Parts
+
+| Part   | Élément         |
+| ------ | --------------- |
+| `base` | Wrapper du slot |
+
+---
+
+### `ar-tab-panel`
+
+#### Attributs
+
+| Attribut | Type     | Défaut | Description                               |
+| -------- | -------- | ------ | ----------------------------------------- |
+| `name`   | `string` | requis | Nom correspondant à `panel` sur `ar-tab`. |
+
+#### CSS Parts
+
+| Part   | Élément         |
+| ------ | --------------- |
+| `base` | Wrapper du slot |
+
+---
+
+## Usage
+
+```html
+<ar-tab-group active="usage" label="Documentation">
+    <ar-tab panel="intro">Introduction</ar-tab>
+    <ar-tab panel="usage">Utilisation</ar-tab>
+    <ar-tab panel="api" disabled>API</ar-tab>
+
+    <ar-tab-panel name="intro">Contenu introduction…</ar-tab-panel>
+    <ar-tab-panel name="usage">Contenu utilisation…</ar-tab-panel>
+    <ar-tab-panel name="api">Contenu API…</ar-tab-panel>
+</ar-tab-group>
+
+<!-- Activation manuelle -->
+<ar-tab-group manual-activation>…</ar-tab-group>
+
+<!-- Scroll hints -->
+<ar-tab-group scroll-hints>…</ar-tab-group>
+```
+
+---
+
+## Architecture
+
+### Structure DOM
+
+```html
+<!-- Light DOM (utilisateur) -->
+<ar-tab-group active="usage" label="Documentation">
+    <!-- slot="tab" posé automatiquement par le registry sur chaque ar-tab -->
+    <ar-tab
+        slot="tab"
+        panel="intro"
+        role="tab"
+        id="pfx-tab-intro"
+        aria-controls="pfx-panel-intro"
+        aria-selected="false"
+        tabindex="-1"
+    >
+        Introduction
+    </ar-tab>
+    <ar-tab
+        slot="tab"
+        panel="usage"
+        role="tab"
+        id="pfx-tab-usage"
+        aria-controls="pfx-panel-usage"
+        aria-selected="true"
+        tabindex="0"
+    >
+        Utilisation
+    </ar-tab>
+
+    <ar-tab-panel
+        name="intro"
+        role="tabpanel"
+        id="pfx-panel-intro"
+        aria-labelledby="pfx-tab-intro"
+        tabindex="0"
+        hidden
+        >…</ar-tab-panel
+    >
+    <ar-tab-panel
+        name="usage"
+        role="tabpanel"
+        id="pfx-panel-usage"
+        aria-labelledby="pfx-tab-usage"
+        tabindex="0"
+        >…</ar-tab-panel
+    >
+</ar-tab-group>
+
+<!-- Shadow DOM de ar-tab-group -->
+<div part="base">
+    <div part="nav">
+        <div part="tabs" role="tablist" aria-label="Documentation">
+            <slot name="tab"></slot>
+        </div>
+    </div>
+    <slot></slot>
+</div>
+
+<!-- Shadow DOM de ar-tab -->
+<slot></slot>
+
+<!-- Shadow DOM de ar-tab-panel -->
+<slot></slot>
+```
+
+### IDs générés
+
+`ar-tab-group` génère un préfixe aléatoire par instance (`pfx`). Les IDs suivent le schéma :
+
+| Élément                     | ID posé sur le host |
+| --------------------------- | ------------------- |
+| `<ar-tab panel="foo">`      | `${pfx}-tab-foo`    |
+| `<ar-tab-panel name="foo">` | `${pfx}-panel-foo`  |
+
+`aria-controls` sur `ar-tab` et `aria-labelledby` sur `ar-tab-panel` référencent tous les deux des éléments en light DOM → IDREF dans le même arbre, pas de problème cross-shadow.
+
+### Context registry
+
+```typescript
+// tabs.context.ts
+interface TabGroupRegistry {
+    registerTab(tab: ArTab): void;
+    unregisterTab(tab: ArTab): void;
+    registerPanel(panel: ArTabPanel): void;
+    unregisterPanel(panel: ArTabPanel): void;
+    activate(name: string): void;
+    readonly active: string;
+}
+```
+
+À `registerTab()`, le registry pose `slot="tab"` sur le host `ar-tab` — l'utilisateur n'a pas à l'écrire.
+
+### Attributs ARIA posés par le registry
+
+**Sur chaque `ar-tab` (host light DOM) :**
+
+```
+role="tab"
+slot="tab"
+id="${pfx}-tab-${panel}"
+aria-controls="${pfx}-panel-${panel}"
+aria-selected="true|false"
+aria-disabled="true"        ← uniquement si disabled
+tabindex="0|-1"             ← roving tabindex
+```
+
+**Sur chaque `ar-tab-panel` (host light DOM) :**
+
+```
+role="tabpanel"
+id="${pfx}-panel-${name}"
+aria-labelledby="${pfx}-tab-${name}"
+tabindex="0"
+hidden                      ← attribut natif quand inactif
+```
+
+**Sur `div[role="tablist"]` (shadow de ar-tab-group) :**
+
+```
+aria-label="${label}"       ← si label défini
+```
+
+### Navigation clavier
+
+| Touche        | Effet                                                                |
+| ------------- | -------------------------------------------------------------------- |
+| `←` / `→`     | Déplace le focus (+ active immédiatement si pas `manual-activation`) |
+| `Home`        | Focus sur le premier onglet non-disabled                             |
+| `End`         | Focus sur le dernier onglet non-disabled                             |
+| `Enter/Space` | Active l'onglet focusé (mode `manual-activation` uniquement)         |
+| `Tab`         | Quitte le tablist → focus sur le panel actif (`tabindex="0"`)        |
+
+Le roving tabindex est géré directement dans `ar-tab-group` (inline, liste plate — pas de controller dédié).
+
+Les onglets `disabled` sont skippés à la navigation clavier.
+
+### Scroll & overflow
+
+**Par défaut :** `part="nav"` a `overflow-x: auto`. `scrollIntoView({ block: 'nearest', inline: 'nearest' })` est appelé sur l'onglet actif à chaque changement → tous les onglets restent atteignables au clavier.
+
+**`scroll-hints` :** quand l'attribut est présent, un `ResizeObserver` + un listener `scroll` observent `part="nav"` et posent dynamiquement :
+
+| Classe               | Condition                                                          |
+| -------------------- | ------------------------------------------------------------------ |
+| `has-overflow-start` | Du contenu caché à gauche (scrollLeft > 0)                         |
+| `has-overflow-end`   | Du contenu caché à droite (scrollLeft + clientWidth < scrollWidth) |
+
+Le design system branche son CSS sur ces classes (typiquement `mask-image`). `part="nav"` est aussi exposé pour styler la scrollbar via `::part(nav)::-webkit-scrollbar`.
+
+---
+
+## Accessibilité
+
+| Critère WCAG 2.2                   | Implémentation                                                        |
+| ---------------------------------- | --------------------------------------------------------------------- |
+| 1.3.1 — Info and Relationships (A) | `role="tablist/tab/tabpanel"` + `aria-controls` + `aria-labelledby`   |
+| 2.1.1 — Keyboard (A)               | Roving tabindex, flèches ←/→, Home/End, Tab vers panel                |
+| 2.4.3 — Focus Order (A)            | Tab → panel actif (tabindex="0"), panels inactifs exclus (hidden)     |
+| 4.1.2 — Name, Role, Value (A)      | `aria-selected`, `aria-disabled`, `aria-label` sur le tablist         |
+| 1.4.10 — Reflow (AA)               | Scroll horizontal + scrollIntoView — exception "2D layout" documentée |
+| 2.5.3 — Label in Name (AA)         | Texte visible de l'onglet = son nom accessible (slot direct)          |
+
+La doc inclut un bloc **Accessibilité** dédié sur la gestion du scroll overflow (recommandations WCAG 1.4.10, démo `scroll-hints` + scrollbar custom via `::part(nav)`).
+
+---
+
+## Tests
+
+### `tab-group.test.ts` (Vitest)
+
+- Render : shadow DOM correct (`part="base/nav/tabs"`, `role="tablist"`).
+- Premier onglet non-disabled actif si `active` absent.
+- `active="foo"` → `ar-tab[panel="foo"]` a `aria-selected="true"`, `tabindex="0"`.
+- `ar-tab-panel[name="foo"]` visible, les autres ont `hidden`.
+- `aria-controls` sur chaque tab pointe vers l'ID du panel correspondant.
+- `aria-labelledby` sur chaque panel pointe vers l'ID du tab correspondant.
+- `disabled` sur un tab → `aria-disabled="true"`, skipé au clavier.
+- `ar-tab-group-change` émis avec `{ active: string }` au changement d'onglet.
+- `manual-activation` → le changement n'a pas lieu sur flèche, seulement sur Enter/Space.
+- Warn si `panel` d'un `ar-tab` ne correspond à aucun `ar-tab-panel`.
+- `slot="tab"` posé automatiquement sur chaque `ar-tab` à l'enregistrement.
+
+### `tab-group.browser.test.ts` (WTR)
+
+- Clic sur un onglet → panel correspondant visible, onglet précédent masqué.
+- `←` / `→` → focus se déplace entre onglets, activation immédiate (mode auto).
+- `←` / `→` en `manual-activation` → focus déplacé, panel inchangé jusqu'à Enter.
+- `Home` / `End` → focus sur premier / dernier onglet non-disabled.
+- `Tab` depuis un onglet actif → focus sur le panel actif.
+- `scroll-hints` → classes `has-overflow-start` / `has-overflow-end` présentes/absentes selon scroll.
+- `scrollIntoView` appelé sur l'onglet actif après activation clavier.
+- Ajout dynamique d'un `ar-tab` + `ar-tab-panel` → intégré dans le registry, navigable.
+
+### `tab-group.a11y.test.ts` (axe-core)
+
+- axe-core sur le tab-group avec onglet actif.
+- axe-core sur le tab-group avec `disabled` et `manual-activation`.
+- Vérification `aria-controls` / `aria-labelledby` croisés tab ↔ panel.
+
+---
+
+## Ce qui n'est pas dans ce composant
+
+- **Orientation verticale** — ↑/↓ + `aria-orientation="vertical"` — backlog, hors scope v1.
+- **Collapse vers `<select>` sur mobile** — décision design system, pas fondation.
+- **Fermeture/suppression d'onglets** — pattern différent (closable tabs), hors scope.
+- **Onglets comme liens (`<a href>`)** — pattern navigation, différent du pattern tabs WAI-ARIA.
+- **Lazy loading des panels** — responsabilité du design system / de l'application.

--- a/docs/superpowers/specs/2026-05-08-ar-tab-group-style-design.md
+++ b/docs/superpowers/specs/2026-05-08-ar-tab-group-style-design.md
@@ -1,0 +1,204 @@
+# Spec : Application de l'ADR-004 sur ar-tab-group
+
+**Date :** 2026-05-08  
+**Branche :** feat/ar-tab-group  
+**ADR de référence :** ADR-004 — Philosophie de style des composants
+
+---
+
+## Périmètre
+
+Trois composants concernés, niveaux de travail très différents :
+
+- **`ar-tab`** — essentiel. Zéro token actuellement, pas d'état actif stylé, pas d'état hover. C'est le cœur du travail.
+- **`ar-tab-group`** — mineur. Déjà un token (`--ar-tab-group-gap`), styles structurels corrects. Ajouter uniquement les tokens de séparateur et aligner le JSDoc.
+- **`ar-tab-panel`** — rien. Styles purement structurels, conforme à l'ADR tel quel.
+
+---
+
+## Architecture : trois couches (ADR-004)
+
+### Couche 1 — Styles internes fixes (`ar-tab`)
+
+Ces styles restent dans le Shadow DOM sans token associé. Ils garantissent la structure et les signaux a11y obligatoires.
+
+| Propriété                       | Valeur                                  | Raison                                         |
+| ------------------------------- | --------------------------------------- | ---------------------------------------------- |
+| `:host` `display`               | `inline-flex`                           | Layout structurel                              |
+| `:host` `white-space`           | `nowrap`                                | Empêche le retour à la ligne dans la tablist   |
+| `:host` `user-select`           | `none`                                  | UX universelle sur les onglets                 |
+| `:host` `cursor`                | `pointer`                               | Signal interactif non-négociable               |
+| `:host([disabled])` `cursor`    | `not-allowed`                           | Signal disabled non-négociable                 |
+| `:host(:focus-visible)` outline | via tokens globaux `--ar-focus-ring-*`  | Signal focus a11y, existence fixe              |
+| Présence de l'indicateur actif  | box-shadow via `--ar-tab-active-shadow` | Existence fixe, forme via token                |
+| `[part="base"]` `position`      | `relative`                              | Nécessaire pour positionnement de l'indicateur |
+
+Le focus ring s'appuie sur les tokens globaux déjà en place dans `default.css` :
+
+```css
+:host(:focus-visible) {
+    outline: 2px solid var(--ar-focus-ring-color, currentColor);
+    outline-offset: var(--ar-focus-ring-offset, 2px);
+}
+```
+
+### Couche 2 — Tokens CSS `--ar-tab-*`
+
+#### Convention de nommage
+
+Le thème utilise déjà `padding-x` / `padding-y` sur `button` et `table`. Par cohérence avec l'existant, les tokens de tab suivent la même convention (`-x` / `-y`). Une migration globale vers les propriétés logiques CSS (`inline` / `block`) sera l'objet d'un ADR séparé si décidée.
+
+#### Tokens `ar-tab` — état par défaut
+
+| Token                    | Défaut dans le composant | Description         |
+| ------------------------ | ------------------------ | ------------------- |
+| `--ar-tab-color`         | `inherit`                | Couleur du texte    |
+| `--ar-tab-bg`            | `transparent`            | Fond de l'onglet    |
+| `--ar-tab-padding-x`     | `1rem`                   | Padding horizontal  |
+| `--ar-tab-padding-y`     | `0.5rem`                 | Padding vertical    |
+| `--ar-tab-border-radius` | `0`                      | Rayon (pill, card…) |
+| `--ar-tab-font-weight`   | `inherit`                | Graisse du texte    |
+
+#### Tokens `ar-tab` — état hover
+
+| Token                  | Défaut dans le composant | Description                |
+| ---------------------- | ------------------------ | -------------------------- |
+| `--ar-tab-hover-color` | `inherit`                | Couleur du texte au survol |
+| `--ar-tab-hover-bg`    | `transparent`            | Fond au survol             |
+
+#### Tokens `ar-tab` — état actif (`[aria-selected="true"]`)
+
+Deux niveaux de contrôle :
+
+**Niveau 1 — tokens ergonomiques** (utilisés par le thème pour composer le shadow) :
+
+| Token                      | Rôle dans le thème par défaut                                  |
+| -------------------------- | -------------------------------------------------------------- |
+| `--ar-tab-active-color`    | Couleur du texte de l'onglet actif                             |
+| `--ar-tab-active-bg`       | Fond de l'onglet actif (`transparent` dans le thème underline) |
+| `--ar-tab-indicator-color` | Couleur de l'indicateur actif                                  |
+| `--ar-tab-indicator-width` | Épaisseur de l'indicateur (`2px` par défaut)                   |
+
+**Niveau 2 — token brut** (override complet du signal visuel actif) :
+
+| Token                    | Description                                         |
+| ------------------------ | --------------------------------------------------- |
+| `--ar-tab-active-shadow` | Valeur complète de `box-shadow` sur `[part="base"]` |
+
+Dans `default.css`, le thème compose `--ar-tab-active-shadow` à partir des tokens ergonomiques :
+
+```css
+ar-tab {
+    --ar-tab-active-shadow: inset 0 calc(-1 * var(--ar-tab-indicator-width, 2px)) 0
+        var(--ar-tab-indicator-color, currentColor);
+}
+```
+
+Un intégrateur qui veut un indicateur en haut override uniquement `--ar-tab-active-shadow` :
+
+```css
+ar-tab {
+    --ar-tab-active-shadow: inset 0 3px 0 blue;
+}
+```
+
+Un intégrateur pill désactive le shadow et active le fond :
+
+```css
+ar-tab {
+    --ar-tab-active-shadow: none;
+    --ar-tab-active-bg: var(--ar-color-interactive-subtle);
+    --ar-tab-border-radius: var(--ar-border-radius-full);
+}
+```
+
+#### Tokens `ar-tab` — état disabled
+
+| Token                       | Défaut dans le composant | Description                                              |
+| --------------------------- | ------------------------ | -------------------------------------------------------- |
+| `--ar-tab-disabled-opacity` | `0.5`                    | Opacité (signal a11y — existence fixe, valeur via token) |
+
+#### Tokens `ar-tab-group` (complément)
+
+| Token                         | Défaut existant | Description                                           |
+| ----------------------------- | --------------- | ----------------------------------------------------- |
+| `--ar-tab-group-gap`          | `0`             | Espace entre la tablist et les panels (déjà en place) |
+| `--ar-tab-group-border-color` | `transparent`   | Couleur du trait séparateur sous la tablist           |
+| `--ar-tab-group-border-width` | `0`             | Épaisseur du séparateur                               |
+
+Le séparateur entre tablist et panels est un pattern fréquent (ligne horizontale). Le token est exposé mais désactivé par défaut (`0`). Le thème l'active s'il le souhaite.
+
+### Couche 3 — `::part()` stratégiques
+
+Les parts existants couvrent le besoin sans ajout. Confirmation :
+
+| Composant      | Part   | Utilité                                                                          |
+| -------------- | ------ | -------------------------------------------------------------------------------- |
+| `ar-tab-group` | `base` | Conteneur flex global                                                            |
+| `ar-tab-group` | `nav`  | Zone scrollable (scroll hints, mask)                                             |
+| `ar-tab-group` | `tabs` | Le `[role="tablist"]`                                                            |
+| `ar-tab`       | `base` | Wrapper du slot — accès direct au bouton pour fond, bordure, typographie avancée |
+
+Aucun ajout nécessaire sur `ar-tab-panel`.
+
+---
+
+## Fichiers à modifier
+
+| Fichier                                                      | Nature des changements                                                                                           |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| `packages/core/src/components/tab/tab.styles.ts`             | Appliquer tous les tokens état par défaut, hover, actif, disabled ; aligner le focus ring sur les tokens globaux |
+| `packages/core/src/components/tab-group/tab-group.styles.ts` | Ajouter le séparateur tablist/panels via `--ar-tab-group-border-*`                                               |
+| `packages/core/src/components/tab/tab.ts`                    | Ajouter les `@cssprop` JSDoc pour tous les tokens                                                                |
+| `packages/core/src/components/tab-group/tab-group.ts`        | Ajouter les `@cssprop` JSDoc pour les deux nouveaux tokens de séparateur                                         |
+| `packages/core/src/styles/themes/default.css`                | Ajouter la section `/* tab */` avec les valeurs de thème                                                         |
+| `apps/docs/src/content/components/ar-tab-group.mdx`          | Mettre à jour la description des variantes pour refléter les tokens disponibles                                  |
+
+---
+
+## Valeurs dans `default.css`
+
+Section à ajouter en fin de section 6 (tokens composants) :
+
+```css
+/* tab */
+--ar-tab-color: var(--ar-color-text-muted);
+--ar-tab-bg: transparent;
+--ar-tab-padding-x: 1rem;
+--ar-tab-padding-y: 0.5rem;
+--ar-tab-border-radius: 0;
+--ar-tab-font-weight: var(--ar-font-weight-normal);
+
+--ar-tab-hover-color: var(--ar-color-text);
+--ar-tab-hover-bg: transparent;
+
+--ar-tab-active-color: var(--ar-color-interactive);
+--ar-tab-active-bg: transparent;
+--ar-tab-indicator-color: var(--ar-color-interactive);
+--ar-tab-indicator-width: 2px;
+--ar-tab-active-shadow: inset 0 calc(-1 * var(--ar-tab-indicator-width)) 0
+    var(--ar-tab-indicator-color);
+
+--ar-tab-disabled-opacity: 0.5;
+
+--ar-tab-group-border-color: var(--ar-color-border);
+--ar-tab-group-border-width: 0;
+```
+
+Pas de surcharge dark mode nécessaire : les tokens composants référencent des tokens sémantiques (`--ar-color-interactive`, `--ar-color-text-muted`, `--ar-color-border`) qui sont déjà surchargeables en dark mode.
+
+---
+
+## Tests
+
+Les tests existants (unitaires et browser) ne testent pas les styles — c'est correct, les styles Shadow DOM ne sont pas observables depuis les tests. Aucun test à ajouter pour les tokens CSS.
+
+Le focus reste sur les tests comportementaux déjà en place.
+
+---
+
+## Hors périmètre
+
+- Audit des autres composants (dropdown, breadcrumb, stepper) pour conformité ADR-004 — issue séparée.
+- Migration globale `padding-x`/`padding-y` → `padding-inline`/`padding-block` — ADR séparé si décidé.
+- Styles de démo MDX avancés (animation d'indicateur, transitions hover) — appartient aux docs, pas au composant.

--- a/packages/core/src/autoloader.ts
+++ b/packages/core/src/autoloader.ts
@@ -27,6 +27,9 @@ const COMPONENT_MAP: Record<string, () => Promise<unknown>> = {
     'ar-dialog': () => import('./components/dialog/dialog.js'),
     'ar-dropdown': () => import('./components/dropdown/dropdown.js'),
     'ar-dropdown-item': () => import('./components/dropdown-item/dropdown-item.js'),
+    'ar-tab-group': () => import('./components/tab-group/tab-group.js'),
+    'ar-tab': () => import('./components/tab/tab.js'),
+    'ar-tab-panel': () => import('./components/tab-panel/tab-panel.js'),
     // ⚠ Mis à jour automatiquement par le script create-component.js
 };
 

--- a/packages/core/src/components/tab-group/tab-group.a11y.test.ts
+++ b/packages/core/src/components/tab-group/tab-group.a11y.test.ts
@@ -1,0 +1,155 @@
+/// <reference types="mocha" />
+/**
+ * Tests d'accessibilité structurels — WAI-ARIA Tabs pattern.
+ */
+import { fixture, html, expect } from '@open-wc/testing';
+import type { ArTabGroup } from './tab-group.js';
+import './tab-group.js';
+import '../tab/tab.js';
+import '../tab-panel/tab-panel.js';
+
+describe('ar-tab-group — accessibilité', () => {
+    // ── Rôles ARIA ─────────────────────────────────────────────────────────
+
+    describe('rôles ARIA', () => {
+        it('le tablist a role="tablist"', async () => {
+            const el = await fixture<ArTabGroup>(html`
+                <ar-tab-group>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            const tablist = el.shadowRoot?.querySelector('[part="tabs"]');
+            expect(tablist?.getAttribute('role')).to.equal('tablist');
+        });
+
+        it('chaque ar-tab a role="tab"', async () => {
+            const el = await fixture<ArTabGroup>(html`
+                <ar-tab-group>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab panel="b">B</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            el.querySelectorAll('ar-tab').forEach((tab) => {
+                expect(tab.getAttribute('role')).to.equal('tab');
+            });
+        });
+
+        it('chaque ar-tab-panel a role="tabpanel"', async () => {
+            const el = await fixture<ArTabGroup>(html`
+                <ar-tab-group>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            expect(el.querySelector('ar-tab-panel')!.getAttribute('role')).to.equal('tabpanel');
+        });
+    });
+
+    // ── Associations ARIA ──────────────────────────────────────────────────
+
+    describe('associations ARIA (light DOM → light DOM)', () => {
+        it("aria-controls du tab pointe vers l'ID du panel (même arbre)", async () => {
+            const el = await fixture<ArTabGroup>(html`
+                <ar-tab-group>
+                    <ar-tab panel="intro">Intro</ar-tab>
+                    <ar-tab-panel name="intro">Contenu</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            const tab = el.querySelector<HTMLElement>('ar-tab[panel="intro"]')!;
+            const panel = el.querySelector<HTMLElement>('ar-tab-panel[name="intro"]')!;
+            expect(tab.getAttribute('aria-controls')).to.equal(panel.id);
+            expect(document.getElementById(panel.id)).to.equal(panel);
+        });
+
+        it("aria-labelledby du panel pointe vers l'ID du tab (même arbre)", async () => {
+            const el = await fixture<ArTabGroup>(html`
+                <ar-tab-group>
+                    <ar-tab panel="intro">Intro</ar-tab>
+                    <ar-tab-panel name="intro">Contenu</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            const tab = el.querySelector<HTMLElement>('ar-tab[panel="intro"]')!;
+            const panel = el.querySelector<HTMLElement>('ar-tab-panel[name="intro"]')!;
+            expect(panel.getAttribute('aria-labelledby')).to.equal(tab.id);
+            expect(document.getElementById(tab.id)).to.equal(tab);
+        });
+    });
+
+    // ── État sélectionné ───────────────────────────────────────────────────
+
+    describe('état sélectionné', () => {
+        it('le tab actif a aria-selected="true"', async () => {
+            const el = await fixture<ArTabGroup>(html`
+                <ar-tab-group>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            expect(el.querySelector('ar-tab')!.getAttribute('aria-selected')).to.equal('true');
+        });
+
+        it('les tabs inactifs ont aria-selected="false"', async () => {
+            const el = await fixture<ArTabGroup>(html`
+                <ar-tab-group>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab panel="b">B</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            expect(el.querySelector('ar-tab[panel="b"]')!.getAttribute('aria-selected')).to.equal(
+                'false',
+            );
+        });
+    });
+
+    // ── Panneau masqué ─────────────────────────────────────────────────────
+
+    describe('panneau masqué', () => {
+        it("le panel inactif a l'attribut hidden", async () => {
+            const el = await fixture<ArTabGroup>(html`
+                <ar-tab-group>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab panel="b">B</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            expect(el.querySelector('ar-tab-panel[name="b"]')!.hasAttribute('hidden')).to.equal(
+                true,
+            );
+        });
+
+        it("le panel actif n'a pas l'attribut hidden", async () => {
+            const el = await fixture<ArTabGroup>(html`
+                <ar-tab-group>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            expect(el.querySelector('ar-tab-panel[name="a"]')!.hasAttribute('hidden')).to.equal(
+                false,
+            );
+        });
+    });
+
+    // ── Roving tabindex ────────────────────────────────────────────────────
+
+    describe('roving tabindex', () => {
+        it('le tab actif a tabindex="0", les inactifs tabindex="-1"', async () => {
+            const el = await fixture<ArTabGroup>(html`
+                <ar-tab-group>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab panel="b">B</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            expect(el.querySelector('ar-tab[panel="a"]')!.getAttribute('tabindex')).to.equal('0');
+            expect(el.querySelector('ar-tab[panel="b"]')!.getAttribute('tabindex')).to.equal('-1');
+        });
+    });
+});

--- a/packages/core/src/components/tab-group/tab-group.browser.test.ts
+++ b/packages/core/src/components/tab-group/tab-group.browser.test.ts
@@ -173,13 +173,60 @@ describe('ar-tab-group — browser', () => {
         });
     });
 
-    // ── scroll-hints ───────────────────────────────────────────────────────
+    // ── scrollNav ─────────────────────────────────────────────────────────
 
-    describe('scroll-hints', () => {
+    describe('scrollNav', () => {
+        it('scrolle vers la droite quand appelé avec "end"', async () => {
+            const wrapper = await fixture<HTMLElement>(html`
+                <div style="width: 100px; overflow: hidden;">
+                    <ar-tab-group>
+                        <ar-tab panel="a" style="min-width:60px">A</ar-tab>
+                        <ar-tab panel="b" style="min-width:60px">B</ar-tab>
+                        <ar-tab panel="c" style="min-width:60px">C</ar-tab>
+                        <ar-tab-panel name="a">A</ar-tab-panel>
+                        <ar-tab-panel name="b">B</ar-tab-panel>
+                        <ar-tab-panel name="c">C</ar-tab-panel>
+                    </ar-tab-group>
+                </div>
+            `);
+            const el = wrapper.querySelector<ArTabGroup>('ar-tab-group')!;
+            el.scrollNav('end');
+            await aTimeout(150);
+            const nav = el.shadowRoot!.querySelector<HTMLElement>('[part="nav"]')!;
+            expect(nav.scrollLeft).to.be.greaterThan(0);
+        });
+
+        it('scrolle vers la gauche quand appelé avec "start"', async () => {
+            const wrapper = await fixture<HTMLElement>(html`
+                <div style="width: 100px; overflow: hidden;">
+                    <ar-tab-group>
+                        <ar-tab panel="a" style="min-width:60px">A</ar-tab>
+                        <ar-tab panel="b" style="min-width:60px">B</ar-tab>
+                        <ar-tab panel="c" style="min-width:60px">C</ar-tab>
+                        <ar-tab-panel name="a">A</ar-tab-panel>
+                        <ar-tab-panel name="b">B</ar-tab-panel>
+                        <ar-tab-panel name="c">C</ar-tab-panel>
+                    </ar-tab-group>
+                </div>
+            `);
+            const el = wrapper.querySelector<ArTabGroup>('ar-tab-group')!;
+            el.scrollNav('end', 999);
+            await aTimeout(150);
+            const nav = el.shadowRoot!.querySelector<HTMLElement>('[part="nav"]')!;
+            const scrollAfterEnd = nav.scrollLeft;
+            el.scrollNav('start');
+            await aTimeout(150);
+            expect(nav.scrollLeft).to.be.lessThan(scrollAfterEnd);
+        });
+    });
+
+    // ── overflow tracking (toujours actif) ────────────────────────────────
+
+    describe('overflow tracking', () => {
         it('ajoute has-overflow-end quand le contenu déborde', async () => {
             const wrapper = await fixture<HTMLElement>(html`
                 <div style="width: 100px; overflow: hidden;">
-                    <ar-tab-group scroll-hints>
+                    <ar-tab-group>
                         <ar-tab panel="a" style="min-width:60px">A</ar-tab>
                         <ar-tab panel="b" style="min-width:60px">B</ar-tab>
                         <ar-tab panel="c" style="min-width:60px">C</ar-tab>
@@ -197,7 +244,7 @@ describe('ar-tab-group — browser', () => {
         it("n'ajoute pas has-overflow-start si scroll à 0", async () => {
             const wrapper = await fixture<HTMLElement>(html`
                 <div style="width: 100px; overflow: hidden;">
-                    <ar-tab-group scroll-hints>
+                    <ar-tab-group>
                         <ar-tab panel="a" style="min-width:60px">A</ar-tab>
                         <ar-tab panel="b" style="min-width:60px">B</ar-tab>
                         <ar-tab panel="c" style="min-width:60px">C</ar-tab>

--- a/packages/core/src/components/tab-group/tab-group.browser.test.ts
+++ b/packages/core/src/components/tab-group/tab-group.browser.test.ts
@@ -17,12 +17,6 @@ function getTab(el: ArTabGroup, panel: string): HTMLElement {
     return tab;
 }
 
-function getNav(el: ArTabGroup): HTMLElement {
-    const nav = el.shadowRoot?.querySelector<HTMLElement>('[part="nav"]');
-    if (!nav) throw new Error('[part="nav"] introuvable');
-    return nav;
-}
-
 describe('ar-tab-group — browser', () => {
     // ── Activation par clic ────────────────────────────────────────────────
 
@@ -197,8 +191,7 @@ describe('ar-tab-group — browser', () => {
             `);
             const el = wrapper.querySelector<ArTabGroup>('ar-tab-group')!;
             await aTimeout(50);
-            const nav = getNav(el);
-            expect(nav.classList.contains('has-overflow-end')).to.equal(true);
+            expect(el.classList.contains('has-overflow-end')).to.equal(true);
         });
 
         it("n'ajoute pas has-overflow-start si scroll à 0", async () => {
@@ -216,8 +209,7 @@ describe('ar-tab-group — browser', () => {
             `);
             const el = wrapper.querySelector<ArTabGroup>('ar-tab-group')!;
             await aTimeout(50);
-            const nav = getNav(el);
-            expect(nav.classList.contains('has-overflow-start')).to.equal(false);
+            expect(el.classList.contains('has-overflow-start')).to.equal(false);
         });
     });
 });

--- a/packages/core/src/components/tab-group/tab-group.browser.test.ts
+++ b/packages/core/src/components/tab-group/tab-group.browser.test.ts
@@ -310,5 +310,102 @@ describe('ar-tab-group — browser', () => {
             await aTimeout(50);
             expect(el.classList.contains('has-overflow-start')).to.equal(false);
         });
+
+        it('les classes overflow restent à jour après disconnect+reconnect', async () => {
+            const wrapper = await fixture<HTMLElement>(html`
+                <div style="width: 100px; overflow: hidden;">
+                    <ar-tab-group>
+                        <ar-tab panel="a" style="min-width:60px">A</ar-tab>
+                        <ar-tab panel="b" style="min-width:60px">B</ar-tab>
+                        <ar-tab panel="c" style="min-width:60px">C</ar-tab>
+                        <ar-tab-panel name="a">A</ar-tab-panel>
+                        <ar-tab-panel name="b">B</ar-tab-panel>
+                        <ar-tab-panel name="c">C</ar-tab-panel>
+                    </ar-tab-group>
+                </div>
+            `);
+            const el = wrapper.querySelector<ArTabGroup>('ar-tab-group')!;
+            await aTimeout(50);
+            const parent = el.parentElement!;
+            parent.removeChild(el);
+            parent.appendChild(el);
+            await aTimeout(50);
+            el.scrollNav('end', 999);
+            await aTimeout(200);
+            expect(el.classList.contains('has-overflow-start')).to.equal(true);
+        });
+    });
+
+    // ── Clavier — cas limites ──────────────────────────────────────────────
+
+    describe('clavier — cas limites', () => {
+        it('Space appelle preventDefault en mode automatique pour éviter le scroll de la page', async () => {
+            const el = await fixture<ArTabGroup>(html`
+                <ar-tab-group>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab panel="b">B</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            await el.updateComplete;
+            const tabA = getTab(el, 'a');
+            tabA.focus();
+            const event = new KeyboardEvent('keydown', {
+                key: ' ',
+                bubbles: true,
+                composed: true,
+                cancelable: true,
+            });
+            tabA.dispatchEvent(event);
+            expect(event.defaultPrevented).to.equal(true);
+        });
+
+        it('ne plante pas si tous les onglets sont désactivés et ArrowRight est pressé', async () => {
+            const el = await fixture<ArTabGroup>(html`
+                <ar-tab-group>
+                    <ar-tab panel="a" disabled>A</ar-tab>
+                    <ar-tab panel="b" disabled>B</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            await el.updateComplete;
+            const tabA = getTab(el, 'a');
+            tabA.focus();
+            tabA.dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, composed: true }),
+            );
+            tabA.dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'Home', bubbles: true, composed: true }),
+            );
+            tabA.dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'End', bubbles: true, composed: true }),
+            );
+            await el.updateComplete;
+        });
+
+        it('ArrowLeft depuis un onglet désactivé focusé atteint le dernier onglet actif (pas N-2)', async () => {
+            const el = await fixture<ArTabGroup>(html`
+                <ar-tab-group>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab panel="b">B</ar-tab>
+                    <ar-tab panel="dis" disabled>Dis</ar-tab>
+                    <ar-tab panel="c">C</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                    <ar-tab-panel name="dis">Dis</ar-tab-panel>
+                    <ar-tab-panel name="c">C</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            await el.updateComplete;
+            const disTab = getTab(el, 'dis');
+            disTab.focus();
+            disTab.dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true, composed: true }),
+            );
+            await el.updateComplete;
+            expect(el.active).to.equal('c');
+        });
     });
 });

--- a/packages/core/src/components/tab-group/tab-group.browser.test.ts
+++ b/packages/core/src/components/tab-group/tab-group.browser.test.ts
@@ -1,0 +1,223 @@
+/// <reference types="mocha" />
+/**
+ * Tests nécessitant un vrai navigateur (Chromium via @web/test-runner) :
+ *   - Navigation clavier (flèches, Home, End, Enter/Space)
+ *   - Activation automatique vs manuelle
+ *   - scroll-hints (has-overflow-start / has-overflow-end)
+ */
+import { fixture, html, expect, aTimeout } from '@open-wc/testing';
+import type { ArTabGroup } from './tab-group.js';
+import './tab-group.js';
+import '../tab/tab.js';
+import '../tab-panel/tab-panel.js';
+
+function getTab(el: ArTabGroup, panel: string): HTMLElement {
+    const tab = el.querySelector<HTMLElement>(`ar-tab[panel="${panel}"]`);
+    if (!tab) throw new Error(`ar-tab[panel="${panel}"] introuvable`);
+    return tab;
+}
+
+function getNav(el: ArTabGroup): HTMLElement {
+    const nav = el.shadowRoot?.querySelector<HTMLElement>('[part="nav"]');
+    if (!nav) throw new Error('[part="nav"] introuvable');
+    return nav;
+}
+
+describe('ar-tab-group — browser', () => {
+    // ── Activation par clic ────────────────────────────────────────────────
+
+    describe('activation par clic', () => {
+        it('affiche le panel correspondant et masque les autres', async () => {
+            const el = await fixture<ArTabGroup>(html`
+                <ar-tab-group>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab panel="b">B</ar-tab>
+                    <ar-tab-panel name="a">Panel A</ar-tab-panel>
+                    <ar-tab-panel name="b">Panel B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            getTab(el, 'b').click();
+            await el.updateComplete;
+            expect(el.querySelector('ar-tab-panel[name="b"]')!.hasAttribute('hidden')).to.equal(
+                false,
+            );
+            expect(el.querySelector('ar-tab-panel[name="a"]')!.hasAttribute('hidden')).to.equal(
+                true,
+            );
+        });
+
+        it('émet ar-tab-group-change avec { active }', async () => {
+            const el = await fixture<ArTabGroup>(html`
+                <ar-tab-group>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab panel="b">B</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            const events: CustomEvent[] = [];
+            el.addEventListener('ar-tab-group-change', (e) => events.push(e as CustomEvent));
+            getTab(el, 'b').click();
+            await el.updateComplete;
+            expect(events[0].detail.active).to.equal('b');
+        });
+    });
+
+    // ── Navigation clavier — activation automatique ────────────────────────
+
+    describe('navigation clavier — mode automatique', () => {
+        it('ArrowRight active le tab suivant', async () => {
+            const el = await fixture<ArTabGroup>(html`
+                <ar-tab-group>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab panel="b">B</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            getTab(el, 'a').focus();
+            getTab(el, 'a').dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, composed: true }),
+            );
+            await el.updateComplete;
+            expect(el.active).to.equal('b');
+            expect(getTab(el, 'b').getAttribute('aria-selected')).to.equal('true');
+        });
+
+        it('ArrowLeft active le tab précédent (wrap)', async () => {
+            const el = await fixture<ArTabGroup>(html`
+                <ar-tab-group>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab panel="b">B</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            getTab(el, 'a').focus();
+            getTab(el, 'a').dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true, composed: true }),
+            );
+            await el.updateComplete;
+            expect(el.active).to.equal('b');
+        });
+
+        it('Home active le premier tab', async () => {
+            const el = await fixture<ArTabGroup>(html`
+                <ar-tab-group active="b">
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab panel="b">B</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            getTab(el, 'b').focus();
+            getTab(el, 'b').dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'Home', bubbles: true, composed: true }),
+            );
+            await el.updateComplete;
+            expect(el.active).to.equal('a');
+        });
+
+        it('End active le dernier tab', async () => {
+            const el = await fixture<ArTabGroup>(html`
+                <ar-tab-group>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab panel="b">B</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            getTab(el, 'a').focus();
+            getTab(el, 'a').dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'End', bubbles: true, composed: true }),
+            );
+            await el.updateComplete;
+            expect(el.active).to.equal('b');
+        });
+    });
+
+    // ── Navigation clavier — activation manuelle ───────────────────────────
+
+    describe('navigation clavier — manual-activation', () => {
+        it('ArrowRight déplace le focus sans changer active', async () => {
+            const el = await fixture<ArTabGroup>(html`
+                <ar-tab-group active="a" manual-activation>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab panel="b">B</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            getTab(el, 'a').focus();
+            getTab(el, 'a').dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, composed: true }),
+            );
+            await el.updateComplete;
+            expect(el.active).to.equal('a');
+            expect(document.activeElement).to.equal(getTab(el, 'b'));
+        });
+
+        it('Enter sur le tab focusé active le panel', async () => {
+            const el = await fixture<ArTabGroup>(html`
+                <ar-tab-group manual-activation>
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab panel="b">B</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            getTab(el, 'a').focus();
+            getTab(el, 'a').dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, composed: true }),
+            );
+            await el.updateComplete;
+            getTab(el, 'b').dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, composed: true }),
+            );
+            await el.updateComplete;
+            expect(el.active).to.equal('b');
+        });
+    });
+
+    // ── scroll-hints ───────────────────────────────────────────────────────
+
+    describe('scroll-hints', () => {
+        it('ajoute has-overflow-end quand le contenu déborde', async () => {
+            const wrapper = await fixture<HTMLElement>(html`
+                <div style="width: 100px; overflow: hidden;">
+                    <ar-tab-group scroll-hints>
+                        <ar-tab panel="a" style="min-width:60px">A</ar-tab>
+                        <ar-tab panel="b" style="min-width:60px">B</ar-tab>
+                        <ar-tab panel="c" style="min-width:60px">C</ar-tab>
+                        <ar-tab-panel name="a">A</ar-tab-panel>
+                        <ar-tab-panel name="b">B</ar-tab-panel>
+                        <ar-tab-panel name="c">C</ar-tab-panel>
+                    </ar-tab-group>
+                </div>
+            `);
+            const el = wrapper.querySelector<ArTabGroup>('ar-tab-group')!;
+            await aTimeout(50);
+            const nav = getNav(el);
+            expect(nav.classList.contains('has-overflow-end')).to.equal(true);
+        });
+
+        it("n'ajoute pas has-overflow-start si scroll à 0", async () => {
+            const wrapper = await fixture<HTMLElement>(html`
+                <div style="width: 100px; overflow: hidden;">
+                    <ar-tab-group scroll-hints>
+                        <ar-tab panel="a" style="min-width:60px">A</ar-tab>
+                        <ar-tab panel="b" style="min-width:60px">B</ar-tab>
+                        <ar-tab panel="c" style="min-width:60px">C</ar-tab>
+                        <ar-tab-panel name="a">A</ar-tab-panel>
+                        <ar-tab-panel name="b">B</ar-tab-panel>
+                        <ar-tab-panel name="c">C</ar-tab-panel>
+                    </ar-tab-group>
+                </div>
+            `);
+            const el = wrapper.querySelector<ArTabGroup>('ar-tab-group')!;
+            await aTimeout(50);
+            const nav = getNav(el);
+            expect(nav.classList.contains('has-overflow-start')).to.equal(false);
+        });
+    });
+});

--- a/packages/core/src/components/tab-group/tab-group.browser.test.ts
+++ b/packages/core/src/components/tab-group/tab-group.browser.test.ts
@@ -220,6 +220,58 @@ describe('ar-tab-group — browser', () => {
         });
     });
 
+    // ── suppression dynamique ─────────────────────────────────────────────
+
+    describe('suppression dynamique', () => {
+        it('émet ar-tab-group-change quand le tab actif est supprimé', async () => {
+            const el = await fixture<ArTabGroup>(html`
+                <ar-tab-group active="a">
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab panel="b">B</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            const events: CustomEvent[] = [];
+            el.addEventListener('ar-tab-group-change', (e) => events.push(e as CustomEvent));
+            getTab(el, 'a').remove();
+            await el.updateComplete;
+            expect(events).to.have.length(1);
+            expect(events[0].detail.active).to.equal('b');
+        });
+
+        it('met à jour active quand le tab actif est supprimé', async () => {
+            const el = await fixture<ArTabGroup>(html`
+                <ar-tab-group active="a">
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab panel="b">B</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            getTab(el, 'a').remove();
+            await el.updateComplete;
+            expect(el.active).to.equal('b');
+        });
+
+        it("n'émet pas ar-tab-group-change quand un tab inactif est supprimé", async () => {
+            const el = await fixture<ArTabGroup>(html`
+                <ar-tab-group active="a">
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab panel="b">B</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            const events: CustomEvent[] = [];
+            el.addEventListener('ar-tab-group-change', (e) => events.push(e as CustomEvent));
+            getTab(el, 'b').remove();
+            await el.updateComplete;
+            expect(events).to.have.length(0);
+            expect(el.active).to.equal('a');
+        });
+    });
+
     // ── overflow tracking (toujours actif) ────────────────────────────────
 
     describe('overflow tracking', () => {

--- a/packages/core/src/components/tab-group/tab-group.styles.ts
+++ b/packages/core/src/components/tab-group/tab-group.styles.ts
@@ -14,6 +14,8 @@ export default css`
     [part='nav'] {
         overflow-x: auto;
         scrollbar-width: none;
+        border-bottom: var(--ar-tab-group-border-width, 0) solid
+            var(--ar-tab-group-border-color, transparent);
     }
 
     [part='nav']::-webkit-scrollbar {

--- a/packages/core/src/components/tab-group/tab-group.styles.ts
+++ b/packages/core/src/components/tab-group/tab-group.styles.ts
@@ -8,14 +8,13 @@ export default css`
     [part='base'] {
         display: flex;
         flex-direction: column;
-        gap: var(--ar-tab-group-gap, 0);
+        gap: var(--ar-tab-group-gap);
     }
 
     [part='nav'] {
         overflow-x: auto;
         scrollbar-width: none;
-        border-bottom: var(--ar-tab-group-border-width, 0) solid
-            var(--ar-tab-group-border-color, transparent);
+        border-bottom: var(--ar-tab-group-border-width) solid var(--ar-tab-group-border-color);
     }
 
     [part='nav']::-webkit-scrollbar {

--- a/packages/core/src/components/tab-group/tab-group.styles.ts
+++ b/packages/core/src/components/tab-group/tab-group.styles.ts
@@ -1,0 +1,27 @@
+import { css } from 'lit';
+
+export default css`
+    :host {
+        display: block;
+    }
+
+    [part='base'] {
+        display: flex;
+        flex-direction: column;
+        gap: var(--ar-tab-group-gap, 0);
+    }
+
+    [part='nav'] {
+        overflow-x: auto;
+        scrollbar-width: none;
+    }
+
+    [part='nav']::-webkit-scrollbar {
+        display: none;
+    }
+
+    [part='tabs'] {
+        display: flex;
+        flex-direction: row;
+    }
+`;

--- a/packages/core/src/components/tab-group/tab-group.styles.ts
+++ b/packages/core/src/components/tab-group/tab-group.styles.ts
@@ -14,7 +14,6 @@ export default css`
     [part='nav'] {
         overflow-x: auto;
         scrollbar-width: none;
-        border-bottom: var(--ar-tab-group-border-width) solid var(--ar-tab-group-border-color);
     }
 
     [part='nav']::-webkit-scrollbar {
@@ -24,5 +23,9 @@ export default css`
     [part='tabs'] {
         display: flex;
         flex-direction: row;
+        min-width: 100%;
+        border-top: var(--ar-tab-group-border-top-width) solid var(--ar-tab-group-border-color);
+        border-bottom: var(--ar-tab-group-border-bottom-width) solid
+            var(--ar-tab-group-border-color);
     }
 `;

--- a/packages/core/src/components/tab-group/tab-group.test.ts
+++ b/packages/core/src/components/tab-group/tab-group.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fixture, waitForUpdate, getPart } from '../../test-utils.js';
+import type { ArTabGroup } from './tab-group.js';
+import './tab-group.js';
+import '../tab/tab.js';
+import '../tab-panel/tab-panel.js';
+
+const DEFAULT_HTML = `
+    <ar-tab-group>
+        <ar-tab panel="a">Tab A</ar-tab>
+        <ar-tab panel="b">Tab B</ar-tab>
+        <ar-tab-panel name="a">Panel A</ar-tab-panel>
+        <ar-tab-panel name="b">Panel B</ar-tab-panel>
+    </ar-tab-group>
+`;
+
+describe('ArTabGroup', () => {
+    let el: ArTabGroup;
+    afterEach(() => el?.remove());
+
+    // ── Rendu ───────────────────────────────────────────────────────────────
+
+    describe('rendu', () => {
+        beforeEach(async () => {
+            el = await fixture('<ar-tab-group></ar-tab-group>');
+        });
+
+        it('monte un shadow DOM', () => {
+            expect(el.shadowRoot).not.toBeNull();
+        });
+
+        it('contient part="base"', () => {
+            expect(getPart(el, 'base')).not.toBeNull();
+        });
+
+        it('contient part="nav"', () => {
+            expect(getPart(el, 'nav')).not.toBeNull();
+        });
+
+        it('contient part="tabs" avec role="tablist"', () => {
+            expect(getPart(el, 'tabs')?.getAttribute('role')).toBe('tablist');
+        });
+    });
+
+    // ── Valeurs par défaut ─────────────────────────────────────────────────
+
+    describe('valeurs par défaut', () => {
+        beforeEach(async () => {
+            el = await fixture('<ar-tab-group></ar-tab-group>');
+        });
+
+        it('active vaut chaîne vide', () => expect(el.active).toBe(''));
+        it('label vaut chaîne vide', () => expect(el.label).toBe(''));
+        it('manualActivation vaut false', () => expect(el.manualActivation).toBe(false));
+        it('scrollHints vaut false', () => expect(el.scrollHints).toBe(false));
+    });
+
+    // ── Onglet actif par défaut ────────────────────────────────────────────
+
+    describe('onglet actif par défaut', () => {
+        it('active le premier onglet non-disabled si active est absent', async () => {
+            el = await fixture(DEFAULT_HTML);
+            await waitForUpdate(el);
+            const tabA = el.querySelector<HTMLElement>('ar-tab[panel="a"]')!;
+            expect(tabA.getAttribute('aria-selected')).toBe('true');
+            expect(tabA.getAttribute('tabindex')).toBe('0');
+        });
+
+        it('masque le panel inactif avec hidden', async () => {
+            el = await fixture(DEFAULT_HTML);
+            await waitForUpdate(el);
+            const panelB = el.querySelector<HTMLElement>('ar-tab-panel[name="b"]')!;
+            expect(panelB.hasAttribute('hidden')).toBe(true);
+        });
+
+        it('affiche le panel actif sans hidden', async () => {
+            el = await fixture(DEFAULT_HTML);
+            await waitForUpdate(el);
+            const panelA = el.querySelector<HTMLElement>('ar-tab-panel[name="a"]')!;
+            expect(panelA.hasAttribute('hidden')).toBe(false);
+        });
+    });
+
+    // ── Attribut active ────────────────────────────────────────────────────
+
+    describe('attribut active', () => {
+        it('active le bon onglet selon active="b"', async () => {
+            el = await fixture(`
+                <ar-tab-group active="b">
+                    <ar-tab panel="a">Tab A</ar-tab>
+                    <ar-tab panel="b">Tab B</ar-tab>
+                    <ar-tab-panel name="a">Panel A</ar-tab-panel>
+                    <ar-tab-panel name="b">Panel B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            await waitForUpdate(el);
+            const tabB = el.querySelector<HTMLElement>('ar-tab[panel="b"]')!;
+            expect(tabB.getAttribute('aria-selected')).toBe('true');
+        });
+
+        it("changer active programmatiquement met à jour l'ARIA", async () => {
+            el = await fixture(DEFAULT_HTML);
+            await waitForUpdate(el);
+            el.active = 'b';
+            await waitForUpdate(el);
+            const tabB = el.querySelector<HTMLElement>('ar-tab[panel="b"]')!;
+            expect(tabB.getAttribute('aria-selected')).toBe('true');
+            const panelB = el.querySelector<HTMLElement>('ar-tab-panel[name="b"]')!;
+            expect(panelB.hasAttribute('hidden')).toBe(false);
+        });
+    });
+
+    // ── ARIA IDs et associations ───────────────────────────────────────────
+
+    describe('ARIA — IDs et associations', () => {
+        beforeEach(async () => {
+            el = await fixture(DEFAULT_HTML);
+            await waitForUpdate(el);
+        });
+
+        it('chaque ar-tab a role="tab"', () => {
+            el.querySelectorAll('ar-tab').forEach((tab) => {
+                expect(tab.getAttribute('role')).toBe('tab');
+            });
+        });
+
+        it('chaque ar-tab-panel a role="tabpanel"', () => {
+            el.querySelectorAll('ar-tab-panel').forEach((panel) => {
+                expect(panel.getAttribute('role')).toBe('tabpanel');
+            });
+        });
+
+        it("aria-controls sur ar-tab pointe vers l'ID du panel correspondant", () => {
+            const tabA = el.querySelector<HTMLElement>('ar-tab[panel="a"]')!;
+            const panelA = el.querySelector<HTMLElement>('ar-tab-panel[name="a"]')!;
+            expect(tabA.getAttribute('aria-controls')).toBe(panelA.id);
+        });
+
+        it("aria-labelledby sur ar-tab-panel pointe vers l'ID du tab correspondant", () => {
+            const tabA = el.querySelector<HTMLElement>('ar-tab[panel="a"]')!;
+            const panelA = el.querySelector<HTMLElement>('ar-tab-panel[name="a"]')!;
+            expect(panelA.getAttribute('aria-labelledby')).toBe(tabA.id);
+        });
+
+        it('chaque ar-tab-panel a tabindex="0"', () => {
+            el.querySelectorAll('ar-tab-panel').forEach((panel) => {
+                expect(panel.getAttribute('tabindex')).toBe('0');
+            });
+        });
+    });
+
+    // ── label ──────────────────────────────────────────────────────────────
+
+    describe('attribut label', () => {
+        it('pose aria-label sur le tablist', async () => {
+            el = await fixture(`
+                <ar-tab-group label="Navigation principale">
+                    <ar-tab panel="a">A</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            expect(getPart(el, 'tabs')?.getAttribute('aria-label')).toBe('Navigation principale');
+        });
+    });
+
+    // ── disabled ───────────────────────────────────────────────────────────
+
+    describe('ar-tab disabled', () => {
+        it('pose aria-disabled="true" sur l\'onglet désactivé', async () => {
+            el = await fixture(`
+                <ar-tab-group>
+                    <ar-tab panel="a" disabled>Tab A</ar-tab>
+                    <ar-tab panel="b">Tab B</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            await waitForUpdate(el);
+            const tabA = el.querySelector<HTMLElement>('ar-tab[panel="a"]')!;
+            expect(tabA.getAttribute('aria-disabled')).toBe('true');
+        });
+
+        it('saute le premier onglet si disabled et active le suivant', async () => {
+            el = await fixture(`
+                <ar-tab-group>
+                    <ar-tab panel="a" disabled>Tab A</ar-tab>
+                    <ar-tab panel="b">Tab B</ar-tab>
+                    <ar-tab-panel name="a">A</ar-tab-panel>
+                    <ar-tab-panel name="b">B</ar-tab-panel>
+                </ar-tab-group>
+            `);
+            await waitForUpdate(el);
+            const tabB = el.querySelector<HTMLElement>('ar-tab[panel="b"]')!;
+            expect(tabB.getAttribute('aria-selected')).toBe('true');
+        });
+    });
+
+    // ── Événement ─────────────────────────────────────────────────────────
+
+    describe('événement ar-tab-group-change', () => {
+        it('émet ar-tab-group-change avec { active } au clic', async () => {
+            el = await fixture(DEFAULT_HTML);
+            await waitForUpdate(el);
+            const events: CustomEvent[] = [];
+            el.addEventListener('ar-tab-group-change', (e) => events.push(e as CustomEvent));
+            const tabB = el.querySelector<HTMLElement>('ar-tab[panel="b"]')!;
+            tabB.click();
+            await waitForUpdate(el);
+            expect(events.length).toBe(1);
+            expect(events[0].detail).toEqual({ active: 'b' });
+        });
+    });
+
+    // ── warn() ─────────────────────────────────────────────────────────────
+
+    describe('warn() — panel orphelin', () => {
+        it("affiche un warn si panel d'un ar-tab n'a pas de ar-tab-panel correspondant", async () => {
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            el = await fixture(`
+                <ar-tab-group>
+                    <ar-tab panel="orphan">Tab</ar-tab>
+                </ar-tab-group>
+            `);
+            await waitForUpdate(el);
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('orphan'));
+            warnSpy.mockRestore();
+        });
+    });
+
+    // ── slot="tab" automatique ─────────────────────────────────────────────
+
+    describe('slot="tab" automatique', () => {
+        it('pose slot="tab" sur chaque ar-tab enregistré', async () => {
+            el = await fixture(DEFAULT_HTML);
+            await waitForUpdate(el);
+            el.querySelectorAll('ar-tab').forEach((tab) => {
+                expect(tab.getAttribute('slot')).toBe('tab');
+            });
+        });
+    });
+});

--- a/packages/core/src/components/tab-group/tab-group.test.ts
+++ b/packages/core/src/components/tab-group/tab-group.test.ts
@@ -52,7 +52,6 @@ describe('ArTabGroup', () => {
         it('active vaut chaîne vide', () => expect(el.active).toBe(''));
         it('label vaut chaîne vide', () => expect(el.label).toBe(''));
         it('manualActivation vaut false', () => expect(el.manualActivation).toBe(false));
-        it('scrollHints vaut false', () => expect(el.scrollHints).toBe(false));
     });
 
     // ── Onglet actif par défaut ────────────────────────────────────────────

--- a/packages/core/src/components/tab-group/tab-group.ts
+++ b/packages/core/src/components/tab-group/tab-group.ts
@@ -17,9 +17,9 @@ import styles from './tab-group.styles.js';
  * @csspart nav  - Zone scrollable (overflow-x: auto).
  * @csspart tabs - div[role="tablist"].
  *
- * @cssprop [--ar-tab-group-gap=0] - Espacement entre tablist et panels.
- * @cssprop [--ar-tab-group-border-width=0] - Épaisseur du trait séparateur sous la tablist. Mettre à 1px pour l'activer.
- * @cssprop [--ar-tab-group-border-color=transparent] - Couleur du trait séparateur sous la tablist.
+ * @cssprop --ar-tab-group-gap - Espacement entre tablist et panels.
+ * @cssprop --ar-tab-group-border-width - Épaisseur du trait séparateur sous la tablist. Mettre à 1px pour l'activer.
+ * @cssprop --ar-tab-group-border-color - Couleur du trait séparateur sous la tablist.
  *
  * @event {CustomEvent<{ active: string }>} ar-tab-group-change - Émis quand l'onglet actif change.
  */

--- a/packages/core/src/components/tab-group/tab-group.ts
+++ b/packages/core/src/components/tab-group/tab-group.ts
@@ -98,18 +98,12 @@ export class ArTabGroup extends LitElement {
             this._syncAll();
             this._scrollActiveTabIntoView();
         }
-        if (changed.has('label')) {
-            const tablist = this.shadowRoot?.querySelector('[part="tabs"]');
-            if (tablist) {
-                if (this.label) tablist.setAttribute('aria-label', this.label);
-                else tablist.removeAttribute('aria-label');
-            }
-        }
     }
 
     override connectedCallback(): void {
         super.connectedCallback();
         this.addEventListener('keydown', this._handleKeyDown);
+        if (this._initialized) this._setupScrollHints();
     }
 
     override firstUpdated(): void {
@@ -201,6 +195,8 @@ export class ArTabGroup extends LitElement {
         if (!this._tabs.some((t) => t === target)) return;
 
         const enabledTabs = this._tabs.filter((t) => !t.disabled);
+        if (enabledTabs.length === 0) return;
+
         const currentIdx = enabledTabs.findIndex((t) => t === target);
 
         switch (e.key) {
@@ -208,7 +204,12 @@ export class ArTabGroup extends LitElement {
             case 'ArrowRight': {
                 e.preventDefault();
                 const dir = e.key === 'ArrowLeft' ? -1 : 1;
-                const newIdx = (currentIdx + dir + enabledTabs.length) % enabledTabs.length;
+                const newIdx =
+                    currentIdx === -1
+                        ? dir === 1
+                            ? 0
+                            : enabledTabs.length - 1
+                        : (currentIdx + dir + enabledTabs.length) % enabledTabs.length;
                 this._moveFocusTo(enabledTabs[newIdx]);
                 if (!this.manualActivation) {
                     this._registry.activate(enabledTabs[newIdx].panel);
@@ -228,8 +229,8 @@ export class ArTabGroup extends LitElement {
                 break;
             case 'Enter':
             case ' ':
+                e.preventDefault();
                 if (this.manualActivation) {
-                    e.preventDefault();
                     const tab = this._tabs.find((t) => t === target);
                     if (tab) this._registry.activate(tab.panel);
                 }
@@ -252,10 +253,11 @@ export class ArTabGroup extends LitElement {
         if (!nav) return;
 
         const update = () => {
-            this.classList.toggle('has-overflow-start', nav.scrollLeft > 0);
+            const scrollLeft = Math.abs(nav.scrollLeft);
+            this.classList.toggle('has-overflow-start', scrollLeft > 0);
             this.classList.toggle(
                 'has-overflow-end',
-                Math.ceil(nav.scrollLeft + nav.clientWidth) < nav.scrollWidth,
+                Math.ceil(scrollLeft + nav.clientWidth) < nav.scrollWidth,
             );
         };
 

--- a/packages/core/src/components/tab-group/tab-group.ts
+++ b/packages/core/src/components/tab-group/tab-group.ts
@@ -59,8 +59,14 @@ export class ArTabGroup extends LitElement {
             this._syncAll();
         },
         unregisterTab: (tab: ArTab) => {
+            const wasActive = tab.panel === this.active;
             this._tabs = this._tabs.filter((t) => t !== tab);
             this._syncAll();
+            if (wasActive) {
+                const newActive = this._effectiveActive;
+                this.active = newActive;
+                this._emit('ar-tab-group-change', { active: newActive });
+            }
         },
         registerPanel: (panel: ArTabPanel) => {
             if (!this._panels.includes(panel)) {

--- a/packages/core/src/components/tab-group/tab-group.ts
+++ b/packages/core/src/components/tab-group/tab-group.ts
@@ -17,6 +17,9 @@ import styles from './tab-group.styles.js';
  * @csspart nav  - Zone scrollable (overflow-x: auto).
  * @csspart tabs - div[role="tablist"].
  *
+ * Les classes `has-overflow-start` et `has-overflow-end` sont ajoutées automatiquement sur l'hôte
+ * quand le contenu de la tablist déborde à gauche ou à droite.
+ *
  * @cssprop --ar-tab-group-gap - Espacement entre tablist et panels.
  * @cssprop --ar-tab-group-border-top-width - Épaisseur du trait séparateur en haut de la la tablist. Mettre à 1px pour l'activer.
  * @cssprop --ar-tab-group-border-bottom-width - Épaisseur du trait séparateur sous la tablist. Mettre à 1px pour l'activer.
@@ -37,10 +40,6 @@ export class ArTabGroup extends LitElement {
     /** Active le mode manuel : les flèches déplacent le focus sans activer l'onglet. */
     @property({ attribute: 'manual-activation', reflect: true, type: Boolean })
     manualActivation = false;
-
-    /** Active les classes has-overflow-start / has-overflow-end sur part="nav". */
-    @property({ attribute: 'scroll-hints', reflect: true, type: Boolean })
-    scrollHints = false;
 
     private _tabs: ArTab[] = [];
     private _panels: ArTabPanel[] = [];
@@ -99,14 +98,15 @@ export class ArTabGroup extends LitElement {
                 else tablist.removeAttribute('aria-label');
             }
         }
-        if (changed.has('scrollHints')) {
-            this._setupScrollHints();
-        }
     }
 
     override connectedCallback(): void {
         super.connectedCallback();
         this.addEventListener('keydown', this._handleKeyDown);
+    }
+
+    override firstUpdated(): void {
+        this._setupScrollHints();
     }
 
     override disconnectedCallback(): void {
@@ -168,6 +168,12 @@ export class ArTabGroup extends LitElement {
                 panel.setAttribute('hidden', '');
             }
         });
+    }
+
+    /** Scrolle la zone de navigation d'un certain nombre de pixels vers `'start'` ou `'end'`. */
+    scrollNav(direction: 'start' | 'end', amount = 200): void {
+        const nav = this.shadowRoot?.querySelector<HTMLElement>('[part="nav"]');
+        nav?.scrollBy({ left: direction === 'end' ? amount : -amount, behavior: 'smooth' });
     }
 
     private _scrollActiveTabIntoView(): void {
@@ -233,7 +239,7 @@ export class ArTabGroup extends LitElement {
         this._scrollHintsUnlisten = undefined;
 
         const nav = this.shadowRoot?.querySelector<HTMLElement>('[part="nav"]');
-        if (!nav || !this.scrollHints) return;
+        if (!nav) return;
 
         const update = () => {
             this.classList.toggle('has-overflow-start', nav.scrollLeft > 0);

--- a/packages/core/src/components/tab-group/tab-group.ts
+++ b/packages/core/src/components/tab-group/tab-group.ts
@@ -44,6 +44,7 @@ export class ArTabGroup extends LitElement {
     private _tabs: ArTab[] = [];
     private _panels: ArTabPanel[] = [];
     private readonly _prefix = Math.random().toString(36).slice(2, 9);
+    private _initialized = false;
     private _resizeObserver?: ResizeObserver | undefined;
     private _scrollHintsUnlisten?: (() => void) | undefined;
 
@@ -112,6 +113,7 @@ export class ArTabGroup extends LitElement {
     }
 
     override firstUpdated(): void {
+        this._initialized = true;
         this._setupScrollHints();
     }
 
@@ -158,7 +160,9 @@ export class ArTabGroup extends LitElement {
                 tab.removeAttribute('aria-disabled');
             }
             if (tab.panel && !this._panels.find((p) => p.name === tab.panel)) {
-                warn('ar-tab-group', `Aucun ar-tab-panel avec name="${tab.panel}" trouvé.`);
+                if (this._initialized) {
+                    warn('ar-tab-group', `Aucun ar-tab-panel avec name="${tab.panel}" trouvé.`);
+                }
             }
         });
 

--- a/packages/core/src/components/tab-group/tab-group.ts
+++ b/packages/core/src/components/tab-group/tab-group.ts
@@ -18,7 +18,8 @@ import styles from './tab-group.styles.js';
  * @csspart tabs - div[role="tablist"].
  *
  * @cssprop --ar-tab-group-gap - Espacement entre tablist et panels.
- * @cssprop --ar-tab-group-border-width - Épaisseur du trait séparateur sous la tablist. Mettre à 1px pour l'activer.
+ * @cssprop --ar-tab-group-border-top-width - Épaisseur du trait séparateur en haut de la la tablist. Mettre à 1px pour l'activer.
+ * @cssprop --ar-tab-group-border-bottom-width - Épaisseur du trait séparateur sous la tablist. Mettre à 1px pour l'activer.
  * @cssprop --ar-tab-group-border-color - Couleur du trait séparateur sous la tablist.
  *
  * @event {CustomEvent<{ active: string }>} ar-tab-group-change - Émis quand l'onglet actif change.

--- a/packages/core/src/components/tab-group/tab-group.ts
+++ b/packages/core/src/components/tab-group/tab-group.ts
@@ -233,10 +233,10 @@ export class ArTabGroup extends LitElement {
         if (!nav || !this.scrollHints) return;
 
         const update = () => {
-            nav.classList.toggle('has-overflow-start', nav.scrollLeft > 0);
-            nav.classList.toggle(
+            this.classList.toggle('has-overflow-start', nav.scrollLeft > 0);
+            this.classList.toggle(
                 'has-overflow-end',
-                nav.scrollLeft + nav.clientWidth < nav.scrollWidth,
+                Math.ceil(nav.scrollLeft + nav.clientWidth) < nav.scrollWidth,
             );
         };
 

--- a/packages/core/src/components/tab-group/tab-group.ts
+++ b/packages/core/src/components/tab-group/tab-group.ts
@@ -1,0 +1,255 @@
+import { LitElement, html, nothing, type PropertyValues } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { ContextProvider } from '@lit/context';
+import { tabGroupContext, type TabGroupRegistry } from '../../context/tabs.context.js';
+import type { ArTab } from '../tab/tab.js';
+import type { ArTabPanel } from '../tab-panel/tab-panel.js';
+import { warn } from '../../utils/warn.js';
+import styles from './tab-group.styles.js';
+
+/**
+ * @summary Groupe d'onglets accessibles — pattern WAI-ARIA Tabs complet.
+ * @display demo
+ *
+ * @slot - ar-tab et ar-tab-panel enfants.
+ *
+ * @csspart base - Conteneur racine.
+ * @csspart nav  - Zone scrollable (overflow-x: auto).
+ * @csspart tabs - div[role="tablist"].
+ *
+ * @cssprop [--ar-tab-group-gap=0] - Espacement entre tablist et panels.
+ *
+ * @event {CustomEvent<{ active: string }>} ar-tab-group-change - Émis quand l'onglet actif change.
+ */
+@customElement('ar-tab-group')
+export class ArTabGroup extends LitElement {
+    static override styles = [styles];
+
+    /** Nom de l'onglet actif. Si absent, le premier onglet non-disabled s'active. */
+    @property({ reflect: true }) active = '';
+
+    /** aria-label sur le tablist — recommandé si plusieurs ar-tab-group sur la page. */
+    @property({ reflect: true }) label = '';
+
+    /** Active le mode manuel : les flèches déplacent le focus sans activer l'onglet. */
+    @property({ attribute: 'manual-activation', reflect: true, type: Boolean })
+    manualActivation = false;
+
+    /** Active les classes has-overflow-start / has-overflow-end sur part="nav". */
+    @property({ attribute: 'scroll-hints', reflect: true, type: Boolean })
+    scrollHints = false;
+
+    private _tabs: ArTab[] = [];
+    private _panels: ArTabPanel[] = [];
+    private readonly _prefix = Math.random().toString(36).slice(2, 9);
+    private _resizeObserver?: ResizeObserver | undefined;
+    private _scrollHintsUnlisten?: (() => void) | undefined;
+
+    private readonly _registry: TabGroupRegistry = {
+        registerTab: (tab: ArTab) => {
+            if (!this._tabs.includes(tab)) {
+                this._tabs.push(tab);
+                this._tabs.sort((a, b) =>
+                    a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1,
+                );
+            }
+            tab.setAttribute('slot', 'tab');
+            this._syncAll();
+        },
+        unregisterTab: (tab: ArTab) => {
+            this._tabs = this._tabs.filter((t) => t !== tab);
+            this._syncAll();
+        },
+        registerPanel: (panel: ArTabPanel) => {
+            if (!this._panels.includes(panel)) {
+                this._panels.push(panel);
+            }
+            this._syncAll();
+        },
+        unregisterPanel: (panel: ArTabPanel) => {
+            this._panels = this._panels.filter((p) => p !== panel);
+            this._syncAll();
+        },
+        activate: (name: string) => {
+            if (this.active === name) return;
+            this.active = name;
+            this._syncAll();
+            this._scrollActiveTabIntoView();
+            this._emit('ar-tab-group-change', { active: name });
+        },
+    };
+
+    protected readonly _provider = new ContextProvider(this, {
+        context: tabGroupContext,
+        initialValue: this._registry,
+    });
+
+    override updated(changed: PropertyValues<this>): void {
+        if (changed.has('active')) {
+            this._syncAll();
+            this._scrollActiveTabIntoView();
+        }
+        if (changed.has('label')) {
+            const tablist = this.shadowRoot?.querySelector('[part="tabs"]');
+            if (tablist) {
+                if (this.label) tablist.setAttribute('aria-label', this.label);
+                else tablist.removeAttribute('aria-label');
+            }
+        }
+        if (changed.has('scrollHints')) {
+            this._setupScrollHints();
+        }
+    }
+
+    override connectedCallback(): void {
+        super.connectedCallback();
+        this.addEventListener('keydown', this._handleKeyDown);
+    }
+
+    override disconnectedCallback(): void {
+        super.disconnectedCallback();
+        this.removeEventListener('keydown', this._handleKeyDown);
+        this._resizeObserver?.disconnect();
+        this._scrollHintsUnlisten?.();
+    }
+
+    override render() {
+        return html`
+            <div part="base">
+                <div part="nav">
+                    <div part="tabs" role="tablist" aria-label=${this.label || nothing}>
+                        <slot name="tab"></slot>
+                    </div>
+                </div>
+                <slot></slot>
+            </div>
+        `;
+    }
+
+    private get _effectiveActive(): string {
+        const found = this._tabs.find((t) => t.panel === this.active && !t.disabled);
+        if (found) return this.active;
+        return this._tabs.find((t) => !t.disabled)?.panel ?? '';
+    }
+
+    private _syncAll(): void {
+        const active = this._effectiveActive;
+        const pfx = this._prefix;
+
+        this._tabs.forEach((tab) => {
+            const isActive = tab.panel === active;
+            tab.setAttribute('role', 'tab');
+            tab.id = `${pfx}-tab-${tab.panel}`;
+            tab.setAttribute('aria-controls', `${pfx}-panel-${tab.panel}`);
+            tab.setAttribute('aria-selected', String(isActive));
+            tab.setAttribute('tabindex', isActive ? '0' : '-1');
+            if (tab.disabled) {
+                tab.setAttribute('aria-disabled', 'true');
+            } else {
+                tab.removeAttribute('aria-disabled');
+            }
+            if (tab.panel && !this._panels.find((p) => p.name === tab.panel)) {
+                warn('ar-tab-group', `Aucun ar-tab-panel avec name="${tab.panel}" trouvé.`);
+            }
+        });
+
+        this._panels.forEach((panel) => {
+            const isActive = panel.name === active;
+            panel.setAttribute('role', 'tabpanel');
+            panel.id = `${pfx}-panel-${panel.name}`;
+            panel.setAttribute('aria-labelledby', `${pfx}-tab-${panel.name}`);
+            panel.setAttribute('tabindex', '0');
+            if (isActive) {
+                panel.removeAttribute('hidden');
+            } else {
+                panel.setAttribute('hidden', '');
+            }
+        });
+    }
+
+    private _scrollActiveTabIntoView(): void {
+        const active = this._effectiveActive;
+        const tab = this._tabs.find((t) => t.panel === active);
+        tab?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+    }
+
+    private _emit(name: string, detail: unknown): void {
+        this.dispatchEvent(new CustomEvent(name, { detail, bubbles: true, composed: true }));
+    }
+
+    private _handleKeyDown = (e: KeyboardEvent): void => {
+        const target = e.composedPath()[0] as Element;
+        if (!this._tabs.some((t) => t === target)) return;
+
+        const enabledTabs = this._tabs.filter((t) => !t.disabled);
+        const currentIdx = enabledTabs.findIndex((t) => t === target);
+
+        switch (e.key) {
+            case 'ArrowLeft':
+            case 'ArrowRight': {
+                e.preventDefault();
+                const dir = e.key === 'ArrowLeft' ? -1 : 1;
+                const newIdx = (currentIdx + dir + enabledTabs.length) % enabledTabs.length;
+                this._moveFocusTo(enabledTabs[newIdx]);
+                if (!this.manualActivation) {
+                    this._registry.activate(enabledTabs[newIdx].panel);
+                }
+                break;
+            }
+            case 'Home':
+                e.preventDefault();
+                this._moveFocusTo(enabledTabs[0]);
+                if (!this.manualActivation) this._registry.activate(enabledTabs[0].panel);
+                break;
+            case 'End':
+                e.preventDefault();
+                this._moveFocusTo(enabledTabs[enabledTabs.length - 1]);
+                if (!this.manualActivation)
+                    this._registry.activate(enabledTabs[enabledTabs.length - 1].panel);
+                break;
+            case 'Enter':
+            case ' ':
+                if (this.manualActivation) {
+                    e.preventDefault();
+                    const tab = this._tabs.find((t) => t === target);
+                    if (tab) this._registry.activate(tab.panel);
+                }
+                break;
+        }
+    };
+
+    private _moveFocusTo(tab: ArTab): void {
+        this._tabs.forEach((t) => t.setAttribute('tabindex', '-1'));
+        tab.setAttribute('tabindex', '0');
+        tab.focus();
+    }
+
+    private _setupScrollHints(): void {
+        this._resizeObserver?.disconnect();
+        this._scrollHintsUnlisten?.();
+        this._scrollHintsUnlisten = undefined;
+
+        const nav = this.shadowRoot?.querySelector<HTMLElement>('[part="nav"]');
+        if (!nav || !this.scrollHints) return;
+
+        const update = () => {
+            nav.classList.toggle('has-overflow-start', nav.scrollLeft > 0);
+            nav.classList.toggle(
+                'has-overflow-end',
+                nav.scrollLeft + nav.clientWidth < nav.scrollWidth,
+            );
+        };
+
+        this._resizeObserver = new ResizeObserver(update);
+        this._resizeObserver.observe(nav);
+        nav.addEventListener('scroll', update, { passive: true });
+        this._scrollHintsUnlisten = () => nav.removeEventListener('scroll', update);
+        update();
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'ar-tab-group': ArTabGroup;
+    }
+}

--- a/packages/core/src/components/tab-group/tab-group.ts
+++ b/packages/core/src/components/tab-group/tab-group.ts
@@ -18,6 +18,8 @@ import styles from './tab-group.styles.js';
  * @csspart tabs - div[role="tablist"].
  *
  * @cssprop [--ar-tab-group-gap=0] - Espacement entre tablist et panels.
+ * @cssprop [--ar-tab-group-border-width=0] - Épaisseur du trait séparateur sous la tablist. Mettre à 1px pour l'activer.
+ * @cssprop [--ar-tab-group-border-color=transparent] - Couleur du trait séparateur sous la tablist.
  *
  * @event {CustomEvent<{ active: string }>} ar-tab-group-change - Émis quand l'onglet actif change.
  */

--- a/packages/core/src/components/tab-panel/tab-panel.styles.ts
+++ b/packages/core/src/components/tab-panel/tab-panel.styles.ts
@@ -3,6 +3,9 @@ import { css } from 'lit';
 export default css`
     :host {
         display: block;
-        box-sizing: border-box;
+    }
+
+    :host([hidden]) {
+        display: none;
     }
 `;

--- a/packages/core/src/components/tab-panel/tab-panel.styles.ts
+++ b/packages/core/src/components/tab-panel/tab-panel.styles.ts
@@ -1,0 +1,8 @@
+import { css } from 'lit';
+
+export default css`
+    :host {
+        display: block;
+        box-sizing: border-box;
+    }
+`;

--- a/packages/core/src/components/tab-panel/tab-panel.test.ts
+++ b/packages/core/src/components/tab-panel/tab-panel.test.ts
@@ -1,66 +1,38 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
+import { fixture, waitForUpdate } from '../../test-utils.js';
 import type { ArTabPanel } from './tab-panel.js';
-import { fixture, getPart } from '../../test-utils.js';
 import './tab-panel.js';
-
-// ─── Aide-mémoire tests Lit ────────────────────────────────────────────────────
-//
-// fixture(html)          — monte un élément dans le DOM et attend le premier rendu
-// waitForUpdate(el)      — attend le prochain cycle de rendu après une mutation
-// getPart(el, 'name')    — retourne un part="name" du Shadow DOM (| null)
-//                          → utiliser pour les assertions .toBeNull() / .not.toBeNull()
-// requirePart(el, 'name')— idem, mais lance une erreur si absent
-//                          → utiliser quand on enchaîne .getAttribute, .classList, etc.
-//
-// ⚠ happy-dom ne sérialise pas les Text nodes dynamiques Lit en textContent.
-//   Tester le contenu textuel via la propriété JS (el.myProp) plutôt que textContent.
-//
-// ⚠ Les propriétés ARIA assignées via .ariaCurrent, .ariaExpanded, etc. (liaisons
-//   Lit) ne reflètent pas en attribut HTML dans happy-dom. Tester la propriété
-//   JS : (el as unknown as { ariaCurrent: string }).ariaCurrent.
-//
-// ─── Éléments à tester selon le type de composant ─────────────────────────────
-//
-// Composant standard (avec Shadow DOM) :
-//   - Rendu : shadowRoot non null, parts présents (getPart)
-//   - Valeurs par défaut : vérifier chaque propriété à l'état initial
-//   - Attributs reflect : el.prop = x → await waitForUpdate → el.getAttribute(...)
-//   - Comportement : interactions (clic, événements custom)
-//   - Accessibilité : role, aria-*, labels sr-only
-//
-// Sous-composant (sans Shadow DOM, createRenderRoot → this) :
-//   - shadowRoot est null
-//   - setRegistry() appelle registerItem / unregisterItem
-//   - disconnectedCallback() appelle unregisterItem
-//   - updated() appelle notifyItemChanged après le premier rendu seulement
-// ──────────────────────────────────────────────────────────────────────────────
 
 describe('ArTabPanel', () => {
     let el: ArTabPanel;
-
     afterEach(() => el?.remove());
 
-    // ── Rendu ─────────────────────────────────────────────────────────────────
-
     describe('rendu', () => {
-        beforeEach(async () => {
-            el = await fixture('<ar-tab-panel></ar-tab-panel>');
-        });
-
-        it('monte un shadow DOM', () => {
+        it('monte un shadow DOM avec un slot', async () => {
+            el = await fixture('<ar-tab-panel name="a">Contenu</ar-tab-panel>');
             expect(el.shadowRoot).not.toBeNull();
-        });
-
-        it('contient un élément racine avec part="base"', () => {
-            expect(getPart(el, 'base')).not.toBeNull();
+            expect(el.shadowRoot?.querySelector('slot')).not.toBeNull();
         });
     });
 
-    // ── Valeurs par défaut ────────────────────────────────────────────────────
+    describe('valeurs par défaut', () => {
+        it('name vaut chaîne vide', async () => {
+            el = await fixture('<ar-tab-panel>Contenu</ar-tab-panel>');
+            expect(el.name).toBe('');
+        });
+    });
 
-    // describe('valeurs par défaut', () => { ... });
+    describe('attribut name', () => {
+        it("lit name depuis l'attribut HTML", async () => {
+            el = await fixture('<ar-tab-panel name="intro">Contenu</ar-tab-panel>');
+            expect(el.name).toBe('intro');
+        });
 
-    // ── Propriétés ────────────────────────────────────────────────────────────
-
-    // describe('propriétés', () => { ... });
+        it('reflète name en attribut', async () => {
+            el = await fixture('<ar-tab-panel name="intro">Contenu</ar-tab-panel>');
+            el.name = 'usage';
+            await waitForUpdate(el);
+            expect(el.getAttribute('name')).toBe('usage');
+        });
+    });
 });

--- a/packages/core/src/components/tab-panel/tab-panel.test.ts
+++ b/packages/core/src/components/tab-panel/tab-panel.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { ArTabPanel } from './tab-panel.js';
+import { fixture, getPart } from '../../test-utils.js';
+import './tab-panel.js';
+
+// ─── Aide-mémoire tests Lit ────────────────────────────────────────────────────
+//
+// fixture(html)          — monte un élément dans le DOM et attend le premier rendu
+// waitForUpdate(el)      — attend le prochain cycle de rendu après une mutation
+// getPart(el, 'name')    — retourne un part="name" du Shadow DOM (| null)
+//                          → utiliser pour les assertions .toBeNull() / .not.toBeNull()
+// requirePart(el, 'name')— idem, mais lance une erreur si absent
+//                          → utiliser quand on enchaîne .getAttribute, .classList, etc.
+//
+// ⚠ happy-dom ne sérialise pas les Text nodes dynamiques Lit en textContent.
+//   Tester le contenu textuel via la propriété JS (el.myProp) plutôt que textContent.
+//
+// ⚠ Les propriétés ARIA assignées via .ariaCurrent, .ariaExpanded, etc. (liaisons
+//   Lit) ne reflètent pas en attribut HTML dans happy-dom. Tester la propriété
+//   JS : (el as unknown as { ariaCurrent: string }).ariaCurrent.
+//
+// ─── Éléments à tester selon le type de composant ─────────────────────────────
+//
+// Composant standard (avec Shadow DOM) :
+//   - Rendu : shadowRoot non null, parts présents (getPart)
+//   - Valeurs par défaut : vérifier chaque propriété à l'état initial
+//   - Attributs reflect : el.prop = x → await waitForUpdate → el.getAttribute(...)
+//   - Comportement : interactions (clic, événements custom)
+//   - Accessibilité : role, aria-*, labels sr-only
+//
+// Sous-composant (sans Shadow DOM, createRenderRoot → this) :
+//   - shadowRoot est null
+//   - setRegistry() appelle registerItem / unregisterItem
+//   - disconnectedCallback() appelle unregisterItem
+//   - updated() appelle notifyItemChanged après le premier rendu seulement
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('ArTabPanel', () => {
+    let el: ArTabPanel;
+
+    afterEach(() => el?.remove());
+
+    // ── Rendu ─────────────────────────────────────────────────────────────────
+
+    describe('rendu', () => {
+        beforeEach(async () => {
+            el = await fixture('<ar-tab-panel></ar-tab-panel>');
+        });
+
+        it('monte un shadow DOM', () => {
+            expect(el.shadowRoot).not.toBeNull();
+        });
+
+        it('contient un élément racine avec part="base"', () => {
+            expect(getPart(el, 'base')).not.toBeNull();
+        });
+    });
+
+    // ── Valeurs par défaut ────────────────────────────────────────────────────
+
+    // describe('valeurs par défaut', () => { ... });
+
+    // ── Propriétés ────────────────────────────────────────────────────────────
+
+    // describe('propriétés', () => { ... });
+});

--- a/packages/core/src/components/tab-panel/tab-panel.ts
+++ b/packages/core/src/components/tab-panel/tab-panel.ts
@@ -20,7 +20,7 @@ export class ArTabPanel extends LitElement {
     /** Nom correspondant à l'attribut `panel` du ar-tab associé. Requis. */
     @property({ reflect: true }) name = '';
 
-    private _registry?: TabGroupRegistry;
+    private _registry?: TabGroupRegistry | undefined;
 
     protected readonly _consumer = new ContextConsumer(this, {
         context: tabGroupContext,

--- a/packages/core/src/components/tab-panel/tab-panel.ts
+++ b/packages/core/src/components/tab-panel/tab-panel.ts
@@ -1,27 +1,49 @@
 import { LitElement, html } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
+import { ContextConsumer } from '@lit/context';
+import { tabGroupContext, type TabGroupRegistry } from '../../context/tabs.context.js';
 import styles from './tab-panel.styles.js';
 
 /**
- * @summary Résumé du composant ar-tab-panel.
+ * @summary Panneau de contenu pour ar-tab-group.
+ * @parent ar-tab-group
+ * @display docs
  *
- * @slot         - Contenu principal.
+ * @slot - Contenu du panel.
  *
- * @csspart base - L'élément racine du composant.
- * @cssprop [--ar-tab-panel-size=auto] - Taille du composant.
- *
- * @event {CustomEvent} ar-tab-panel-change - Émis lors d'un changement.
+ * @csspart base - Wrapper du slot.
  */
 @customElement('ar-tab-panel')
 export class ArTabPanel extends LitElement {
     static override styles = [styles];
 
+    /** Nom correspondant à l'attribut `panel` du ar-tab associé. Requis. */
+    @property({ reflect: true }) name = '';
+
+    private _registry?: TabGroupRegistry;
+
+    protected readonly _consumer = new ContextConsumer(this, {
+        context: tabGroupContext,
+        subscribe: true,
+        callback: (registry) => this._setRegistry(registry),
+    });
+
+    private _setRegistry(registry: TabGroupRegistry): void {
+        if (this._registry) {
+            this._registry.unregisterPanel(this);
+        }
+        this._registry = registry;
+        registry.registerPanel(this);
+    }
+
+    override disconnectedCallback(): void {
+        this._registry?.unregisterPanel(this);
+        this._registry = undefined;
+        super.disconnectedCallback();
+    }
+
     override render() {
-        return html`
-            <div part="base">
-                <slot></slot>
-            </div>
-        `;
+        return html`<div part="base"><slot></slot></div>`;
     }
 }
 

--- a/packages/core/src/components/tab-panel/tab-panel.ts
+++ b/packages/core/src/components/tab-panel/tab-panel.ts
@@ -1,0 +1,32 @@
+import { LitElement, html } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import styles from './tab-panel.styles.js';
+
+/**
+ * @summary Résumé du composant ar-tab-panel.
+ *
+ * @slot         - Contenu principal.
+ *
+ * @csspart base - L'élément racine du composant.
+ * @cssprop [--ar-tab-panel-size=auto] - Taille du composant.
+ *
+ * @event {CustomEvent} ar-tab-panel-change - Émis lors d'un changement.
+ */
+@customElement('ar-tab-panel')
+export class ArTabPanel extends LitElement {
+    static override styles = [styles];
+
+    override render() {
+        return html`
+            <div part="base">
+                <slot></slot>
+            </div>
+        `;
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'ar-tab-panel': ArTabPanel;
+    }
+}

--- a/packages/core/src/components/tab/tab.styles.ts
+++ b/packages/core/src/components/tab/tab.styles.ts
@@ -6,33 +6,33 @@ export default css`
         cursor: pointer;
         white-space: nowrap;
         user-select: none;
-        border-radius: var(--ar-tab-border-radius, 0);
-        font-weight: var(--ar-tab-font-weight, inherit);
+        border-radius: var(--ar-tab-border-radius);
+        font-weight: var(--ar-tab-font-weight);
     }
 
     [part='base'] {
         display: flex;
         align-items: center;
-        color: var(--ar-tab-color, inherit);
-        background: var(--ar-tab-bg, transparent);
-        padding: var(--ar-tab-padding-y, 0.5rem) var(--ar-tab-padding-x, 1rem);
+        color: var(--ar-tab-color);
+        background: var(--ar-tab-bg);
+        padding: var(--ar-tab-padding-y) var(--ar-tab-padding-x);
         border-radius: inherit;
     }
 
     :host(:hover:not([disabled]):not([aria-selected='true'])) [part='base'] {
-        color: var(--ar-tab-hover-color, inherit);
-        background: var(--ar-tab-hover-bg, transparent);
+        color: var(--ar-tab-hover-color);
+        background: var(--ar-tab-hover-bg);
     }
 
     :host([aria-selected='true']) [part='base'] {
-        color: var(--ar-tab-active-color, inherit);
-        background: var(--ar-tab-active-bg, transparent);
-        box-shadow: var(--ar-tab-active-shadow, none);
+        color: var(--ar-tab-active-color);
+        background: var(--ar-tab-active-bg);
+        box-shadow: var(--ar-tab-active-shadow);
     }
 
     :host([disabled]) {
         cursor: not-allowed;
-        opacity: var(--ar-tab-disabled-opacity, 0.5);
+        opacity: var(--ar-tab-disabled-opacity);
     }
 
     :host([aria-selected='true']:not([disabled])) {
@@ -40,7 +40,7 @@ export default css`
     }
 
     :host(:focus-visible) {
-        outline: 2px solid var(--ar-focus-ring-color, currentColor);
-        outline-offset: var(--ar-tab-focus-ring-offset, -2px);
+        outline: 2px solid var(--ar-focus-ring-color);
+        outline-offset: var(--ar-tab-focus-ring-offset);
     }
 `;

--- a/packages/core/src/components/tab/tab.styles.ts
+++ b/packages/core/src/components/tab/tab.styles.ts
@@ -17,6 +17,8 @@ export default css`
         background: var(--ar-tab-bg);
         padding: var(--ar-tab-padding-y) var(--ar-tab-padding-x);
         border-radius: inherit;
+        margin-block-start: calc(-1 * var(--ar-tab-group-border-top-width, 0px));
+        margin-block-end: calc(-1 * var(--ar-tab-group-border-bottom-width, 0px));
     }
 
     :host(:hover:not([disabled]):not([aria-selected='true'])) [part='base'] {

--- a/packages/core/src/components/tab/tab.styles.ts
+++ b/packages/core/src/components/tab/tab.styles.ts
@@ -6,15 +6,37 @@ export default css`
         cursor: pointer;
         white-space: nowrap;
         user-select: none;
+        border-radius: var(--ar-tab-border-radius, 0);
+        font-weight: var(--ar-tab-font-weight, inherit);
+    }
+
+    [part='base'] {
+        display: flex;
+        align-items: center;
+        color: var(--ar-tab-color, inherit);
+        background: var(--ar-tab-bg, transparent);
+        padding: var(--ar-tab-padding-y, 0.5rem) var(--ar-tab-padding-x, 1rem);
+        border-radius: inherit;
+    }
+
+    :host(:hover:not([disabled])) [part='base'] {
+        color: var(--ar-tab-hover-color, inherit);
+        background: var(--ar-tab-hover-bg, transparent);
+    }
+
+    :host([aria-selected='true']) [part='base'] {
+        color: var(--ar-tab-active-color, inherit);
+        background: var(--ar-tab-active-bg, transparent);
+        box-shadow: var(--ar-tab-active-shadow, none);
     }
 
     :host([disabled]) {
         cursor: not-allowed;
-        opacity: 0.5;
+        opacity: var(--ar-tab-disabled-opacity, 0.5);
     }
 
     :host(:focus-visible) {
-        outline: 2px solid currentColor;
-        outline-offset: -2px;
+        outline: 2px solid var(--ar-focus-ring-color, currentColor);
+        outline-offset: var(--ar-focus-ring-offset, 2px);
     }
 `;

--- a/packages/core/src/components/tab/tab.styles.ts
+++ b/packages/core/src/components/tab/tab.styles.ts
@@ -35,7 +35,7 @@ export default css`
         opacity: var(--ar-tab-disabled-opacity, 0.5);
     }
 
-    :host([aria-selected='true']) {
+    :host([aria-selected='true']:not([disabled])) {
         cursor: default;
     }
 

--- a/packages/core/src/components/tab/tab.styles.ts
+++ b/packages/core/src/components/tab/tab.styles.ts
@@ -2,7 +2,19 @@ import { css } from 'lit';
 
 export default css`
     :host {
-        display: block;
-        box-sizing: border-box;
+        display: inline-flex;
+        cursor: pointer;
+        white-space: nowrap;
+        user-select: none;
+    }
+
+    :host([disabled]) {
+        cursor: not-allowed;
+        opacity: 0.5;
+    }
+
+    :host(:focus-visible) {
+        outline: 2px solid currentColor;
+        outline-offset: -2px;
     }
 `;

--- a/packages/core/src/components/tab/tab.styles.ts
+++ b/packages/core/src/components/tab/tab.styles.ts
@@ -19,7 +19,7 @@ export default css`
         border-radius: inherit;
     }
 
-    :host(:hover:not([disabled])) [part='base'] {
+    :host(:hover:not([disabled]):not([aria-selected='true'])) [part='base'] {
         color: var(--ar-tab-hover-color, inherit);
         background: var(--ar-tab-hover-bg, transparent);
     }
@@ -35,8 +35,12 @@ export default css`
         opacity: var(--ar-tab-disabled-opacity, 0.5);
     }
 
+    :host([aria-selected='true']) {
+        cursor: default;
+    }
+
     :host(:focus-visible) {
         outline: 2px solid var(--ar-focus-ring-color, currentColor);
-        outline-offset: var(--ar-focus-ring-offset, 2px);
+        outline-offset: var(--ar-tab-focus-ring-offset, -2px);
     }
 `;

--- a/packages/core/src/components/tab/tab.styles.ts
+++ b/packages/core/src/components/tab/tab.styles.ts
@@ -1,0 +1,8 @@
+import { css } from 'lit';
+
+export default css`
+    :host {
+        display: block;
+        box-sizing: border-box;
+    }
+`;

--- a/packages/core/src/components/tab/tab.test.ts
+++ b/packages/core/src/components/tab/tab.test.ts
@@ -1,66 +1,70 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fixture, waitForUpdate } from '../../test-utils.js';
 import type { ArTab } from './tab.js';
-import { fixture, getPart } from '../../test-utils.js';
 import './tab.js';
-
-// ─── Aide-mémoire tests Lit ────────────────────────────────────────────────────
-//
-// fixture(html)          — monte un élément dans le DOM et attend le premier rendu
-// waitForUpdate(el)      — attend le prochain cycle de rendu après une mutation
-// getPart(el, 'name')    — retourne un part="name" du Shadow DOM (| null)
-//                          → utiliser pour les assertions .toBeNull() / .not.toBeNull()
-// requirePart(el, 'name')— idem, mais lance une erreur si absent
-//                          → utiliser quand on enchaîne .getAttribute, .classList, etc.
-//
-// ⚠ happy-dom ne sérialise pas les Text nodes dynamiques Lit en textContent.
-//   Tester le contenu textuel via la propriété JS (el.myProp) plutôt que textContent.
-//
-// ⚠ Les propriétés ARIA assignées via .ariaCurrent, .ariaExpanded, etc. (liaisons
-//   Lit) ne reflètent pas en attribut HTML dans happy-dom. Tester la propriété
-//   JS : (el as unknown as { ariaCurrent: string }).ariaCurrent.
-//
-// ─── Éléments à tester selon le type de composant ─────────────────────────────
-//
-// Composant standard (avec Shadow DOM) :
-//   - Rendu : shadowRoot non null, parts présents (getPart)
-//   - Valeurs par défaut : vérifier chaque propriété à l'état initial
-//   - Attributs reflect : el.prop = x → await waitForUpdate → el.getAttribute(...)
-//   - Comportement : interactions (clic, événements custom)
-//   - Accessibilité : role, aria-*, labels sr-only
-//
-// Sous-composant (sans Shadow DOM, createRenderRoot → this) :
-//   - shadowRoot est null
-//   - setRegistry() appelle registerItem / unregisterItem
-//   - disconnectedCallback() appelle unregisterItem
-//   - updated() appelle notifyItemChanged après le premier rendu seulement
-// ──────────────────────────────────────────────────────────────────────────────
 
 describe('ArTab', () => {
     let el: ArTab;
-
     afterEach(() => el?.remove());
 
-    // ── Rendu ─────────────────────────────────────────────────────────────────
-
     describe('rendu', () => {
-        beforeEach(async () => {
-            el = await fixture('<ar-tab></ar-tab>');
-        });
-
-        it('monte un shadow DOM', () => {
+        it('monte un shadow DOM avec un slot', async () => {
+            el = await fixture('<ar-tab panel="a">Tab A</ar-tab>');
             expect(el.shadowRoot).not.toBeNull();
-        });
-
-        it('contient un élément racine avec part="base"', () => {
-            expect(getPart(el, 'base')).not.toBeNull();
+            expect(el.shadowRoot?.querySelector('slot')).not.toBeNull();
         });
     });
 
-    // ── Valeurs par défaut ────────────────────────────────────────────────────
+    describe('valeurs par défaut', () => {
+        it('panel vaut chaîne vide', async () => {
+            el = await fixture('<ar-tab>Tab</ar-tab>');
+            expect(el.panel).toBe('');
+        });
 
-    // describe('valeurs par défaut', () => { ... });
+        it('disabled vaut false', async () => {
+            el = await fixture('<ar-tab panel="a">Tab A</ar-tab>');
+            expect(el.disabled).toBe(false);
+        });
+    });
 
-    // ── Propriétés ────────────────────────────────────────────────────────────
+    describe('attribut panel', () => {
+        it("lit panel depuis l'attribut HTML", async () => {
+            el = await fixture('<ar-tab panel="intro">Tab</ar-tab>');
+            expect(el.panel).toBe('intro');
+        });
 
-    // describe('propriétés', () => { ... });
+        it('reflète panel en attribut', async () => {
+            el = await fixture('<ar-tab panel="intro">Tab</ar-tab>');
+            el.panel = 'usage';
+            await waitForUpdate(el);
+            expect(el.getAttribute('panel')).toBe('usage');
+        });
+    });
+
+    describe('disabled', () => {
+        it('reflète disabled en attribut', async () => {
+            el = await fixture('<ar-tab panel="a">Tab</ar-tab>');
+            el.disabled = true;
+            await waitForUpdate(el);
+            expect(el.hasAttribute('disabled')).toBe(true);
+        });
+
+        it('ne déclenche pas activate si disabled', async () => {
+            el = await fixture('<ar-tab panel="a" disabled>Tab</ar-tab>');
+            const spy = vi.fn();
+            (el as any)._registry = { activate: spy, registerTab: vi.fn(), unregisterTab: vi.fn() };
+            el.click();
+            expect(spy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('click', () => {
+        it('appelle registry.activate(panel) au clic', async () => {
+            el = await fixture('<ar-tab panel="test">Tab</ar-tab>');
+            const activate = vi.fn();
+            (el as any)._registry = { activate, registerTab: vi.fn(), unregisterTab: vi.fn() };
+            el.click();
+            expect(activate).toHaveBeenCalledWith('test');
+        });
+    });
 });

--- a/packages/core/src/components/tab/tab.test.ts
+++ b/packages/core/src/components/tab/tab.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { ArTab } from './tab.js';
+import { fixture, getPart } from '../../test-utils.js';
+import './tab.js';
+
+// ─── Aide-mémoire tests Lit ────────────────────────────────────────────────────
+//
+// fixture(html)          — monte un élément dans le DOM et attend le premier rendu
+// waitForUpdate(el)      — attend le prochain cycle de rendu après une mutation
+// getPart(el, 'name')    — retourne un part="name" du Shadow DOM (| null)
+//                          → utiliser pour les assertions .toBeNull() / .not.toBeNull()
+// requirePart(el, 'name')— idem, mais lance une erreur si absent
+//                          → utiliser quand on enchaîne .getAttribute, .classList, etc.
+//
+// ⚠ happy-dom ne sérialise pas les Text nodes dynamiques Lit en textContent.
+//   Tester le contenu textuel via la propriété JS (el.myProp) plutôt que textContent.
+//
+// ⚠ Les propriétés ARIA assignées via .ariaCurrent, .ariaExpanded, etc. (liaisons
+//   Lit) ne reflètent pas en attribut HTML dans happy-dom. Tester la propriété
+//   JS : (el as unknown as { ariaCurrent: string }).ariaCurrent.
+//
+// ─── Éléments à tester selon le type de composant ─────────────────────────────
+//
+// Composant standard (avec Shadow DOM) :
+//   - Rendu : shadowRoot non null, parts présents (getPart)
+//   - Valeurs par défaut : vérifier chaque propriété à l'état initial
+//   - Attributs reflect : el.prop = x → await waitForUpdate → el.getAttribute(...)
+//   - Comportement : interactions (clic, événements custom)
+//   - Accessibilité : role, aria-*, labels sr-only
+//
+// Sous-composant (sans Shadow DOM, createRenderRoot → this) :
+//   - shadowRoot est null
+//   - setRegistry() appelle registerItem / unregisterItem
+//   - disconnectedCallback() appelle unregisterItem
+//   - updated() appelle notifyItemChanged après le premier rendu seulement
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('ArTab', () => {
+    let el: ArTab;
+
+    afterEach(() => el?.remove());
+
+    // ── Rendu ─────────────────────────────────────────────────────────────────
+
+    describe('rendu', () => {
+        beforeEach(async () => {
+            el = await fixture('<ar-tab></ar-tab>');
+        });
+
+        it('monte un shadow DOM', () => {
+            expect(el.shadowRoot).not.toBeNull();
+        });
+
+        it('contient un élément racine avec part="base"', () => {
+            expect(getPart(el, 'base')).not.toBeNull();
+        });
+    });
+
+    // ── Valeurs par défaut ────────────────────────────────────────────────────
+
+    // describe('valeurs par défaut', () => { ... });
+
+    // ── Propriétés ────────────────────────────────────────────────────────────
+
+    // describe('propriétés', () => { ... });
+});

--- a/packages/core/src/components/tab/tab.ts
+++ b/packages/core/src/components/tab/tab.ts
@@ -11,7 +11,22 @@ import styles from './tab.styles.js';
  *
  * @slot - Libellé de l'onglet.
  *
- * @csspart base - Wrapper du slot.
+ * @csspart base - Wrapper du slot — couleur, fond, padding, box-shadow actif.
+ *
+ * @cssprop [--ar-tab-color=inherit] - Couleur du texte (état par défaut).
+ * @cssprop [--ar-tab-bg=transparent] - Fond (état par défaut).
+ * @cssprop [--ar-tab-padding-x=1rem] - Padding horizontal.
+ * @cssprop [--ar-tab-padding-y=0.5rem] - Padding vertical.
+ * @cssprop [--ar-tab-border-radius=0] - Rayon de bordure (utile pour le style pill).
+ * @cssprop [--ar-tab-font-weight=inherit] - Graisse du texte.
+ * @cssprop [--ar-tab-hover-color=inherit] - Couleur du texte au survol.
+ * @cssprop [--ar-tab-hover-bg=transparent] - Fond au survol.
+ * @cssprop [--ar-tab-active-color=inherit] - Couleur du texte quand l'onglet est actif.
+ * @cssprop [--ar-tab-active-bg=transparent] - Fond quand l'onglet est actif.
+ * @cssprop [--ar-tab-active-shadow=none] - box-shadow complet sur part="base" quand actif. Le thème par défaut le compose depuis --ar-tab-indicator-color et --ar-tab-indicator-width.
+ * @cssprop [--ar-tab-indicator-color=currentColor] - Couleur de l'indicateur actif (utilisé par le thème pour composer --ar-tab-active-shadow).
+ * @cssprop [--ar-tab-indicator-width=2px] - Épaisseur de l'indicateur actif (utilisé par le thème pour composer --ar-tab-active-shadow).
+ * @cssprop [--ar-tab-disabled-opacity=0.5] - Opacité de l'onglet désactivé.
  */
 @customElement('ar-tab')
 export class ArTab extends LitElement {

--- a/packages/core/src/components/tab/tab.ts
+++ b/packages/core/src/components/tab/tab.ts
@@ -27,6 +27,7 @@ import styles from './tab.styles.js';
  * @cssprop [--ar-tab-indicator-color=currentColor] - Couleur de l'indicateur actif (utilisé par le thème pour composer --ar-tab-active-shadow).
  * @cssprop [--ar-tab-indicator-width=2px] - Épaisseur de l'indicateur actif (utilisé par le thème pour composer --ar-tab-active-shadow).
  * @cssprop [--ar-tab-disabled-opacity=0.5] - Opacité de l'onglet désactivé.
+ * @cssprop [--ar-tab-focus-ring-offset=-2px] - Décalage de la bague de focus. Valeur négative = inset (non coupée par le conteneur overflow du tab-group). Surcharge le token global --ar-focus-ring-offset pour ce composant.
  */
 @customElement('ar-tab')
 export class ArTab extends LitElement {

--- a/packages/core/src/components/tab/tab.ts
+++ b/packages/core/src/components/tab/tab.ts
@@ -23,7 +23,7 @@ export class ArTab extends LitElement {
     /** Désactive l'onglet — non sélectionnable, ignoré au clavier. */
     @property({ reflect: true, type: Boolean }) disabled = false;
 
-    _registry?: TabGroupRegistry;
+    _registry?: TabGroupRegistry | undefined;
 
     protected readonly _consumer = new ContextConsumer(this, {
         context: tabGroupContext,

--- a/packages/core/src/components/tab/tab.ts
+++ b/packages/core/src/components/tab/tab.ts
@@ -13,21 +13,21 @@ import styles from './tab.styles.js';
  *
  * @csspart base - Wrapper du slot — couleur, fond, padding, box-shadow actif.
  *
- * @cssprop [--ar-tab-color=inherit] - Couleur du texte (état par défaut).
- * @cssprop [--ar-tab-bg=transparent] - Fond (état par défaut).
- * @cssprop [--ar-tab-padding-x=1rem] - Padding horizontal.
- * @cssprop [--ar-tab-padding-y=0.5rem] - Padding vertical.
- * @cssprop [--ar-tab-border-radius=0] - Rayon de bordure (utile pour le style pill).
- * @cssprop [--ar-tab-font-weight=inherit] - Graisse du texte.
- * @cssprop [--ar-tab-hover-color=inherit] - Couleur du texte au survol.
- * @cssprop [--ar-tab-hover-bg=transparent] - Fond au survol.
- * @cssprop [--ar-tab-active-color=inherit] - Couleur du texte quand l'onglet est actif.
- * @cssprop [--ar-tab-active-bg=transparent] - Fond quand l'onglet est actif.
- * @cssprop [--ar-tab-active-shadow=none] - box-shadow complet sur part="base" quand actif. Le thème par défaut le compose depuis --ar-tab-indicator-color et --ar-tab-indicator-width.
- * @cssprop [--ar-tab-indicator-color=currentColor] - Couleur de l'indicateur actif (utilisé par le thème pour composer --ar-tab-active-shadow).
- * @cssprop [--ar-tab-indicator-width=2px] - Épaisseur de l'indicateur actif (utilisé par le thème pour composer --ar-tab-active-shadow).
- * @cssprop [--ar-tab-disabled-opacity=0.5] - Opacité de l'onglet désactivé.
- * @cssprop [--ar-tab-focus-ring-offset=-2px] - Décalage de la bague de focus. Valeur négative = inset (non coupée par le conteneur overflow du tab-group). Surcharge le token global --ar-focus-ring-offset pour ce composant.
+ * @cssprop --ar-tab-color - Couleur du texte (état par défaut).
+ * @cssprop --ar-tab-bg - Fond (état par défaut).
+ * @cssprop --ar-tab-padding-x - Padding horizontal.
+ * @cssprop --ar-tab-padding-y - Padding vertical.
+ * @cssprop --ar-tab-border-radius - Rayon de bordure (utile pour le style pill).
+ * @cssprop --ar-tab-font-weight - Graisse du texte.
+ * @cssprop --ar-tab-hover-color - Couleur du texte au survol.
+ * @cssprop --ar-tab-hover-bg - Fond au survol.
+ * @cssprop --ar-tab-active-color - Couleur du texte quand l'onglet est actif.
+ * @cssprop --ar-tab-active-bg - Fond quand l'onglet est actif.
+ * @cssprop --ar-tab-active-shadow - box-shadow complet sur part="base" quand actif. Le thème par défaut le compose depuis --ar-tab-indicator-color et --ar-tab-indicator-width.
+ * @cssprop --ar-tab-indicator-color - Couleur de l'indicateur actif (utilisé par le thème pour composer --ar-tab-active-shadow).
+ * @cssprop --ar-tab-indicator-width - Épaisseur de l'indicateur actif (utilisé par le thème pour composer --ar-tab-active-shadow).
+ * @cssprop --ar-tab-disabled-opacity - Opacité de l'onglet désactivé.
+ * @cssprop --ar-tab-focus-ring-offset - Décalage de la bague de focus. Valeur négative = inset (non coupée par le conteneur overflow du tab-group). Surcharge le token global --ar-focus-ring-offset pour ce composant.
  */
 @customElement('ar-tab')
 export class ArTab extends LitElement {

--- a/packages/core/src/components/tab/tab.ts
+++ b/packages/core/src/components/tab/tab.ts
@@ -1,27 +1,64 @@
 import { LitElement, html } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
+import { ContextConsumer } from '@lit/context';
+import { tabGroupContext, type TabGroupRegistry } from '../../context/tabs.context.js';
 import styles from './tab.styles.js';
 
 /**
- * @summary Résumé du composant ar-tab.
+ * @summary Onglet déclencheur pour ar-tab-group.
+ * @parent ar-tab-group
+ * @display docs
  *
- * @slot         - Contenu principal.
+ * @slot - Libellé de l'onglet.
  *
- * @csspart base - L'élément racine du composant.
- * @cssprop [--ar-tab-size=auto] - Taille du composant.
- *
- * @event {CustomEvent} ar-tab-change - Émis lors d'un changement.
+ * @csspart base - Wrapper du slot.
  */
 @customElement('ar-tab')
 export class ArTab extends LitElement {
     static override styles = [styles];
 
+    /** Nom du ar-tab-panel associé. Requis. */
+    @property({ reflect: true }) panel = '';
+
+    /** Désactive l'onglet — non sélectionnable, ignoré au clavier. */
+    @property({ reflect: true, type: Boolean }) disabled = false;
+
+    _registry?: TabGroupRegistry;
+
+    protected readonly _consumer = new ContextConsumer(this, {
+        context: tabGroupContext,
+        subscribe: true,
+        callback: (registry) => this._setRegistry(registry),
+    });
+
+    private _setRegistry(registry: TabGroupRegistry): void {
+        if (this._registry) {
+            this._registry.unregisterTab(this);
+        }
+        this._registry = registry;
+        registry.registerTab(this);
+    }
+
+    override connectedCallback(): void {
+        super.connectedCallback();
+        this.addEventListener('click', this._handleClick);
+    }
+
+    override disconnectedCallback(): void {
+        this._registry?.unregisterTab(this);
+        this._registry = undefined;
+        this.removeEventListener('click', this._handleClick);
+        super.disconnectedCallback();
+    }
+
+    private _handleClick = (): void => {
+        if (!this.disabled) {
+            this._registry?.activate(this.panel);
+        }
+    };
+
     override render() {
-        return html`
-            <div part="base">
-                <slot></slot>
-            </div>
-        `;
+        return html`<div part="base"><slot></slot></div>`;
     }
 }
 

--- a/packages/core/src/components/tab/tab.ts
+++ b/packages/core/src/components/tab/tab.ts
@@ -1,0 +1,32 @@
+import { LitElement, html } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import styles from './tab.styles.js';
+
+/**
+ * @summary Résumé du composant ar-tab.
+ *
+ * @slot         - Contenu principal.
+ *
+ * @csspart base - L'élément racine du composant.
+ * @cssprop [--ar-tab-size=auto] - Taille du composant.
+ *
+ * @event {CustomEvent} ar-tab-change - Émis lors d'un changement.
+ */
+@customElement('ar-tab')
+export class ArTab extends LitElement {
+    static override styles = [styles];
+
+    override render() {
+        return html`
+            <div part="base">
+                <slot></slot>
+            </div>
+        `;
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'ar-tab': ArTab;
+    }
+}

--- a/packages/core/src/context/tabs.context.ts
+++ b/packages/core/src/context/tabs.context.ts
@@ -1,0 +1,13 @@
+import { createContext } from '@lit/context';
+import type { ArTab } from '../components/tab/tab.js';
+import type { ArTabPanel } from '../components/tab-panel/tab-panel.js';
+
+export interface TabGroupRegistry {
+    registerTab(tab: ArTab): void;
+    unregisterTab(tab: ArTab): void;
+    registerPanel(panel: ArTabPanel): void;
+    unregisterPanel(panel: ArTabPanel): void;
+    activate(name: string): void;
+}
+
+export const tabGroupContext = createContext<TabGroupRegistry>(Symbol('ar-tab-group'));

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,3 +23,6 @@ export { AnchoredController } from './controllers/anchored.controller.js';
 export { TooltipController } from './controllers/tooltip.controller.js';
 export { ArTooltip } from './components/tooltip/tooltip.js';
 export type { ArTooltipPlacement } from './components/tooltip/tooltip.js';
+export { ArTabGroup } from './components/tab-group/tab-group.js';
+export { ArTab } from './components/tab/tab.js';
+export { ArTabPanel } from './components/tab-panel/tab-panel.js';

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -359,8 +359,8 @@
         /* tab */
         --ar-tab-color: var(--ar-color-text-muted);
         --ar-tab-bg: transparent;
-        --ar-tab-padding-x: 1rem;
-        --ar-tab-padding-y: 0.5rem;
+        --ar-tab-padding-x: 1.5rem;
+        --ar-tab-padding-y: 1rem;
         --ar-tab-border-radius: 0;
         --ar-tab-font-weight: var(--ar-font-weight-normal);
 

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -365,7 +365,7 @@
         --ar-tab-font-weight: var(--ar-font-weight-normal);
 
         --ar-tab-hover-color: var(--ar-color-text);
-        --ar-tab-hover-bg: transparent;
+        --ar-tab-hover-bg: var(--ar-color-bg-subtle);
 
         --ar-tab-active-color: var(--ar-color-interactive);
         --ar-tab-active-bg: transparent;
@@ -375,6 +375,7 @@
             var(--ar-tab-indicator-color);
 
         --ar-tab-disabled-opacity: 0.5;
+        --ar-tab-focus-ring-offset: -2px;
 
         --ar-tab-group-border-color: var(--ar-color-border);
         --ar-tab-group-border-width: 0;

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -355,6 +355,29 @@
 
         /* table */
         --ar-table-padding-x: 1rem;
+
+        /* tab */
+        --ar-tab-color: var(--ar-color-text-muted);
+        --ar-tab-bg: transparent;
+        --ar-tab-padding-x: 1rem;
+        --ar-tab-padding-y: 0.5rem;
+        --ar-tab-border-radius: 0;
+        --ar-tab-font-weight: var(--ar-font-weight-normal);
+
+        --ar-tab-hover-color: var(--ar-color-text);
+        --ar-tab-hover-bg: transparent;
+
+        --ar-tab-active-color: var(--ar-color-interactive);
+        --ar-tab-active-bg: transparent;
+        --ar-tab-indicator-color: var(--ar-color-interactive);
+        --ar-tab-indicator-width: 2px;
+        --ar-tab-active-shadow: inset 0 calc(-1 * var(--ar-tab-indicator-width)) 0
+            var(--ar-tab-indicator-color);
+
+        --ar-tab-disabled-opacity: 0.5;
+
+        --ar-tab-group-border-color: var(--ar-color-border);
+        --ar-tab-group-border-width: 0;
     }
 
     /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -377,6 +377,7 @@
         --ar-tab-disabled-opacity: 0.5;
         --ar-tab-focus-ring-offset: -2px;
 
+        --ar-tab-group-gap: 0;
         --ar-tab-group-border-color: var(--ar-color-border);
         --ar-tab-group-border-width: 0;
     }

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -379,7 +379,8 @@
 
         --ar-tab-group-gap: 0;
         --ar-tab-group-border-color: var(--ar-color-border);
-        --ar-tab-group-border-width: 0;
+        --ar-tab-group-border-top-width: 0;
+        --ar-tab-group-border-bottom-width: 1px;
     }
 
     /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/packages/core/web-test-runner.config.js
+++ b/packages/core/web-test-runner.config.js
@@ -8,7 +8,13 @@ export default {
     files: 'src/**/*.{browser,a11y}.test.{js,ts}',
 
     // Chromium uniquement en CI ; WebKit peut être ajouté plus tard
-    browsers: [playwrightLauncher({ product: 'chromium' })],
+    // --no-sandbox requis sur les runners Linux GitHub Actions (pas de user namespace)
+    browsers: [
+        playwrightLauncher({
+            product: 'chromium',
+            launchOptions: { args: ['--no-sandbox', '--disable-setuid-sandbox'] },
+        }),
+    ],
 
     // Plugin esbuild pour transpiler TypeScript à la volée.
     // tsconfig.wtr.json est un fichier plat (sans "extends") qui transmet

--- a/packages/core/web-test-runner.config.js
+++ b/packages/core/web-test-runner.config.js
@@ -8,11 +8,15 @@ export default {
     files: 'src/**/*.{browser,a11y}.test.{js,ts}',
 
     // Chromium uniquement en CI ; WebKit peut être ajouté plus tard
-    // --no-sandbox requis sur les runners Linux GitHub Actions (pas de user namespace)
+    // En CI : utilise google-chrome-stable préinstallé sur le runner (évite le téléchargement).
+    // --no-sandbox requis sur les runners Linux (pas de user namespace dans les conteneurs).
     browsers: [
         playwrightLauncher({
             product: 'chromium',
-            launchOptions: { args: ['--no-sandbox', '--disable-setuid-sandbox'] },
+            launchOptions: {
+                executablePath: process.env.CI ? '/usr/bin/google-chrome-stable' : undefined,
+                args: ['--no-sandbox', '--disable-setuid-sandbox'],
+            },
         }),
     ],
 


### PR DESCRIPTION
## Summary

- Implémente le pattern WAI-ARIA Tabs complet via trois éléments : `ar-tab-group`, `ar-tab`, `ar-tab-panel`
- Communication via `@lit/context` registry — ARIA (role, IDs, aria-controls, aria-labelledby) posé sur les hôtes light DOM
- Roving tabindex, navigation clavier ←/→ Home/End, activation automatique et manuelle (`manual-activation`)
- Scroll horizontal avec `scrollIntoView` + mécanisme `scroll-hints` (classes CSS dynamiques)

## Test plan

- [x] `npm run test` — 438 tests Vitest passent
- [x] `npm run test:all` — 137 tests WTR browser + a11y passent
- [x] Tester manuellement la navigation clavier dans le navigateur
- [x] Vérifier la démo scroll-hints dans la doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)