### PR TITLE
feat(collapse): ar-collapse — dual trigger, accordéon, animation height

### DIFF
--- a/apps/docs/src/content/components/ar-collapse.mdx
+++ b/apps/docs/src/content/components/ar-collapse.mdx
@@ -34,15 +34,15 @@ variants:
       html: |
           <div style="display:flex;flex-direction:column;gap:0.5rem">
               <ar-collapse name="faq" style="--ar-collapse-duration:200ms">
-                  <button slot="trigger" class="btn btn-secondary" style="width:100%;text-align:left">Question 1</button>
+                  <button slot="trigger" class="btn btn-secondary">Question 1</button>
                   <div style="padding:0.75rem 0"><p>Réponse à la question 1.</p></div>
               </ar-collapse>
               <ar-collapse name="faq" style="--ar-collapse-duration:200ms">
-                  <button slot="trigger" class="btn btn-secondary" style="width:100%;text-align:left">Question 2</button>
+                  <button slot="trigger" class="btn btn-secondary">Question 2</button>
                   <div style="padding:0.75rem 0"><p>Réponse à la question 2.</p></div>
               </ar-collapse>
               <ar-collapse name="faq" style="--ar-collapse-duration:200ms">
-                  <button slot="trigger" class="btn btn-secondary" style="width:100%;text-align:left">Question 3</button>
+                  <button slot="trigger" class="btn btn-secondary">Question 3</button>
                   <div style="padding:0.75rem 0"><p>Réponse à la question 3.</p></div>
               </ar-collapse>
           </div>
@@ -64,12 +64,16 @@ variants:
           `trigger-position="after"` place le trigger après le contenu dans le DOM (et visuellement).
           Utile pour les patterns "Lire la suite" où le bouton apparaît sous le texte tronqué.
       html: |
-          <ar-collapse trigger-position="after" style="--ar-collapse-duration:200ms">
-              <div style="padding:0.75rem 0">
-                  <p>Contenu révélé. Le trigger est positionné après dans le DOM et visuellement.</p>
-              </div>
-              <button slot="trigger" class="btn btn-secondary">Lire la suite</button>
-          </ar-collapse>
+          <div>
+              <p style="margin:0 0 0.5rem">Les chimpanzés utilisent des outils, communiquent par gestes et sons, vivent en groupes sociaux complexes avec hiérarchies et alliances.</p>
+              <ar-collapse trigger-position="after" style="--ar-collapse-duration:200ms">
+                  <div>
+                      <p style="margin:0 0 0.5rem">Leur génome est similaire à 98,7 % à celui de l'humain. Ils fabriquent des outils en bois pour extraire des termites, et utilisent des pierres comme enclumes pour casser des noix.</p>
+                      <p style="margin:0">Les femelles transmettent ces techniques à leurs petits, une forme d'apprentissage culturel rare dans le règne animal.</p>
+                  </div>
+                  <button slot="trigger" style="background:none;border:none;padding:0.25rem 0 0;color:var(--ar-color-interactive,#283276);text-decoration:underline;cursor:pointer;font:inherit">Lire la suite ↓</button>
+              </ar-collapse>
+          </div>
     - name: disabled
       label: Désactivé
       description: |

--- a/apps/docs/src/content/components/ar-collapse.mdx
+++ b/apps/docs/src/content/components/ar-collapse.mdx
@@ -1,0 +1,12 @@
+---
+tagName: ar-collapse
+title: Collapse
+description: Description du composant ar-collapse.
+variants:
+    - name: Par défaut
+      description: Rendu par défaut du composant.
+      html: |
+          <ar-collapse></ar-collapse>
+---
+
+Documentation narrative du composant `ar-collapse`.

--- a/apps/docs/src/content/components/ar-collapse.mdx
+++ b/apps/docs/src/content/components/ar-collapse.mdx
@@ -1,12 +1,118 @@
 ---
 tagName: ar-collapse
 title: Collapse
-description: Description du composant ar-collapse.
+description: Panneau pliable/dépliable accessible — animation de hauteur, trigger interne ou externe, mode accordéon via attribut name.
+playgroundTemplate: default
 variants:
-    - name: Par défaut
-      description: Rendu par défaut du composant.
+    - name: default
+      label: Standalone
+      description: |
+          Collapse simple avec un trigger interne via `slot="trigger"`.
+          L'animation de hauteur est activée via `--ar-collapse-duration`.
       html: |
-          <ar-collapse></ar-collapse>
+          <ar-collapse style="--ar-collapse-duration:200ms;--ar-collapse-easing:ease">
+              <button slot="trigger" class="btn btn-secondary">Voir plus</button>
+              <div style="padding:1rem 0">
+                  <p>Contenu qui se révèle à l'ouverture. Peut contenir n'importe quel HTML.</p>
+              </div>
+          </ar-collapse>
+    - name: open
+      label: Ouvert par défaut
+      description: L'attribut `open` ouvre le panel sans animation au chargement.
+      html: |
+          <ar-collapse open style="--ar-collapse-duration:200ms">
+              <button slot="trigger" class="btn btn-secondary">Fermer</button>
+              <div style="padding:1rem 0">
+                  <p>Contenu visible dès le chargement.</p>
+              </div>
+          </ar-collapse>
+    - name: accordion
+      label: Accordéon (name)
+      description: |
+          Tous les `ar-collapse` partageant le même attribut `name` forment un groupe accordéon :
+          ouvrir un item ferme automatiquement les autres.
+      html: |
+          <div style="display:flex;flex-direction:column;gap:0.5rem">
+              <ar-collapse name="faq" style="--ar-collapse-duration:200ms">
+                  <button slot="trigger" class="btn btn-secondary" style="width:100%;text-align:left">Question 1</button>
+                  <div style="padding:0.75rem 0"><p>Réponse à la question 1.</p></div>
+              </ar-collapse>
+              <ar-collapse name="faq" style="--ar-collapse-duration:200ms">
+                  <button slot="trigger" class="btn btn-secondary" style="width:100%;text-align:left">Question 2</button>
+                  <div style="padding:0.75rem 0"><p>Réponse à la question 2.</p></div>
+              </ar-collapse>
+              <ar-collapse name="faq" style="--ar-collapse-duration:200ms">
+                  <button slot="trigger" class="btn btn-secondary" style="width:100%;text-align:left">Question 3</button>
+                  <div style="padding:0.75rem 0"><p>Réponse à la question 3.</p></div>
+              </ar-collapse>
+          </div>
+    - name: external-trigger
+      label: Trigger externe (for)
+      description: |
+          L'attribut `for` accepte l'ID d'un bouton natif situé n'importe où dans la page.
+          `aria-expanded` et `aria-controls` sont posés automatiquement sur ce bouton.
+      html: |
+          <button id="ar-doc-collapse-ext" class="btn btn-secondary">Révéler le contenu</button>
+          <ar-collapse for="ar-doc-collapse-ext" style="--ar-collapse-duration:200ms">
+              <div style="padding:0.75rem 0">
+                  <p>Contenu piloté par un trigger externe. Utile quand trigger et panel ne peuvent pas être enveloppés dans un wrapper commun.</p>
+              </div>
+          </ar-collapse>
+    - name: trigger-after
+      label: Trigger après le contenu
+      description: |
+          `trigger-position="after"` place le trigger après le contenu dans le DOM (et visuellement).
+          Utile pour les patterns "Lire la suite" où le bouton apparaît sous le texte tronqué.
+      html: |
+          <ar-collapse trigger-position="after" style="--ar-collapse-duration:200ms">
+              <div style="padding:0.75rem 0">
+                  <p>Contenu révélé. Le trigger est positionné après dans le DOM et visuellement.</p>
+              </div>
+              <button slot="trigger" class="btn btn-secondary">Lire la suite</button>
+          </ar-collapse>
+    - name: disabled
+      label: Désactivé
+      description: |
+          L'attribut `disabled` bloque l'interaction. Le composant pose `disabled` et
+          `aria-disabled="true"` sur le trigger interne.
+      html: |
+          <ar-collapse disabled>
+              <button slot="trigger" class="btn btn-secondary">Toggle (désactivé)</button>
+              <div style="padding:0.75rem 0"><p>Ce contenu ne peut pas être révélé.</p></div>
+          </ar-collapse>
 ---
 
-Documentation narrative du composant `ar-collapse`.
+import WcagRef from '../../components/WcagRef.astro';
+
+## Accessibilité
+
+### Pris en charge automatiquement
+
+`ar-collapse` gère les attributs ARIA et les comportements keyboard sans intervention :
+
+- `aria-expanded` est posé sur le trigger (interne ou externe) et mis à jour à chaque ouverture/fermeture.
+- `aria-controls` est posé sur le trigger et pointe vers l'`id` du host `ar-collapse`. Si l'auteur ne fournit pas d'`id`, un identifiant unique est généré automatiquement.
+- Le panel utilise l'attribut `hidden` pour les états stables (pas de `display:none` inline) — compatible avec les styles qui surchargeraient `display`.
+- `prefers-reduced-motion` : si l'utilisateur a activé la préférence système de réduction de mouvement, les animations sont supprimées et les transitions sont instantanées.
+
+Les critères WCAG suivants sont implémentés :
+
+- `aria-expanded` indique l'état ouvert/fermé du panel aux technologies d'assistance (<WcagRef criterion="4.1.2" summary="Name, Role, Value : aria-expanded communique l'état du composant aux AT." />)
+- L'ordre DOM du trigger reflète l'ordre visuel — `trigger-position` modifie le DOM, pas le CSS `order` (<WcagRef criterion="2.4.3" summary="Focus Order : l'ordre de focus suit l'ordre visuel." />)
+
+### Limitations connues
+
+- **Cross-shadow DOM** : `for` et `aria-controls` reposent sur des IDs résolus dans le document. Si le trigger et le panel se trouvent dans des shadow roots différents, la référence `aria-controls` ne sera pas résolue par les technologies d'assistance. De même, le mode accordéon (`name`) ne fonctionne pas entre shadow roots distincts.
+- **`ariaControlsElements`** : la propriété IDL permettant des références cross-shadow est prévue mais le support navigateur est insuffisant en 2026. À adopter quand il sera stable.
+
+### À votre charge
+
+- Le trigger doit être un élément focusable avec un nom accessible (texte visible, `aria-label`, ou `aria-labelledby`).
+- Pour un pattern accordéon, ajouter `role="region"` et `aria-labelledby` sur chaque panel si le contexte sémantique le demande (ex: FAQ dans un article).
+- L'animation `height` via `--ar-collapse-duration` n'est pas automatique — vous devez activer la transition dans votre thème :
+
+```css
+ar-collapse::part(panel) {
+    transition: height var(--ar-collapse-duration, 0s) var(--ar-collapse-easing, ease);
+}
+```

--- a/apps/docs/src/content/components/ar-collapse.mdx
+++ b/apps/docs/src/content/components/ar-collapse.mdx
@@ -52,12 +52,14 @@ variants:
           L'attribut `for` accepte l'ID d'un bouton natif situé n'importe où dans la page.
           `aria-expanded` et `aria-controls` sont posés automatiquement sur ce bouton.
       html: |
-          <button id="ar-doc-collapse-ext" class="btn btn-secondary">Révéler le contenu</button>
-          <ar-collapse for="ar-doc-collapse-ext" style="--ar-collapse-duration:200ms">
-              <div style="padding-top:0.75rem">
-                  <p style="margin:0">Contenu piloté par un trigger externe. Utile quand trigger et panel ne peuvent pas être enveloppés dans un wrapper commun.</p>
-              </div>
-          </ar-collapse>
+          <div>
+              <button id="ar-doc-collapse-ext" class="btn btn-secondary">Révéler le contenu</button>
+              <ar-collapse for="ar-doc-collapse-ext" style="--ar-collapse-duration:200ms">
+                  <div style="padding-top:0.75rem">
+                      <p style="margin:0">Contenu piloté par un trigger externe. Utile quand trigger et panel ne peuvent pas être enveloppés dans un wrapper commun.</p>
+                  </div>
+              </ar-collapse>
+          </div>
     - name: trigger-after
       label: Trigger après le contenu
       description: |

--- a/apps/docs/src/content/components/ar-collapse.mdx
+++ b/apps/docs/src/content/components/ar-collapse.mdx
@@ -109,7 +109,7 @@ Les critères WCAG suivants sont implémentés :
 ### Limitations connues
 
 - **Cross-shadow DOM** : `for` et `aria-controls` reposent sur des IDs résolus dans le document. Si le trigger et le panel se trouvent dans des shadow roots différents, la référence `aria-controls` ne sera pas résolue par les technologies d'assistance. De même, le mode accordéon (`name`) ne fonctionne pas entre shadow roots distincts.
-- **`ariaControlsElements`** : la propriété IDL permettant des références cross-shadow est prévue mais le support navigateur est insuffisant en 2026. À adopter quand il sera stable.
+- **`aria-controls` → host element** : `aria-controls` pointe sur l'élément `<ar-collapse>` lui-même (pas sur le panel interne du shadow DOM). Les AT qui traversent le shadow DOM (NVDA 2024+, JAWS 2024+, VoiceOver macOS 14+) résolvent correctement la référence vers le contenu. Sur les AT plus anciens, la relation peut être ignorée. Mitigation en attente : `ElementInternals.ariaControlsElements` (référence cross-shadow IDL) sera adoptée quand le support navigateur sera suffisant.
 
 ### À votre charge
 

--- a/apps/docs/src/content/components/ar-collapse.mdx
+++ b/apps/docs/src/content/components/ar-collapse.mdx
@@ -12,8 +12,8 @@ variants:
       html: |
           <ar-collapse style="--ar-collapse-duration:200ms;--ar-collapse-easing:ease">
               <button slot="trigger" class="btn btn-secondary">Voir plus</button>
-              <div style="padding:1rem 0">
-                  <p>Contenu qui se révèle à l'ouverture. Peut contenir n'importe quel HTML.</p>
+              <div style="padding-top:1rem">
+                  <p style="margin:0">Contenu qui se révèle à l'ouverture. Peut contenir n'importe quel HTML.</p>
               </div>
           </ar-collapse>
     - name: open
@@ -22,8 +22,8 @@ variants:
       html: |
           <ar-collapse open style="--ar-collapse-duration:200ms">
               <button slot="trigger" class="btn btn-secondary">Fermer</button>
-              <div style="padding:1rem 0">
-                  <p>Contenu visible dès le chargement.</p>
+              <div style="padding-top:1rem">
+                  <p style="margin:0">Contenu visible dès le chargement.</p>
               </div>
           </ar-collapse>
     - name: accordion
@@ -35,15 +35,15 @@ variants:
           <div style="display:flex;flex-direction:column;gap:0.5rem">
               <ar-collapse name="faq" style="--ar-collapse-duration:200ms">
                   <button slot="trigger" class="btn btn-secondary">Question 1</button>
-                  <div style="padding:0.75rem 0"><p>Réponse à la question 1.</p></div>
+                  <div style="padding:0.75rem 0"><p style="margin:0">Réponse à la question 1.</p></div>
               </ar-collapse>
               <ar-collapse name="faq" style="--ar-collapse-duration:200ms">
                   <button slot="trigger" class="btn btn-secondary">Question 2</button>
-                  <div style="padding:0.75rem 0"><p>Réponse à la question 2.</p></div>
+                  <div style="padding:0.75rem 0"><p style="margin:0">Réponse à la question 2.</p></div>
               </ar-collapse>
               <ar-collapse name="faq" style="--ar-collapse-duration:200ms">
                   <button slot="trigger" class="btn btn-secondary">Question 3</button>
-                  <div style="padding:0.75rem 0"><p>Réponse à la question 3.</p></div>
+                  <div style="padding:0.75rem 0"><p style="margin:0">Réponse à la question 3.</p></div>
               </ar-collapse>
           </div>
     - name: external-trigger
@@ -54,8 +54,8 @@ variants:
       html: |
           <button id="ar-doc-collapse-ext" class="btn btn-secondary">Révéler le contenu</button>
           <ar-collapse for="ar-doc-collapse-ext" style="--ar-collapse-duration:200ms">
-              <div style="padding:0.75rem 0">
-                  <p>Contenu piloté par un trigger externe. Utile quand trigger et panel ne peuvent pas être enveloppés dans un wrapper commun.</p>
+              <div style="padding-top:0.75rem">
+                  <p style="margin:0">Contenu piloté par un trigger externe. Utile quand trigger et panel ne peuvent pas être enveloppés dans un wrapper commun.</p>
               </div>
           </ar-collapse>
     - name: trigger-after
@@ -67,7 +67,7 @@ variants:
           <div>
               <p style="margin:0 0 0.5rem">Les chimpanzés utilisent des outils, communiquent par gestes et sons, vivent en groupes sociaux complexes avec hiérarchies et alliances.</p>
               <ar-collapse trigger-position="after" style="--ar-collapse-duration:200ms">
-                  <div>
+                  <div style="padding-bottom: 0.5rem">
                       <p style="margin:0 0 0.5rem">Leur génome est similaire à 98,7 % à celui de l'humain. Ils fabriquent des outils en bois pour extraire des termites, et utilisent des pierres comme enclumes pour casser des noix.</p>
                       <p style="margin:0">Les femelles transmettent ces techniques à leurs petits, une forme d'apprentissage culturel rare dans le règne animal.</p>
                   </div>

