### PR TITLE
feat(anchor): config globale distance/offset via custom properties CSS

### DIFF
--- a/apps/docs/src/content/components/ar-dropdown.mdx
+++ b/apps/docs/src/content/components/ar-dropdown.mdx
@@ -46,9 +46,9 @@ variants:
           </ar-dropdown>
     - name: distance
       label: Distance personnalisée
-      description: Espacement en pixels entre le trigger et le panel (axe principal). La valeur par défaut est 4px.
+      description: 'Espacement en pixels entre le trigger et le panel (axe principal), piloté par la custom property CSS `--ar-dropdown-distance` (défaut : `var(--ar-anchor-distance)`, 4px).'
       html: |
-          <ar-dropdown distance="16">
+          <ar-dropdown style="--ar-dropdown-distance: 16px">
               <button class="btn btn-secondary" slot="trigger">Distance 16px ▾</button>
               <ar-dropdown-item><button>Item 1</button></ar-dropdown-item>
               <ar-dropdown-item><button>Item 2</button></ar-dropdown-item>
@@ -56,9 +56,9 @@ variants:
           </ar-dropdown>
     - name: offset
       label: Offset latéral
-      description: Décalage latéral en pixels du panel par rapport au trigger (axe transversal). La valeur par défaut est 0.
+      description: 'Décalage latéral en pixels du panel par rapport au trigger (axe transversal), piloté par la custom property CSS `--ar-dropdown-offset` (défaut : `var(--ar-anchor-offset)`, 0).'
       html: |
-          <ar-dropdown offset="32">
+          <ar-dropdown style="--ar-dropdown-offset: 32px">
               <button class="btn btn-secondary" slot="trigger">Offset 32px ▾</button>
               <ar-dropdown-item><button>Item 1</button></ar-dropdown-item>
               <ar-dropdown-item><button>Item 2</button></ar-dropdown-item>

--- a/docs/superpowers/plans/2026-07-07-anchor-distance-offset-tokens.md
+++ b/docs/superpowers/plans/2026-07-07-anchor-distance-offset-tokens.md
@@ -166,13 +166,13 @@ Ajouter la méthode privée juste avant `_roundByDPR` :
     }
 ```
 
-- [ ] **Étape 4 : Vérifier que ça compile et que les tests passent (vert)**
+- [ ] **Étape 4 : Vérifier que ça compile (dans le périmètre de cette tâche) et que les tests passent (vert)**
 
 Run: `cd /Users/jon/Code/Active_projects/ariane/packages/core && npx tsc --noEmit`
-Expected: aucune erreur.
+Expected : aucune erreur liée à `popover.ts` ou `popover.browser.test.ts`. En revanche, il est **normal et attendu** que cette commande rapporte encore des erreurs dans exactement 4 fichiers hors périmètre de cette tâche — `anchored.controller.ts`, `tooltip.controller.ts`, `components/dropdown/dropdown.ts`, `components/tooltip/tooltip.ts` — car ils appellent encore `setDistance`/`setOffset`, supprimés ici. Ces 4 fichiers sont corrigés dans les Tasks 2, 3, 5, 6. Vérifier que les erreurs sont bien confinées à ces 4 fichiers, rien d'autre.
 
 Run: `cd /Users/jon/Code/Active_projects/ariane/packages/core && npx web-test-runner --group default --files "src/utils/popover.browser.test.ts"`
-Expected: tous les tests passent, y compris les 2 nouveaux.
+Expected: tous les tests passent, y compris les 2 nouveaux (web-test-runner transpile fichier par fichier via esbuild et ne type-check pas le reste du projet — les erreurs TS des 4 fichiers hors périmètre n'affectent pas ce test).
 
 - [ ] **Étape 5 : Commit**
 
@@ -336,10 +336,10 @@ Ajouter la méthode privée juste avant `hostConnected()` :
     }
 ```
 
-- [ ] **Étape 4 : Vérifier que ça compile et que les tests passent (vert)**
+- [ ] **Étape 4 : Vérifier que ça compile (dans le périmètre de cette tâche) et que les tests passent (vert)**
 
 Run: `cd /Users/jon/Code/Active_projects/ariane/packages/core && npx tsc --noEmit`
