### PR TITLE
fix(breadcrumb): supprime le double déclenchement de ar-breadcrumb-close

### DIFF
--- a/packages/core/src/components/breadcrumb/breadcrumb.browser.test.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.browser.test.ts
@@ -77,19 +77,19 @@ describe('ar-breadcrumb — browser', () => {
     });
 
     describe('light-dismiss', () => {
-        it('un hidePopover() externe ferme le panel et émet ar-breadcrumb-close', async () => {
+        it('un hidePopover() externe ferme le panel et émet ar-breadcrumb-close une seule fois', async () => {
             el = await mobileBreadcrumb();
-            const closeHandler = (() => {
-                (closeHandler as { called?: boolean }).called = true;
-            }) as EventListener & { called?: boolean };
-            el.addEventListener('ar-breadcrumb-close', closeHandler);
+            let callCount = 0;
+            el.addEventListener('ar-breadcrumb-close', () => {
+                callCount += 1;
+            });
             getBtn(el).click();
             await aTimeout(50);
 
             (getPanel(el) as HTMLElement & { hidePopover(): void }).hidePopover();
             await aTimeout(50);
 
-            expect(closeHandler.called).to.equal(true);
+            expect(callCount).to.equal(1);
             expect(getPanel(el).matches(':popover-open')).to.equal(false);
         });
     });

--- a/packages/core/src/components/breadcrumb/breadcrumb.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.ts
@@ -85,9 +85,6 @@ export class ArBreadcrumb extends LitElement {
         placement: 'bottom-end',
         onExternalClose: () => {
             this.open = false;
-            this.dispatchEvent(
-                new CustomEvent('ar-breadcrumb-close', { bubbles: true, composed: true }),
-            );
         },
     });
 


### PR DESCRIPTION
## Summary
- `onExternalClose` (fermeture externe du dropdown mobile : clic en dehors / Escape) dispatchait `ar-breadcrumb-close` directement, en plus de `updated()` qui le redispatche déjà lors du passage de `open` à `false` — l'event partait deux fois au lieu d'une.
- `updated()` reste l'unique source d'émission de l'event.

## Test plan
- [x] Test browser existant renforcé pour compter les émissions (`callCount`) au lieu d'un simple booléen — reproduit le bug (2 au lieu de 1) avant correctif
- [x] `npx web-test-runner` (packages/core) : 6/6 tests breadcrumb passent après correctif
- [x] `npx vitest run src/components/breadcrumb` : 40/40 tests unitaires passent

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)