--- a/docs/superpowers/plans/2026-06-11-ar-collapse.md
+++ b/docs/superpowers/plans/2026-06-11-ar-collapse.md
@@ -1,0 +1,1356 @@
+# ar-collapse Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implémenter `ar-collapse`, un composant de panneau pliable/dépliable accessible avec dual trigger (interne `slot="trigger"` + externe `for`), mode accordéon via attribut `name`, et animation de hauteur pilotée par JS.
+
+**Architecture:** Composant unique `ar-collapse` suivant le pattern `ar-dropdown` — dual trigger, propriété `open` avec reflect, méthodes `show()`/`hide()`. L'animation repose sur `height: 0 → scrollHeight` géré en JS + `transitionend`, `overflow: hidden` dans les styles structurels. Le mode accordéon coordonne les panels via `document.querySelectorAll`.
+
+**Tech Stack:** Lit 3, TypeScript, Vitest (unit), @web/test-runner (browser + a11y), axe-core.
+
+**Spec:** `docs/superpowers/specs/2026-06-11-ar-collapse-design.md`
+
+---
+
+## Task 0 : Créer la branche de travail
+
+- [ ] **Step 1 : Créer et basculer sur la branche feature**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git checkout -b feat/ar-collapse
+```
+
+Expected: branche `feat/ar-collapse` créée depuis `dev`.
+
+---
+
+## Fichiers créés / modifiés
+
+| Fichier                                                          | Action                     |
+| ---------------------------------------------------------------- | -------------------------- |
+| `packages/core/src/components/collapse/collapse.ts`              | Créé (scaffold → remplacé) |
+| `packages/core/src/components/collapse/collapse.styles.ts`       | Créé (scaffold → remplacé) |
+| `packages/core/src/components/collapse/collapse.test.ts`         | Créé (scaffold → remplacé) |
+| `packages/core/src/components/collapse/collapse.browser.test.ts` | Créé manuellement          |
+| `packages/core/src/components/collapse/collapse.a11y.test.ts`    | Créé manuellement          |
+| `packages/core/src/index.ts`                                     | Modifié par scaffold       |
+| `apps/docs/src/content/components/ar-collapse.mdx`               | Créé (scaffold → remplacé) |
+
+---
+
+## Task 1 : Scaffold + styles structurels
+
+**Files:**
+
+- Create: `packages/core/src/components/collapse/collapse.ts` (via scaffold)
+- Create: `packages/core/src/components/collapse/collapse.styles.ts`
+- Modify: `packages/core/src/index.ts`
+
+- [ ] **Step 1 : Lancer le scaffold depuis la racine du projet**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+npm run create ar-collapse
+```
+
+Expected: fichiers générés dans `packages/core/src/components/collapse/`, entrée ajoutée dans `src/index.ts` et `src/autoloader.ts`.
+
+- [ ] **Step 2 : Remplacer le contenu de `collapse.styles.ts`**
+
+```typescript
+// packages/core/src/components/collapse/collapse.styles.ts
+import { css } from 'lit';
+
+export default css`
+    :host {
+        display: block;
+    }
+
+    [part='base'] {
+        display: flex;
+        flex-direction: column;
+    }
+
+    [part='panel'] {
+        overflow: hidden;
+    }
+
+    [part='panel'][hidden] {
+        display: none;
+    }
+`;
+```
+
+`overflow: hidden` est structurel (nécessaire au clipping pendant l'animation). `display: none` via `[hidden]` est l'état stable fermé.
+
+- [ ] **Step 3 : Commit**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git add packages/core/src/components/collapse/ packages/core/src/index.ts packages/core/src/autoloader.ts apps/docs/src/content/components/ar-collapse.mdx
+git commit -m "chore(collapse): scaffold ar-collapse"
+```
+
+---
+
+## Task 2 : Shell du composant — propriétés, render, types
+
+**Files:**
+
+- Modify: `packages/core/src/components/collapse/collapse.ts`
+
+- [ ] **Step 1 : Remplacer entièrement `collapse.ts` par le shell complet**
+
+```typescript
+// packages/core/src/components/collapse/collapse.ts
+import { LitElement, html, type TemplateResult, type PropertyValues } from 'lit';
+import { customElement, property, query } from 'lit/decorators.js';
+import { warn } from '../../utils/warn.js';
+import { prefersReducedMotion } from '../../utils/media.js';
+import styles from './collapse.styles.js';
+
+export type ArCollapseEvents =
+    | 'ar-collapse-show'
+    | 'ar-collapse-shown'
+    | 'ar-collapse-hide'
+    | 'ar-collapse-hidden';
+
+/**
+ * @summary Panneau pliable/dépliable accessible avec animation de hauteur.
+ * @display demo
+ *
+ * @slot trigger - Élément déclencheur (ignoré si `for` est défini).
+ * @slot         - Contenu collapsible.
+ *
+ * @csspart base              - Conteneur racine.
+ * @csspart trigger-container - Wrapper du slot trigger.
+ * @csspart panel             - Zone animée (overflow hidden, height 0 → auto).
+ * @csspart content           - Wrapper interne du contenu.
+ *
+ * @cssprop [--ar-collapse-duration=0s]  - Durée de la transition height.
+ * @cssprop [--ar-collapse-easing=ease]  - Easing de la transition height.
+ *
+ * @event {CustomEvent} ar-collapse-show   - Avant l'ouverture. Annulable.
+ * @event {CustomEvent} ar-collapse-shown  - Après la fin de l'animation d'ouverture.
+ * @event {CustomEvent} ar-collapse-hide   - Avant la fermeture. Annulable.
+ * @event {CustomEvent} ar-collapse-hidden - Après la fin de l'animation de fermeture.
+ */
+@customElement('ar-collapse')
+export class ArCollapse extends LitElement {
+    static override styles = [styles];
+    static readonly NAME = 'ArCollapse';
+    private static _idCounter = 0;
+
+    /** Ouvre ou ferme le panel. */
+    @property({ reflect: true, type: Boolean }) open = false;
+
+    /**
+     * ID d'un élément déclencheur externe (light DOM).
+     * Quand défini, le slot `trigger` est ignoré.
+     */
+    @property({ reflect: true }) for = '';
+
+    /** Groupe accordéon — les panels partageant le même `name` se ferment mutuellement. */
+    @property({ reflect: true }) name = '';
+
+    /**
+     * Position du slot trigger par rapport au contenu dans le DOM.
+     * `before` (défaut) : trigger avant le panel. `after` : trigger après le panel.
+     * L'ordre DOM reflète l'ordre visuel — pas de CSS `order` — pour respecter WCAG 2.4.3.
+     */
+    @property({ attribute: 'trigger-position', reflect: true })
+    triggerPosition: 'before' | 'after' = 'before';
+
+    /** Désactive le composant — le trigger ne répond plus aux clics. */
+    @property({ reflect: true, type: Boolean }) disabled = false;
+
+    @query('[part="panel"]') private _panel!: HTMLElement;
+
+    private _animating = false;
+    private _initialized = false;
+    private _externalTrigger: HTMLElement | null = null;
+
+    override connectedCallback(): void {
+        super.connectedCallback();
+        if (!this.id) {
+            this.id = `ar-collapse-${++ArCollapse._idCounter}`;
+        }
+    }
+
+    override firstUpdated(): void {
+        if (this.for) {
+            this._warnIfBothTriggers();
+            this._attachExternalTrigger();
+        }
+        this._syncTriggerAria();
+        // État initial sans animation — updated() gère les changements ultérieurs.
+        if (this.open) {
+            this._panel.removeAttribute('hidden');
+            this._panel.style.height = 'auto';
+        }
+        this._initialized = true;
+    }
+
+    override updated(changed: PropertyValues<this>): void {
+        // firstUpdated gère le premier rendu ; updated ne traite que les changements suivants.
+        if (!this._initialized) return;
+        if (changed.has('for')) {
+            this._detachExternalTrigger();
+            if (this.for) {
+                this._warnIfBothTriggers();
+                this._attachExternalTrigger();
+            }
+        }
+        if (changed.has('open')) {
+            if (this.open) this._show();
+            else this._hide();
+        }
+        if (changed.has('disabled')) {
+            this._syncTriggerDisabled();
+        }
+    }
+
+    override disconnectedCallback(): void {
+        super.disconnectedCallback();
+        this._detachExternalTrigger();
+    }
+
+    override render(): TemplateResult {
+        const trigger = html`
+            <slot
+                name="trigger"
+                part="trigger-container"
+                @slotchange=${this._handleTriggerSlotChange}
+            ></slot>
+        `;
+        const panel = html`
+            <div part="panel" hidden>
+                <div part="content">
+                    <slot></slot>
+                </div>
+            </div>
+        `;
+        return html`
+            <div part="base">
+                ${this.triggerPosition === 'after'
+                    ? html`${panel}${trigger}`
+                    : html`${trigger}${panel}`}
+            </div>
+        `;
+    }
+
+    /** Ouvre le panel. No-op si déjà ouvert, en cours d'animation, ou disabled. */
+    show(): void {
+        if (this.open || this._animating || this.disabled) return;
+        this.open = true;
+    }
+
+    /** Ferme le panel. No-op si déjà fermé ou en cours d'animation. */
+    hide(): void {
+        if (!this.open || this._animating) return;
+        this.open = false;
+    }
+
+    private _warnIfBothTriggers(): void {
+        if (!this.for) return;
+        const slot = this.shadowRoot?.querySelector<HTMLSlotElement>('slot[name="trigger"]');
+        if (slot?.assignedElements({ flatten: true }).length) {
+            warn(
+                'ar-collapse',
+                'for et slot="trigger" sont tous les deux définis — for prend la priorité.',
+            );
+        }
+    }
+
+    private _attachExternalTrigger(): void {
+        const el = document.getElementById(this.for);
+        if (!el) {
+            warn('ar-collapse', `Aucun élément trouvé avec l'id "${this.for}".`);
+            return;
+        }
+        this._externalTrigger = el;
+        el.addEventListener('click', this._handleTriggerClick);
+        this._syncTriggerAria();
+    }
+
+    private _detachExternalTrigger(): void {
+        if (!this._externalTrigger) return;
+        this._externalTrigger.removeEventListener('click', this._handleTriggerClick);
+        this._externalTrigger.removeAttribute('aria-expanded');
+        this._externalTrigger.removeAttribute('aria-controls');
+        this._externalTrigger = null;
+    }
+
+    private _handleTriggerSlotChange(): void {
+        if (this.for) {
+            this._warnIfBothTriggers();
+            return;
+        }
+        const trigger = this._resolvedTrigger;
+        if (!trigger) return;
+        trigger.addEventListener('click', this._handleTriggerClick);
+        this._syncTriggerAria();
+        this._syncTriggerDisabled();
+    }
+
+    private readonly _handleTriggerClick = (): void => {
+        if (this.disabled) return;
+        this.open = !this.open;
+    };
+
+    private get _resolvedTrigger(): HTMLElement | null {
+        if (this.for) return this._externalTrigger;
+        const slot = this.shadowRoot?.querySelector<HTMLSlotElement>('slot[name="trigger"]');
+        return (slot?.assignedElements({ flatten: true })[0] as HTMLElement | undefined) ?? null;
+    }
+
+    private _syncTriggerAria(): void {
+        const trigger = this._resolvedTrigger;
+        if (!trigger) return;
+        trigger.setAttribute('aria-expanded', String(this.open));
+        trigger.setAttribute('aria-controls', this.id);
+    }
+
+    private _syncTriggerDisabled(): void {
+        if (this.for) return;
+        const trigger = this._resolvedTrigger;
+        if (!trigger) return;
+        if (this.disabled) {
+            trigger.setAttribute('disabled', '');
+            trigger.setAttribute('aria-disabled', 'true');
+        } else {
+            trigger.removeAttribute('disabled');
+            trigger.removeAttribute('aria-disabled');
+        }
+    }
+
+    private _closeGroupSiblings(): void {
+        if (!this.name) return;
+        document.querySelectorAll<ArCollapse>(`ar-collapse[name="${this.name}"]`).forEach((el) => {
+            if (el !== this && el.open) el.hide();
+        });
+    }
+
+    private _shouldAnimate(): boolean {
+        // transitionend ne se déclenche pas si duration=0s (défaut headless sans thème).
+        // On vérifie la durée calculée pour éviter que _animating reste bloqué à true.
+        const d = parseFloat(getComputedStyle(this._panel).transitionDuration) || 0;
+        return !prefersReducedMotion() && d > 0;
+    }
+
+    private _show(): void {
+        const ev = this._emit('ar-collapse-show');
+        if (ev.defaultPrevented) {
+            this.open = false;
+            return;
+        }
+        this._closeGroupSiblings();
+        this._syncTriggerAria();
+        this._animating = true;
+        const panel = this._panel;
+        panel.style.height = '0px';
+        panel.removeAttribute('hidden');
+        const targetH = panel.scrollHeight;
+        void panel.offsetHeight; // force reflow
+        if (!this._shouldAnimate()) {
+            panel.style.height = 'auto';
+            this._animating = false;
+            this._emit('ar-collapse-shown');
+            return;
+        }
+        panel.style.height = `${targetH}px`;
+        panel.addEventListener(
+            'transitionend',
+            () => {
+                this._animating = false;
+                panel.style.height = 'auto';
+                this._emit('ar-collapse-shown');
+            },
+            { once: true },
+        );
+    }
+
+    private _hide(): void {
+        const ev = this._emit('ar-collapse-hide');
+        if (ev.defaultPrevented) {
+            this.open = true;
+            return;
+        }
+        this._syncTriggerAria();
+        this._animating = true;
+        const panel = this._panel;
+        panel.style.height = `${panel.scrollHeight}px`;
+        void panel.offsetHeight; // force reflow
+        if (!this._shouldAnimate()) {
+            this._animating = false;
+            panel.setAttribute('hidden', '');
+            panel.style.height = '';
+            this._emit('ar-collapse-hidden');
+            return;
+        }
+        panel.style.height = '0px';
+        panel.addEventListener(
+            'transitionend',
+            () => {
+                this._animating = false;
+                panel.setAttribute('hidden', '');
+                panel.style.height = '';
+                this._emit('ar-collapse-hidden');
+            },
+            { once: true },
+        );
+    }
+
+    private _emit(name: ArCollapseEvents): CustomEvent {
+        const e = new CustomEvent(name, { bubbles: true, composed: true, cancelable: true });
+        this.dispatchEvent(e);
+        return e;
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'ar-collapse': ArCollapse;
+    }
+}
+```
+
+- [ ] **Step 2 : Commit**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git add packages/core/src/components/collapse/collapse.ts packages/core/src/components/collapse/collapse.styles.ts
+git commit -m "feat(collapse): shell ar-collapse — propriétés, render, types"
+```
+
+---
+
+## Task 3 : Tests unitaires Vitest — render + props + trigger interne
+
+**Files:**
+
+- Modify: `packages/core/src/components/collapse/collapse.test.ts`
+
+Les tests Vitest tournent sous happy-dom qui ne déclenche pas les transitions CSS. On mocke `prefersReducedMotion` → `true` pour que `show()`/`hide()` s'exécutent de façon synchrone (branch reduced-motion).
+
+- [ ] **Step 1 : Remplacer entièrement `collapse.test.ts`**
+
+```typescript
+// packages/core/src/components/collapse/collapse.test.ts
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fixture, waitForUpdate, getPart, requirePart } from '../../test-utils.js';
+import type { ArCollapse } from './collapse.js';
+import './collapse.js';
+
+// happy-dom ne déclenche pas transitionend — prefersReducedMotion=true
+// fait passer show/hide dans la branche synchrone.
+vi.mock('../../utils/media.js', () => ({ prefersReducedMotion: () => true }));
+
+describe('ArCollapse', () => {
+    let el: ArCollapse;
+
+    afterEach(() => {
+        el?.remove();
+        document.body.innerHTML = '';
+    });
+
+    // ── Valeurs par défaut ────────────────────────────────────────────────────
+
+    describe('valeurs par défaut', () => {
+        beforeEach(async () => {
+            el = await fixture('<ar-collapse></ar-collapse>');
+        });
+
+        it('open=false', () => expect(el.open).toBe(false));
+        it('for=""', () => expect(el.for).toBe(''));
+        it('name=""', () => expect(el.name).toBe(''));
+        it('triggerPosition="before"', () => expect(el.triggerPosition).toBe('before'));
+        it('disabled=false', () => expect(el.disabled).toBe(false));
+    });
+
+    // ── Reflect attributs ─────────────────────────────────────────────────────
+
+    describe('reflect', () => {
+        beforeEach(async () => {
+            el = await fixture('<ar-collapse></ar-collapse>');
+        });
+
+        it('open reflète en attribut', async () => {
+            el.show();
+            await waitForUpdate(el);
+            expect(el.hasAttribute('open')).toBe(true);
+        });
+
+        it('for reflète en attribut', async () => {
+            el.for = 'btn';
+            await waitForUpdate(el);
+            expect(el.getAttribute('for')).toBe('btn');
+        });
+
+        it('name reflète en attribut', async () => {
+            el.name = 'group-a';
+            await waitForUpdate(el);
+            expect(el.getAttribute('name')).toBe('group-a');
+        });
+
+        it('trigger-position reflète en attribut', async () => {
+            el.triggerPosition = 'after';
+            await waitForUpdate(el);
+            expect(el.getAttribute('trigger-position')).toBe('after');
+        });
+
+        it('disabled reflète en attribut', async () => {
+            el.disabled = true;
+            await waitForUpdate(el);
+            expect(el.hasAttribute('disabled')).toBe(true);
+        });
+    });
+
+    // ── Rendu shadow DOM ──────────────────────────────────────────────────────
+
+    describe('rendu shadow DOM', () => {
+        beforeEach(async () => {
+            el = await fixture('<ar-collapse></ar-collapse>');
+        });
+
+        it('contient part="base"', () => expect(getPart(el, 'base')).not.toBeNull());
+        it('contient part="trigger-container"', () =>
+            expect(getPart(el, 'trigger-container')).not.toBeNull());
+        it('contient part="panel"', () => expect(getPart(el, 'panel')).not.toBeNull());
+        it('contient part="content"', () => expect(getPart(el, 'content')).not.toBeNull());
+        it('panel a hidden au départ', () => {
+            expect(requirePart(el, 'panel').hasAttribute('hidden')).toBe(true);
+        });
+    });
+
+    // ── id auto-généré ─────────────────────────────────────────────────────────
+
+    describe('id auto-généré', () => {
+        it('génère un id sur le host si absent', async () => {
+            el = await fixture('<ar-collapse></ar-collapse>');
+            expect(el.id).toMatch(/^ar-collapse-\d+$/);
+        });
+
+        it("ne remplace pas un id fourni par l'auteur", async () => {
+            el = await fixture('<ar-collapse id="mon-id"></ar-collapse>');
+            expect(el.id).toBe('mon-id');
+        });
+    });
+
+    // ── show() / hide() ───────────────────────────────────────────────────────
+
+    describe('show() / hide()', () => {
+        beforeEach(async () => {
+            el = await fixture('<ar-collapse></ar-collapse>');
+        });
+
+        it('show() passe open à true', async () => {
+            el.show();
+            await waitForUpdate(el);
+            expect(el.open).toBe(true);
+        });
+
+        it('show() retire hidden du panel', async () => {
+            el.show();
+            await waitForUpdate(el);
+            expect(requirePart(el, 'panel').hasAttribute('hidden')).toBe(false);
+        });
+
+        it('hide() passe open à false et repose hidden', async () => {
+            el.show();
+            await waitForUpdate(el);
+            el.hide();
+            await waitForUpdate(el);
+            expect(el.open).toBe(false);
+            expect(requirePart(el, 'panel').hasAttribute('hidden')).toBe(true);
+        });
+
+        it('show() est no-op si déjà open', async () => {
+            el.show();
+            await waitForUpdate(el);
+            let count = 0;
+            el.addEventListener('ar-collapse-show', () => count++);
+            el.show();
+            await waitForUpdate(el);
+            expect(count).toBe(0);
+        });
+
+        it('hide() est no-op si déjà fermé', async () => {
+            let count = 0;
+            el.addEventListener('ar-collapse-hide', () => count++);
+            el.hide();
+            await waitForUpdate(el);
+            expect(count).toBe(0);
+        });
+    });
+
+    // ── Événements ────────────────────────────────────────────────────────────
+
+    describe('événements', () => {
+        beforeEach(async () => {
+            el = await fixture('<ar-collapse></ar-collapse>');
+        });
+
+        it('show() émet ar-collapse-show puis ar-collapse-shown', async () => {
+            const order: string[] = [];
+            el.addEventListener('ar-collapse-show', () => order.push('show'));
+            el.addEventListener('ar-collapse-shown', () => order.push('shown'));
+            el.show();
+            await waitForUpdate(el);
+            expect(order).toEqual(['show', 'shown']);
+        });
+
+        it('hide() émet ar-collapse-hide puis ar-collapse-hidden', async () => {
+            el.show();
+            await waitForUpdate(el);
+            const order: string[] = [];
+            el.addEventListener('ar-collapse-hide', () => order.push('hide'));
+            el.addEventListener('ar-collapse-hidden', () => order.push('hidden'));
+            el.hide();
+            await waitForUpdate(el);
+            expect(order).toEqual(['hide', 'hidden']);
+        });
+
+        it("annuler ar-collapse-show empêche l'ouverture", async () => {
+            el.addEventListener('ar-collapse-show', (e) => e.preventDefault());
+            el.show();
+            await waitForUpdate(el);
+            expect(el.open).toBe(false);
+        });
+
+        it('annuler ar-collapse-hide empêche la fermeture', async () => {
+            el.show();
+            await waitForUpdate(el);
+            el.addEventListener('ar-collapse-hide', (e) => e.preventDefault());
+            el.hide();
+            await waitForUpdate(el);
+            expect(el.open).toBe(true);
+        });
+    });
+
+    // ── Trigger interne + ARIA ────────────────────────────────────────────────
+
+    describe('trigger interne (slot)', () => {
+        it('pose aria-expanded=false sur le trigger au départ', async () => {
+            el = await fixture(`
+                <ar-collapse>
+                    <button slot="trigger">Toggle</button>
+                </ar-collapse>
+            `);
+            const btn = el.querySelector('button')!;
+            await waitForUpdate(el);
+            expect(btn.getAttribute('aria-expanded')).toBe('false');
+        });
+
+        it("met à jour aria-expanded=true à l'ouverture", async () => {
+            el = await fixture(`
+                <ar-collapse>
+                    <button slot="trigger">Toggle</button>
+                </ar-collapse>
+            `);
+            const btn = el.querySelector('button')!;
+            el.show();
+            await waitForUpdate(el);
+            expect(btn.getAttribute('aria-expanded')).toBe('true');
+        });
+
+        it("pose aria-controls pointant vers l'id du host", async () => {
+            el = await fixture(`
+                <ar-collapse id="my-collapse">
+                    <button slot="trigger">Toggle</button>
+                </ar-collapse>
+            `);
+            const btn = el.querySelector('button')!;
+            await waitForUpdate(el);
+            expect(btn.getAttribute('aria-controls')).toBe('my-collapse');
+        });
+
+        it('un clic sur le trigger ouvre le panel', async () => {
+            el = await fixture(`
+                <ar-collapse>
+                    <button slot="trigger">Toggle</button>
+                </ar-collapse>
+            `);
+            const btn = el.querySelector<HTMLButtonElement>('button')!;
+            btn.click();
+            await waitForUpdate(el);
+            expect(el.open).toBe(true);
+        });
+
+        it('un clic sur le trigger ferme le panel si ouvert', async () => {
+            el = await fixture(`
+                <ar-collapse open>
+                    <button slot="trigger">Toggle</button>
+                </ar-collapse>
+            `);
+            const btn = el.querySelector<HTMLButtonElement>('button')!;
+            btn.click();
+            await waitForUpdate(el);
+            expect(el.open).toBe(false);
+        });
+    });
+
+    // ── Trigger externe (for) ─────────────────────────────────────────────────
+
+    describe('trigger externe (for)', () => {
+        it('pose aria-expanded et aria-controls sur le bouton externe', async () => {
+            document.body.innerHTML = '<button id="ext-btn">Toggle</button>';
+            el = await fixture('<ar-collapse id="panel-1" for="ext-btn"></ar-collapse>');
+            const btn = document.getElementById('ext-btn')!;
+            expect(btn.getAttribute('aria-expanded')).toBe('false');
+            expect(btn.getAttribute('aria-controls')).toBe('panel-1');
+        });
+
+        it('un clic sur le bouton externe ouvre le panel', async () => {
+            document.body.innerHTML = '<button id="ext-btn2">Toggle</button>';
+            el = await fixture('<ar-collapse for="ext-btn2"></ar-collapse>');
+            document.getElementById('ext-btn2')!.click();
+            await waitForUpdate(el);
+            expect(el.open).toBe(true);
+        });
+
+        it("émet un warn si l'id est introuvable", async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            el = await fixture('<ar-collapse for="inexistant"></ar-collapse>');
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('inexistant'));
+            spy.mockRestore();
+        });
+
+        it('émet un warn si for et slot trigger sont tous les deux définis', async () => {
+            document.body.innerHTML = '<button id="ext-btn3">Btn</button>';
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            el = await fixture(`
+                <ar-collapse for="ext-btn3">
+                    <button slot="trigger">Slot btn</button>
+                </ar-collapse>
+            `);
+            await waitForUpdate(el);
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('for'));
+            spy.mockRestore();
+        });
+
+        it('retire aria-controls du trigger externe lors du changement de for', async () => {
+            document.body.innerHTML = '<button id="ext-btn4">Btn</button>';
+            el = await fixture('<ar-collapse for="ext-btn4"></ar-collapse>');
+            const btn = document.getElementById('ext-btn4')!;
+            expect(btn.getAttribute('aria-controls')).not.toBeNull();
+            el.for = '';
+            await waitForUpdate(el);
+            expect(btn.getAttribute('aria-controls')).toBeNull();
+        });
+    });
+
+    // ── Accordéon (name) ──────────────────────────────────────────────────────
+
+    describe('accordéon (name)', () => {
+        let el2: ArCollapse;
+        let el3: ArCollapse;
+
+        afterEach(() => {
+            el2?.remove();
+            el3?.remove();
+        });
+
+        it('ouvrir un item ferme les autres du même groupe', async () => {
+            el = await fixture('<ar-collapse name="faq"></ar-collapse>');
+            el2 = await fixture('<ar-collapse name="faq"></ar-collapse>');
+            el.show();
+            await waitForUpdate(el);
+            expect(el.open).toBe(true);
+            el2.show();
+            await waitForUpdate(el2);
+            await waitForUpdate(el);
+            expect(el2.open).toBe(true);
+            expect(el.open).toBe(false);
+        });
+
+        it("ne ferme pas les panels d'un groupe différent", async () => {
+            el = await fixture('<ar-collapse name="group-a"></ar-collapse>');
+            el2 = await fixture('<ar-collapse name="group-b"></ar-collapse>');
+            el.show();
+            await waitForUpdate(el);
+            el2.show();
+            await waitForUpdate(el2);
+            expect(el.open).toBe(true);
+            expect(el2.open).toBe(true);
+        });
+
+        it('sans name, plusieurs panels peuvent être ouverts', async () => {
+            el = await fixture('<ar-collapse></ar-collapse>');
+            el2 = await fixture('<ar-collapse></ar-collapse>');
+            el.show();
+            el2.show();
+            await waitForUpdate(el);
+            await waitForUpdate(el2);
+            expect(el.open).toBe(true);
+            expect(el2.open).toBe(true);
+        });
+    });
+
+    // ── disabled ──────────────────────────────────────────────────────────────
+
+    describe('disabled', () => {
+        it('show() est no-op quand disabled=true', async () => {
+            el = await fixture('<ar-collapse disabled></ar-collapse>');
+            el.show();
+            await waitForUpdate(el);
+            expect(el.open).toBe(false);
+        });
+
+        it('pose disabled et aria-disabled sur le trigger interne', async () => {
+            el = await fixture(`
+                <ar-collapse disabled>
+                    <button slot="trigger">Toggle</button>
+                </ar-collapse>
+            `);
+            const btn = el.querySelector('button')!;
+            await waitForUpdate(el);
+            expect(btn.hasAttribute('disabled')).toBe(true);
+            expect(btn.getAttribute('aria-disabled')).toBe('true');
+        });
+
+        it('retire disabled et aria-disabled quand disabled passe à false', async () => {
+            el = await fixture(`
+                <ar-collapse disabled>
+                    <button slot="trigger">Toggle</button>
+                </ar-collapse>
+            `);
+            const btn = el.querySelector('button')!;
+            el.disabled = false;
+            await waitForUpdate(el);
+            expect(btn.hasAttribute('disabled')).toBe(false);
+            expect(btn.getAttribute('aria-disabled')).toBeNull();
+        });
+
+        it("un clic ne déclenche pas l'ouverture quand disabled", async () => {
+            el = await fixture(`
+                <ar-collapse disabled>
+                    <button slot="trigger">Toggle</button>
+                </ar-collapse>
+            `);
+            el.querySelector<HTMLButtonElement>('button')!.click();
+            await waitForUpdate(el);
+            expect(el.open).toBe(false);
+        });
+    });
+
+    // ── trigger-position ──────────────────────────────────────────────────────
+
+    describe('trigger-position', () => {
+        it('trigger-position="before" : trigger avant panel dans le DOM', async () => {
+            el = await fixture(`
+                <ar-collapse trigger-position="before">
+                    <button slot="trigger">T</button>
+                </ar-collapse>
+            `);
+            const base = requirePart(el, 'base');
+            const children = Array.from(base.children);
+            const triggerIdx = children.findIndex(
+                (c) => c.getAttribute('part') === 'trigger-container',
+            );
+            const panelIdx = children.findIndex((c) => c.getAttribute('part') === 'panel');
+            expect(triggerIdx).toBeLessThan(panelIdx);
+        });
+
+        it('trigger-position="after" : panel avant trigger dans le DOM', async () => {
+            el = await fixture(`
+                <ar-collapse trigger-position="after">
+                    <button slot="trigger">T</button>
+                </ar-collapse>
+            `);
+            const base = requirePart(el, 'base');
+            const children = Array.from(base.children);
+            const triggerIdx = children.findIndex(
+                (c) => c.getAttribute('part') === 'trigger-container',
+            );
+            const panelIdx = children.findIndex((c) => c.getAttribute('part') === 'panel');
+            expect(panelIdx).toBeLessThan(triggerIdx);
+        });
+    });
+});
+```
+
+- [ ] **Step 2 : Lancer les tests — ils doivent passer**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+npm run test -- --reporter=verbose collapse.test
+```
+
+Expected: tous les tests passent (le composant est déjà implémenté en Task 2).
+
+Si des tests échouent, corriger `collapse.ts` avant de continuer.
+
+- [ ] **Step 3 : Commit**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git add packages/core/src/components/collapse/collapse.test.ts
+git commit -m "test(collapse): tests unitaires Vitest — render, props, ARIA, events, accordion, disabled, trigger-position"
+```
+
+---
+
+## Task 4 : Tests browser (WTR) — animation height + transitionend
+
+**Files:**
+
+- Create: `packages/core/src/components/collapse/collapse.browser.test.ts`
+
+Ces tests tournent dans un vrai navigateur (Chromium) via `@web/test-runner`. Ils vérifient l'animation réelle de hauteur et les événements `transitionend`.
+
+- [ ] **Step 1 : Créer `collapse.browser.test.ts`**
+
+```typescript
+// packages/core/src/components/collapse/collapse.browser.test.ts
+/// <reference types="mocha" />
+import { fixture, html, expect, aTimeout } from '@open-wc/testing';
+import type { ArCollapse } from './collapse.js';
+import './collapse.js';
+
+const ANIM_MS = 400; // durée max d'attente après transition
+
+// La transition est sur ::part(panel) dans le thème consommateur.
+// On l'injecte globalement pour que _shouldAnimate() retourne true.
+let styleEl: HTMLStyleElement;
+before(() => {
+    styleEl = document.createElement('style');
+    styleEl.textContent = 'ar-collapse::part(panel) { transition: height 100ms ease; }';
+    document.head.appendChild(styleEl);
+});
+after(() => styleEl.remove());
+
+function getPanel(el: ArCollapse): HTMLElement {
+    const p = el.shadowRoot?.querySelector<HTMLElement>('[part="panel"]');
+    if (!p) throw new Error('panel introuvable');
+    return p;
+}
+
+describe('ar-collapse — browser', () => {
+    let el: ArCollapse;
+
+    afterEach(() => el?.remove());
+
+    // ── Ouverture avec animation ───────────────────────────────────────────────
+
+    describe('ouverture', () => {
+        beforeEach(async () => {
+            el = await fixture(html`
+                <ar-collapse>
+                    <button slot="trigger">Toggle</button>
+                    <p>Contenu</p>
+                </ar-collapse>
+            `);
+        });
+
+        it('retire hidden du panel', async () => {
+            el.show();
+            await aTimeout(10);
+            expect(getPanel(el).hasAttribute('hidden')).to.equal(false);
+        });
+
+        it('émet ar-collapse-shown après transitionend', async () => {
+            let fired = false;
+            el.addEventListener('ar-collapse-shown', () => {
+                fired = true;
+            });
+            el.show();
+            await aTimeout(ANIM_MS);
+            expect(fired).to.equal(true);
+        });
+
+        it('height est "auto" après la fin de l\'animation', async () => {
+            el.show();
+            await aTimeout(ANIM_MS);
+            expect(getPanel(el).style.height).to.equal('auto');
+        });
+
+        it('_animating bloque un double appel', async () => {
+            let count = 0;
+            el.addEventListener('ar-collapse-shown', () => count++);
+            el.show();
+            el.show(); // second appel immédiat
+            await aTimeout(ANIM_MS);
+            expect(count).to.equal(1);
+        });
+    });
+
+    // ── Fermeture avec animation ──────────────────────────────────────────────
+
+    describe('fermeture', () => {
+        beforeEach(async () => {
+            el = await fixture(html`
+                <ar-collapse open>
+                    <button slot="trigger">Toggle</button>
+                    <p>Contenu</p>
+                </ar-collapse>
+            `);
+            await aTimeout(ANIM_MS); // attendre fin ouverture initiale
+        });
+
+        it('émet ar-collapse-hidden après transitionend', async () => {
+            let fired = false;
+            el.addEventListener('ar-collapse-hidden', () => {
+                fired = true;
+            });
+            el.hide();
+            await aTimeout(ANIM_MS);
+            expect(fired).to.equal(true);
+        });
+
+        it('repose hidden sur le panel après fermeture', async () => {
+            el.hide();
+            await aTimeout(ANIM_MS);
+            expect(getPanel(el).hasAttribute('hidden')).to.equal(true);
+        });
+
+        it('height inline est vidé après fermeture', async () => {
+            el.hide();
+            await aTimeout(ANIM_MS);
+            expect(getPanel(el).style.height).to.equal('');
+        });
+    });
+});
+```
+
+- [ ] **Step 2 : Lancer les browser tests**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+npm run test:browser -- collapse.browser.test
+```
+
+Expected: tous les tests passent.
+
+- [ ] **Step 3 : Commit**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git add packages/core/src/components/collapse/collapse.browser.test.ts
+git commit -m "test(collapse): browser tests WTR — animation height, transitionend"
+```
+
+---
+
+## Task 5 : Tests a11y (WTR + axe-core)
+
+**Files:**
+
+- Create: `packages/core/src/components/collapse/collapse.a11y.test.ts`
+
+- [ ] **Step 1 : Créer `collapse.a11y.test.ts`**
+
+```typescript
+// packages/core/src/components/collapse/collapse.a11y.test.ts
+/// <reference types="mocha" />
+import { fixture, html, expect } from '@open-wc/testing';
+import type { ArCollapse } from './collapse.js';
+import './collapse.js';
+
+describe('ar-collapse — accessibilité', () => {
+    let el: ArCollapse;
+
+    afterEach(() => {
+        el?.remove();
+        document.body.innerHTML = '';
+    });
+
+    // ── Pas de violations axe-core ────────────────────────────────────────────
+
+    describe('axe-core', () => {
+        it('panel fermé — aucune violation', async () => {
+            el = await fixture(html`
+                <ar-collapse>
+                    <button slot="trigger">Voir plus</button>
+                    <p>Contenu</p>
+                </ar-collapse>
+            `);
+            await expect(el).to.be.accessible();
+        });
+
+        it('panel ouvert — aucune violation', async () => {
+            el = await fixture(html`
+                <ar-collapse open>
+                    <button slot="trigger">Voir plus</button>
+                    <p>Contenu</p>
+                </ar-collapse>
+            `);
+            await expect(el).to.be.accessible();
+        });
+    });
+
+    // ── Trigger interne ───────────────────────────────────────────────────────
+
+    describe('trigger interne', () => {
+        it('aria-expanded="false" sur le trigger au départ', async () => {
+            el = await fixture(html`
+                <ar-collapse>
+                    <button slot="trigger">Toggle</button>
+                </ar-collapse>
+            `);
+            expect(el.querySelector('button')!.getAttribute('aria-expanded')).to.equal('false');
+        });
+
+        it("aria-controls pointe vers l'id du host", async () => {
+            el = await fixture(html`
+                <ar-collapse id="acc-1">
+                    <button slot="trigger">Toggle</button>
+                </ar-collapse>
+            `);
+            const ctrl = el.querySelector('button')!.getAttribute('aria-controls');
+            expect(ctrl).to.equal('acc-1');
+            expect(document.getElementById(ctrl!)).to.equal(el);
+        });
+    });
+
+    // ── Trigger externe ───────────────────────────────────────────────────────
+
+    describe('trigger externe (for)', () => {
+        it('aria-expanded et aria-controls posés sur le bouton natif', async () => {
+            document.body.innerHTML = '<button id="ext-a11y">Btn</button>';
+            el = await fixture(html`<ar-collapse id="panel-a11y" for="ext-a11y"></ar-collapse>`);
+            const btn = document.getElementById('ext-a11y')!;
+            expect(btn.getAttribute('aria-expanded')).to.equal('false');
+            expect(btn.getAttribute('aria-controls')).to.equal('panel-a11y');
+        });
+    });
+});
+```
+
+- [ ] **Step 2 : Lancer les tests a11y**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+npm run test:browser -- collapse.a11y.test
+```
+
+Expected: tous les tests passent, aucune violation axe.
+
+- [ ] **Step 3 : Commit**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git add packages/core/src/components/collapse/collapse.a11y.test.ts
+git commit -m "test(collapse): tests a11y axe-core — trigger interne et externe"
+```
+
+---
+
+## Task 6 : Documentation MDX
+
+**Files:**
+
+- Modify: `apps/docs/src/content/components/ar-collapse.mdx`
+
+- [ ] **Step 1 : Remplacer le stub par la doc complète**
+
+````mdx
+---
+tagName: ar-collapse
+title: Collapse
+description: Panneau pliable/dépliable accessible — animation de hauteur, trigger interne ou externe, mode accordéon via attribut name.
+playgroundTemplate: default
+variants:
+    - name: default
+      label: Standalone
+      description: |
+          Collapse simple avec un trigger interne via `slot="trigger"`.
+          L'animation de hauteur est activée via `--ar-collapse-duration`.
+      html: |
+          <ar-collapse style="--ar-collapse-duration:200ms;--ar-collapse-easing:ease">
+              <button slot="trigger" class="btn btn-secondary">Voir plus</button>
+              <div style="padding:1rem 0">
+                  <p>Contenu qui se révèle à l'ouverture. Peut contenir n'importe quel HTML.</p>
+              </div>
+          </ar-collapse>
+    - name: open
+      label: Ouvert par défaut
+      description: L'attribut `open` ouvre le panel sans animation au chargement.
+      html: |
+          <ar-collapse open style="--ar-collapse-duration:200ms">
+              <button slot="trigger" class="btn btn-secondary">Fermer</button>
+              <div style="padding:1rem 0">
+                  <p>Contenu visible dès le chargement.</p>
+              </div>
+          </ar-collapse>
+    - name: accordion
+      label: Accordéon (name)
+      description: |
+          Tous les `ar-collapse` partageant le même attribut `name` forment un groupe accordéon :
+          ouvrir un item ferme automatiquement les autres.
+      html: |
+          <div style="display:flex;flex-direction:column;gap:0.5rem">
+              <ar-collapse name="faq" style="--ar-collapse-duration:200ms">
+                  <button slot="trigger" class="btn btn-secondary" style="width:100%;text-align:left">Question 1</button>
+                  <div style="padding:0.75rem 0"><p>Réponse à la question 1.</p></div>
+              </ar-collapse>
+              <ar-collapse name="faq" style="--ar-collapse-duration:200ms">
+                  <button slot="trigger" class="btn btn-secondary" style="width:100%;text-align:left">Question 2</button>
+                  <div style="padding:0.75rem 0"><p>Réponse à la question 2.</p></div>
+              </ar-collapse>
+              <ar-collapse name="faq" style="--ar-collapse-duration:200ms">
+                  <button slot="trigger" class="btn btn-secondary" style="width:100%;text-align:left">Question 3</button>
+                  <div style="padding:0.75rem 0"><p>Réponse à la question 3.</p></div>
+              </ar-collapse>
+          </div>
+    - name: external-trigger
+      label: Trigger externe (for)
+      description: |
+          L'attribut `for` accepte l'ID d'un bouton natif situé n'importe où dans la page.
+          `aria-expanded` et `aria-controls` sont posés automatiquement sur ce bouton.
+      html: |
+          <button id="ar-doc-collapse-ext" class="btn btn-secondary">Révéler le contenu</button>
+          <ar-collapse for="ar-doc-collapse-ext" style="--ar-collapse-duration:200ms">
+              <div style="padding:0.75rem 0">
+                  <p>Contenu piloté par un trigger externe. Utile quand trigger et panel ne peuvent pas être enveloppés dans un wrapper commun.</p>
+              </div>
+          </ar-collapse>
+    - name: trigger-after
+      label: Trigger après le contenu
+      description: |
+          `trigger-position="after"` place le trigger après le contenu dans le DOM (et visuellement).
+          Utile pour les patterns "Lire la suite" où le bouton apparaît sous le texte tronqué.
+      html: |
+          <ar-collapse trigger-position="after" style="--ar-collapse-duration:200ms">
+              <div style="padding:0.75rem 0">
+                  <p>Contenu révélé. Le trigger est positionné après dans le DOM et visuellement.</p>
+              </div>
+              <button slot="trigger" class="btn btn-secondary">Lire la suite</button>
+          </ar-collapse>
+    - name: disabled
+      label: Désactivé
+      description: |
+          L'attribut `disabled` bloque l'interaction. Le composant pose `disabled` et
+          `aria-disabled="true"` sur le trigger interne.
+      html: |
+          <ar-collapse disabled>
+              <button slot="trigger" class="btn btn-secondary">Toggle (désactivé)</button>
+              <div style="padding:0.75rem 0"><p>Ce contenu ne peut pas être révélé.</p></div>
+          </ar-collapse>
+---
+
+import WcagRef from '../../components/WcagRef.astro';
+
+## Accessibilité
+
+### Pris en charge automatiquement
+
+`ar-collapse` gère les attributs ARIA et les comportements keyboard sans intervention :
+
+- `aria-expanded` est posé sur le trigger (interne ou externe) et mis à jour à chaque ouverture/fermeture.
+- `aria-controls` est posé sur le trigger et pointe vers l'`id` du host `ar-collapse`. Si l'auteur ne fournit pas d'`id`, un identifiant unique est généré automatiquement.
+- Le panel utilise l'attribut `hidden` pour les états stables (pas de `display:none` inline) — compatible avec les styles qui surchargeraient `display`.
+- `prefers-reduced-motion` : si l'utilisateur a activé la préférence système de réduction de mouvement, les animations sont supprimées et les transitions sont instantanées.
+
+Les critères WCAG suivants sont implémentés :
+
+- `aria-expanded` indique l'état ouvert/fermé du panel aux technologies d'assistance (<WcagRef criterion="4.1.2" summary="Name, Role, Value : aria-expanded communique l'état du composant aux AT." />)
+- L'ordre DOM du trigger reflète l'ordre visuel — `trigger-position` modifie le DOM, pas le CSS `order` (<WcagRef criterion="2.4.3" summary="Focus Order : l'ordre de focus suit l'ordre visuel." />)
+
+### Limitations connues
+
+- **Cross-shadow DOM** : `for` et `aria-controls` reposent sur des IDs résolus dans le document. Si le trigger et le panel se trouvent dans des shadow roots différents, la référence `aria-controls` ne sera pas résolue par les technologies d'assistance. De même, le mode accordéon (`name`) ne fonctionne pas entre shadow roots distincts.
+- **`ariaControlsElements`** : la propriété IDL permettant des références cross-shadow est prévue mais le support navigateur est insuffisant en 2026. À adopter quand il sera stable.
+
+### À votre charge
+
+- Le trigger doit être un élément focusable avec un nom accessible (texte visible, `aria-label`, ou `aria-labelledby`).
+- Pour un pattern accordéon, ajouter `role="region"` et `aria-labelledby` sur chaque panel si le contexte sémantique le demande (ex: FAQ dans un article).
+- L'animation `height` via `--ar-collapse-duration` n'est pas automatique — vous devez activer la transition dans votre thème :
+
+```css
+ar-collapse::part(panel) {
+    transition: height var(--ar-collapse-duration, 0s) var(--ar-collapse-easing, ease);
+}
+```
+````
+
+````
+---
+
+- [ ] **Step 2 : Commit**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git add apps/docs/src/content/components/ar-collapse.mdx
+git commit -m "docs(collapse): page documentation ar-collapse"
+````
+
+---
+
+## Task 7 : Build manifest + suite de tests complète
+
+**Files:**
+
+- Modify: `packages/core/custom-elements.json` (régénéré)
+
+- [ ] **Step 1 : Régénérer le manifest**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+npm run build:manifest
+```
+
+Expected: `packages/core/custom-elements.json` mis à jour avec `ar-collapse`.
+
+- [ ] **Step 2 : Lancer la suite de tests complète**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+npm run test:all
+```
+
+Expected: tous les tests passent (Vitest + WTR).
+
+- [ ] **Step 3 : Commit final**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git add packages/core/custom-elements.json
+git commit -m "feat(collapse): ar-collapse — dual trigger, accordéon name, animation height"
+```
+
+---
+
+## Task 8 : Créer la Pull Request
+
+- [ ] **Step 1 : Pousser la branche**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git push -u origin feat/ar-collapse
+```
+
+- [ ] **Step 2 : Créer la PR vers `dev`**
+
+```bash
+gh pr create --base dev --title "feat(collapse): ar-collapse — dual trigger, accordéon, animation height" --body "$(cat <<'EOF'
+## Summary
+
+- Nouveau composant `ar-collapse` — panneau pliable/dépliable accessible
+- Dual trigger : `slot=\"trigger\"` (interne) et `for=\"id\"` (externe), cohérent avec `ar-dropdown`
+- Mode accordéon via attribut `name` — coordination par DOM query, sans wrapper parent
+- Animation height pilotée par JS (`scrollHeight`) + `transitionend`, bypass si `prefers-reduced-motion` ou durée 0s
+- Tests : Vitest (unit), WTR browser (animation), WTR a11y (axe-core)
+- Documentation : page MDX avec 6 variantes playground
+
+## Test plan
+
+- [ ] `npm run test:all` passe sans régression
+- [ ] Playground doc — toutes les variantes fonctionnent (standalone, accordéon, trigger externe, trigger-position, disabled)
+- [ ] Vérification manuelle : animation avec `--ar-collapse-duration:300ms`, reduced motion, clavier
+
+🤖 Generated with [Claude Code](https://claude.ai/claude-code)
+EOF
+)"
+```
+
+---
+
+## Checklist de vérification post-implémentation
+
+- [ ] `npm run test:all` — tous les tests passent
+- [ ] `npm run build:manifest` — custom-elements.json contient `ar-collapse`
+- [ ] `npm run dev` — le playground de la doc affiche et joue toutes les variantes
+- [ ] Vérifier manuellement : trigger interne, trigger externe, accordéon, trigger-position="after", disabled, animation avec `--ar-collapse-duration:300ms`

--- a/docs/superpowers/plans/2026-06-12-ar-collapse-bugfixes.md
+++ b/docs/superpowers/plans/2026-06-12-ar-collapse-bugfixes.md
@@ -1,0 +1,513 @@
+# ar-collapse — Bugfixes (code review) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Corriger les 8 findings issus de la code review de `ar-collapse` : robustesse du cycle d'animation, CSS injection, accordéon, accessibilité du trigger externe.
+
+**Architecture:** Toutes les corrections sont dans `packages/core/src/components/collapse/collapse.ts`. Le refacto le plus structurant est le remplacement du listener `transitionend` anonyme par une référence stockée + une méthode `_abortAnimation()`, qui résout les bugs d'état liés à l'animation. Les autres corrections sont indépendantes et chirurgicales.
+
+**Tech Stack:** Lit 3, TypeScript, Vitest (tests unitaires), Web Test Runner / open-wc (tests browser).
+
+---
+
+## Fichiers modifiés
+
+| Fichier                                                          | Raison                   |
+| ---------------------------------------------------------------- | ------------------------ |
+| `packages/core/src/components/collapse/collapse.ts`              | Toutes les corrections   |
+| `packages/core/src/components/collapse/collapse.test.ts`         | Tests unitaires nouveaux |
+| `packages/core/src/components/collapse/collapse.browser.test.ts` | Tests browser nouveaux   |
+
+---
+
+## Task 1 — Refacto système d'animation (findings 1, 2, 3, 5)
+
+**Findings adressés :**
+
+- **1** : `_animating` reste `true` après disconnect mid-animation
+- **2** : annuler `ar-collapse-show` → `_hide()` sur panel `display:none` → `_animating` bloqué
+- **3** : `el.open = true` pendant animation → double listener transitionend
+- **5** : frère accordéon mid-animation non fermé
+
+**Principe :** Stocker la référence du listener `transitionend` pour pouvoir le retirer. Ajouter `_abortAnimation()` appelé en début de `_show()` / `_hide()` / `disconnectedCallback`. Dans `_hide()`, détecter si une animation était en cours (`wasAnimating`) pour décider entre snap immédiat et animation normale. Retirer le guard `_animating` de `hide()` public pour que l'accordéon puisse interrompre un frère.
+
+**Fichiers :**
+
+- Modify: `packages/core/src/components/collapse/collapse.ts`
+- Modify: `packages/core/src/components/collapse/collapse.test.ts`
+- Modify: `packages/core/src/components/collapse/collapse.browser.test.ts`
+
+---
+
+- [ ] **Étape 1 — Écrire les tests unitaires qui échouent**
+
+Dans `collapse.test.ts`, ajouter dans la section `show() / hide()` existante (après le `describe` existant) :
+
+```typescript
+describe('robustesse animation', () => {
+    it('annuler ar-collapse-show ne verrouille pas le composant', async () => {
+        el = await fixture('<ar-collapse><button slot="trigger">T</button></ar-collapse>');
+        const cancel = (e: Event) => e.preventDefault();
+        el.addEventListener('ar-collapse-show', cancel);
+        el.show();
+        await waitForUpdate(el);
+        expect(el.open).toBe(false);
+        el.removeEventListener('ar-collapse-show', cancel);
+        // Après annulation, show() doit fonctionner normalement
+        el.show();
+        await waitForUpdate(el);
+        expect(el.open).toBe(true);
+    });
+});
+```
+
+- [ ] **Étape 2 — Vérifier que le test échoue**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && npm run test -- --reporter=verbose 2>&1 | grep -A5 "verrouille"
+```
+
+Résultat attendu : le test échoue car `el.open` reste `false` (composant bloqué).
+
+- [ ] **Étape 3 — Écrire les tests browser qui échouent**
+
+Dans `collapse.browser.test.ts`, ajouter après les `describe` existants :
+
+```typescript
+describe('robustesse animation', () => {
+    it('disconnect mid-animation ne bloque pas le composant après reconnect', async () => {
+        el = await fixture(html`
+            <ar-collapse>
+                <button slot="trigger">T</button>
+                <p>Contenu</p>
+            </ar-collapse>
+        `);
+        el.show();
+        await aTimeout(30); // mi-animation
+        const parent = el.parentElement!;
+        el.remove();
+        parent.appendChild(el);
+        el.show();
+        await aTimeout(ANIM_MS);
+        expect(getPanel(el).style.height).to.equal('auto');
+    });
+
+    it('assigner el.open=true pendant animation émet ar-collapse-shown une seule fois', async () => {
+        el = await fixture(html`
+            <ar-collapse>
+                <button slot="trigger">T</button>
+                <p>Contenu</p>
+            </ar-collapse>
+        `);
+        el.show();
+        await aTimeout(30); // mi-ouverture
+
+        let count = 0;
+        el.addEventListener('ar-collapse-shown', () => count++);
+        el.open = true; // forcer pendant animation
+        await aTimeout(ANIM_MS * 2);
+        expect(count).to.equal(1);
+    });
+});
+
+describe('accordéon — snap mid-animation', () => {
+    it('ouvrir item B ferme item A même si A est mid-animation', async () => {
+        const elA = await fixture<ArCollapse>(html`
+            <ar-collapse name="snap-grp">
+                <button slot="trigger">A</button>
+                <p>Contenu A</p>
+            </ar-collapse>
+        `);
+        const elB = await fixture<ArCollapse>(html`
+            <ar-collapse name="snap-grp">
+                <button slot="trigger">B</button>
+                <p>Contenu B</p>
+            </ar-collapse>
+        `);
+
+        elA.show();
+        await aTimeout(30); // A mid-animation
+
+        elB.show(); // doit fermer A immédiatement
+        await aTimeout(ANIM_MS);
+
+        expect(elA.open).to.equal(false);
+        expect(getPanel(elA).hasAttribute('hidden')).to.equal(true);
+        expect(elB.open).to.equal(true);
+        elA.remove();
+        elB.remove();
+    });
+});
+```
+
+- [ ] **Étape 4 — Vérifier que les tests browser échouent**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && npm run test:all 2>&1 | grep -E "(passing|failing|robustesse|accordéon)"
+```
+
+Résultat attendu : les nouveaux tests browser échouent.
+
+- [ ] **Étape 5 — Implémenter le fix dans `collapse.ts`**
+
+**5a — Ajouter le champ `_onTransitionEnd`** (après `_internalTrigger`) :
+
+```typescript
+private _onTransitionEnd: (() => void) | null = null;
+```
+
+**5b — Ajouter la méthode `_abortAnimation()`** (avant `_closeGroupSiblings`) :
+
+```typescript
+private _abortAnimation(): void {
+    if (this._onTransitionEnd) {
+        this._panel.removeEventListener('transitionend', this._onTransitionEnd);
+        this._onTransitionEnd = null;
+    }
+    this._animating = false;
+}
+```
+
+**5c — Mettre à jour `disconnectedCallback`** — remplacer le corps par :
+
+```typescript
+override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this._abortAnimation();
+    this._detachExternalTrigger();
+    if (this._internalTrigger) {
+        this._internalTrigger.removeEventListener('click', this._handleTriggerClick);
+        this._internalTrigger = null;
+    }
+}
+```
+
+**5d — Mettre à jour `hide()` public** — retirer le guard `_animating` :
+
+```typescript
+hide(): void {
+    if (!this.open) return;
+    this.open = false;
+}
+```
+
+**5e — Remplacer `_show()` entièrement** :
+
+```typescript
+private _show(): void {
+    const ev = this._emit('ar-collapse-show');
+    if (ev.defaultPrevented) {
+        this.open = false;
+        return;
+    }
+    this._abortAnimation();
+    this._closeGroupSiblings();
+    this._syncTriggerAria();
+    this._animating = true;
+    const panel = this._panel;
+    panel.style.height = '0px';
+    panel.removeAttribute('hidden');
+    const targetH = panel.scrollHeight;
+    void panel.offsetHeight; // force reflow
+    if (!this._shouldAnimate()) {
+        panel.style.height = 'auto';
+        this._animating = false;
+        this._emit('ar-collapse-shown');
+        return;
+    }
+    panel.style.height = `${targetH}px`;
+    const onEnd = () => {
+        this._onTransitionEnd = null;
+        this._animating = false;
+        panel.style.height = 'auto';
+        this._emit('ar-collapse-shown');
+    };
+    this._onTransitionEnd = onEnd;
+    panel.addEventListener('transitionend', onEnd, { once: true });
+}
+```
+
+**5f — Remplacer `_hide()` entièrement** :
+
+```typescript
+private _hide(): void {
+    // finding 2 : panel déjà caché (ex. ar-collapse-show annulé → open=false déclenché)
+    if (this._panel.hasAttribute('hidden') && !this._animating) return;
+    const ev = this._emit('ar-collapse-hide');
+    if (ev.defaultPrevented) {
+        this.open = true;
+        return;
+    }
+    const wasAnimating = this._animating;
+    this._abortAnimation();
+    this._syncTriggerAria();
+    if (wasAnimating) {
+        // finding 5 : snap immédiat — frère accordéon ou interruption externe
+        this._panel.setAttribute('hidden', '');
+        this._panel.style.height = '';
+        this._emit('ar-collapse-hidden');
+        return;
+    }
+    this._animating = true;
+    const panel = this._panel;
+    panel.style.height = `${panel.scrollHeight}px`;
+    void panel.offsetHeight; // force reflow
+    if (!this._shouldAnimate()) {
+        this._animating = false;
+        panel.setAttribute('hidden', '');
+        panel.style.height = '';
+        this._emit('ar-collapse-hidden');
+        return;
+    }
+    panel.style.height = '0px';
+    const onEnd = () => {
+        this._onTransitionEnd = null;
+        this._animating = false;
+        panel.setAttribute('hidden', '');
+        panel.style.height = '';
+        this._emit('ar-collapse-hidden');
+    };
+    this._onTransitionEnd = onEnd;
+    panel.addEventListener('transitionend', onEnd, { once: true });
+}
+```
+
+- [ ] **Étape 6 — Lancer tous les tests**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && npm run test:all 2>&1 | grep -E "(passing|failing)"
+```
+
+Résultat attendu : tous les tests passent.
+
+- [ ] **Étape 7 — Commit**
+
+```bash
+git -C /Users/jon/Code/Active_projects/ariane add packages/core/src/components/collapse/collapse.ts packages/core/src/components/collapse/collapse.test.ts packages/core/src/components/collapse/collapse.browser.test.ts
+git -C /Users/jon/Code/Active_projects/ariane commit -m "fix(collapse): _abortAnimation() — corrige _animating bloqué, double listener, snap accordéon"
+```
+
+---
+
+## Task 2 — CSS.escape + scope getRootNode (findings 4, 7)
+
+**Findings adressés :**
+
+- **4** : `name='foo"]'` → DOMException dans `querySelectorAll`
+- **7** : `document.querySelectorAll` scope global → contamination entre accordéons indépendants partageant le même `name`
+
+**Principe :** Remplacer `document` par `this.getRootNode()` et wrapper `this.name` dans `CSS.escape()`. Un seul appel, deux problèmes résolus.
+
+**Fichiers :**
+
+- Modify: `packages/core/src/components/collapse/collapse.ts`
+- Modify: `packages/core/src/components/collapse/collapse.test.ts`
+
+---
+
+- [ ] **Étape 1 — Écrire les tests unitaires qui échouent**
+
+Dans `collapse.test.ts`, ajouter dans la section `accordéon (name)` existante :
+
+```typescript
+it('un name contenant des guillemets ne crash pas', async () => {
+    el = await fixture('<ar-collapse name=\'foo"]\''></ar-collapse>');
+    // _closeGroupSiblings() est appelé dans _show() — ne doit pas lever d'exception
+    expect(() => el.show()).not.toThrow();
+    await waitForUpdate(el);
+});
+
+it('deux accordéons indépendants avec le même name ne se contaminent pas', async () => {
+    // Simuler deux groupes dans des roots distincts via deux fixtures isolées
+    // On vérifie que ouvrir el n'appelle pas hide() sur el2 quand ils sont dans
+    // des arbres différents.
+    // Note : dans les tests unitaires, les deux fixtures sont dans le même document.
+    // Ce test valide surtout que la méthode ne plante pas avec getRootNode().
+    el = await fixture('<ar-collapse name="shared"></ar-collapse>');
+    const el2 = await fixture('<ar-collapse name="shared"></ar-collapse>');
+    el.show();
+    await waitForUpdate(el);
+    expect(el.open).toBe(true);
+    el2.remove();
+});
+```
+
+- [ ] **Étape 2 — Vérifier que le test avec guillemets échoue**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && npm run test -- --reporter=verbose 2>&1 | grep -A5 "guillemets"
+```
+
+Résultat attendu : DOMException levée, test échoue.
+
+- [ ] **Étape 3 — Implémenter le fix**
+
+Dans `collapse.ts`, méthode `_closeGroupSiblings()`, remplacer les deux lignes du `querySelectorAll` :
+
+```typescript
+private _closeGroupSiblings(): void {
+    if (!this.name) return;
+    const root = this.getRootNode() as Document | ShadowRoot;
+    root.querySelectorAll<ArCollapse>(`ar-collapse[name="${CSS.escape(this.name)}"]`).forEach((el) => {
+        if (el !== this && el.open) el.hide();
+    });
+}
+```
+
+- [ ] **Étape 4 — Lancer les tests**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && npm run test 2>&1 | grep -E "(passing|failing)"
+```
+
+Résultat attendu : tous les tests passent.
+
+- [ ] **Étape 5 — Commit**
+
+```bash
+git -C /Users/jon/Code/Active_projects/ariane add packages/core/src/components/collapse/collapse.ts packages/core/src/components/collapse/collapse.test.ts
+git -C /Users/jon/Code/Active_projects/ariane commit -m "fix(collapse): CSS.escape(name) + getRootNode() dans _closeGroupSiblings"
+```
+
+---
+
+## Task 3 — Trigger externe désactivé (finding 6)
+
+**Finding adressé :**
+
+- **6** : `disabled=true` avec `for` défini → le bouton externe garde son apparence active, `aria-disabled` absent → violation WCAG 4.1.2
+
+**Principe :** Retirer le `return` anticipé de `_syncTriggerDisabled()` pour le trigger externe, et poser `aria-disabled="true"` (sans `disabled` natif — on veut que le bouton reste focusable et announceable). Un bouton natif avec `disabled` disparaît du flow de focus, ce qui est pire pour l'accessibilité que `aria-disabled` seul.
+
+**Fichiers :**
+
+- Modify: `packages/core/src/components/collapse/collapse.ts`
+- Modify: `packages/core/src/components/collapse/collapse.test.ts`
+
+---
+
+- [ ] **Étape 1 — Écrire les tests unitaires qui échouent**
+
+Dans `collapse.test.ts`, ajouter dans la section `trigger externe (for)` :
+
+```typescript
+it('pose aria-disabled sur le bouton externe quand disabled=true', async () => {
+    document.body.innerHTML = '<button id="ext-dis">Btn</button>';
+    el = await fixture('<ar-collapse for="ext-dis" disabled></ar-collapse>');
+    await waitForUpdate(el);
+    const btn = document.getElementById('ext-dis')!;
+    expect(btn.getAttribute('aria-disabled')).toBe('true');
+});
+
+it('retire aria-disabled du bouton externe quand disabled repasse à false', async () => {
+    document.body.innerHTML = '<button id="ext-dis2">Btn</button>';
+    el = await fixture('<ar-collapse for="ext-dis2" disabled></ar-collapse>');
+    await waitForUpdate(el);
+    el.disabled = false;
+    await waitForUpdate(el);
+    const btn = document.getElementById('ext-dis2')!;
+    expect(btn.getAttribute('aria-disabled')).toBeNull();
+});
+```
+
+- [ ] **Étape 2 — Vérifier que les tests échouent**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && npm run test -- --reporter=verbose 2>&1 | grep -A5 "aria-disabled"
+```
+
+Résultat attendu : `aria-disabled` est `null` au lieu de `'true'`.
+
+- [ ] **Étape 3 — Implémenter le fix**
+
+Dans `collapse.ts`, remplacer `_syncTriggerDisabled()` entièrement :
+
+```typescript
+private _syncTriggerDisabled(): void {
+    const trigger = this._resolvedTrigger;
+    if (!trigger) return;
+    if (this.disabled) {
+        if (!this.for) {
+            // Trigger interne natif : disabled + aria-disabled
+            trigger.setAttribute('disabled', '');
+        }
+        trigger.setAttribute('aria-disabled', 'true');
+    } else {
+        trigger.removeAttribute('disabled');
+        trigger.removeAttribute('aria-disabled');
+    }
+}
+```
+
+Note : le trigger externe ne reçoit pas `disabled` natif (pour rester focusable), mais reçoit `aria-disabled`. Le clic est déjà bloqué dans `_handleTriggerClick`.
+
+- [ ] **Étape 4 — Lancer les tests**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && npm run test 2>&1 | grep -E "(passing|failing)"
+```
+
+Résultat attendu : tous les tests passent.
+
+- [ ] **Étape 5 — Commit**
+
+```bash
+git -C /Users/jon/Code/Active_projects/ariane add packages/core/src/components/collapse/collapse.ts packages/core/src/components/collapse/collapse.test.ts
+git -C /Users/jon/Code/Active_projects/ariane commit -m "fix(collapse): aria-disabled sur trigger externe quand disabled=true (WCAG 4.1.2)"
+```
+
+---
+
+## Task 4 — Accessibilité aria-controls (finding 8)
+
+**Finding adressé :**
+
+- **8** : `aria-controls` pointe sur le host `<ar-collapse>`, pas sur la région collapsible dans le shadow DOM — les AT naviguent vers un shell sans rôle.
+
+**Principe :** Le host element exposé par le shadow DOM est traversé par les AT modernes (NVDA, JAWS, VoiceOver). Mais sans `role` sur le host, `aria-controls` pointe vers un élément générique. La mitigation disponible : exposer le panel via `ElementInternals.ariaControlsElements` (API IDL, cross-shadow reference) quand disponible, sinon conserver le comportement actuel. À défaut de support navigateur suffisant en 2026, on documente la limitation et on améliore la page de doc.
+
+**Fichiers :**
+
+- Modify: `apps/docs/src/content/components/ar-collapse.mdx`
+
+---
+
+- [ ] **Étape 1 — Vérifier le support `ariaControlsElements`**
+
+L'API `ElementInternals.ariaControlsElements` est en cours de standardisation. Vérifier si les navigateurs cibles (Chromium 126+, Firefox 128+) la supportent.
+
+```bash
+node -e "const el = document.createElement('div'); console.log('ariaControlsElements' in el);" 2>/dev/null || echo "vérifier manuellement sur MDN"
+```
+
+Si non supportée : implémenter uniquement la documentation. Si supportée : implémenter les deux.
+
+- [ ] **Étape 2 — Mettre à jour la documentation**
+
+Dans `ar-collapse.mdx`, section **Limitations connues**, remplacer le paragraphe `aria-controls` par :
+
+```mdx
+- **`aria-controls` → host element** : `aria-controls` pointe sur l'élément `<ar-collapse>` lui-même (pas sur le panel interne). Les AT qui traversent le shadow DOM (NVDA 2024+, JAWS 2024+, VoiceOver macOS 14+) résolvent correctement la référence vers le contenu. Sur les AT plus anciens, la relation peut être ignorée. Mitigation en attente : `ElementInternals.ariaControlsElements` (référence cross-shadow IDL) sera adoptée quand le support navigateur sera suffisant.
+```
+
+- [ ] **Étape 3 — Commit**
+
+```bash
+git -C /Users/jon/Code/Active_projects/ariane add apps/docs/src/content/components/ar-collapse.mdx
+git -C /Users/jon/Code/Active_projects/ariane commit -m "docs(collapse): préciser limitation aria-controls + shadow DOM dans les limitations connues"
+```
+
+---
+
+## Récapitulatif des findings couverts
+
+| Finding                                        | Task | Type de fix                                      |
+| ---------------------------------------------- | ---- | ------------------------------------------------ |
+| 1 — `_animating` bloqué (disconnect)           | 1    | `_abortAnimation()` dans `disconnectedCallback`  |
+| 2 — show annulé → `_hide()` sur panel caché    | 1    | Guard `hasAttribute('hidden')` dans `_hide()`    |
+| 3 — `el.open = true` pendant animation         | 1    | `_abortAnimation()` en début de `_show()`        |
+| 4 — CSS injection via `name`                   | 2    | `CSS.escape()`                                   |
+| 5 — Accordéon : frère mid-animation non fermé  | 1    | Snap via `wasAnimating` + retrait guard `hide()` |
+| 6 — Trigger externe non désactivé visuellement | 3    | `aria-disabled` dans `_syncTriggerDisabled()`    |
+| 7 — `querySelectorAll` scope global            | 2    | `getRootNode()`                                  |
+| 8 — `aria-controls` → host element             | 4    | Documentation                                    |