-Expected: aucune erreur.
+Expected : aucune erreur liée à `anchored.controller.ts` ou `anchored.controller.browser.test.ts`. Il est **normal et attendu** que cette commande rapporte encore des erreurs dans exactement 3 fichiers hors périmètre — `tooltip.controller.ts` (Task 3), `components/dropdown/dropdown.ts` (Task 5), `components/tooltip/tooltip.ts` (Task 6). Vérifier que les erreurs sont bien confinées à ces 3 fichiers, rien d'autre.
 
 Run: `cd /Users/jon/Code/Active_projects/ariane/packages/core && npx web-test-runner --group default --files "src/controllers/anchored.controller.browser.test.ts"`
 Expected: tous les tests passent, y compris les 2 nouveaux.

--- a/packages/core/src/components/breadcrumb/breadcrumb.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.ts
@@ -37,6 +37,8 @@ import { AnchoredController } from '../../controllers/anchored.controller.js';
  * @cssprop [--ar-breadcrumb-bullet-color=var(--ar-color-neutral-80)] - Couleur des puces de la liste mobile.
  * @cssprop [--ar-breadcrumb-panel-min-width=var(--ar-panel-min-width)] - Largeur min du panel mobile (cascade vers --ar-panel-min-width).
  * @cssprop [--ar-breadcrumb-panel-max-width=var(--ar-panel-max-width)] - Largeur max du panel mobile (cascade vers --ar-panel-max-width).
+ * @cssprop [--ar-breadcrumb-distance=var(--ar-anchor-distance)] - Espacement entre le trigger et le panel mobile.
+ * @cssprop [--ar-breadcrumb-offset=var(--ar-anchor-offset)] - Décalage latéral du panel mobile.
  *
  * @event {CustomEvent} ar-breadcrumb-open  - Émis à l'ouverture du dropdown mobile.
  * @event {CustomEvent} ar-breadcrumb-close - Émis à la fermeture du dropdown mobile.
