### PR TITLE
feat(docs): afficher les méthodes publiques dans la Référence API

### DIFF
--- a/apps/docs/src/components/ComponentApi.astro
+++ b/apps/docs/src/components/ComponentApi.astro
@@ -84,6 +84,48 @@ function swatchColor(value: string | undefined): string | undefined {
         </section>
     )}
 
+    {/* ── Méthodes ── */}
+    {component.members && component.members.some((m) => m.kind === 'method' && m.privacy !== 'private' && m.privacy !== 'protected') && (
+        <section>
+            <h4 id="api-methodes" class="subsection-title">Méthodes</h4>
+            <div class="table-wrap">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Nom</th>
+                            <th>Paramètres</th>
+                            <th>Retour</th>
+                            <th>Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {component.members
+                            .filter((m) => m.kind === 'method' && m.privacy !== 'private' && m.privacy !== 'protected')
+                            .map((m) => {
+                                const params = (m.parameters ?? [])
+                                    .map((p) => {
+                                        let s = p.name;
+                                        if (p.type?.text) s += `: ${p.type.text}`;
+                                        if (p.default !== undefined) s += ` = ${p.default}`;
+                                        return s;
+                                    })
+                                    .join(', ');
+                                const returnType = m.return?.type?.text ?? 'void';
+                                return (
+                                    <tr>
+                                        <td><code>{m.name}()</code></td>
+                                        <td>{params ? <code>{params}</code> : <span class="muted">—</span>}</td>
+                                        <td><code>{returnType}</code></td>
+                                        <td>{m.description ?? ''}</td>
+                                    </tr>
+                                );
+                            })}
+                    </tbody>
+                </table>
+            </div>
+        </section>
+    )}
+
     {/* ── CSS Parts ── */}
     {component.cssParts && component.cssParts.length > 0 && (
         <section>

--- a/apps/docs/src/utils/cem-types.ts
+++ b/apps/docs/src/utils/cem-types.ts
@@ -10,6 +10,13 @@
 
 // ─── Membres d'un composant (propriétés, méthodes) ───────────────────────────
 
+export interface CemParameter {
+    name: string;
+    type?: { text: string };
+    default?: string;
+    optional?: boolean;
+}
+
 export interface CemMember {
     kind: string;
     name: string;
@@ -21,6 +28,8 @@ export interface CemMember {
     type?: { text: string };
     default?: string;
     description?: string;
+    parameters?: CemParameter[];
+    return?: { type?: { text: string } };
 }
 
 // ─── Autres éléments d'API ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Ajoute une interface `CemParameter` dans `cem-types.ts` avec `name`, `type`, `default`, `optional`
- Étend `CemMember` avec `parameters` et `return` pour typer les méthodes
- Ajoute une section **Méthodes** dans `ComponentApi.astro`, visible uniquement si le composant expose des méthodes publiques (non `private`/`protected`)
- `scrollNav` sur `ar-tab-group` est maintenant documenté dans la Référence API

## Test plan

- [x] Vérifier la page `ar-tab-group` dans la doc — la table Méthodes affiche `scrollNav`
- [x] Vérifier qu'aucune méthode interne (`_*`) n'apparaît
- [x] Vérifier qu'un composant sans méthodes publiques n'affiche pas la section

🤖 Generated with [Claude Code](https://claude.com/claude-code)