--- a/docs/superpowers/specs/2026-06-11-ar-collapse-design.md
+++ b/docs/superpowers/specs/2026-06-11-ar-collapse-design.md
@@ -1,0 +1,200 @@
+# ar-collapse — Design Spec
+
+**Date** : 2026-06-11  
+**Statut** : approuvé  
+**Composant** : `ar-collapse`  
+**Issue backlog** : #13 (roadmap v1 — remplace l'entrée `ar-collapse-trigger` + `ar-collapse-panel`)
+
+---
+
+## Résumé
+
+Composant de panneau pliable/dépliable accessible. Supporte un trigger interne (slot) ou externe (attribut `for`), un mode accordéon via l'attribut `name`, et une animation de hauteur pilotée par JS avec transition CSS à la charge de l'auteur (modèle headless).
+
+---
+
+## Architecture
+
+### Composant unique : `ar-collapse`
+
+L'entrée backlog `ar-collapse-trigger` + `ar-collapse-panel` est remplacée par un seul composant `ar-collapse`, suivant le même pattern que `ar-dropdown`.
+
+### Dual trigger
+
+Deux modes de déclenchement, mutuellement exclusifs (`for` a la priorité) :
+
+- **Trigger externe** — `for="btn-id"` : le composant pointe vers un bouton natif (`<button>`) dans la page. Le composant pose `aria-expanded` et `aria-controls` sur ce bouton.
+- **Trigger interne** — `slot="trigger"` : un élément est sloté directement dans le composant. Le composant pose `aria-expanded` et `aria-controls` sur l'élément sloté.
+
+Si les deux sont présents simultanément, `for` prend la priorité et un warning est émis.
+
+### Mode accordéon
+
+L'attribut `name` groupe plusieurs `ar-collapse` en accordéon. À l'ouverture d'un item, le composant effectue `document.querySelectorAll('ar-collapse[name="x"]')` et appelle `.hide()` sur tous les autres membres du groupe.
+
+**Limitation connue** : le DOM query est document-scoped. Le mode accordéon ne fonctionne pas entre des `ar-collapse` situés dans des shadow roots différents. Acceptable pour l'usage typique — à réévaluer si un besoin cross-shadow émerge.
+
+### Structure du shadow DOM
+
+```
+<div part="base">
+  <!-- ordre DOM selon trigger-position -->
+  <slot name="trigger" part="trigger-container">
+  <div part="panel">   ← overflow:hidden via collapse.styles.ts (structurel)
+    <div part="content">
+      <slot>
+```
+
+`trigger-position` contrôle l'ordre de rendu dans le template Lit (pas via CSS `order`, pour respecter l'ordre focus DOM = ordre visuel — WCAG 2.4.3 et 1.3.2).
+
+`overflow: hidden` est un style structurel (nécessaire au clipping pendant l'animation) — il va dans `collapse.styles.ts`, pas inline. Seul `height` est posé en inline style par JS, uniquement pendant la transition. En état stable : attribut `hidden` (fermé) ou absence de `height` inline (ouvert).
+
+---
+
+## API publique
+
+### Propriétés / Attributs
+
+| Attribut           | Type                | Défaut     | Reflect | Description                  |
+| ------------------ | ------------------- | ---------- | ------- | ---------------------------- |
+| `open`             | `Boolean`           | `false`    | oui     | État ouvert/fermé            |
+| `for`              | `String`            | `''`       | oui     | ID du trigger externe        |
+| `name`             | `String`            | `''`       | oui     | Groupe accordéon             |
+| `trigger-position` | `'before'\|'after'` | `'before'` | oui     | Position DOM du slot trigger |
+| `disabled`         | `Boolean`           | `false`    | oui     | Désactive le déclencheur     |
+
+### Méthodes
+
+- `show()` — ouvre le panel. Émet `ar-collapse-show` (annulable). No-op si déjà ouvert ou animating.
+- `hide()` — ferme le panel. Émet `ar-collapse-hide` (annulable). No-op si déjà fermé ou animating.
+
+### Événements
+
+| Événement            | Annulable | Moment                                   |
+| -------------------- | --------- | ---------------------------------------- |
+| `ar-collapse-show`   | oui       | avant l'ouverture                        |
+| `ar-collapse-shown`  | non       | après la fin de l'animation d'ouverture  |
+| `ar-collapse-hide`   | oui       | avant la fermeture                       |
+| `ar-collapse-hidden` | non       | après la fin de l'animation de fermeture |
+
+### Slots
+
+| Slot       | Description                                      |
+| ---------- | ------------------------------------------------ |
+| `trigger`  | Élément déclencheur. Ignoré si `for` est défini. |
+| _(défaut)_ | Contenu collapsible                              |
+
+### CSS Parts
+
+| Part                | Description                                              |
+| ------------------- | -------------------------------------------------------- |
+| `base`              | Conteneur racine                                         |
+| `trigger-container` | Wrapper du slot trigger                                  |
+| `panel`             | Zone animée (height 0 → auto)                            |
+| `content`           | Wrapper interne du contenu (isole overflow des paddings) |
+
+### CSS Custom Properties
+
+| Propriété                | Défaut structurel | Description                  |
+| ------------------------ | ----------------- | ---------------------------- |
+| `--ar-collapse-duration` | `0s`              | Durée de l'animation height  |
+| `--ar-collapse-easing`   | `ease`            | Easing de l'animation height |
+
+Le défaut `0s` = pas d'animation sans thème, conforme au modèle headless. La `transition` est posée par l'auteur :
+
+```css
+ar-collapse::part(panel) {
+    transition: height var(--ar-collapse-duration, 0s) var(--ar-collapse-easing, ease);
+}
+```
+
+---
+
+## Comportement ARIA
+
+Le composant pose automatiquement sur le trigger (interne ou externe) :
+
+- `aria-expanded="true|false"`
+- `aria-controls="<id-panel>"` — l'`id` est auto-généré sur l'hôte si absent
+
+**Limitation** : `aria-controls` (IDREF) est résolu dans le même root. Si le trigger et le panel sont dans des shadow roots différents, l'AT ne résout pas la référence. Même contrainte que l'attribut `for` (tous deux reposent sur des IDs document-scoped).
+
+`ariaControlsElements` (IDL, références directes cross-shadow) est au backlog — support navigateur insuffisant en 2026-06.
+
+Quand `disabled` :
+
+- Trigger interne : `disabled` + `aria-disabled="true"` posés sur l'élément sloté
+- Trigger externe : clics ignorés par le composant
+
+---
+
+## Animation
+
+### Ouverture
+
+1. Émet `ar-collapse-show` (annulable)
+2. `aria-expanded="true"` sur le trigger
+3. Retire `hidden` du panel, mesure `scrollHeight`
+4. Pose `height: 0` puis `height: {scrollHeight}px`
+5. Attend `transitionend` → pose `height: auto` + émet `ar-collapse-shown`
+
+### Fermeture
+
+1. Émet `ar-collapse-hide` (annulable)
+2. `aria-expanded="false"` sur le trigger
+3. Fixe `height: {scrollHeight}px` (point de départ explicite)
+4. Force reflow (`panel.offsetHeight`)
+5. Pose `height: 0`
+6. Attend `transitionend` → pose `hidden` + émet `ar-collapse-hidden`
+
+### Reduced motion
+
+Si `prefers-reduced-motion: reduce` : skip de la transition, toggle immédiat (même pattern que `ar-dialog`).
+
+### État `_animating`
+
+Flag interne bloquant les appels `show()`/`hide()` pendant une transition en cours. Empêche les états intermédiaires corrompus.
+
+---
+
+## Tests
+
+### Vitest — `collapse.test.ts`
+
+- Toggle `open` via `show()` / `hide()`
+- Événements émis dans le bon ordre ; annulation fonctionne
+- `aria-expanded` / `aria-controls` posés correctement (trigger interne et externe)
+- Accordion : ouverture d'un item ferme les autres du même `name`
+- `disabled` bloque `show()` / `hide()`
+- `trigger-position="after"` place le trigger après le panel dans le DOM
+- `for` inexistant → warning via `warn()`
+
+### WTR browser — `collapse.browser.test.ts`
+
+- Animation height 0 → auto (mesure `scrollHeight` avant/après)
+- `transitionend` déclenche `ar-collapse-shown` / `ar-collapse-hidden`
+- Reduced motion : pas de transition, toggle immédiat
+- `_animating` bloque un double appel concurrent
+
+### Axe-core — `collapse.a11y.test.ts`
+
+- Violations axe sur états open et closed
+- Trigger interne : `aria-expanded`, `aria-controls`, `id` auto-générés
+- Trigger externe (`for`) : mêmes attributs posés sur le bouton natif
+
+---
+
+## Documentation Astro
+
+- Fichier : `apps/docs/src/content/docs/components/collapse.mdx`
+- Playground : toggle `open`, switch `trigger-position`, groupe accordéon avec `name`
+- Exemples : standalone, accordéon, trigger externe via `for`
+- Section limitations : cross-shadow `for` / `aria-controls`, `ariaControlsElements` au backlog
+
+---
+
+## Limitations connues (à documenter)
+
+1. **Cross-shadow** : `for` et `aria-controls` reposent sur des IDs document-scoped. Ne fonctionne pas si trigger et panel sont dans des shadow roots différents.
+2. **Accordion cross-shadow** : le DOM query `querySelectorAll` ne traverse pas les shadow roots — les groupes `name` ne fonctionnent qu'au sein du même document.
+3. **`ariaControlsElements`** : au backlog — à adopter quand le support navigateur sera stable.

--- a/packages/core/src/autoloader.ts
+++ b/packages/core/src/autoloader.ts
@@ -32,6 +32,7 @@ const COMPONENT_MAP: Record<string, () => Promise<unknown>> = {
     'ar-tab-panel': () => import('./components/tab-panel/tab-panel.js'),
     'ar-table-sort': () => import('./components/table-sort/table-sort.js'),
     'ar-charcounter': () => import('./components/charcounter/charcounter.js'),
+    'ar-collapse': () => import('./components/collapse/collapse.js'),
     // ⚠ Mis à jour automatiquement par le script create-component.js
 };
 

--- a/packages/core/src/components/collapse/collapse.a11y.test.ts
+++ b/packages/core/src/components/collapse/collapse.a11y.test.ts
@@ -10,8 +10,6 @@ describe('ar-collapse — accessibilité', () => {
         el?.remove();
     });
 
-    // ── Pas de violations axe-core ────────────────────────────────────────────
-
     describe('axe-core', () => {
         it('panel fermé — aucune violation', async () => {
             el = await fixture(html`
@@ -33,8 +31,6 @@ describe('ar-collapse — accessibilité', () => {
             await expect(el).to.be.accessible();
         });
     });
-
-    // ── Trigger interne ───────────────────────────────────────────────────────
 
     describe('trigger interne', () => {
         it('aria-expanded="false" sur le trigger au départ', async () => {
@@ -58,18 +54,24 @@ describe('ar-collapse — accessibilité', () => {
         });
     });
 
-    // ── Trigger externe ───────────────────────────────────────────────────────
-
     describe('trigger externe (for)', () => {
-        it('aria-expanded et aria-controls posés sur le bouton natif', async () => {
-            const btn = document.createElement('button');
+        let btn: HTMLButtonElement;
+
+        beforeEach(() => {
+            btn = document.createElement('button');
             btn.id = 'ext-a11y';
             btn.textContent = 'Btn';
             document.body.appendChild(btn);
+        });
+
+        afterEach(() => {
+            btn?.remove();
+        });
+
+        it('aria-expanded et aria-controls posés sur le bouton natif', async () => {
             el = await fixture(html`<ar-collapse id="panel-a11y" for="ext-a11y"></ar-collapse>`);
             expect(btn.getAttribute('aria-expanded')).to.equal('false');
             expect(btn.getAttribute('aria-controls')).to.equal('panel-a11y');
-            btn.remove();
         });
     });
 });

--- a/packages/core/src/components/collapse/collapse.a11y.test.ts
+++ b/packages/core/src/components/collapse/collapse.a11y.test.ts
@@ -1,0 +1,75 @@
+/// <reference types="mocha" />
+import { fixture, html, expect } from '@open-wc/testing';
+import type { ArCollapse } from './collapse.js';
+import './collapse.js';
+
+describe('ar-collapse — accessibilité', () => {
+    let el: ArCollapse;
+
+    afterEach(() => {
+        el?.remove();
+    });
+
+    // ── Pas de violations axe-core ────────────────────────────────────────────
+
+    describe('axe-core', () => {
+        it('panel fermé — aucune violation', async () => {
+            el = await fixture(html`
+                <ar-collapse>
+                    <button slot="trigger">Voir plus</button>
+                    <p>Contenu</p>
+                </ar-collapse>
+            `);
+            await expect(el).to.be.accessible();
+        });
+
+        it('panel ouvert — aucune violation', async () => {
+            el = await fixture(html`
+                <ar-collapse open>
+                    <button slot="trigger">Voir plus</button>
+                    <p>Contenu</p>
+                </ar-collapse>
+            `);
+            await expect(el).to.be.accessible();
+        });
+    });
+
+    // ── Trigger interne ───────────────────────────────────────────────────────
+
+    describe('trigger interne', () => {
+        it('aria-expanded="false" sur le trigger au départ', async () => {
+            el = await fixture(html`
+                <ar-collapse>
+                    <button slot="trigger">Toggle</button>
+                </ar-collapse>
+            `);
+            expect(el.querySelector('button')!.getAttribute('aria-expanded')).to.equal('false');
+        });
+
+        it("aria-controls pointe vers l'id du host", async () => {
+            el = await fixture(html`
+                <ar-collapse id="acc-1">
+                    <button slot="trigger">Toggle</button>
+                </ar-collapse>
+            `);
+            const ctrl = el.querySelector('button')!.getAttribute('aria-controls');
+            expect(ctrl).to.equal('acc-1');
+            expect(document.getElementById(ctrl!)).to.equal(el);
+        });
+    });
+
+    // ── Trigger externe ───────────────────────────────────────────────────────
+
+    describe('trigger externe (for)', () => {
+        it('aria-expanded et aria-controls posés sur le bouton natif', async () => {
+            const btn = document.createElement('button');
+            btn.id = 'ext-a11y';
+            btn.textContent = 'Btn';
+            document.body.appendChild(btn);
+            el = await fixture(html`<ar-collapse id="panel-a11y" for="ext-a11y"></ar-collapse>`);
+            expect(btn.getAttribute('aria-expanded')).to.equal('false');
+            expect(btn.getAttribute('aria-controls')).to.equal('panel-a11y');
+            btn.remove();
+        });
+    });
+});

--- a/packages/core/src/components/collapse/collapse.browser.test.ts
+++ b/packages/core/src/components/collapse/collapse.browser.test.ts
@@ -1,0 +1,108 @@
+/// <reference types="mocha" />
+import { fixture, html, expect, aTimeout } from '@open-wc/testing';
+import type { ArCollapse } from './collapse.js';
+import './collapse.js';
+
+const ANIM_MS = 400;
+
+// La transition est sur ::part(panel) dans le thème consommateur.
+// On l'injecte globalement pour que _shouldAnimate() retourne true.
+let styleEl: HTMLStyleElement;
+before(() => {
+    styleEl = document.createElement('style');
+    styleEl.textContent = 'ar-collapse::part(panel) { transition: height 100ms ease; }';
+    document.head.appendChild(styleEl);
+});
+after(() => styleEl.remove());
+
+function getPanel(el: ArCollapse): HTMLElement {
+    const p = el.shadowRoot?.querySelector<HTMLElement>('[part="panel"]');
+    if (!p) throw new Error('panel introuvable');
+    return p;
+}
+
+describe('ar-collapse — browser', () => {
+    let el: ArCollapse;
+
+    afterEach(() => el?.remove());
+
+    // ── Ouverture avec animation ───────────────────────────────────────────────
+
+    describe('ouverture', () => {
+        beforeEach(async () => {
+            el = await fixture(html`
+                <ar-collapse>
+                    <button slot="trigger">Toggle</button>
+                    <p>Contenu</p>
+                </ar-collapse>
+            `);
+        });
+
+        it('retire hidden du panel', async () => {
+            el.show();
+            await aTimeout(10);
+            expect(getPanel(el).hasAttribute('hidden')).to.equal(false);
+        });
+
+        it('émet ar-collapse-shown après transitionend', async () => {
+            let fired = false;
+            el.addEventListener('ar-collapse-shown', () => {
+                fired = true;
+            });
+            el.show();
+            await aTimeout(ANIM_MS);
+            expect(fired).to.equal(true);
+        });
+
+        it('height est "auto" après la fin de l\'animation', async () => {
+            el.show();
+            await aTimeout(ANIM_MS);
+            expect(getPanel(el).style.height).to.equal('auto');
+        });
+
+        it('_animating bloque un double appel', async () => {
+            let count = 0;
+            el.addEventListener('ar-collapse-shown', () => count++);
+            el.show();
+            el.show(); // second appel immédiat
+            await aTimeout(ANIM_MS);
+            expect(count).to.equal(1);
+        });
+    });
+
+    // ── Fermeture avec animation ──────────────────────────────────────────────
+
+    describe('fermeture', () => {
+        beforeEach(async () => {
+            el = await fixture(html`
+                <ar-collapse open>
+                    <button slot="trigger">Toggle</button>
+                    <p>Contenu</p>
+                </ar-collapse>
+            `);
+            await aTimeout(ANIM_MS); // attendre fin ouverture initiale
+        });
+
+        it('émet ar-collapse-hidden après transitionend', async () => {
+            let fired = false;
+            el.addEventListener('ar-collapse-hidden', () => {
+                fired = true;
+            });
+            el.hide();
+            await aTimeout(ANIM_MS);
+            expect(fired).to.equal(true);
+        });
+
+        it('repose hidden sur le panel après fermeture', async () => {
+            el.hide();
+            await aTimeout(ANIM_MS);
+            expect(getPanel(el).hasAttribute('hidden')).to.equal(true);
+        });
+
+        it('height inline est vidé après fermeture', async () => {
+            el.hide();
+            await aTimeout(ANIM_MS);
+            expect(getPanel(el).style.height).to.equal('');
+        });
+    });
+});

--- a/packages/core/src/components/collapse/collapse.browser.test.ts
+++ b/packages/core/src/components/collapse/collapse.browser.test.ts
@@ -26,6 +26,75 @@ describe('ar-collapse — browser', () => {
 
     afterEach(() => el?.remove());
 
+    // ── Robustesse animation ──────────────────────────────────────────────────
+
+    describe('robustesse animation', () => {
+        it('disconnect mid-animation ne bloque pas le composant après reconnect', async () => {
+            el = await fixture(html`
+                <ar-collapse>
+                    <button slot="trigger">T</button>
+                    <p>Contenu</p>
+                </ar-collapse>
+            `);
+            el.show();
+            await aTimeout(30); // mi-animation
+            const parent = el.parentElement!;
+            el.remove();
+            parent.appendChild(el);
+            el.show();
+            await aTimeout(ANIM_MS);
+            expect(getPanel(el).style.height).to.equal('auto');
+        });
+
+        it('assigner el.open=true pendant animation émet ar-collapse-shown une seule fois', async () => {
+            el = await fixture(html`
+                <ar-collapse>
+                    <button slot="trigger">T</button>
+                    <p>Contenu</p>
+                </ar-collapse>
+            `);
+            el.show();
+            await aTimeout(30); // mi-ouverture
+
+            let count = 0;
+            el.addEventListener('ar-collapse-shown', () => count++);
+            el.open = true; // forcer pendant animation
+            await aTimeout(ANIM_MS * 2);
+            expect(count).to.equal(1);
+        });
+    });
+
+    // ── Accordéon — snap mid-animation ───────────────────────────────────────
+
+    describe('accordéon — snap mid-animation', () => {
+        it('ouvrir item B ferme item A même si A est mid-animation', async () => {
+            const elA = await fixture<ArCollapse>(html`
+                <ar-collapse name="snap-grp">
+                    <button slot="trigger">A</button>
+                    <p>Contenu A</p>
+                </ar-collapse>
+            `);
+            const elB = await fixture<ArCollapse>(html`
+                <ar-collapse name="snap-grp">
+                    <button slot="trigger">B</button>
+                    <p>Contenu B</p>
+                </ar-collapse>
+            `);
+
+            elA.show();
+            await aTimeout(30); // A mid-animation
+
+            elB.show(); // doit fermer A immédiatement
+            await aTimeout(ANIM_MS);
+
+            expect(elA.open).to.equal(false);
+            expect(getPanel(elA).hasAttribute('hidden')).to.equal(true);
+            expect(elB.open).to.equal(true);
+            elA.remove();
+            elB.remove();
+        });
+    });
+
     // ── Ouverture avec animation ───────────────────────────────────────────────
 
     describe('ouverture', () => {

--- a/packages/core/src/components/collapse/collapse.styles.ts
+++ b/packages/core/src/components/collapse/collapse.styles.ts
@@ -8,6 +8,7 @@ export default css`
     [part='base'] {
         display: flex;
         flex-direction: column;
+        align-items: flex-start;
     }
 
     [part='panel'] {

--- a/packages/core/src/components/collapse/collapse.styles.ts
+++ b/packages/core/src/components/collapse/collapse.styles.ts
@@ -1,0 +1,20 @@
+import { css } from 'lit';
+
+export default css`
+    :host {
+        display: block;
+    }
+
+    [part='base'] {
+        display: flex;
+        flex-direction: column;
+    }
+
+    [part='panel'] {
+        overflow: hidden;
+    }
+
+    [part='panel'][hidden] {
+        display: none;
+    }
+`;

--- a/packages/core/src/components/collapse/collapse.test.ts
+++ b/packages/core/src/components/collapse/collapse.test.ts
@@ -1,66 +1,435 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fixture, waitForUpdate, getPart, requirePart } from '../../test-utils.js';
 import type { ArCollapse } from './collapse.js';
-import { fixture, getPart } from '../../test-utils.js';
 import './collapse.js';
 
-// ─── Aide-mémoire tests Lit ────────────────────────────────────────────────────
-//
-// fixture(html)          — monte un élément dans le DOM et attend le premier rendu
-// waitForUpdate(el)      — attend le prochain cycle de rendu après une mutation
-// getPart(el, 'name')    — retourne un part="name" du Shadow DOM (| null)
-//                          → utiliser pour les assertions .toBeNull() / .not.toBeNull()
-// requirePart(el, 'name')— idem, mais lance une erreur si absent
-//                          → utiliser quand on enchaîne .getAttribute, .classList, etc.
-//
-// ⚠ happy-dom ne sérialise pas les Text nodes dynamiques Lit en textContent.
-//   Tester le contenu textuel via la propriété JS (el.myProp) plutôt que textContent.
-//
-// ⚠ Les propriétés ARIA assignées via .ariaCurrent, .ariaExpanded, etc. (liaisons
-//   Lit) ne reflètent pas en attribut HTML dans happy-dom. Tester la propriété
-//   JS : (el as unknown as { ariaCurrent: string }).ariaCurrent.
-//
-// ─── Éléments à tester selon le type de composant ─────────────────────────────
-//
-// Composant standard (avec Shadow DOM) :
-//   - Rendu : shadowRoot non null, parts présents (getPart)
-//   - Valeurs par défaut : vérifier chaque propriété à l'état initial
-//   - Attributs reflect : el.prop = x → await waitForUpdate → el.getAttribute(...)
-//   - Comportement : interactions (clic, événements custom)
-//   - Accessibilité : role, aria-*, labels sr-only
-//
-// Sous-composant (sans Shadow DOM, createRenderRoot → this) :
-//   - shadowRoot est null
-//   - setRegistry() appelle registerItem / unregisterItem
-//   - disconnectedCallback() appelle unregisterItem
-//   - updated() appelle notifyItemChanged après le premier rendu seulement
-// ──────────────────────────────────────────────────────────────────────────────
+// happy-dom ne déclenche pas transitionend — prefersReducedMotion=true
+// fait passer show/hide dans la branche synchrone.
+vi.mock('../../utils/media.js', () => ({ prefersReducedMotion: () => true }));
 
 describe('ArCollapse', () => {
     let el: ArCollapse;
 
-    afterEach(() => el?.remove());
-
-    // ── Rendu ─────────────────────────────────────────────────────────────────
-
-    describe('rendu', () => {
-        beforeEach(async () => {
-            el = await fixture('<ar-collapse></ar-collapse>');
-        });
-
-        it('monte un shadow DOM', () => {
-            expect(el.shadowRoot).not.toBeNull();
-        });
-
-        it('contient un élément racine avec part="base"', () => {
-            expect(getPart(el, 'base')).not.toBeNull();
-        });
+    afterEach(() => {
+        el?.remove();
+        document.body.innerHTML = '';
     });
 
     // ── Valeurs par défaut ────────────────────────────────────────────────────
 
-    // describe('valeurs par défaut', () => { ... });
+    describe('valeurs par défaut', () => {
+        beforeEach(async () => {
+            el = await fixture('<ar-collapse></ar-collapse>');
+        });
 
-    // ── Propriétés ────────────────────────────────────────────────────────────
+        it('open=false', () => expect(el.open).toBe(false));
+        it('for=""', () => expect(el.for).toBe(''));
+        it('name=""', () => expect(el.name).toBe(''));
+        it('triggerPosition="before"', () => expect(el.triggerPosition).toBe('before'));
+        it('disabled=false', () => expect(el.disabled).toBe(false));
+    });
 
-    // describe('propriétés', () => { ... });
+    // ── Reflect attributs ─────────────────────────────────────────────────────
+
+    describe('reflect', () => {
+        beforeEach(async () => {
+            el = await fixture('<ar-collapse></ar-collapse>');
+        });
+
+        it('open reflète en attribut', async () => {
+            el.show();
+            await waitForUpdate(el);
+            expect(el.hasAttribute('open')).toBe(true);
+        });
+
+        it('for reflète en attribut', async () => {
+            el.for = 'btn';
+            await waitForUpdate(el);
+            expect(el.getAttribute('for')).toBe('btn');
+        });
+
+        it('name reflète en attribut', async () => {
+            el.name = 'group-a';
+            await waitForUpdate(el);
+            expect(el.getAttribute('name')).toBe('group-a');
+        });
+
+        it('trigger-position reflète en attribut', async () => {
+            el.triggerPosition = 'after';
+            await waitForUpdate(el);
+            expect(el.getAttribute('trigger-position')).toBe('after');
+        });
+
+        it('disabled reflète en attribut', async () => {
+            el.disabled = true;
+            await waitForUpdate(el);
+            expect(el.hasAttribute('disabled')).toBe(true);
+        });
+    });
+
+    // ── Rendu shadow DOM ──────────────────────────────────────────────────────
+
+    describe('rendu shadow DOM', () => {
+        beforeEach(async () => {
+            el = await fixture('<ar-collapse></ar-collapse>');
+        });
+
+        it('contient part="base"', () => expect(getPart(el, 'base')).not.toBeNull());
+        it('contient part="trigger-container"', () =>
+            expect(getPart(el, 'trigger-container')).not.toBeNull());
+        it('contient part="panel"', () => expect(getPart(el, 'panel')).not.toBeNull());
+        it('contient part="content"', () => expect(getPart(el, 'content')).not.toBeNull());
+        it('panel a hidden au départ', () => {
+            expect(requirePart(el, 'panel').hasAttribute('hidden')).toBe(true);
+        });
+    });
+
+    // ── id auto-généré ─────────────────────────────────────────────────────────
+
+    describe('id auto-généré', () => {
+        it('génère un id sur le host si absent', async () => {
+            el = await fixture('<ar-collapse></ar-collapse>');
+            expect(el.id).toMatch(/^ar-collapse-\d+$/);
+        });
+
+        it("ne remplace pas un id fourni par l'auteur", async () => {
+            el = await fixture('<ar-collapse id="mon-id"></ar-collapse>');
+            expect(el.id).toBe('mon-id');
+        });
+    });
+
+    // ── show() / hide() ───────────────────────────────────────────────────────
+
+    describe('show() / hide()', () => {
+        beforeEach(async () => {
+            el = await fixture('<ar-collapse></ar-collapse>');
+        });
+
+        it('show() passe open à true', async () => {
+            el.show();
+            await waitForUpdate(el);
+            expect(el.open).toBe(true);
+        });
+
+        it('show() retire hidden du panel', async () => {
+            el.show();
+            await waitForUpdate(el);
+            expect(requirePart(el, 'panel').hasAttribute('hidden')).toBe(false);
+        });
+
+        it('hide() passe open à false et repose hidden', async () => {
+            el.show();
+            await waitForUpdate(el);
+            el.hide();
+            await waitForUpdate(el);
+            expect(el.open).toBe(false);
+            expect(requirePart(el, 'panel').hasAttribute('hidden')).toBe(true);
+        });
+
+        it('show() est no-op si déjà open', async () => {
+            el.show();
+            await waitForUpdate(el);
+            let count = 0;
+            el.addEventListener('ar-collapse-show', () => count++);
+            el.show();
+            await waitForUpdate(el);
+            expect(count).toBe(0);
+        });
+
+        it('hide() est no-op si déjà fermé', async () => {
+            let count = 0;
+            el.addEventListener('ar-collapse-hide', () => count++);
+            el.hide();
+            await waitForUpdate(el);
+            expect(count).toBe(0);
+        });
+    });
+
+    // ── Événements ────────────────────────────────────────────────────────────
+
+    describe('événements', () => {
+        beforeEach(async () => {
+            el = await fixture('<ar-collapse></ar-collapse>');
+        });
+
+        it('show() émet ar-collapse-show puis ar-collapse-shown', async () => {
+            const order: string[] = [];
+            el.addEventListener('ar-collapse-show', () => order.push('show'));
+            el.addEventListener('ar-collapse-shown', () => order.push('shown'));
+            el.show();
+            await waitForUpdate(el);
+            expect(order).toEqual(['show', 'shown']);
+        });
+
+        it('hide() émet ar-collapse-hide puis ar-collapse-hidden', async () => {
+            el.show();
+            await waitForUpdate(el);
+            const order: string[] = [];
+            el.addEventListener('ar-collapse-hide', () => order.push('hide'));
+            el.addEventListener('ar-collapse-hidden', () => order.push('hidden'));
+            el.hide();
+            await waitForUpdate(el);
+            expect(order).toEqual(['hide', 'hidden']);
+        });
+
+        it("annuler ar-collapse-show empêche l'ouverture", async () => {
+            el.addEventListener('ar-collapse-show', (e) => e.preventDefault());
+            el.show();
+            await waitForUpdate(el);
+            expect(el.open).toBe(false);
+        });
+
+        it('annuler ar-collapse-hide empêche la fermeture', async () => {
+            el.show();
+            await waitForUpdate(el);
+            el.addEventListener('ar-collapse-hide', (e) => e.preventDefault());
+            el.hide();
+            await waitForUpdate(el);
+            expect(el.open).toBe(true);
+        });
+    });
+
+    // ── Trigger interne + ARIA ────────────────────────────────────────────────
+
+    describe('trigger interne (slot)', () => {
+        it('pose aria-expanded=false sur le trigger au départ', async () => {
+            el = await fixture(`
+                <ar-collapse>
+                    <button slot="trigger">Toggle</button>
+                </ar-collapse>
+            `);
+            const btn = el.querySelector('button')!;
+            await waitForUpdate(el);
+            expect(btn.getAttribute('aria-expanded')).toBe('false');
+        });
+
+        it("met à jour aria-expanded=true à l'ouverture", async () => {
+            el = await fixture(`
+                <ar-collapse>
+                    <button slot="trigger">Toggle</button>
+                </ar-collapse>
+            `);
+            const btn = el.querySelector('button')!;
+            el.show();
+            await waitForUpdate(el);
+            expect(btn.getAttribute('aria-expanded')).toBe('true');
+        });
+
+        it("pose aria-controls pointant vers l'id du host", async () => {
+            el = await fixture(`
+                <ar-collapse id="my-collapse">
+                    <button slot="trigger">Toggle</button>
+                </ar-collapse>
+            `);
+            const btn = el.querySelector('button')!;
+            await waitForUpdate(el);
+            expect(btn.getAttribute('aria-controls')).toBe('my-collapse');
+        });
+
+        it('un clic sur le trigger ouvre le panel', async () => {
+            el = await fixture(`
+                <ar-collapse>
+                    <button slot="trigger">Toggle</button>
+                </ar-collapse>
+            `);
+            // Double await : le slotchange peut être asynchrone en happy-dom
+            await waitForUpdate(el);
+            const btn = el.querySelector<HTMLButtonElement>('button')!;
+            btn.click();
+            await waitForUpdate(el);
+            expect(el.open).toBe(true);
+        });
+
+        it('un clic sur le trigger ferme le panel si ouvert', async () => {
+            el = await fixture(`
+                <ar-collapse open>
+                    <button slot="trigger">Toggle</button>
+                </ar-collapse>
+            `);
+            // Double await : le slotchange peut être asynchrone en happy-dom
+            await waitForUpdate(el);
+            const btn = el.querySelector<HTMLButtonElement>('button')!;
+            btn.click();
+            await waitForUpdate(el);
+            expect(el.open).toBe(false);
+        });
+    });
+
+    // ── Trigger externe (for) ─────────────────────────────────────────────────
+
+    describe('trigger externe (for)', () => {
+        it('pose aria-expanded et aria-controls sur le bouton externe', async () => {
+            document.body.innerHTML = '<button id="ext-btn">Toggle</button>';
+            el = await fixture('<ar-collapse id="panel-1" for="ext-btn"></ar-collapse>');
+            const btn = document.getElementById('ext-btn')!;
+            expect(btn.getAttribute('aria-expanded')).toBe('false');
+            expect(btn.getAttribute('aria-controls')).toBe('panel-1');
+        });
+
+        it('un clic sur le bouton externe ouvre le panel', async () => {
+            document.body.innerHTML = '<button id="ext-btn2">Toggle</button>';
+            el = await fixture('<ar-collapse for="ext-btn2"></ar-collapse>');
+            document.getElementById('ext-btn2')!.click();
+            await waitForUpdate(el);
+            expect(el.open).toBe(true);
+        });
+
+        it("émet un warn si l'id est introuvable", async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            el = await fixture('<ar-collapse for="inexistant"></ar-collapse>');
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('inexistant'));
+            spy.mockRestore();
+        });
+
+        it('émet un warn si for et slot trigger sont tous les deux définis', async () => {
+            document.body.innerHTML = '<button id="ext-btn3">Btn</button>';
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            el = await fixture(`
+                <ar-collapse for="ext-btn3">
+                    <button slot="trigger">Slot btn</button>
+                </ar-collapse>
+            `);
+            await waitForUpdate(el);
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('for'));
+            spy.mockRestore();
+        });
+
+        it('retire aria-controls du trigger externe lors du changement de for', async () => {
+            document.body.innerHTML = '<button id="ext-btn4">Btn</button>';
+            el = await fixture('<ar-collapse for="ext-btn4"></ar-collapse>');
+            const btn = document.getElementById('ext-btn4')!;
+            expect(btn.getAttribute('aria-controls')).not.toBeNull();
+            el.for = '';
+            await waitForUpdate(el);
+            expect(btn.getAttribute('aria-controls')).toBeNull();
+        });
+    });
+
+    // ── Accordéon (name) ──────────────────────────────────────────────────────
+
+    describe('accordéon (name)', () => {
+        let el2: ArCollapse;
+        let el3: ArCollapse;
+
+        afterEach(() => {
+            el2?.remove();
+            el3?.remove();
+        });
+
+        it('ouvrir un item ferme les autres du même groupe', async () => {
+            el = await fixture('<ar-collapse name="faq"></ar-collapse>');
+            el2 = await fixture('<ar-collapse name="faq"></ar-collapse>');
+            el.show();
+            await waitForUpdate(el);
+            expect(el.open).toBe(true);
+            el2.show();
+            await waitForUpdate(el2);
+            await waitForUpdate(el);
+            expect(el2.open).toBe(true);
+            expect(el.open).toBe(false);
+        });
+
+        it("ne ferme pas les panels d'un groupe différent", async () => {
+            el = await fixture('<ar-collapse name="group-a"></ar-collapse>');
+            el2 = await fixture('<ar-collapse name="group-b"></ar-collapse>');
+            el.show();
+            await waitForUpdate(el);
+            el2.show();
+            await waitForUpdate(el2);
+            expect(el.open).toBe(true);
+            expect(el2.open).toBe(true);
+        });
+
+        it('sans name, plusieurs panels peuvent être ouverts', async () => {
+            el = await fixture('<ar-collapse></ar-collapse>');
+            el2 = await fixture('<ar-collapse></ar-collapse>');
+            el.show();
+            el2.show();
+            await waitForUpdate(el);
+            await waitForUpdate(el2);
+            expect(el.open).toBe(true);
+            expect(el2.open).toBe(true);
+        });
+    });
+
+    // ── disabled ──────────────────────────────────────────────────────────────
+
+    describe('disabled', () => {
+        it('show() est no-op quand disabled=true', async () => {
+            el = await fixture('<ar-collapse disabled></ar-collapse>');
+            el.show();
+            await waitForUpdate(el);
+            expect(el.open).toBe(false);
+        });
+
+        it('pose disabled et aria-disabled sur le trigger interne', async () => {
+            el = await fixture(`
+                <ar-collapse disabled>
+                    <button slot="trigger">Toggle</button>
+                </ar-collapse>
+            `);
+            const btn = el.querySelector('button')!;
+            await waitForUpdate(el);
+            expect(btn.hasAttribute('disabled')).toBe(true);
+            expect(btn.getAttribute('aria-disabled')).toBe('true');
+        });
+
+        it('retire disabled et aria-disabled quand disabled passe à false', async () => {
+            el = await fixture(`
+                <ar-collapse disabled>
+                    <button slot="trigger">Toggle</button>
+                </ar-collapse>
+            `);
+            const btn = el.querySelector('button')!;
+            el.disabled = false;
+            await waitForUpdate(el);
+            expect(btn.hasAttribute('disabled')).toBe(false);
+            expect(btn.getAttribute('aria-disabled')).toBeNull();
+        });
+
+        it("un clic ne déclenche pas l'ouverture quand disabled", async () => {
+            el = await fixture(`
+                <ar-collapse disabled>
+                    <button slot="trigger">Toggle</button>
+                </ar-collapse>
+            `);
+            el.querySelector<HTMLButtonElement>('button')!.click();
+            await waitForUpdate(el);
+            expect(el.open).toBe(false);
+        });
+    });
+
+    // ── trigger-position ──────────────────────────────────────────────────────
+
+    describe('trigger-position', () => {
+        it('trigger-position="before" : trigger avant panel dans le DOM', async () => {
+            el = await fixture(`
+                <ar-collapse trigger-position="before">
+                    <button slot="trigger">T</button>
+                </ar-collapse>
+            `);
+            const base = requirePart(el, 'base');
+            const children = Array.from(base.children);
+            const triggerIdx = children.findIndex(
+                (c) => c.getAttribute('part') === 'trigger-container',
+            );
+            const panelIdx = children.findIndex((c) => c.getAttribute('part') === 'panel');
+            expect(triggerIdx).toBeLessThan(panelIdx);
+        });
+
+        it('trigger-position="after" : panel avant trigger dans le DOM', async () => {
+            el = await fixture(`
+                <ar-collapse trigger-position="after">
+                    <button slot="trigger">T</button>
+                </ar-collapse>
+            `);
+            const base = requirePart(el, 'base');
+            const children = Array.from(base.children);
+            const triggerIdx = children.findIndex(
+                (c) => c.getAttribute('part') === 'trigger-container',
+            );
+            const panelIdx = children.findIndex((c) => c.getAttribute('part') === 'panel');
+            expect(panelIdx).toBeLessThan(triggerIdx);
+        });
+    });
 });

--- a/packages/core/src/components/collapse/collapse.test.ts
+++ b/packages/core/src/components/collapse/collapse.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { ArCollapse } from './collapse.js';
+import { fixture, getPart } from '../../test-utils.js';
+import './collapse.js';
+
+// ─── Aide-mémoire tests Lit ────────────────────────────────────────────────────
+//
+// fixture(html)          — monte un élément dans le DOM et attend le premier rendu
+// waitForUpdate(el)      — attend le prochain cycle de rendu après une mutation
+// getPart(el, 'name')    — retourne un part="name" du Shadow DOM (| null)
+//                          → utiliser pour les assertions .toBeNull() / .not.toBeNull()
+// requirePart(el, 'name')— idem, mais lance une erreur si absent
+//                          → utiliser quand on enchaîne .getAttribute, .classList, etc.
+//
+// ⚠ happy-dom ne sérialise pas les Text nodes dynamiques Lit en textContent.
+//   Tester le contenu textuel via la propriété JS (el.myProp) plutôt que textContent.
+//
+// ⚠ Les propriétés ARIA assignées via .ariaCurrent, .ariaExpanded, etc. (liaisons
+//   Lit) ne reflètent pas en attribut HTML dans happy-dom. Tester la propriété
+//   JS : (el as unknown as { ariaCurrent: string }).ariaCurrent.
+//
+// ─── Éléments à tester selon le type de composant ─────────────────────────────
+//
+// Composant standard (avec Shadow DOM) :
+//   - Rendu : shadowRoot non null, parts présents (getPart)
+//   - Valeurs par défaut : vérifier chaque propriété à l'état initial
+//   - Attributs reflect : el.prop = x → await waitForUpdate → el.getAttribute(...)
+//   - Comportement : interactions (clic, événements custom)
+//   - Accessibilité : role, aria-*, labels sr-only
+//
+// Sous-composant (sans Shadow DOM, createRenderRoot → this) :
+//   - shadowRoot est null
+//   - setRegistry() appelle registerItem / unregisterItem
+//   - disconnectedCallback() appelle unregisterItem
+//   - updated() appelle notifyItemChanged après le premier rendu seulement
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('ArCollapse', () => {
+    let el: ArCollapse;
+
+    afterEach(() => el?.remove());
+
+    // ── Rendu ─────────────────────────────────────────────────────────────────
+
+    describe('rendu', () => {
+        beforeEach(async () => {
+            el = await fixture('<ar-collapse></ar-collapse>');
+        });
+
+        it('monte un shadow DOM', () => {
+            expect(el.shadowRoot).not.toBeNull();
+        });
+
+        it('contient un élément racine avec part="base"', () => {
+            expect(getPart(el, 'base')).not.toBeNull();
+        });
+    });
+
+    // ── Valeurs par défaut ────────────────────────────────────────────────────
+
+    // describe('valeurs par défaut', () => { ... });
+
+    // ── Propriétés ────────────────────────────────────────────────────────────
+
+    // describe('propriétés', () => { ... });
+});

--- a/packages/core/src/components/collapse/collapse.test.ts
+++ b/packages/core/src/components/collapse/collapse.test.ts
@@ -433,6 +433,24 @@ describe('ArCollapse', () => {
             await waitForUpdate(el);
             expect(el.open).toBe(false);
         });
+
+        it('pose aria-disabled sur le bouton externe quand disabled=true', async () => {
+            document.body.innerHTML = '<button id="ext-dis">Btn</button>';
+            el = await fixture('<ar-collapse for="ext-dis" disabled></ar-collapse>');
+            await waitForUpdate(el);
+            const btn = document.getElementById('ext-dis')!;
+            expect(btn.getAttribute('aria-disabled')).toBe('true');
+        });
+
+        it('retire aria-disabled du bouton externe quand disabled repasse à false', async () => {
+            document.body.innerHTML = '<button id="ext-dis2">Btn</button>';
+            el = await fixture('<ar-collapse for="ext-dis2" disabled></ar-collapse>');
+            await waitForUpdate(el);
+            el.disabled = false;
+            await waitForUpdate(el);
+            const btn = document.getElementById('ext-dis2')!;
+            expect(btn.getAttribute('aria-disabled')).toBeNull();
+        });
     });
 
     // ── trigger-position ──────────────────────────────────────────────────────

--- a/packages/core/src/components/collapse/collapse.test.ts
+++ b/packages/core/src/components/collapse/collapse.test.ts
@@ -371,6 +371,21 @@ describe('ArCollapse', () => {
             expect(el.open).toBe(true);
             expect(el2.open).toBe(true);
         });
+
+        it('un name contenant des guillemets ne crash pas', async () => {
+            el = await fixture("<ar-collapse name='foo\"]' ></ar-collapse>");
+            expect(() => el.show()).not.toThrow();
+            await waitForUpdate(el);
+        });
+
+        it('deux accordéons indépendants avec le même name ne se contaminent pas', async () => {
+            el = await fixture('<ar-collapse name="shared"></ar-collapse>');
+            el2 = await fixture('<ar-collapse name="shared"></ar-collapse>');
+            el.show();
+            await waitForUpdate(el);
+            expect(el.open).toBe(true);
+            el2.remove();
+        });
     });
 
     // ── disabled ──────────────────────────────────────────────────────────────

--- a/packages/core/src/components/collapse/collapse.test.ts
+++ b/packages/core/src/components/collapse/collapse.test.ts
@@ -232,7 +232,6 @@ describe('ArCollapse', () => {
                     <button slot="trigger">Toggle</button>
                 </ar-collapse>
             `);
-            // Double await : le slotchange peut être asynchrone en happy-dom
             await waitForUpdate(el);
             const btn = el.querySelector<HTMLButtonElement>('button')!;
             btn.click();
@@ -246,7 +245,6 @@ describe('ArCollapse', () => {
                     <button slot="trigger">Toggle</button>
                 </ar-collapse>
             `);
-            // Double await : le slotchange peut être asynchrone en happy-dom
             await waitForUpdate(el);
             const btn = el.querySelector<HTMLButtonElement>('button')!;
             btn.click();
@@ -258,9 +256,14 @@ describe('ArCollapse', () => {
     // ── Trigger externe (for) ─────────────────────────────────────────────────
 
     describe('trigger externe (for)', () => {
+        afterEach(() => {
+            document.body.innerHTML = '';
+        });
+
         it('pose aria-expanded et aria-controls sur le bouton externe', async () => {
             document.body.innerHTML = '<button id="ext-btn">Toggle</button>';
             el = await fixture('<ar-collapse id="panel-1" for="ext-btn"></ar-collapse>');
+            await waitForUpdate(el);
             const btn = document.getElementById('ext-btn')!;
             expect(btn.getAttribute('aria-expanded')).toBe('false');
             expect(btn.getAttribute('aria-controls')).toBe('panel-1');

--- a/packages/core/src/components/collapse/collapse.test.ts
+++ b/packages/core/src/components/collapse/collapse.test.ts
@@ -145,6 +145,24 @@ describe('ArCollapse', () => {
         });
     });
 
+    // ── Robustesse animation ──────────────────────────────────────────────────
+
+    describe('robustesse animation', () => {
+        it('annuler ar-collapse-show ne verrouille pas le composant', async () => {
+            el = await fixture('<ar-collapse><button slot="trigger">T</button></ar-collapse>');
+            const cancel = (e: Event) => e.preventDefault();
+            el.addEventListener('ar-collapse-show', cancel);
+            el.show();
+            await waitForUpdate(el);
+            expect(el.open).toBe(false);
+            el.removeEventListener('ar-collapse-show', cancel);
+            // Après annulation, show() doit fonctionner normalement
+            el.show();
+            await waitForUpdate(el);
+            expect(el.open).toBe(true);
+        });
+    });
+
     // ── Événements ────────────────────────────────────────────────────────────
 
     describe('événements', () => {

--- a/packages/core/src/components/collapse/collapse.ts
+++ b/packages/core/src/components/collapse/collapse.ts
@@ -223,11 +223,13 @@ export class ArCollapse extends LitElement {
     }
 
     private _syncTriggerDisabled(): void {
-        if (this.for) return;
         const trigger = this._resolvedTrigger;
         if (!trigger) return;
         if (this.disabled) {
-            trigger.setAttribute('disabled', '');
+            if (!this.for) {
+                // Trigger interne natif : disabled + aria-disabled
+                trigger.setAttribute('disabled', '');
+            }
             trigger.setAttribute('aria-disabled', 'true');
         } else {
             trigger.removeAttribute('disabled');

--- a/packages/core/src/components/collapse/collapse.ts
+++ b/packages/core/src/components/collapse/collapse.ts
@@ -65,6 +65,7 @@ export class ArCollapse extends LitElement {
     private _initialized = false;
     private _externalTrigger: HTMLElement | null = null;
     private _internalTrigger: HTMLElement | null = null;
+    private _onTransitionEnd: (() => void) | null = null;
 
     override connectedCallback(): void {
         super.connectedCallback();
@@ -111,6 +112,7 @@ export class ArCollapse extends LitElement {
 
     override disconnectedCallback(): void {
         super.disconnectedCallback();
+        this._abortAnimation();
         this._detachExternalTrigger();
         if (this._internalTrigger) {
             this._internalTrigger.removeEventListener('click', this._handleTriggerClick);
@@ -148,9 +150,9 @@ export class ArCollapse extends LitElement {
         this.open = true;
     }
 
-    /** Ferme le panel. No-op si déjà fermé ou en cours d'animation. */
+    /** Ferme le panel. No-op si déjà fermé. */
     hide(): void {
-        if (!this.open || this._animating) return;
+        if (!this.open) return;
         this.open = false;
     }
 
@@ -233,6 +235,21 @@ export class ArCollapse extends LitElement {
         }
     }
 
+    private _abortAnimation(): void {
+        if (!this._onTransitionEnd) return;
+        this._panel.removeEventListener('transitionend', this._onTransitionEnd);
+        this._onTransitionEnd = null;
+        this._animating = false;
+        // Finalise l'état du panel dans la direction en cours pour que open reste cohérent.
+        if (this.open) {
+            this._panel.removeAttribute('hidden');
+            this._panel.style.height = 'auto';
+        } else {
+            this._panel.setAttribute('hidden', '');
+            this._panel.style.height = '';
+        }
+    }
+
     private _closeGroupSiblings(): void {
         if (!this.name) return;
         document.querySelectorAll<ArCollapse>(`ar-collapse[name="${this.name}"]`).forEach((el) => {
@@ -253,6 +270,7 @@ export class ArCollapse extends LitElement {
             this.open = false;
             return;
         }
+        this._abortAnimation();
         this._closeGroupSiblings();
         this._syncTriggerAria();
         this._animating = true;
@@ -268,24 +286,34 @@ export class ArCollapse extends LitElement {
             return;
         }
         panel.style.height = `${targetH}px`;
-        panel.addEventListener(
-            'transitionend',
-            () => {
-                this._animating = false;
-                panel.style.height = 'auto';
-                this._emit('ar-collapse-shown');
-            },
-            { once: true },
-        );
+        const onShow = () => {
+            this._onTransitionEnd = null;
+            this._animating = false;
+            panel.style.height = 'auto';
+            this._emit('ar-collapse-shown');
+        };
+        this._onTransitionEnd = onShow;
+        panel.addEventListener('transitionend', onShow, { once: true });
     }
 
     private _hide(): void {
+        // finding 2 : panel déjà caché (ex. ar-collapse-show annulé → open=false déclenché)
+        if (this._panel.hasAttribute('hidden') && !this._animating) return;
         const ev = this._emit('ar-collapse-hide');
         if (ev.defaultPrevented) {
             this.open = true;
             return;
         }
+        const wasAnimating = this._animating;
+        this._abortAnimation();
         this._syncTriggerAria();
+        if (wasAnimating) {
+            // finding 5 : snap immédiat — frère accordéon ou interruption externe
+            this._panel.setAttribute('hidden', '');
+            this._panel.style.height = '';
+            this._emit('ar-collapse-hidden');
+            return;
+        }
         this._animating = true;
         const panel = this._panel;
         panel.style.height = `${panel.scrollHeight}px`;
@@ -298,16 +326,15 @@ export class ArCollapse extends LitElement {
             return;
         }
         panel.style.height = '0px';
-        panel.addEventListener(
-            'transitionend',
-            () => {
-                this._animating = false;
-                panel.setAttribute('hidden', '');
-                panel.style.height = '';
-                this._emit('ar-collapse-hidden');
-            },
-            { once: true },
-        );
+        const onHide = () => {
+            this._onTransitionEnd = null;
+            this._animating = false;
+            panel.setAttribute('hidden', '');
+            panel.style.height = '';
+            this._emit('ar-collapse-hidden');
+        };
+        this._onTransitionEnd = onHide;
+        panel.addEventListener('transitionend', onHide, { once: true });
     }
 
     private _emit(name: ArCollapseEvents): CustomEvent {

--- a/packages/core/src/components/collapse/collapse.ts
+++ b/packages/core/src/components/collapse/collapse.ts
@@ -252,9 +252,12 @@ export class ArCollapse extends LitElement {
 
     private _closeGroupSiblings(): void {
         if (!this.name) return;
-        document.querySelectorAll<ArCollapse>(`ar-collapse[name="${this.name}"]`).forEach((el) => {
-            if (el !== this && el.open) el.hide();
-        });
+        const root = this.getRootNode() as Document | ShadowRoot;
+        root.querySelectorAll<ArCollapse>(`ar-collapse[name='${CSS.escape(this.name)}']`).forEach(
+            (el) => {
+                if (el !== this && el.open) el.hide();
+            },
+        );
     }
 
     private _shouldAnimate(): boolean {

--- a/packages/core/src/components/collapse/collapse.ts
+++ b/packages/core/src/components/collapse/collapse.ts
@@ -64,6 +64,7 @@ export class ArCollapse extends LitElement {
     private _animating = false;
     private _initialized = false;
     private _externalTrigger: HTMLElement | null = null;
+    private _internalTrigger: HTMLElement | null = null;
 
     override connectedCallback(): void {
         super.connectedCallback();
@@ -87,7 +88,6 @@ export class ArCollapse extends LitElement {
     }
 
     override updated(changed: PropertyValues<this>): void {
-        // firstUpdated gère le premier rendu ; updated ne traite que les changements suivants.
         if (!this._initialized) return;
         if (changed.has('for')) {
             this._detachExternalTrigger();
@@ -108,6 +108,10 @@ export class ArCollapse extends LitElement {
     override disconnectedCallback(): void {
         super.disconnectedCallback();
         this._detachExternalTrigger();
+        if (this._internalTrigger) {
+            this._internalTrigger.removeEventListener('click', this._handleTriggerClick);
+            this._internalTrigger = null;
+        }
     }
 
     override render(): TemplateResult {
@@ -181,8 +185,14 @@ export class ArCollapse extends LitElement {
             this._warnIfBothTriggers();
             return;
         }
+        // Détacher l'ancien trigger interne avant d'en attacher un nouveau
+        if (this._internalTrigger) {
+            this._internalTrigger.removeEventListener('click', this._handleTriggerClick);
+            this._internalTrigger = null;
+        }
         const trigger = this._resolvedTrigger;
         if (!trigger) return;
+        this._internalTrigger = trigger;
         trigger.addEventListener('click', this._handleTriggerClick);
         this._syncTriggerAria();
         this._syncTriggerDisabled();

--- a/packages/core/src/components/collapse/collapse.ts
+++ b/packages/core/src/components/collapse/collapse.ts
@@ -1,0 +1,32 @@
+import { LitElement, html } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import styles from './collapse.styles.js';
+
+/**
+ * @summary Résumé du composant ar-collapse.
+ *
+ * @slot         - Contenu principal.
+ *
+ * @csspart base - L'élément racine du composant.
+ * @cssprop [--ar-collapse-size=auto] - Taille du composant.
+ *
+ * @event {CustomEvent} ar-collapse-change - Émis lors d'un changement.
+ */
+@customElement('ar-collapse')
+export class ArCollapse extends LitElement {
+    static override styles = [styles];
+
+    override render() {
+        return html`
+            <div part="base">
+                <slot></slot>
+            </div>
+        `;
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'ar-collapse': ArCollapse;
+    }
+}

--- a/packages/core/src/components/collapse/collapse.ts
+++ b/packages/core/src/components/collapse/collapse.ts
@@ -1,27 +1,305 @@
-import { LitElement, html } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { LitElement, html, type TemplateResult, type PropertyValues } from 'lit';
+import { customElement, property, query } from 'lit/decorators.js';
+import { warn } from '../../utils/warn.js';
+import { prefersReducedMotion } from '../../utils/media.js';
 import styles from './collapse.styles.js';
 
+export type ArCollapseEvents =
+    | 'ar-collapse-show'
+    | 'ar-collapse-shown'
+    | 'ar-collapse-hide'
+    | 'ar-collapse-hidden';
+
 /**
- * @summary Résumé du composant ar-collapse.
+ * @summary Panneau pliable/dépliable accessible avec animation de hauteur.
+ * @display demo
  *
- * @slot         - Contenu principal.
+ * @slot trigger - Élément déclencheur (ignoré si `for` est défini).
+ * @slot         - Contenu collapsible.
  *
- * @csspart base - L'élément racine du composant.
- * @cssprop [--ar-collapse-size=auto] - Taille du composant.
+ * @csspart base              - Conteneur racine.
+ * @csspart trigger-container - Wrapper du slot trigger.
+ * @csspart panel             - Zone animée (overflow hidden, height 0 → auto).
+ * @csspart content           - Wrapper interne du contenu.
  *
- * @event {CustomEvent} ar-collapse-change - Émis lors d'un changement.
+ * @cssprop [--ar-collapse-duration=0s]  - Durée de la transition height.
+ * @cssprop [--ar-collapse-easing=ease]  - Easing de la transition height.
+ *
+ * @event {CustomEvent} ar-collapse-show   - Avant l'ouverture. Annulable.
+ * @event {CustomEvent} ar-collapse-shown  - Après la fin de l'animation d'ouverture.
+ * @event {CustomEvent} ar-collapse-hide   - Avant la fermeture. Annulable.
+ * @event {CustomEvent} ar-collapse-hidden - Après la fin de l'animation de fermeture.
  */
 @customElement('ar-collapse')
 export class ArCollapse extends LitElement {
     static override styles = [styles];
+    static readonly NAME = 'ArCollapse';
+    private static _idCounter = 0;
 
-    override render() {
-        return html`
-            <div part="base">
-                <slot></slot>
+    /** Ouvre ou ferme le panel. */
+    @property({ reflect: true, type: Boolean }) open = false;
+
+    /**
+     * ID d'un élément déclencheur externe (light DOM).
+     * Quand défini, le slot `trigger` est ignoré.
+     */
+    @property({ reflect: true }) for = '';
+
+    /** Groupe accordéon — les panels partageant le même `name` se ferment mutuellement. */
+    @property({ reflect: true }) name = '';
+
+    /**
+     * Position du slot trigger par rapport au contenu dans le DOM.
+     * `before` (défaut) : trigger avant le panel. `after` : trigger après le panel.
+     * L'ordre DOM reflète l'ordre visuel — pas de CSS `order` — pour respecter WCAG 2.4.3.
+     */
+    @property({ attribute: 'trigger-position', reflect: true })
+    triggerPosition: 'before' | 'after' = 'before';
+
+    /** Désactive le composant — le trigger ne répond plus aux clics. */
+    @property({ reflect: true, type: Boolean }) disabled = false;
+
+    @query('[part="panel"]') private _panel!: HTMLElement;
+
+    private _animating = false;
+    private _initialized = false;
+    private _externalTrigger: HTMLElement | null = null;
+
+    override connectedCallback(): void {
+        super.connectedCallback();
+        if (!this.id) {
+            this.id = `ar-collapse-${++ArCollapse._idCounter}`;
+        }
+    }
+
+    override firstUpdated(): void {
+        if (this.for) {
+            this._warnIfBothTriggers();
+            this._attachExternalTrigger();
+        }
+        this._syncTriggerAria();
+        // État initial sans animation — updated() gère les changements ultérieurs.
+        if (this.open) {
+            this._panel.removeAttribute('hidden');
+            this._panel.style.height = 'auto';
+        }
+        this._initialized = true;
+    }
+
+    override updated(changed: PropertyValues<this>): void {
+        // firstUpdated gère le premier rendu ; updated ne traite que les changements suivants.
+        if (!this._initialized) return;
+        if (changed.has('for')) {
+            this._detachExternalTrigger();
+            if (this.for) {
+                this._warnIfBothTriggers();
+                this._attachExternalTrigger();
+            }
+        }
+        if (changed.has('open')) {
+            if (this.open) this._show();
+            else this._hide();
+        }
+        if (changed.has('disabled')) {
+            this._syncTriggerDisabled();
+        }
+    }
+
+    override disconnectedCallback(): void {
+        super.disconnectedCallback();
+        this._detachExternalTrigger();
+    }
+
+    override render(): TemplateResult {
+        const trigger = html`
+            <slot
+                name="trigger"
+                part="trigger-container"
+                @slotchange=${this._handleTriggerSlotChange}
+            ></slot>
+        `;
+        const panel = html`
+            <div part="panel" hidden>
+                <div part="content">
+                    <slot></slot>
+                </div>
             </div>
         `;
+        return html`
+            <div part="base">
+                ${this.triggerPosition === 'after'
+                    ? html`${panel}${trigger}`
+                    : html`${trigger}${panel}`}
+            </div>
+        `;
+    }
+
+    /** Ouvre le panel. No-op si déjà ouvert, en cours d'animation, ou disabled. */
+    show(): void {
+        if (this.open || this._animating || this.disabled) return;
+        this.open = true;
+    }
+
+    /** Ferme le panel. No-op si déjà fermé ou en cours d'animation. */
+    hide(): void {
+        if (!this.open || this._animating) return;
+        this.open = false;
+    }
+
+    private _warnIfBothTriggers(): void {
+        if (!this.for) return;
+        const slot = this.shadowRoot?.querySelector<HTMLSlotElement>('slot[name="trigger"]');
+        if (slot?.assignedElements({ flatten: true }).length) {
+            warn(
+                'ar-collapse',
+                'for et slot="trigger" sont tous les deux définis — for prend la priorité.',
+            );
+        }
+    }
+
+    private _attachExternalTrigger(): void {
+        const el = document.getElementById(this.for);
+        if (!el) {
+            warn('ar-collapse', `Aucun élément trouvé avec l'id "${this.for}".`);
+            return;
+        }
+        this._externalTrigger = el;
+        el.addEventListener('click', this._handleTriggerClick);
+        this._syncTriggerAria();
+    }
+
+    private _detachExternalTrigger(): void {
+        if (!this._externalTrigger) return;
+        this._externalTrigger.removeEventListener('click', this._handleTriggerClick);
+        this._externalTrigger.removeAttribute('aria-expanded');
+        this._externalTrigger.removeAttribute('aria-controls');
+        this._externalTrigger = null;
+    }
+
+    private _handleTriggerSlotChange(): void {
+        if (this.for) {
+            this._warnIfBothTriggers();
+            return;
+        }
+        const trigger = this._resolvedTrigger;
+        if (!trigger) return;
+        trigger.addEventListener('click', this._handleTriggerClick);
+        this._syncTriggerAria();
+        this._syncTriggerDisabled();
+    }
+
+    private readonly _handleTriggerClick = (): void => {
+        if (this.disabled) return;
+        this.open = !this.open;
+    };
+
+    private get _resolvedTrigger(): HTMLElement | null {
+        if (this.for) return this._externalTrigger;
+        const slot = this.shadowRoot?.querySelector<HTMLSlotElement>('slot[name="trigger"]');
+        return (slot?.assignedElements({ flatten: true })[0] as HTMLElement | undefined) ?? null;
+    }
+
+    private _syncTriggerAria(): void {
+        const trigger = this._resolvedTrigger;
+        if (!trigger) return;
+        trigger.setAttribute('aria-expanded', String(this.open));
+        trigger.setAttribute('aria-controls', this.id);
+    }
+
+    private _syncTriggerDisabled(): void {
+        if (this.for) return;
+        const trigger = this._resolvedTrigger;
+        if (!trigger) return;
+        if (this.disabled) {
+            trigger.setAttribute('disabled', '');
+            trigger.setAttribute('aria-disabled', 'true');
+        } else {
+            trigger.removeAttribute('disabled');
+            trigger.removeAttribute('aria-disabled');
+        }
+    }
+
+    private _closeGroupSiblings(): void {
+        if (!this.name) return;
+        document.querySelectorAll<ArCollapse>(`ar-collapse[name="${this.name}"]`).forEach((el) => {
+            if (el !== this && el.open) el.hide();
+        });
+    }
+
+    private _shouldAnimate(): boolean {
+        // transitionend ne se déclenche pas si duration=0s (défaut headless sans thème).
+        // On vérifie la durée calculée pour éviter que _animating reste bloqué à true.
+        const d = parseFloat(getComputedStyle(this._panel).transitionDuration) || 0;
+        return !prefersReducedMotion() && d > 0;
+    }
+
+    private _show(): void {
+        const ev = this._emit('ar-collapse-show');
+        if (ev.defaultPrevented) {
+            this.open = false;
+            return;
+        }
+        this._closeGroupSiblings();
+        this._syncTriggerAria();
+        this._animating = true;
+        const panel = this._panel;
+        panel.style.height = '0px';
+        panel.removeAttribute('hidden');
+        const targetH = panel.scrollHeight;
+        void panel.offsetHeight; // force reflow
+        if (!this._shouldAnimate()) {
+            panel.style.height = 'auto';
+            this._animating = false;
+            this._emit('ar-collapse-shown');
+            return;
+        }
+        panel.style.height = `${targetH}px`;
+        panel.addEventListener(
+            'transitionend',
+            () => {
+                this._animating = false;
+                panel.style.height = 'auto';
+                this._emit('ar-collapse-shown');
+            },
+            { once: true },
+        );
+    }
+
+    private _hide(): void {
+        const ev = this._emit('ar-collapse-hide');
+        if (ev.defaultPrevented) {
+            this.open = true;
+            return;
+        }
+        this._syncTriggerAria();
+        this._animating = true;
+        const panel = this._panel;
+        panel.style.height = `${panel.scrollHeight}px`;
+        void panel.offsetHeight; // force reflow
+        if (!this._shouldAnimate()) {
+            this._animating = false;
+            panel.setAttribute('hidden', '');
+            panel.style.height = '';
+            this._emit('ar-collapse-hidden');
+            return;
+        }
+        panel.style.height = '0px';
+        panel.addEventListener(
+            'transitionend',
+            () => {
+                this._animating = false;
+                panel.setAttribute('hidden', '');
+                panel.style.height = '';
+                this._emit('ar-collapse-hidden');
+            },
+            { once: true },
+        );
+    }
+
+    private _emit(name: ArCollapseEvents): CustomEvent {
+        const e = new CustomEvent(name, { bubbles: true, composed: true, cancelable: true });
+        this.dispatchEvent(e);
+        return e;
     }
 }
 

--- a/packages/core/src/components/collapse/collapse.ts
+++ b/packages/core/src/components/collapse/collapse.ts
@@ -100,7 +100,7 @@ export class ArCollapse extends LitElement {
                 this._attachExternalTrigger();
             }
         }
-        if (changed.has('open')) {
+        if (changed.has('open') && changed.get('open') !== undefined) {
             if (this.open) this._show();
             else this._hide();
         }

--- a/packages/core/src/components/collapse/collapse.ts
+++ b/packages/core/src/components/collapse/collapse.ts
@@ -77,6 +77,10 @@ export class ArCollapse extends LitElement {
         if (this.for) {
             this._warnIfBothTriggers();
             this._attachExternalTrigger();
+        } else {
+            // Initialise le trigger interne si le slot est déjà peuplé au premier rendu.
+            // _handleTriggerSlotChange() sera rappelé si le slot change ultérieurement.
+            this._handleTriggerSlotChange();
         }
         this._syncTriggerAria();
         // État initial sans animation — updated() gère les changements ultérieurs.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,3 +30,4 @@ export { ArTableSort } from './components/table-sort/table-sort.js';
 export type { TableSortType, TableSortOrder } from './components/table-sort/table-sort.js';
 export { ArCharcounter } from './components/charcounter/charcounter.js';
 export type { CharcounterState } from './components/charcounter/charcounter.js';
+export { ArCollapse } from './components/collapse/collapse.js';

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -557,4 +557,8 @@
             --ar-tooltip-color: var(--ar-color-neutral-10);
         }
     }
+
+    ar-collapse::part(panel) {
+        transition: height var(--ar-collapse-duration, 0s) var(--ar-collapse-easing, ease);
+    }
 }


### PR DESCRIPTION
## Summary

- Nouveau composant `ar-collapse` — panneau pliable/dépliable accessible
- Dual trigger : `slot="trigger"` (interne) et `for="id"` (externe), cohérent avec `ar-dropdown`
- Mode accordéon via attribut `name` — coordination par DOM query, sans wrapper parent
- Animation height pilotée par JS (`scrollHeight`) + `transitionend`, bypass si `prefers-reduced-motion` ou durée 0s
- Tests : Vitest (unit), WTR browser (animation), WTR a11y (axe-core)
- Documentation : page MDX avec 6 variantes playground

## Test plan

- [x] `npm run test:all` passe sans régression
- [x] Playground doc — toutes les variantes fonctionnent (standalone, accordéon, trigger externe, trigger-position, disabled)
- [x] Vérification manuelle : animation avec `--ar-collapse-duration:300ms`, reduced motion, clavier

🤖 Generated with [Claude Code](https://claude.ai/claude-code)