@@ -83,6 +85,7 @@ export class ArBreadcrumb extends LitElement {
         lockScroll: false,
         popupMode: 'menu',
         placement: 'bottom-end',
+        cssVarPrefix: 'breadcrumb',
         onExternalClose: () => {
             this.open = false;
         },

--- a/packages/core/src/components/datepicker/datepicker.ts
+++ b/packages/core/src/components/datepicker/datepicker.ts
@@ -42,6 +42,8 @@ import styles from './datepicker.styles.js';
  * @csspart close-btn  - Bouton « Fermer ».
  *
  * @cssprop [--ar-datepicker-panel-width]        - Largeur du popover.
+ * @cssprop [--ar-datepicker-distance=var(--ar-anchor-distance)] - Espacement entre le trigger et le panel.
+ * @cssprop [--ar-datepicker-offset=var(--ar-anchor-offset)] - Décalage latéral du panel.
  * @cssprop [--ar-datepicker-header-font-size]         - Taille de police de l'en-tête.
  * @cssprop [--ar-datepicker-header-padding]           - Padding de l'en-tête.
  * @cssprop [--ar-datepicker-header-margin]            - Margin de l'en-tête.
@@ -113,6 +115,7 @@ export class ArDatepicker extends LitElement {
     private readonly _anchored = new AnchoredController(this, {
         popupMode: 'dialog',
         placement: 'bottom-start',
+        cssVarPrefix: 'datepicker',
         onExternalClose: () => {
             this.open = false;
             if (!document.activeElement || document.activeElement === document.body) {

--- a/packages/core/src/components/dropdown/dropdown.test.ts
+++ b/packages/core/src/components/dropdown/dropdown.test.ts
@@ -46,8 +46,6 @@ describe('ArDropdown', () => {
         it('placement="bottom-start"', () => expect(el.placement).toBe('bottom-start'));
         it('disabled=false', () => expect(el.disabled).toBe(false));
         it('noScrollLock=false', () => expect(el.noScrollLock).toBe(false));
-        it('distance=4', () => expect(el.distance).toBe(4));
-        it('offset=0', () => expect(el.offset).toBe(0));
         it('for=""', () => expect(el.for).toBe(''));
     });
 
@@ -81,18 +79,6 @@ describe('ArDropdown', () => {
             el.noScrollLock = true;
             await waitForUpdate(el);
             expect(el.hasAttribute('no-scroll-lock')).toBe(true);
-        });
-
-        it('distance reflète en attribut', async () => {
-            el.distance = 12;
-            await waitForUpdate(el);
-            expect(el.getAttribute('distance')).toBe('12');
-        });
-
-        it('offset reflète en attribut', async () => {
-            el.offset = 8;
-            await waitForUpdate(el);
-            expect(el.getAttribute('offset')).toBe('8');
         });
 
         it('for reflète en attribut', async () => {

--- a/packages/core/src/components/dropdown/dropdown.ts
+++ b/packages/core/src/components/dropdown/dropdown.ts
@@ -36,6 +36,8 @@ export type ArDropdownPlacement =
  * @cssprop [--ar-dropdown-border-color=var(--ar-panel-border-color)] - Bordure (cascade vers --ar-panel-border-color).
  * @cssprop [--ar-dropdown-border-radius=var(--ar-panel-radius)] - Arrondi (cascade vers --ar-panel-radius).
  * @cssprop [--ar-dropdown-shadow=var(--ar-panel-shadow)] - Ombre (cascade vers --ar-panel-shadow).
+ * @cssprop [--ar-dropdown-distance=var(--ar-anchor-distance)] - Espacement entre le trigger et le panel (axe principal).
+ * @cssprop [--ar-dropdown-offset=var(--ar-anchor-offset)] - Décalage latéral du panel (axe transversal).
  *
  * @event {CustomEvent} ar-dropdown-show    - Émis avant l'ouverture (annulable).
  * @event {CustomEvent} ar-dropdown-shown   - Émis après l'ouverture.
@@ -62,12 +64,6 @@ export class ArDropdown extends LitElement {
      */
     @property({ attribute: 'no-scroll-lock', reflect: true, type: Boolean }) noScrollLock = false;
 
-    /** Espacement en pixels entre le trigger et le panel (axe principal). */
-    @property({ reflect: true, type: Number }) distance = 4;
-
-    /** Décalage latéral en pixels du panel par rapport au trigger (axe transversal). */
-    @property({ reflect: true, type: Number }) offset = 0;
-
     /**
      * ID d'un élément déclencheur externe (light DOM). Quand défini, le slot
      * `trigger` est ignoré.
@@ -77,6 +73,7 @@ export class ArDropdown extends LitElement {
     @query('[part="panel"]') private _panel!: HTMLElement;
 
     private readonly _popover = new AnchoredController(this, {
+        cssVarPrefix: 'dropdown',
         onExternalClose: () => {
             this.open = false;
         },
@@ -115,12 +112,6 @@ export class ArDropdown extends LitElement {
         }
         if (changed.has('noScrollLock')) {
             this._popover.setLockScroll(!this.noScrollLock);
-        }
-        if (changed.has('distance')) {
-            this._popover.setDistance(this.distance);
-        }
-        if (changed.has('offset')) {
-            this._popover.setOffset(this.offset);
         }
         if (changed.has('for')) {
             this._externalTrigger?.removeEventListener('click', this._handleTriggerClick);

--- a/packages/core/src/components/stepper/stepper.ts
+++ b/packages/core/src/components/stepper/stepper.ts
@@ -67,6 +67,8 @@ export interface ArStepperStepChangeDetail {
  * @cssprop [--ar-stepper-bullet-radius=0.75rem]                                              - Border-radius de la puce.
  * @cssprop [--ar-stepper-label-color=var(--ar-color-text-muted)]                             - Couleur des labels des étapes inactives.
  * @cssprop [--ar-stepper-active-label-color=var(--ar-color-interactive)]                     - Couleur du label de l'étape active.
+ * @cssprop [--ar-stepper-distance=var(--ar-anchor-distance)]                                 - Espacement entre le trigger et le panel mobile.
+ * @cssprop [--ar-stepper-offset=var(--ar-anchor-offset)]                                     - Décalage latéral du panel mobile.
  *
  * @event {CustomEvent<{ path: string }>} ar-stepper-step-changed - Émis au clic sur une étape.
  */
@@ -160,6 +162,7 @@ export class ArStepper extends LitElement {
     private readonly _popover = new AnchoredController(this, {
         lockScroll: false,
         popupMode: 'menu',
+        cssVarPrefix: 'stepper',
         onExternalClose: () => {
             this.open = false;
         },

--- a/packages/core/src/components/tooltip/tooltip.test.ts
+++ b/packages/core/src/components/tooltip/tooltip.test.ts
@@ -51,8 +51,6 @@ describe('ArTooltip', () => {
         });
 
         it('placement="top"', () => expect(el.placement).toBe('top'));
-        it('distance=6', () => expect(el.distance).toBe(6));
-        it('offset=0', () => expect(el.offset).toBe(0));
         it('showDelay=300', () => expect(el.showDelay).toBe(300));
         it('hideDelay=150', () => expect(el.hideDelay).toBe(150));
         it('withoutArrow=false', () => expect(el.withoutArrow).toBe(false));

--- a/packages/core/src/components/tooltip/tooltip.ts
+++ b/packages/core/src/components/tooltip/tooltip.ts
@@ -39,7 +39,7 @@ export type ArTooltipPlacement =
  * @cssprop --ar-tooltip-font-size          - Taille de police.
  * @cssprop --ar-tooltip-max-width              - Largeur maximale.
  * @cssprop --ar-tooltip-arrow-size               - Taille du caret.
- * @cssprop [--ar-tooltip-distance=6px] - Espacement entre le trigger et la bulle.
+ * @cssprop [--ar-tooltip-distance=10px] - Espacement entre le trigger et la bulle.
  * @cssprop [--ar-tooltip-offset=var(--ar-anchor-offset)] - Décalage latéral de la bulle.
  */
 @customElement('ar-tooltip')

--- a/packages/core/src/components/tooltip/tooltip.ts
+++ b/packages/core/src/components/tooltip/tooltip.ts
@@ -39,6 +39,8 @@ export type ArTooltipPlacement =
  * @cssprop --ar-tooltip-font-size          - Taille de police.
  * @cssprop --ar-tooltip-max-width              - Largeur maximale.
  * @cssprop --ar-tooltip-arrow-size               - Taille du caret.
+ * @cssprop [--ar-tooltip-distance=6px] - Espacement entre le trigger et la bulle.
+ * @cssprop [--ar-tooltip-offset=var(--ar-anchor-offset)] - Décalage latéral de la bulle.
  */
 @customElement('ar-tooltip')
 export class ArTooltip extends LitElement {
@@ -49,12 +51,6 @@ export class ArTooltip extends LitElement {
 
     /** Placement Floating UI (12 valeurs, ex: "top", "bottom-start"). */
     @property({ reflect: true }) placement: ArTooltipPlacement = 'top';
-
-    /** Espacement trigger→bulle en px. */
-    @property({ reflect: true, type: Number }) distance = 6;
-
-    /** Décalage latéral en px. */
-    @property({ reflect: true, type: Number }) offset = 0;
 
     /** Délai avant affichage en ms (WCAG 1.4.13). */
     @property({
@@ -86,7 +82,10 @@ export class ArTooltip extends LitElement {
 
     @query('[part="bubble"]') private _bubble!: HTMLElement;
 
-    private readonly _tooltip = new TooltipController(this, { placement: 'top', distance: 6 });
+    private readonly _tooltip = new TooltipController(this, {
+        placement: 'top',
+        cssVarPrefix: 'tooltip',
+    });
     private _trigger: HTMLElement | null = null;
     private _showTimer = 0;
     private _hideTimer = 0;
@@ -103,8 +102,6 @@ export class ArTooltip extends LitElement {
             this._attachTrigger();
         }
         if (changed.has('placement')) this._tooltip.setPlacement(this.placement);
-        if (changed.has('distance')) this._tooltip.setDistance(this.distance);
-        if (changed.has('offset')) this._tooltip.setOffset(this.offset);
         if (changed.has('disabled') && this.disabled) {
             clearTimeout(this._showTimer);
             clearTimeout(this._hideTimer);

--- a/packages/core/src/components/tooltip/tooltip.ts
+++ b/packages/core/src/components/tooltip/tooltip.ts
@@ -33,7 +33,7 @@ export type ArTooltipPlacement =
  * @csspart arrow  - Le caret directionnel.
  *
  * @cssprop --ar-tooltip-bg                  - Fond de la bulle.
- * @cssprop --ar-tooltip-color]                  - Couleur du texte.
+ * @cssprop --ar-tooltip-color                  - Couleur du texte.
  * @cssprop --ar-tooltip-border-radius        - Arrondi.
  * @cssprop --ar-tooltip-padding    - Marge interne.
  * @cssprop --ar-tooltip-font-size          - Taille de police.

--- a/packages/core/src/controllers/anchored.controller.browser.test.ts
+++ b/packages/core/src/controllers/anchored.controller.browser.test.ts
@@ -201,4 +201,43 @@ describe('AnchoredController', () => {
             expect(trigger.getAttribute('aria-expanded')).to.equal('false');
         });
     });
+
+    describe('cssVarPrefix — lecture des custom properties CSS', () => {
+        function parseTranslateY(transform: string): number {
+            const match = transform.match(/translate\([-\d.]+px,\s*([-\d.]+)px\)/);
+            if (!match) throw new Error(`transform inattendu: ${transform}`);
+            return Number(match[1]);
+        }
+
+        it('lit --ar-<prefix>-distance sur le host et la répercute au positionnement', async () => {
+            const { host, panel, ctrl } = await setupAnchored({
+                cssVarPrefix: 'test',
+                placement: 'bottom-start',
+            });
+            host.style.setProperty('--ar-test-distance', '0px');
+            await ctrl.show();
+            const y0 = parseTranslateY(panel.style.transform);
+
+            host.style.setProperty('--ar-test-distance', '20px');
+            window.dispatchEvent(new Event('resize'));
+            await aTimeout(50);
+            const y1 = parseTranslateY(panel.style.transform);
+
+            expect(y1 - y0).to.be.closeTo(20, 1);
+            ctrl.hide();
+        });
+
+        it('sans cssVarPrefix, distance/offset valent 0', async () => {
+            const { panel, ctrl } = await setupAnchored({ placement: 'bottom-start' });
+            await ctrl.show();
+            const y0 = parseTranslateY(panel.style.transform);
+
+            window.dispatchEvent(new Event('resize'));
+            await aTimeout(50);
+            const y1 = parseTranslateY(panel.style.transform);
+
+            expect(y1).to.equal(y0);
+            ctrl.hide();
+        });
+    });
 });

--- a/packages/core/src/controllers/anchored.controller.ts
+++ b/packages/core/src/controllers/anchored.controller.ts
@@ -6,10 +6,11 @@ import { acquireScrollLock, isScrollLocked, releaseScrollLock } from '../utils/s
 export interface AnchoredControllerOptions {
     popupMode?: 'menu' | 'dialog';
     placement?: Placement;
-    /** Espacement perpendiculaire trigger→panel (mainAxis). Défaut : 4. */
-    distance?: number;
-    /** Décalage latéral (crossAxis). Défaut : 0. */
-    offset?: number;
+    /**
+     * Slug utilisé pour lire les custom properties CSS `--ar-<cssVarPrefix>-distance`
+     * et `--ar-<cssVarPrefix>-offset` sur l'hôte. Si omis, distance/offset valent 0.
+     */
+    cssVarPrefix?: string;
     /** Verrouille le scroll des ancêtres scrollables à l'ouverture. Défaut : true. */
     lockScroll?: boolean;
     /** Appelé lors d'un light-dismiss natif (popover auto). */
@@ -17,10 +18,12 @@ export interface AnchoredControllerOptions {
 }
 
 export class AnchoredController implements ReactiveController {
+    private readonly _host: HTMLElement;
     private _trigger: HTMLElement | null = null;
     private _scrollLocks: HTMLElement[] = [];
-    private _opts: Required<Omit<AnchoredControllerOptions, 'onExternalClose'>> & {
+    private _opts: Required<Omit<AnchoredControllerOptions, 'onExternalClose' | 'cssVarPrefix'>> & {
         onExternalClose?: () => void;
+        cssVarPrefix?: string;
     };
     private readonly _popover: Popover;
 
@@ -28,20 +31,20 @@ export class AnchoredController implements ReactiveController {
         host: ReactiveControllerHost & HTMLElement,
         options: AnchoredControllerOptions = {},
     ) {
+        this._host = host;
         this._opts = {
             popupMode: options.popupMode ?? 'menu',
             placement: options.placement ?? 'bottom-start',
-            distance: options.distance ?? 4,
-            offset: options.offset ?? 0,
             lockScroll: options.lockScroll ?? true,
+            ...(options.cssVarPrefix !== undefined && { cssVarPrefix: options.cssVarPrefix }),
             ...(options.onExternalClose !== undefined && {
                 onExternalClose: options.onExternalClose,
             }),
         };
         this._popover = new Popover(host, {
             placement: this._opts.placement,
-            distance: this._opts.distance,
-            offset: this._opts.offset,
+            distance: () => this._readCssVar('distance'),
+            offset: () => this._readCssVar('offset'),
             popoverType: 'auto',
             onExternalClose: () => {
                 this._releaseScrollLocks();
@@ -92,18 +95,17 @@ export class AnchoredController implements ReactiveController {
         this._popover.setPlacement(v);
     }
 
-    setDistance(v: number): void {
-        this._opts.distance = v;
-        this._popover.setDistance(v);
-    }
-
-    setOffset(v: number): void {
-        this._opts.offset = v;
-        this._popover.setOffset(v);
-    }
-
     setLockScroll(v: boolean): void {
         this._opts.lockScroll = v;
+    }
+
+    private _readCssVar(kind: 'distance' | 'offset'): number {
+        if (!this._opts.cssVarPrefix) return 0;
+        const raw = getComputedStyle(this._host)
+            .getPropertyValue(`--ar-${this._opts.cssVarPrefix}-${kind}`)
+            .trim();
+        const parsed = parseFloat(raw);
+        return Number.isFinite(parsed) ? parsed : 0;
     }
 
     hostConnected(): void {}

--- a/packages/core/src/controllers/tooltip.controller.ts
+++ b/packages/core/src/controllers/tooltip.controller.ts
@@ -4,25 +4,28 @@ import { Popover } from '../utils/popover.js';
 
 export interface TooltipControllerOptions {
     placement?: Placement;
-    /** Espacement perpendiculaire trigger→tooltip. Défaut : 6. */
-    distance?: number;
-    /** Décalage latéral. Défaut : 0. */
-    offset?: number;
+    /**
+     * Slug utilisé pour lire les custom properties CSS `--ar-<cssVarPrefix>-distance`
+     * et `--ar-<cssVarPrefix>-offset` sur l'hôte. Si omis, distance/offset valent 0.
+     */
+    cssVarPrefix?: string;
 }
 
 export class TooltipController implements ReactiveController {
     private readonly _host: ReactiveControllerHost & HTMLElement;
     private readonly _popover: Popover;
+    private readonly _cssVarPrefix: string | undefined;
 
     constructor(
         host: ReactiveControllerHost & HTMLElement,
         options: TooltipControllerOptions = {},
     ) {
         this._host = host;
+        this._cssVarPrefix = options.cssVarPrefix;
         this._popover = new Popover(host, {
             placement: options.placement ?? 'top',
-            distance: options.distance ?? 6,
-            offset: options.offset ?? 0,
+            distance: () => this._readCssVar('distance'),
+            offset: () => this._readCssVar('offset'),
             popoverType: 'manual',
         });
         host.addController(this);
@@ -51,14 +54,6 @@ export class TooltipController implements ReactiveController {
         this._popover.setPlacement(v);
     }
 
-    setDistance(v: number): void {
-        this._popover.setDistance(v);
-    }
-
-    setOffset(v: number): void {
-        this._popover.setOffset(v);
-    }
-
     setArrow(el: HTMLElement | null): void {
         this._popover.setArrow(el);
     }
@@ -67,5 +62,14 @@ export class TooltipController implements ReactiveController {
 
     hostDisconnected(): void {
         this._popover.destroy();
+    }
+
+    private _readCssVar(kind: 'distance' | 'offset'): number {
+        if (!this._cssVarPrefix) return 0;
+        const raw = getComputedStyle(this._host)
+            .getPropertyValue(`--ar-${this._cssVarPrefix}-${kind}`)
+            .trim();
+        const parsed = parseFloat(raw);
+        return Number.isFinite(parsed) ? parsed : 0;
     }
 }

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -343,12 +343,16 @@
         --ar-button-ratio-square-lg-width: 3rem;
 
         /* breadcrumb */
+        --ar-breadcrumb-distance: var(--ar-anchor-distance);
+        --ar-breadcrumb-offset: var(--ar-anchor-offset);
         --ar-breadcrumb-separator-color: var(--ar-color-neutral-80);
         --ar-breadcrumb-bullet-color: var(--ar-color-neutral-80);
         --ar-breadcrumb-panel-min-width: var(--ar-panel-min-width);
         --ar-breadcrumb-panel-max-width: var(--ar-panel-max-width);
 
         /* stepper */
+        --ar-stepper-distance: var(--ar-anchor-distance);
+        --ar-stepper-offset: var(--ar-anchor-offset);
         --ar-stepper-label-color: var(--ar-color-text-muted);
         --ar-stepper-bullet-radius: 0.75rem;
         --ar-stepper-bullet-color: var(--ar-color-interactive);
@@ -377,6 +381,8 @@
         --ar-spinner-stroke-color: currentColor;
 
         /* tooltip */
+        --ar-tooltip-distance: 6px;
+        --ar-tooltip-offset: var(--ar-anchor-offset);
         --ar-tooltip-bg: var(--ar-color-neutral-20);
         --ar-tooltip-color: var(--ar-color-white);
         --ar-tooltip-border-radius: var(--ar-border-radius-sm);
@@ -395,7 +401,13 @@
         --ar-panel-min-width: 18rem;
         --ar-panel-max-width: 18rem;
 
+        /* anchor (partagé — positionnement des composants ancrés / popovers) */
+        --ar-anchor-distance: 4px;
+        --ar-anchor-offset: 0px;
+
         /* dropdown */
+        --ar-dropdown-distance: var(--ar-anchor-distance);
+        --ar-dropdown-offset: var(--ar-anchor-offset);
         --ar-dropdown-bg: var(--ar-panel-bg);
         --ar-dropdown-color: var(--ar-panel-text);
         --ar-dropdown-border-color: var(--ar-panel-border-color);
@@ -457,6 +469,8 @@
          * ar-datepicker
          * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
 
+        --ar-datepicker-distance: var(--ar-anchor-distance);
+        --ar-datepicker-offset: var(--ar-anchor-offset);
         --ar-datepicker-gap: 0.35rem;
         --ar-datepicker-label-gap: 0.5rem;
         --ar-datepicker-error-color: var(--ar-color-red-50);

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -381,7 +381,7 @@
         --ar-spinner-stroke-color: currentColor;
 
         /* tooltip */
-        --ar-tooltip-distance: 6px;
+        --ar-tooltip-distance: 10px;
         --ar-tooltip-offset: var(--ar-anchor-offset);
         --ar-tooltip-bg: var(--ar-color-neutral-20);
         --ar-tooltip-color: var(--ar-color-white);

--- a/packages/core/src/utils/popover.browser.test.ts
+++ b/packages/core/src/utils/popover.browser.test.ts
@@ -11,6 +11,9 @@ class TestPopoverHost extends LitElement {
         this.updateCount++;
         return super.requestUpdate();
     }
+    override render() {
+        return html`<slot></slot>`;
+    }
 }
 
 declare global {
@@ -143,6 +146,48 @@ describe('Popover', () => {
             await popover.show();
             popover.destroy();
             expect(panel.matches(':popover-open')).to.equal(false);
+        });
+    });
+
+    describe('distance / offset — fonction résolue à chaque repositionnement', () => {
+        function parseTranslate(transform: string): { x: number; y: number } {
+            const match = transform.match(/translate\(([-\d.]+)px,\s*([-\d.]+)px\)/);
+            if (!match) throw new Error(`transform inattendu: ${transform}`);
+            return { x: Number(match[1]), y: Number(match[2]) };
+        }
+
+        it('distance en fonction est résolue et prise en compte au recalcul (autoUpdate)', async () => {
+            let distance = 0;
+            const { panel, popover } = await setupPopover({
+                placement: 'bottom-start',
+                distance: () => distance,
+            });
+            await popover.show();
+            const y0 = parseTranslate(panel.style.transform).y;
+
+            distance = 20;
+            window.dispatchEvent(new Event('resize'));
+            await aTimeout(50);
+            const y1 = parseTranslate(panel.style.transform).y;
+
+            expect(y1 - y0).to.be.closeTo(20, 1);
+        });
+
+        it('offset en fonction est résolu et pris en compte au recalcul (autoUpdate)', async () => {
+            let lateral = 0;
+            const { panel, popover } = await setupPopover({
+                placement: 'bottom-start',
+                offset: () => lateral,
+            });
+            await popover.show();
+            const x0 = parseTranslate(panel.style.transform).x;
+
+            lateral = 15;
+            window.dispatchEvent(new Event('resize'));
+            await aTimeout(50);
+            const x1 = parseTranslate(panel.style.transform).x;
+
+            expect(x1 - x0).to.be.closeTo(15, 1);
         });
     });
 });

--- a/packages/core/src/utils/popover.ts
+++ b/packages/core/src/utils/popover.ts
@@ -6,10 +6,10 @@ type PopoverPanel = HTMLElement & { showPopover(): void; hidePopover(): void };
 
 export interface PopoverOptions {
     placement?: Placement;
-    /** Espacement perpendiculaire trigger→panel (mainAxis). Défaut : 4. */
-    distance?: number;
-    /** Décalage latéral (crossAxis). Défaut : 0. */
-    offset?: number;
+    /** Espacement perpendiculaire trigger→panel (mainAxis) en px, statique ou résolu à chaque repositionnement. Défaut : 0. */
+    distance?: number | (() => number);
+    /** Décalage latéral (crossAxis) en px, statique ou résolu à chaque repositionnement. Défaut : 0. */
+    offset?: number | (() => number);
     popoverType?: 'auto' | 'manual';
     /** Appelé lors du light-dismiss natif (popoverType 'auto' uniquement). */
     onExternalClose?: () => void;
@@ -32,7 +32,7 @@ export class Popover {
         this._host = host;
         this._opts = {
             placement: options.placement ?? 'bottom-start',
-            distance: options.distance ?? 4,
+            distance: options.distance ?? 0,
             offset: options.offset ?? 0,
             popoverType: options.popoverType ?? 'auto',
             ...(options.onExternalClose !== undefined && {
@@ -48,14 +48,6 @@ export class Popover {
 
     setPlacement(v: Placement): void {
         this._opts.placement = v;
-    }
-
-    setDistance(v: number): void {
-        this._opts.distance = v;
-    }
-
-    setOffset(v: number): void {
-        this._opts.offset = v;
     }
 
     setArrow(el: HTMLElement | null): void {
@@ -141,7 +133,10 @@ export class Popover {
                 placement: this._opts.placement,
                 strategy: 'absolute',
                 middleware: [
-                    offset({ mainAxis: this._opts.distance, crossAxis: this._opts.offset }),
+                    offset({
+                        mainAxis: this._resolve(this._opts.distance),
+                        crossAxis: this._resolve(this._opts.offset),
+                    }),
                     flip(),
                     ...(arrowEl ? [arrow({ element: arrowEl })] : []),
                     shift({ padding: 4 }),
@@ -171,6 +166,10 @@ export class Popover {
                 [staticSide]: `-${halfSize}px`,
             });
         }
+    }
+
+    private _resolve(v: number | (() => number)): number {
+        return typeof v === 'function' ? v() : v;
     }
 
     private _roundByDPR(value: number): number {


### PR DESCRIPTION
## Summary
- Remplace le réglage `distance`/`offset` par attribut JS (`ar-tooltip`, `ar-dropdown`) par des custom properties CSS lues à chaque repositionnement, appliquées aux 5 composants ancrés (`ar-dropdown`, `ar-tooltip`, `ar-datepicker`, `ar-stepper`, `ar-breadcrumb`).
- Nouveau token global `--ar-anchor-distance`/`--ar-anchor-offset` (surchargeable par composant via `--ar-<nom>-distance`/`-offset`, ou par instance).
- `Popover`/`AnchoredController`/`TooltipController` : `distance`/`offset` deviennent `number | (() => number)`, résolus à chaque recalcul de position (`autoUpdate` de Floating UI) — réactif aux changements CSS à chaud.

## Breaking change
Les attributs `distance`/`offset` de `ar-tooltip` et `ar-dropdown` sont retirés. Utiliser les custom properties CSS `--ar-tooltip-distance`/`-offset` et `--ar-dropdown-distance`/`-offset` (ou `--ar-anchor-distance`/`-offset` pour un réglage global).

Voir le design complet : `docs/superpowers/specs/2026-07-07-anchor-distance-offset-tokens-design.md`
Plan d'implémentation : `docs/superpowers/plans/2026-07-07-anchor-distance-offset-tokens.md`

## Test plan
- [x] `npm run lint`
- [x] `npm run test` (Vitest, 652/652)
- [x] `npm run test:all` (Vitest + web-test-runner/Chromium, 220/220 browser)
- [x] `npm run build` (packages/core) — vérifie la génération du manifeste CEM avec les nouveaux `@cssprop`
- [x] Démos playground `ar-dropdown` (distance/offset) mises à jour pour utiliser les custom properties CSS

Exécuté en subagent-driven-development : 9 tâches, chacune revue individuellement (spec + qualité), puis revue globale de branche (1 finding important corrigé : démos doc dropdown obsolètes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)