### PR TITLE
docs: sections Utilisation pour 6 composants

### DIFF
--- a/apps/docs/src/content/components/ar-alert.mdx
+++ b/apps/docs/src/content/components/ar-alert.mdx
@@ -65,3 +65,19 @@ import WcagRef from '../../components/WcagRef.astro';
   `info` pour les informations neutres.
 - **`next-focus` obligatoire sur les alertes dismissibles.** Un bouton de fermeture sans
   destination de focus laisse l'utilisateur clavier sans repère.
+
+## Utilisation
+
+### Fermeture et cycle de vie
+
+À la fermeture, `ar-alert` **se retire du DOM** (`this.remove()`) une fois la transition terminée — l'alerte n'est pas simplement masquée, elle disparaît définitivement de la page. Toute référence conservée à l'élément pointe alors vers un noeud détaché ; il n'existe pas de méthode pour la réafficher.
+
+`ar-alert-close` (sans `detail`) est émis à ce moment-là, après la fin de la transition et juste avant le retrait du DOM :
+
+```js
+document.querySelector('ar-alert').addEventListener('ar-alert-close', () => {
+    console.log('Alerte fermée et retirée du DOM');
+});
+```
+
+Le bouton de fermeture n'est rendu que si `next-focus` est défini et non vide (`canBeHidden`) : sans `next-focus`, l'alerte n'a pas de bouton de fermeture et reste donc affichée en permanence — c'est voulu, pour éviter de fermer une alerte sans savoir où renvoyer le focus clavier.

--- a/apps/docs/src/content/components/ar-breadcrumb.mdx
+++ b/apps/docs/src/content/components/ar-breadcrumb.mdx
@@ -57,3 +57,17 @@ En dessous de **768px**, le composant bascule automatiquement vers un affichage 
 - Le dropdown expose son état via `aria-expanded` — le comportement clavier et vocal est géré automatiquement.
 
 Pour observer ce rendu, utiliser les DevTools du navigateur en mode responsive.
+
+## Utilisation
+
+### Écouter l'ouverture/fermeture du dropdown mobile
+
+En dessous de 768px, `ar-breadcrumb` émet `ar-breadcrumb-open` et `ar-breadcrumb-close` (sans `detail`) à chaque changement d'état du dropdown condensé :
+
+```js
+const breadcrumb = document.querySelector('ar-breadcrumb');
+breadcrumb.addEventListener('ar-breadcrumb-open', () => console.log('Dropdown ouvert'));
+breadcrumb.addEventListener('ar-breadcrumb-close', () => console.log('Dropdown fermé'));
+```
+
+Ces événements se déclenchent à chaque changement d'état du dropdown : clic sur le bouton toggle, mise à jour programmatique de la prop `open`, ou fermeture externe (clic en dehors, `Escape`) — pratique pour synchroniser un état d'UI externe ou pour de l'analytics.

--- a/apps/docs/src/content/components/ar-dialog.mdx
+++ b/apps/docs/src/content/components/ar-dialog.mdx
@@ -116,3 +116,48 @@ import WcagRef from '../../components/WcagRef.astro';
 - **Si vous bloquez la fermeture, renseigner `prevented-message`.** Le message doit expliquer quoi faire pour continuer ou confirmer l'action.
 - **Piloter le focus initial si nécessaire.** Posez `autofocus` sur l'élément qui doit recevoir le focus à l'ouverture — utile par exemple pour un champ de saisie dans un drawer.
 - **Adapter `close-label` à la langue de l'interface.** Par défaut `"Fermer"` — à remplacer si l'interface n'est pas en français (`close-label="Close"`, `close-label="Schließen"`, etc.).
+
+## Utilisation
+
+### Déclaration via `data-ar-dialog-open`
+
+Plutôt que de piloter `open` en JavaScript, un élément cliquable peut ouvrir un dialog par son `id` via l'attribut `data-ar-dialog-open` — un écouteur global au niveau du document intercepte le clic :
+
+```html
+<button data-ar-dialog-open="confirm-dialog">Supprimer</button>
+
+<ar-dialog id="confirm-dialog" label="Confirmer la suppression">
+    Cette action est irréversible.
+    <div slot="footer">
+        <button data-ar-dismiss>Annuler</button>
+        <button data-ar-accept>Confirmer</button>
+    </div>
+</ar-dialog>
+```
+
+### Cycle d'événements
+
+| Événement                       | Moment                                                | Annulable |
+| ------------------------------- | ----------------------------------------------------- | --------- |
+| `ar-dialog-show`                | Avant l'ouverture                                     | Oui       |
+| `ar-dialog-shown`               | Après l'ouverture (post-render)                       | Non       |
+| `ar-dialog-hide`                | Avant la fermeture (Escape, backdrop, `open = false`) | Oui       |
+| `ar-dialog-hide-prevented`      | Si `ar-dialog-hide` est annulé                        | Non       |
+| `ar-dialog-hidden`              | Après la fermeture (post-animation)                   | Non       |
+| `ar-dialog-dismissed`           | Clic sur un élément `data-ar-dismiss`                 | Oui       |
+| `ar-dialog-dismissed-prevented` | Si `ar-dialog-dismissed` est annulé                   | Non       |
+| `ar-dialog-accepted`            | Clic sur un élément `data-ar-accept`                  | Oui       |
+| `ar-dialog-accepted-prevented`  | Si `ar-dialog-accepted` est annulé                    | Non       |
+
+Tous portent `detail: { id }` (l'id du dialog). `data-ar-dismiss` et `data-ar-accept` sont deux conventions distinctes de `ar-dialog-hide` : elles permettent de distinguer une annulation ("Annuler") d'une confirmation ("Confirmer") sur le même geste de fermeture.
+
+```js
+document.getElementById('confirm-dialog').addEventListener('ar-dialog-accepted', (e) => {
+    if (e.defaultPrevented) return;
+    console.log('Confirmé, dialog :', e.detail.id);
+});
+```
+
+### Dialogs empilés
+
+Plusieurs `ar-dialog` peuvent être ouverts simultanément (un dialog ouvert depuis un autre, par exemple). Seul le dialog du dessus de la pile intercepte la touche `Escape` — les dialogs en dessous restent ouverts et inertes tant qu'il n'est pas fermé. Le verrouillage du scroll de la page est partagé entre tous les dialogs ouverts : il n'est relâché que lorsque le dernier dialog de la pile se ferme.

--- a/apps/docs/src/content/components/ar-pagination.mdx
+++ b/apps/docs/src/content/components/ar-pagination.mdx
@@ -54,3 +54,17 @@ En dessous de **640px**, le composant réduit automatiquement le nombre de pages
 
 - Seules les pages **précédente**, **active**, **suivante** et les deux voisines directes restent visibles.
 - Les autres pages sont masquées — aucune configuration nécessaire.
+
+## Utilisation
+
+### Écouter le changement de page
+
+`ar-pagination` émet `ar-pagination-page-change` à chaque changement de page (clic sur une page, précédent/suivant), avec `detail: { from, to }` :
+
+```js
+document.querySelector('ar-pagination').addEventListener('ar-pagination-page-change', (e) => {
+    const { from, to } = e.detail;
+    console.log(`Page ${from} → ${to}`);
+    // Charger les données de la page `to`, puis mettre à jour `current` / `total` si besoin.
+});
+```

--- a/apps/docs/src/content/components/ar-stepper.mdx
+++ b/apps/docs/src/content/components/ar-stepper.mdx
@@ -105,3 +105,44 @@ se déplace dans l'élément ciblé sur desktop, et revient à sa position d'ori
 <aside id="stepper-sidebar"></aside>
 <ar-stepper desktop-target="stepper-sidebar" desktop-from="992"> ... </ar-stepper>
 ```
+
+## Utilisation
+
+### Écouter le changement d'étape
+
+`ar-stepper` émet `ar-stepper-step-changed` au clic sur une étape, avec le `path` (le `href`) de l'étape sélectionnée dans `detail` :
+
+```js
+document.querySelector('ar-stepper').addEventListener('ar-stepper-step-changed', (e) => {
+    console.log('Étape sélectionnée :', e.detail.path);
+});
+```
+
+### Mode `create` vs `edit`
+
+La prop `mode` détermine quelles étapes sont cliquables :
+
+- **`create`** (défaut) : seules les étapes déjà **complétées** (avant l'étape courante) sont cliquables — navigation linéaire, cohérente avec un parcours de création où les étapes suivantes n'ont pas encore de contenu à afficher.
+- **`edit`** : toutes les étapes sauf l'étape courante sont cliquables, y compris celles qui n'ont pas encore été visitées — adapté à un parcours de modification où tout le contenu existe déjà.
+
+```html
+<ar-stepper mode="edit">...</ar-stepper>
+```
+
+### Navigation synchronisée au scroll (`follow-scroll`)
+
+Avec `follow-scroll`, la prop `current-path` se met à jour automatiquement pendant que l'utilisateur scrolle la page : le stepper détecte quelle section est visible et se synchronise sans action de votre part.
+
+```html
+<ar-stepper follow-scroll>...</ar-stepper>
+```
+
+### Navigation programmatique
+
+Mettre à jour `current-path` depuis l'extérieur pilote le stepper comme un clic utilisateur :
+
+```js
+document.querySelector('ar-stepper').currentPath = '#etape-2';
+```
+
+En mode `create`, cette mise à jour ne rend pas les étapes suivantes cliquables pour autant — seul `mode="edit"` lève cette restriction.

--- a/apps/docs/src/content/components/ar-stepper.mdx
+++ b/apps/docs/src/content/components/ar-stepper.mdx
@@ -110,7 +110,7 @@ se déplace dans l'élément ciblé sur desktop, et revient à sa position d'ori
 
 ### Écouter le changement d'étape
 
-`ar-stepper` émet `ar-stepper-step-changed` au clic sur une étape, avec le `path` (le `href`) de l'étape sélectionnée dans `detail` :
+`ar-stepper` émet `ar-stepper-step-changed` au clic sur une étape, avec l'attribut `path` de l'étape sélectionnée dans `detail` :
 
 ```js
 document.querySelector('ar-stepper').addEventListener('ar-stepper-step-changed', (e) => {

--- a/apps/docs/src/content/components/ar-tab-group.mdx
+++ b/apps/docs/src/content/components/ar-tab-group.mdx
@@ -233,3 +233,25 @@ Le tablist utilise un scroll horizontal natif (`overflow-x: auto`). Les onglets 
 
 - **Nommer le tablist** : si la page contient plusieurs `ar-tab-group`, ajoutez l'attribut `label` sur chacun — il devient l'`aria-label` du tablist, permettant aux lecteurs d'écran de les distinguer.
 - **Libellés des onglets** : le texte visible de l'onglet est son nom accessible. Évitez les onglets avec des icônes seules sans texte alternatif (`aria-label` sur `ar-tab`).
+
+## Utilisation
+
+### Écouter le changement d'onglet
+
+`ar-tab-group` émet `ar-tab-group-change` à chaque changement d'onglet actif, avec le nom du panel dans `detail` :
+
+```js
+document.querySelector('ar-tab-group').addEventListener('ar-tab-group-change', (e) => {
+    console.log('Onglet actif :', e.detail.active);
+});
+```
+
+L'événement se déclenche aussi automatiquement quand l'onglet actif est retiré du DOM : un autre onglet est réélu et `ar-tab-group-change` est émis avec son nom, sans action de votre part.
+
+### Activation manuelle vs automatique
+
+Par défaut (`manual-activation` absent), les flèches déplacent le focus **et** activent immédiatement l'onglet ciblé — `ar-tab-group-change` se déclenche à chaque flèche. Avec `manual-activation`, les flèches ne font que déplacer le focus : l'activation (et l'événement) n'a lieu qu'à l'appui sur `Entrée` ou `Espace`.
+
+```html
+<ar-tab-group manual-activation>...</ar-tab-group>
+```

--- a/docs/superpowers/plans/2026-07-03-docs-layout-scroll-toc.md
+++ b/docs/superpowers/plans/2026-07-03-docs-layout-scroll-toc.md
@@ -1,0 +1,325 @@
+# Docs Layout — Scroll de page & accès clavier au TOC Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Faire scroller la page (pas le `<main>`) sur les pages de doc desktop, garder nav/TOC visibles via `position: sticky`, élargir légèrement la colonne TOC, et rendre le TOC atteignable au clavier via un skip link sans réordonner le DOM.
+
+**Architecture:** Modification unique de `apps/docs/src/layouts/Layout.astro` (markup + CSS globale du layout). Aucun autre composant Astro n'est touché.
+
+**Tech Stack:** Astro 6, CSS natif (pas de préprocesseur).
+
+## Global Constraints
+
+- Ne pas réordonner `main`/`aside` dans le DOM (CSS `order`/grid-column) — anti-pattern WCAG 1.3.2 (Meaningful Sequence).
+- Le comportement mobile (`@media (max-width: 768px)`) ne doit pas changer.
+- `grid-template-columns` desktop passe de `270px 1fr 180px` à `270px 1fr 220px` (colonne nav inchangée à 270px).
+- Prettier (100 caractères, 4 espaces, quotes simples) s'applique via lint-staged au commit — pas d'action manuelle requise au-delà d'écrire du code cohérent.
+
+---
+
+## Spec de référence
+
+`docs/superpowers/specs/2026-07-03-docs-layout-scroll-toc-design.md`
+
+---
+
+## Task 0: Créer la branche de travail
+
+**Files:** aucun
+
+- [ ] **Step 1: Créer et basculer sur la branche**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && git checkout dev && git pull && git checkout -b chore/docs-layout-scroll-toc
+```
+
+Expected: `Switched to a new branch 'chore/docs-layout-scroll-toc'`
+
+---
+
+## Task 1: Skip links (accès clavier au TOC sans réordre du DOM)
+
+**Files:**
+
+- Modify: `apps/docs/src/layouts/Layout.astro`
+
+**Interfaces:**
+
+- Produces: ancre `#main-content` sur `<main>`, ancre `#toc` sur `<aside class="toc-column">`, classe CSS `.skip-link`.
+
+- [ ] **Step 1: Ajouter les ancres `id` sur `main` et `aside`**
+
+Dans `Layout.astro`, section markup (repérer le bloc `<main>` / `<aside class="toc-column">` actuel, vers la fin du fichier) :
+
+```astro
+            <main id="main-content">
+                <div class="main-inner">
+                    <slot />
+                </div>
+            </main>
+            {showToc && (
+                <aside class="toc-column" id="toc">
+                    <slot name="toc" />
+                </aside>
+            )}
+```
+
+- [ ] **Step 2: Ajouter les deux liens d'évitement tout en haut de `<body>`**
+
+Juste avant `<div class="alpha-banner" ...>` :
+
+```astro
+    <body>
+        <a href="#main-content" class="skip-link">Aller au contenu principal</a>
+        {showToc && <a href="#toc" class="skip-link">Aller au sommaire</a>}
+
+        <div class="alpha-banner" role="banner">
+```
+
+- [ ] **Step 3: Ajouter le style `.skip-link` (masqué sauf au focus)**
+
+Dans le bloc `<style>` global, juste avant la section `/* ── Header (toujours visible) ──────────────── */` :
+
+```css
+.skip-link {
+    position: absolute;
+    top: -3rem;
+    left: 0.5rem;
+    z-index: 1000;
+    padding: 0.5rem 1rem;
+    background: var(--doc-accent);
+    color: #fff;
+    border-radius: 0 0 0.4rem 0.4rem;
+    text-decoration: none;
+    font-size: 0.85rem;
+    font-weight: 600;
+    transition: top 0.15s ease;
+}
+
+.skip-link:focus {
+    top: 0;
+}
+```
+
+- [ ] **Step 4: Build de vérification**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && npm run build --workspace=@ariane-ui/docs
+```
+
+Expected: build réussi (exit code 0), pas d'erreur Astro.
+
+- [ ] **Step 5: Vérifier la présence du markup dans le HTML généré**
+
+```bash
+grep -o 'class="skip-link"[^>]*' /Users/jon/Code/Active_projects/ariane/apps/docs/dist/components/ar-datepicker/index.html
+grep -o 'id="main-content"' /Users/jon/Code/Active_projects/ariane/apps/docs/dist/components/ar-datepicker/index.html
+grep -o 'id="toc"' /Users/jon/Code/Active_projects/ariane/apps/docs/dist/components/ar-datepicker/index.html
+```
+
+Expected: chaque commande retourne au moins une occurrence.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && git add apps/docs/src/layouts/Layout.astro && git commit -m "feat(docs): ajoute des skip-links vers le contenu et le sommaire"
+```
+
+---
+
+## Task 2: Scroll de page (desktop) + sidebars sticky
+
+**Files:**
+
+- Modify: `apps/docs/src/layouts/Layout.astro`
+
+**Interfaces:**
+
+- Consumes: classes `.layout-body`, `.nav-column`, `main`, `.toc-column` définies en Task précédente (markup inchangé par cette task, uniquement CSS).
+
+- [ ] **Step 1: Supprimer la hauteur fixe de `.layout-body`**
+
+Retirer entièrement cette règle :
+
+```css
+.layout-body {
+    height: calc(100vh - var(--doc-header-h) - var(--doc-alpha-banner-h));
+}
+```
+
+- [ ] **Step 2: Passer `.nav-column` en sidebar sticky à scroll interne**
+
+Remplacer :
+
+```css
+.nav-column {
+    height: 100%;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+}
+```
+
+par :
+
+```css
+.nav-column {
+    position: sticky;
+    top: var(--doc-header-h);
+    max-height: calc(100vh - var(--doc-header-h) - var(--doc-alpha-banner-h));
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+}
+```
+
+- [ ] **Step 3: Retirer le scroll interne de `main`**
+
+Remplacer :
+
+```css
+main {
+    padding: 0;
+    height: 100%;
+    overflow-y: auto;
+}
+```
+
+par :
+
+```css
+main {
+    padding: 0;
+}
+```
+
+- [ ] **Step 4: Passer `.toc-column` en sidebar sticky à scroll interne**
+
+Remplacer :
+
+```css
+.toc-column {
+    height: 100%;
+    overflow-y: auto;
+    padding: 3rem 0.5rem 3rem 0;
+}
+```
+
+par :
+
+```css
+.toc-column {
+    position: sticky;
+    top: var(--doc-header-h);
+    max-height: calc(100vh - var(--doc-header-h) - var(--doc-alpha-banner-h));
+    overflow-y: auto;
+    padding: 3rem 0.5rem 3rem 0;
+}
+```
+
+- [ ] **Step 5: Build de vérification**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && npm run build --workspace=@ariane-ui/docs
+```
+
+Expected: build réussi.
+
+- [ ] **Step 6: Vérification manuelle en dev server**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && npm run dev
+```
+
+Ouvrir `http://localhost:4321/components/ar-datepicker` (ou le port affiché) :
+
+- Scroller la page : la scrollbar du navigateur doit bouger (pas une scrollbar interne au `main`).
+- Vérifier que la nav de gauche et le TOC de droite restent visibles à l'écran pendant le scroll (sticky).
+- Ouvrir le calendrier du datepicker : vérifier que le scroll de la page fonctionne toujours normalement pendant que le popover est ouvert (plus de blocage lié à l'ancien `overflow-y: auto` du `main`).
+
+Arrêter le serveur (`Ctrl+C`) une fois vérifié.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && git add apps/docs/src/layouts/Layout.astro && git commit -m "fix(docs): scroll de page au lieu du scroll interne au main"
+```
+
+---
+
+## Task 3: Élargir la colonne TOC (180px → 220px)
+
+**Files:**
+
+- Modify: `apps/docs/src/layouts/Layout.astro`
+
+- [ ] **Step 1: Modifier `grid-template-columns`**
+
+Remplacer :
+
+```css
+.layout-body.with-nav.with-toc {
+    grid-template-columns: 270px 1fr 180px;
+}
+```
+
+par :
+
+```css
+.layout-body.with-nav.with-toc {
+    grid-template-columns: 270px 1fr 220px;
+}
+```
+
+- [ ] **Step 2: Build de vérification**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && npm run build --workspace=@ariane-ui/docs
+```
+
+Expected: build réussi.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && git add apps/docs/src/layouts/Layout.astro && git commit -m "style(docs): élargit la colonne TOC pour améliorer la lisibilité des sous-titres"
+```
+
+---
+
+## Task 4: Créer la Pull Request
+
+**Files:** aucun
+
+- [ ] **Step 1: Pousser la branche**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && git push -u origin chore/docs-layout-scroll-toc
+```
+
+- [ ] **Step 2: Créer la PR vers `dev`**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && gh pr create --base dev --title "chore(docs): scroll de page, sidebars sticky, skip-links TOC" --body "$(cat <<'EOF'
+## Résumé
+
+- Le scroll de la page remplace le scroll interne au `main` (desktop) — corrige le blocage de scroll quand un popover est ouvert dans le contenu.
+- Nav latérale et TOC restent visibles via `position: sticky` pendant le scroll.
+- Colonne TOC élargie de 180px à 220px pour la lisibilité des sous-titres.
+- Deux skip-links (`sr-only`, focusables) ajoutés en haut de page : accès direct au contenu principal et au sommaire, sans réordonner le DOM (évite l'anti-pattern WCAG 1.3.2).
+
+## Test plan
+
+- [ ] `npm run build --workspace=@ariane-ui/docs` passe
+- [ ] Vérification visuelle sur une page avec TOC et une page sans TOC
+- [ ] Scroll de page fonctionnel avec un popover ouvert (ex. calendrier du datepicker)
+- [ ] Tab depuis le chargement : skip-links visibles au focus, dans l'ordre attendu
+
+Spec : `docs/superpowers/specs/2026-07-03-docs-layout-scroll-toc-design.md`
+EOF
+)"
+```
+
+Expected: URL de la PR affichée en sortie.

--- a/docs/superpowers/plans/2026-07-03-utilisation-sections.md
+++ b/docs/superpowers/plans/2026-07-03-utilisation-sections.md
@@ -1,0 +1,510 @@
+# Sections "Utilisation" (6 composants) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ajouter une section `## Utilisation` à 6 pages de documentation composant (`ar-tab-group`, `ar-stepper`, `ar-pagination`, `ar-breadcrumb`, `ar-dialog`, `ar-alert`), documentant les events custom et comportements non triviaux absents de l'API auto-générée et de la section Accessibilité.
+
+**Architecture:** Chaque page `.mdx` est modifiée indépendamment — un ajout de contenu en fin de fichier, aucune dépendance entre les 6 tâches de contenu (peuvent être exécutées par des agents en parallèle).
+
+**Tech Stack:** Astro 6, MDX.
+
+## Global Constraints
+
+- Section `## Utilisation`, sous-titres `### <sujet>` — même niveau que `ar-datepicker.mdx`.
+- Placée en fin de page, après `## Accessibilité` et après `## Comportement responsive` quand elle existe.
+- Ton : adresse directe au lecteur (tutoiement / "vous"), cohérent avec la revue de terminologie déjà faite sur ces pages.
+- Ne pas dupliquer de contenu déjà présent ailleurs sur la page (Accessibilité, variants).
+- Les noms d'événements et la forme du `detail` doivent correspondre exactement au JSDoc du composant source (vérifié pendant le brainstorming — voir table ci-dessous).
+- Ne pas ajouter `<WcagRef>` dans ces sections — elles ne couvrent pas des critères d'accessibilité, seulement du comportement/API.
+
+## Table de référence événements (vérifiée dans le code source)
+
+| Composant       | Événement                                                                                                   | `detail`                       |
+| --------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| `ar-tab-group`  | `ar-tab-group-change`                                                                                       | `{ active: string }`           |
+| `ar-stepper`    | `ar-stepper-step-changed`                                                                                   | `{ path: string }`             |
+| `ar-pagination` | `ar-pagination-page-change`                                                                                 | `{ from: number, to: number }` |
+| `ar-breadcrumb` | `ar-breadcrumb-open` / `ar-breadcrumb-close`                                                                | aucun                          |
+| `ar-dialog`     | `ar-dialog-show/shown/hide/hide-prevented/hidden/dismissed/dismissed-prevented/accepted/accepted-prevented` | `{ id: string }`               |
+| `ar-alert`      | `ar-alert-close`                                                                                            | aucun                          |
+
+---
+
+## Spec de référence
+
+`docs/superpowers/specs/2026-07-03-utilisation-sections-design.md`
+
+---
+
+## Task 0: Créer la branche de travail
+
+**Files:** aucun
+
+- [ ] **Step 1: Créer et basculer sur la branche**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && git checkout dev && git pull && git checkout -b docs/utilisation-sections
+```
+
+Expected: `Switched to a new branch 'docs/utilisation-sections'`
+
+---
+
+## Task 1: ar-tab-group
+
+**Files:**
+
+- Modify: `apps/docs/src/content/components/ar-tab-group.mdx` (fin de fichier)
+
+- [ ] **Step 1: Ajouter la section Utilisation en fin de fichier**
+
+Le fichier se termine actuellement par (section `### À votre charge`) :
+
+```mdx
+### À votre charge
+
+- **Nommer le tablist** : si la page contient plusieurs `ar-tab-group`, ajoutez l'attribut `label` sur chacun — il devient l'`aria-label` du tablist, permettant aux lecteurs d'écran de les distinguer.
+- **Libellés des onglets** : le texte visible de l'onglet est son nom accessible. Évitez les onglets avec des icônes seules sans texte alternatif (`aria-label` sur `ar-tab`).
+```
+
+Ajouter à la suite :
+
+````mdx
+## Utilisation
+
+### Écouter le changement d'onglet
+
+`ar-tab-group` émet `ar-tab-group-change` à chaque changement d'onglet actif, avec le nom du panel dans `detail` :
+
+```js
+document.querySelector('ar-tab-group').addEventListener('ar-tab-group-change', (e) => {
+    console.log('Onglet actif :', e.detail.active);
+});
+```
+
+L'événement se déclenche aussi automatiquement quand l'onglet actif est retiré du DOM : un autre onglet est réélu et `ar-tab-group-change` est émis avec son nom, sans action de votre part.
+
+### Activation manuelle vs automatique
+
+Par défaut (`manual-activation` absent), les flèches déplacent le focus **et** activent immédiatement l'onglet ciblé — `ar-tab-group-change` se déclenche à chaque flèche. Avec `manual-activation`, les flèches ne font que déplacer le focus : l'activation (et l'événement) n'a lieu qu'à l'appui sur `Entrée` ou `Espace`.
+
+```html
+<ar-tab-group manual-activation>...</ar-tab-group>
+```
+````
+
+- [ ] **Step 2: Build de vérification**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && npm run build --workspace=@ariane-ui/docs
+```
+
+Expected: build réussi, pas d'erreur MDX.
+
+- [ ] **Step 3: Vérifier le rendu du nouveau titre**
+
+```bash
+grep -o "Écouter le changement d'onglet" /Users/jon/Code/Active_projects/ariane/apps/docs/dist/components/ar-tab-group/index.html
+```
+
+Expected: au moins une occurrence.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && git add apps/docs/src/content/components/ar-tab-group.mdx && git commit -m "docs(ar-tab-group): ajoute la section Utilisation (event de changement, activation manuelle)"
+```
+
+---
+
+## Task 2: ar-stepper
+
+**Files:**
+
+- Modify: `apps/docs/src/content/components/ar-stepper.mdx` (fin de fichier)
+
+- [ ] **Step 1: Ajouter la section Utilisation en fin de fichier**
+
+Le fichier se termine actuellement par (section `## Comportement responsive`) :
+
+````mdx
+Quand `desktop-target` est renseigné, la téléportation DOM est également activée : le composant
+se déplace dans l'élément ciblé sur desktop, et revient à sa position d'origine sur mobile.
+
+```html
+<aside id="stepper-sidebar"></aside>
+<ar-stepper desktop-target="stepper-sidebar" desktop-from="992"> ... </ar-stepper>
+```
+````
+
+Ajouter à la suite :
+
+````mdx
+## Utilisation
+
+### Écouter le changement d'étape
+
+`ar-stepper` émet `ar-stepper-step-changed` au clic sur une étape, avec le `path` (le `href`) de l'étape sélectionnée dans `detail` :
+
+```js
+document.querySelector('ar-stepper').addEventListener('ar-stepper-step-changed', (e) => {
+    console.log('Étape sélectionnée :', e.detail.path);
+});
+```
+
+### Mode `create` vs `edit`
+
+La prop `mode` détermine quelles étapes sont cliquables :
+
+- **`create`** (défaut) : seules les étapes déjà **complétées** (avant l'étape courante) sont cliquables — navigation linéaire, cohérente avec un parcours de création où les étapes suivantes n'ont pas encore de contenu à afficher.
+- **`edit`** : toutes les étapes sauf l'étape courante sont cliquables, y compris celles qui n'ont pas encore été visitées — adapté à un parcours de modification où tout le contenu existe déjà.
+
+```html
+<ar-stepper mode="edit">...</ar-stepper>
+```
+
+### Navigation synchronisée au scroll (`follow-scroll`)
+
+Avec `follow-scroll`, la prop `current-path` se met à jour automatiquement pendant que l'utilisateur scrolle la page : le stepper détecte quelle section est visible et se synchronise sans action de votre part.
+
+```html
+<ar-stepper follow-scroll>...</ar-stepper>
+```
+
+### Navigation programmatique
+
+Mettre à jour `current-path` depuis l'extérieur pilote le stepper comme un clic utilisateur :
+
+```js
+document.querySelector('ar-stepper').currentPath = '#etape-2';
+```
+
+En mode `create`, cette mise à jour ne rend pas les étapes suivantes cliquables pour autant — seul `mode="edit"` lève cette restriction.
+````
+
+- [ ] **Step 2: Build de vérification**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && npm run build --workspace=@ariane-ui/docs
+```
+
+Expected: build réussi.
+
+- [ ] **Step 3: Vérifier le rendu du nouveau titre**
+
+```bash
+grep -o "Écouter le changement d'étape" /Users/jon/Code/Active_projects/ariane/apps/docs/dist/components/ar-stepper/index.html
+```
+
+Expected: au moins une occurrence.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && git add apps/docs/src/content/components/ar-stepper.mdx && git commit -m "docs(ar-stepper): ajoute la section Utilisation (event, mode create/edit, follow-scroll, navigation programmatique)"
+```
+
+---
+
+## Task 3: ar-pagination
+
+**Files:**
+
+- Modify: `apps/docs/src/content/components/ar-pagination.mdx` (fin de fichier)
+
+- [ ] **Step 1: Ajouter la section Utilisation en fin de fichier**
+
+Le fichier se termine actuellement par (section `## Comportement responsive`) :
+
+```mdx
+En dessous de **640px**, le composant réduit automatiquement le nombre de pages affichées :
+
+- Seules les pages **précédente**, **active**, **suivante** et les deux voisines directes restent visibles.
+- Les autres pages sont masquées — aucune configuration nécessaire.
+```
+
+Ajouter à la suite :
+
+````mdx
+## Utilisation
+
+### Écouter le changement de page
+
+`ar-pagination` émet `ar-pagination-page-change` à chaque changement de page (clic sur une page, précédent/suivant), avec `detail: { from, to }` :
+
+```js
+document.querySelector('ar-pagination').addEventListener('ar-pagination-page-change', (e) => {
+    const { from, to } = e.detail;
+    console.log(`Page ${from} → ${to}`);
+    // Charger les données de la page `to`, puis mettre à jour `current` / `total` si besoin.
+});
+```
+````
+
+- [ ] **Step 2: Build de vérification**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && npm run build --workspace=@ariane-ui/docs
+```
+
+Expected: build réussi.
+
+- [ ] **Step 3: Vérifier le rendu du nouveau titre**
+
+```bash
+grep -o "Écouter le changement de page" /Users/jon/Code/Active_projects/ariane/apps/docs/dist/components/ar-pagination/index.html
+```
+
+Expected: au moins une occurrence.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && git add apps/docs/src/content/components/ar-pagination.mdx && git commit -m "docs(ar-pagination): ajoute la section Utilisation (event de changement de page)"
+```
+
+---
+
+## Task 4: ar-breadcrumb
+
+**Files:**
+
+- Modify: `apps/docs/src/content/components/ar-breadcrumb.mdx` (fin de fichier)
+
+- [ ] **Step 1: Ajouter la section Utilisation en fin de fichier**
+
+Le fichier se termine actuellement par (section `## Comportement responsive`) :
+
+```mdx
+- Le dropdown expose son état via `aria-expanded` — le comportement clavier et vocal est géré automatiquement.
+
+Pour observer ce rendu, utiliser les DevTools du navigateur en mode responsive.
+```
+
+Ajouter à la suite :
+
+````mdx
+## Utilisation
+
+### Écouter l'ouverture/fermeture du dropdown mobile
+
+En dessous de 768px, `ar-breadcrumb` émet `ar-breadcrumb-open` et `ar-breadcrumb-close` (sans `detail`) à chaque changement d'état du dropdown condensé :
+
+```js
+const breadcrumb = document.querySelector('ar-breadcrumb');
+breadcrumb.addEventListener('ar-breadcrumb-open', () => console.log('Dropdown ouvert'));
+breadcrumb.addEventListener('ar-breadcrumb-close', () => console.log('Dropdown fermé'));
+```
+
+Ces événements se déclenchent de la même façon quelle que soit l'origine du changement : clic sur le bouton toggle, mise à jour programmatique de la prop `open`, ou fermeture externe (clic en dehors, `Escape`) — pratique pour synchroniser un état d'UI externe ou pour de l'analytics.
+````
+
+- [ ] **Step 2: Build de vérification**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && npm run build --workspace=@ariane-ui/docs
+```
+
+Expected: build réussi.
+
+- [ ] **Step 3: Vérifier le rendu du nouveau titre**
+
+```bash
+grep -o "l'ouverture/fermeture du dropdown mobile" /Users/jon/Code/Active_projects/ariane/apps/docs/dist/components/ar-breadcrumb/index.html
+```
+
+Expected: au moins une occurrence.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && git add apps/docs/src/content/components/ar-breadcrumb.mdx && git commit -m "docs(ar-breadcrumb): ajoute la section Utilisation (events open/close du dropdown mobile)"
+```
+
+---
+
+## Task 5: ar-dialog
+
+**Files:**
+
+- Modify: `apps/docs/src/content/components/ar-dialog.mdx` (fin de fichier)
+
+- [ ] **Step 1: Ajouter la section Utilisation en fin de fichier**
+
+Le fichier se termine actuellement par (section `### À votre charge`) :
+
+```mdx
+- **Adapter `close-label` à la langue de l'interface.** Par défaut `"Fermer"` — à remplacer si l'interface n'est pas en français (`close-label="Close"`, `close-label="Schließen"`, etc.).
+```
+
+Ajouter à la suite :
+
+````mdx
+## Utilisation
+
+### Déclaration via `data-ar-dialog-open`
+
+Plutôt que de piloter `open` en JavaScript, un élément cliquable peut ouvrir un dialog par son `id` via l'attribut `data-ar-dialog-open` — un écouteur global au niveau du document intercepte le clic :
+
+```html
+<button data-ar-dialog-open="confirm-dialog">Supprimer</button>
+
+<ar-dialog id="confirm-dialog" label="Confirmer la suppression">
+    Cette action est irréversible.
+    <div slot="footer">
+        <button data-ar-dismiss>Annuler</button>
+        <button data-ar-accept>Confirmer</button>
+    </div>
+</ar-dialog>
+```
+
+### Cycle d'événements
+
+| Événement                       | Moment                                                | Annulable |
+| ------------------------------- | ----------------------------------------------------- | --------- |
+| `ar-dialog-show`                | Avant l'ouverture                                     | Oui       |
+| `ar-dialog-shown`               | Après l'ouverture (post-render)                       | Non       |
+| `ar-dialog-hide`                | Avant la fermeture (Escape, backdrop, `open = false`) | Oui       |
+| `ar-dialog-hide-prevented`      | Si `ar-dialog-hide` est annulé                        | Non       |
+| `ar-dialog-hidden`              | Après la fermeture (post-animation)                   | Non       |
+| `ar-dialog-dismissed`           | Clic sur un élément `data-ar-dismiss`                 | Oui       |
+| `ar-dialog-dismissed-prevented` | Si `ar-dialog-dismissed` est annulé                   | Non       |
+| `ar-dialog-accepted`            | Clic sur un élément `data-ar-accept`                  | Oui       |
+| `ar-dialog-accepted-prevented`  | Si `ar-dialog-accepted` est annulé                    | Non       |
+
+Tous portent `detail: { id }` (l'id du dialog). `data-ar-dismiss` et `data-ar-accept` sont deux conventions distinctes de `ar-dialog-hide` : elles permettent de distinguer une annulation ("Annuler") d'une confirmation ("Confirmer") sur le même geste de fermeture.
+
+```js
+document.getElementById('confirm-dialog').addEventListener('ar-dialog-accepted', (e) => {
+    if (e.defaultPrevented) return;
+    console.log('Confirmé, dialog :', e.detail.id);
+});
+```
+
+### Dialogs empilés
+
+Plusieurs `ar-dialog` peuvent être ouverts simultanément (un dialog ouvert depuis un autre, par exemple). Seul le dialog du dessus de la pile intercepte la touche `Escape` — les dialogs en dessous restent ouverts et inertes tant qu'il n'est pas fermé. Le verrouillage du scroll de la page est partagé entre tous les dialogs ouverts : il n'est relâché que lorsque le dernier dialog de la pile se ferme.
+````
+
+- [ ] **Step 2: Build de vérification**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && npm run build --workspace=@ariane-ui/docs
+```
+
+Expected: build réussi.
+
+- [ ] **Step 3: Vérifier le rendu du nouveau titre**
+
+```bash
+grep -o "Dialogs empilés" /Users/jon/Code/Active_projects/ariane/apps/docs/dist/components/ar-dialog/index.html
+```
+
+Expected: au moins une occurrence.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && git add apps/docs/src/content/components/ar-dialog.mdx && git commit -m "docs(ar-dialog): ajoute la section Utilisation (data-ar-dialog-open, cycle d'événements, dialogs empilés)"
+```
+
+---
+
+## Task 6: ar-alert
+
+**Files:**
+
+- Modify: `apps/docs/src/content/components/ar-alert.mdx` (fin de fichier)
+
+- [ ] **Step 1: Ajouter la section Utilisation en fin de fichier**
+
+Le fichier se termine actuellement par (section `### À votre charge`) :
+
+```mdx
+- **`next-focus` obligatoire sur les alertes dismissibles.** Un bouton de fermeture sans
+  destination de focus laisse l'utilisateur clavier sans repère.
+```
+
+Ajouter à la suite :
+
+````mdx
+## Utilisation
+
+### Fermeture et cycle de vie
+
+À la fermeture, `ar-alert` **se retire du DOM** (`this.remove()`) une fois la transition terminée — l'alerte n'est pas simplement masquée, elle disparaît définitivement de la page. Toute référence conservée à l'élément pointe alors vers un noeud détaché ; il n'existe pas de méthode pour la réafficher.
+
+`ar-alert-close` (sans `detail`) est émis à ce moment-là, après la fin de la transition et juste avant le retrait du DOM :
+
+```js
+document.querySelector('ar-alert').addEventListener('ar-alert-close', () => {
+    console.log('Alerte fermée et retirée du DOM');
+});
+```
+
+Le bouton de fermeture n'est rendu que si `next-focus` est défini et non vide (`canBeHidden`) : sans `next-focus`, l'alerte n'a pas de bouton de fermeture et reste donc affichée en permanence — c'est voulu, pour éviter de fermer une alerte sans savoir où renvoyer le focus clavier.
+````
+
+- [ ] **Step 2: Build de vérification**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && npm run build --workspace=@ariane-ui/docs
+```
+
+Expected: build réussi.
+
+- [ ] **Step 3: Vérifier le rendu du nouveau titre**
+
+```bash
+grep -o "Fermeture et cycle de vie" /Users/jon/Code/Active_projects/ariane/apps/docs/dist/components/ar-alert/index.html
+```
+
+Expected: au moins une occurrence.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && git add apps/docs/src/content/components/ar-alert.mdx && git commit -m "docs(ar-alert): ajoute la section Utilisation (retrait DOM à la fermeture, next-focus)"
+```
+
+---
+
+## Task 7: Créer la Pull Request
+
+**Files:** aucun
+
+- [ ] **Step 1: Pousser la branche**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && git push -u origin docs/utilisation-sections
+```
+
+- [ ] **Step 2: Créer la PR vers `dev`**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && gh pr create --base dev --title "docs: sections Utilisation pour 6 composants" --body "$(cat <<'EOF'
+## Résumé
+
+Ajoute une section `## Utilisation` (sur le modèle de `ar-datepicker`) à 6 pages de documentation, comblant les trous identifiés lors de l'audit (events custom non documentés, comportements non triviaux) :
+
+- **ar-tab-group** — event `ar-tab-group-change`, activation manuelle vs automatique
+- **ar-stepper** — event `ar-stepper-step-changed`, mode `create`/`edit`, `follow-scroll`, navigation programmatique
+- **ar-pagination** — event `ar-pagination-page-change`
+- **ar-breadcrumb** — events `ar-breadcrumb-open`/`ar-breadcrumb-close`
+- **ar-dialog** — convention `data-ar-dialog-open`, catalogue d'événements, dialogs empilés
+- **ar-alert** — retrait du DOM à la fermeture, condition `next-focus`/`canBeHidden`
+
+Les 13 autres composants n'ont pas reçu de section Utilisation — soit un contenu équivalent existe déjà (`ar-table-sort`), soit rien de non-évident à ajouter au-delà de l'API et de l'accessibilité.
+
+## Test plan
+
+- [ ] `npm run build --workspace=@ariane-ui/docs` passe sur les 6 pages
+- [ ] Relecture : pas de duplication avec les sections Accessibilité existantes
+- [ ] Les noms d'événements et `detail` correspondent au JSDoc source
+
+Spec : `docs/superpowers/specs/2026-07-03-utilisation-sections-design.md`
+EOF
+)"
+```
+
+Expected: URL de la PR affichée en sortie.

--- a/docs/superpowers/specs/2026-07-03-docs-layout-scroll-toc-design.md
+++ b/docs/superpowers/specs/2026-07-03-docs-layout-scroll-toc-design.md
@@ -1,0 +1,82 @@
+# Spec — Scroll de page & accès clavier au TOC (docs)
+
+**Date :** 2026-07-03
+**Scope :** `apps/docs/src/layouts/Layout.astro`
+**Approche :** Édition directe du layout partagé (impacte toutes les pages composant)
+
+---
+
+## Contexte
+
+Aujourd'hui, `.layout-body` a une hauteur fixe (`calc(100vh - header - banner)`), et c'est `main` (ainsi que `.nav-column` et `.toc-column`) qui scrollent en interne via `overflow-y: auto`. Ce scroll interne au `main` casse le comportement de scroll quand un popover ouvert dans le contenu (dropdown, datepicker) dépend du scroll de la page pour se repositionner ou se fermer.
+
+Par ailleurs, l'ordre du DOM est `nav` → `main` → `aside` (TOC). Un utilisateur clavier doit tabuler tout le contenu du `main` avant d'atteindre le sommaire (TOC), qui n'est pourtant qu'à un clic visuel.
+
+Ce problème n'existe déjà pas en mobile : le media query `@media (max-width: 768px)` bascule `.layout-body` et `main` en `height: auto` / `overflow-y: visible`, laissant `<body>` scroller nativement. Le desktop diverge du mobile sur ce point.
+
+---
+
+## Objectif
+
+1. `<html>`/`<body>` gèrent le scroll de la page sur desktop comme en mobile — plus de scroll interne au `main`.
+2. La nav latérale et le TOC restent visibles à l'écran pendant que le contenu défile (`position: sticky`), sans réintroduire de piège de scroll.
+3. Le TOC est atteignable rapidement au clavier sans dépendre de l'ordre du DOM (pas de réordre CSS — cf. WCAG 1.3.2 Meaningful Sequence).
+4. La colonne TOC est légèrement élargie pour améliorer la lisibilité des sous-titres.
+
+---
+
+## Changements
+
+### 1. Scroll de page (desktop)
+
+Dans `Layout.astro`, supprimer :
+
+- La hauteur fixe de `.layout-body` (`height: calc(100vh - ...)`).
+- `overflow-y: auto` sur `main`.
+- Le comportement de scroll interne actuellement propre au desktop dans `.nav-column` / `.toc-column`.
+
+`.nav-column` et `.toc-column` passent en sidebar sticky à scroll interne :
+
+```css
+.nav-column,
+.toc-column {
+    position: sticky;
+    top: var(--doc-header-h);
+    max-height: calc(100vh - var(--doc-header-h) - var(--doc-alpha-banner-h));
+    overflow-y: auto;
+}
+```
+
+Le header (`.site-header`) reste `position: sticky; top: 0` (inchangé). Le bloc `@media (max-width: 768px)` existant continue de désactiver ce comportement sticky (nav en drawer, TOC masqué) — pas de changement mobile.
+
+### 2. Largeur de la colonne TOC
+
+`grid-template-columns: 270px 1fr 180px` → `270px 1fr 220px` sur `.layout-body.with-nav.with-toc`. La colonne nav (270px) est inchangée.
+
+### 3. Liens d'évitement (skip links)
+
+Le DOM garde son ordre actuel (`nav`, `main`, `aside`) — **pas de réordre visuel via CSS `order`/grid-column**, qui découplerait l'ordre de lecture/focus de l'ordre visuel (anti-pattern WCAG 1.3.2).
+
+Deux liens `sr-only`, focusables (visibles au focus clavier), ajoutés tout en haut de `<body>`, avant `.alpha-banner` :
+
+- **"Aller au contenu principal"** → `#main-content` (ancre à ajouter sur `<main>`). Toujours présent.
+- **"Aller au sommaire"** → `#toc` (ancre à ajouter sur `<aside class="toc-column">`). Rendu uniquement si `showToc` est vrai.
+
+Style : classe `.skip-link`, positionnée en `sr-only` par défaut, mais visible (`position: fixed; top: 0; left: 0`, fond contrasté, `z-index` au-dessus du header) quand elle reçoit le focus — pattern standard.
+
+---
+
+## Hors scope
+
+- Le contenu ou la structure du TOC lui-même (`TableOfContents.astro`) — seule la largeur de sa colonne change.
+- Le comportement mobile (déjà correct).
+- La deuxième partie du travail (sections "Utilisation" par composant), qui fait l'objet d'un spec séparé.
+
+---
+
+## Tests / vérification
+
+- Vérifier visuellement qu'aucune régression de layout n'apparaît sur une page avec TOC (ex. `/components/ar-datepicker`) et une page sans TOC.
+- Vérifier qu'un popover ouvert dans le contenu (ex. `ar-dropdown` du thème, ou un composant datepicker en page) ne casse plus le scroll de la page lors du défilement.
+- Vérifier à la tab depuis le chargement de la page : le premier skip link ("Aller au contenu principal") apparaît, suivi du second ("Aller au sommaire") si le TOC est présent, avant d'atteindre le burger/nav.
+- Vérifier que nav et TOC restent visibles (sticky) pendant le scroll sur une page longue, en desktop.

--- a/docs/superpowers/specs/2026-07-03-utilisation-sections-design.md
+++ b/docs/superpowers/specs/2026-07-03-utilisation-sections-design.md
@@ -1,0 +1,77 @@
+# Spec — Sections "Utilisation" pour 6 composants
+
+**Date :** 2026-07-03
+**Scope :** `apps/docs/src/content/components/{ar-tab-group,ar-stepper,ar-pagination,ar-breadcrumb,ar-dialog,ar-alert}.mdx`
+**Approche :** Subagent-driven, un agent par fichier (contenu indépendant par composant)
+
+---
+
+## Contexte
+
+`ar-datepicker.mdx` a une section `## Utilisation` couvrant du contenu non trivial au-delà de l'API auto-générée et de l'accessibilité : events custom avec `detail`, comportements avec état/mémoire, patterns d'intégration. Les 18 autres pages composant n'ont que `## Accessibilité` (± `## Comportement responsive`).
+
+Un audit des 13 composants restants (hors datepicker) a établi qu'ils n'ont pas tous besoin d'une telle section — plusieurs ont déjà un contenu équivalent documenté ailleurs (ex. `ar-table-sort` sous Accessibilité), ou sont trop simples pour en justifier une (`ar-progressbar`, `ar-spinner`, `ar-tooltip`, `ar-dropdown`, `ar-collapse`, `ar-charcounter`).
+
+**Critère retenu** : une section Utilisation est justifiée si le composant a du contenu non-évident au-delà de l'API auto-générée et de l'accessibilité — events custom à écouter, comportement avec état/mémoire, patterns d'intégration, ou props qui interagissent entre elles.
+
+6 composants passent ce critère (voir détail par composant ci-dessous). Les 13 autres restent inchangés — aucune section Utilisation forcée.
+
+---
+
+## Contenu par composant
+
+### ar-tab-group
+
+- **### Écouter le changement d'onglet** — documenter `ar-tab-group-change` (`detail: { active: string }`), émis via `activate()` du registre. Préciser qu'il se déclenche aussi quand l'onglet actif est retiré du DOM et qu'un autre est réélu automatiquement.
+- **### Activation manuelle vs automatique** — clarifier l'interaction entre `manual-activation` et le moment exact où l'event se déclenche (Entrée/Espace vs flèches).
+
+### ar-stepper (+ ar-stepper-item)
+
+- **### Écouter le changement d'étape** — documenter `ar-stepper-step-changed` (`detail: { path }`). Ne pas documenter l'event interne non préfixé `step-changed` — usage interne uniquement, pas une garantie d'API publique.
+- **### Mode `create` vs `edit`** — expliquer comment `mode` détermine quelles étapes sont cliquables/navigables (actuellement seulement suggéré via deux variants quasi identiques).
+- **### Navigation synchronisée au scroll (`follow-scroll`)** — documenter que `ScrollFollowController` met à jour `current-path` automatiquement pendant le scroll utilisateur.
+- **### Navigation programmatique** — mettre à jour `current-path` depuis l'extérieur (vs clic utilisateur), et son interaction avec `mode`.
+
+### ar-pagination
+
+- **### Écouter le changement de page** — documenter `ar-pagination-page-change` (`detail: { from, to }`) et le pattern d'intégration typique (fetch de données, mise à jour de `total`/`current`). Une seule section, contenu court.
+
+### ar-breadcrumb (+ ar-breadcrumb-item)
+
+- **### Écouter l'ouverture/fermeture du dropdown mobile** — documenter `ar-breadcrumb-open` / `ar-breadcrumb-close` (pas de `detail`), en précisant qu'ils se déclenchent identiquement que l'origine soit le bouton toggle, la prop `open`, ou une fermeture externe (clic extérieur/Escape).
+
+### ar-dialog
+
+- **### Déclaration via `data-ar-dialog-open`** — expliquer le mécanisme d'écoute globale au niveau document qui ouvre un dialog par id (actuellement seulement démontré via des snippets de variants, jamais expliqué en prose).
+- **### Cycle d'événements** — catalogue complet (`show` / `shown` / `hide` / `hide-prevented` / `hidden` / `dismissed` / `dismissed-prevented` / `accepted` / `accepted-prevented`), leur `detail: { id }` commun, et la distinction dismissed/accepted vs hide (convention des boutons `data-ar-dismiss` / `data-ar-accept`).
+- **### Dialogs empilés** — comportement de la pile (`_dialogStack`) au-delà de ce qui est dit en Accessibilité : seul le dialog du dessus intercepte Escape, le verrou de scroll est partagé/comptabilisé par référence.
+
+### ar-alert
+
+- **### Fermeture et cycle de vie** — expliquer que l'alerte se retire elle-même du DOM (`this.remove()`) à la fin de la transition de fermeture, pas seulement masquée — impossible de la ré-afficher ensuite. Documenter que `ar-alert-close` (sans `detail`) signale cette fermeture, et que `next-focus` conditionne l'affichage même du bouton de fermeture (`canBeHidden` : sans `next-focus`, pas de bouton, donc l'alerte est de fait permanente).
+
+---
+
+## Conventions de rédaction
+
+- Titre de section : `## Utilisation`, sous-titres `### <sujet>` — même niveau que dans `ar-datepicker.mdx`.
+- Placée après `## Accessibilité` (et après `## Comportement responsive` quand présent), à la fin de la page — ordre identique au datepicker.
+- Exemples de code (`html`/`js`) quand un event ou un pattern d'intégration est documenté — cohérent avec le style du datepicker (snippets courts, ciblés).
+- Ton : adresse directe au lecteur (tutoiement / "vous"), cf. [[project_docs_architecture]] et la revue de terminologie déjà faite sur ces pages.
+- Ne pas dupliquer du contenu déjà présent ailleurs sur la page (Accessibilité, variants) — la section Utilisation comble uniquement les trous identifiés ci-dessus.
+
+---
+
+## Hors scope
+
+- Les 13 autres composants (dont `ar-table-sort`, dont le contenu équivalent existe déjà sous Accessibilité) — pas de section Utilisation ajoutée.
+- Toute refonte de la structure Accessibilité existante.
+- Le travail de layout (scroll de page / TOC), qui fait l'objet d'un spec séparé ([[2026-07-03-docs-layout-scroll-toc-design]]).
+
+---
+
+## Tests / vérification
+
+- Chaque page modifiée build sans erreur MDX (`npm run build` côté `apps/docs`).
+- Les events documentés correspondent exactement aux noms et `detail` réels déclarés dans le JSDoc du composant source.
+- Relecture : pas de contenu dupliqué avec les sections Accessibilité existantes.


### PR DESCRIPTION
## Résumé

Ajoute une section `## Utilisation` (sur le modèle de `ar-datepicker`) à 6 pages de documentation, comblant les trous identifiés lors de l'audit (events custom non documentés, comportements non triviaux) :

- **ar-tab-group** — event `ar-tab-group-change`, activation manuelle vs automatique
- **ar-stepper** — event `ar-stepper-step-changed`, mode `create`/`edit`, `follow-scroll`, navigation programmatique
- **ar-pagination** — event `ar-pagination-page-change`
- **ar-breadcrumb** — events `ar-breadcrumb-open`/`ar-breadcrumb-close`
- **ar-dialog** — convention `data-ar-dialog-open`, catalogue d'événements, dialogs empilés
- **ar-alert** — retrait du DOM à la fermeture, condition `next-focus`/`canBeHidden`

Les 13 autres composants n'ont pas reçu de section Utilisation — soit un contenu équivalent existe déjà (`ar-table-sort`), soit rien de non-évident à ajouter au-delà de l'API et de l'accessibilité.

Deux ajustements par rapport au texte initial du plan, découverts et corrigés en cours de revue :
- **ar-stepper** : le `detail.path` de l'événement correspond à l'attribut `path` de l'étape, pas à son `href` (ce sont deux attributs indépendants).
- **ar-breadcrumb** : les events `ar-breadcrumb-open`/`close` ne se déclenchent pas "de la même façon" quelle que soit l'origine — un vrai bug de double-déclenchement de `ar-breadcrumb-close` existe sur la fermeture externe (clic dehors/Escape). Le texte a été adouci pour rester exact ; le bug lui-même est hors scope de cette PR (à traiter séparément dans `packages/core/src/components/breadcrumb/breadcrumb.ts`).

## Test plan

- [x] `npm run build --workspace=@ariane-ui/docs` passe sur les 6 pages
- [x] Relecture : pas de duplication avec les sections Accessibilité existantes
- [x] Les noms d'événements et `detail` vérifiés contre le JSDoc/code source de chaque composant
- [x] Revue finale de branche (spec, plan, scope, cohérence de ton) — prête à merger

## Follow-up (hors scope)

Bug réel trouvé dans `ar-breadcrumb` : `ar-breadcrumb-close` se déclenche deux fois lors d'une fermeture externe (clic en dehors ou Escape), car `onExternalClose` déclenche l'event directement puis `updated()` le redéclenche en réagissant au changement de la prop `open`. À corriger dans une PR séparée sur `packages/core/src/components/breadcrumb/breadcrumb.ts`.

Spec : `docs/superpowers/specs/2026-07-03-utilisation-sections-design.md`
Plan : `docs/superpowers/plans/2026-07-03-utilisation-sections.md`