### PR TITLE
fix(breadcrumb): retire dark/high-contrast morts, ajoute --ar-breadcrumb-color

### DIFF
--- a/apps/docs/src/content/components/ar-breadcrumb.mdx
+++ b/apps/docs/src/content/components/ar-breadcrumb.mdx
@@ -12,15 +12,6 @@ variants:
             <ar-breadcrumb-item label="Mon journal de recherche d'emploi" href="/journal"></ar-breadcrumb-item>
             <ar-breadcrumb-item label="Publiez vos offres d'emploi"></ar-breadcrumb-item>
           </ar-breadcrumb>
-    - name: dark
-      label: Thème sombre
-      description: Variante avec le thème sombre activé.
-      html: |
-          <ar-breadcrumb dark>
-            <ar-breadcrumb-item label="Accueil Espace Personnel" href="/accueil"></ar-breadcrumb-item>
-            <ar-breadcrumb-item label="Mon journal de recherche d'emploi" href="/journal"></ar-breadcrumb-item>
-            <ar-breadcrumb-item label="Publiez vos offres d'emploi"></ar-breadcrumb-item>
-          </ar-breadcrumb>
 ---
 
 import WcagRef from '../../components/WcagRef.astro';
@@ -71,3 +62,16 @@ breadcrumb.addEventListener('ar-breadcrumb-close', () => console.log('Dropdown f
 ```
 
 Ces événements se déclenchent à chaque changement d'état du dropdown : clic sur le bouton toggle, mise à jour programmatique de la prop `open`, ou fermeture externe (clic en dehors, `Escape`) — pratique pour synchroniser un état d'UI externe ou pour de l'analytics.
+
+### Sur un fond sombre ponctuel
+
+`--ar-breadcrumb-color` hérite du token sémantique `--ar-color-text`, qui s'inverse déjà
+automatiquement avec `[data-theme="dark"]`. Si le breadcrumb est posé sur un fond sombre
+**indépendamment du thème global** (bannière, section à fond coloré...), surchargez le token
+localement pour garantir la lisibilité :
+
+```css
+.hero ar-breadcrumb {
+    --ar-breadcrumb-color: white;
+}
+```

--- a/packages/core/src/components/breadcrumb/breadcrumb.styles.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.styles.ts
@@ -17,7 +17,7 @@ export default css`
         padding: 0;
         border-radius: 0;
         background-color: transparent;
-        color: var(--ar-color-text);
+        color: var(--ar-breadcrumb-color);
     }
 
     .breadcrumb-link {
@@ -50,12 +50,8 @@ export default css`
     }
 
     .breadcrumb-item.active {
-        color: var(--ar-color-text);
+        color: var(--ar-breadcrumb-color);
         font-weight: 700;
-    }
-
-    .high-contrast .breadcrumb-item.active {
-        color: var(--ar-color-text);
     }
 
     /* ── Desktop layout ──────────────────────────────────────── */
@@ -78,10 +74,6 @@ export default css`
         width: 1px;
         transform: rotate(15deg);
         transform-origin: center;
-    }
-
-    .high-contrast .breadcrumb-desktop .breadcrumb-item + .breadcrumb-item:before {
-        background-color: var(--ar-color-text);
     }
 
     /* ── Mobile layout ───────────────────────────────────────── */
@@ -107,10 +99,6 @@ export default css`
         margin: 0 0.75rem;
         flex-shrink: 0;
         box-shadow: 0 0 0 2px var(--ar-color-bg);
-    }
-
-    .high-contrast .breadcrumb-mobile .breadcrumb-item:before {
-        background-color: var(--ar-color-neutral-50);
     }
 
     .breadcrumb-mobile .breadcrumb-item:first-child:before,
@@ -143,10 +131,6 @@ export default css`
         background-size: 2px 8px;
         background-position: center 4px;
         background-repeat: repeat-y;
-    }
-
-    .high-contrast .breadcrumb-mobile:before {
-        background-image: linear-gradient(var(--ar-color-neutral-70) 25%, transparent 0);
     }
 
     /* ── Wrapper dropdown mobile ────────────────────────────── */

--- a/packages/core/src/components/breadcrumb/breadcrumb.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.ts
@@ -33,6 +33,7 @@ import { AnchoredController } from '../../controllers/anchored.controller.js';
  * @csspart trigger    - Le bouton d'ouverture du panel mobile.
  * @csspart panel      - Le panel mobile flottant.
  *
+ * @cssprop [--ar-breadcrumb-color=var(--ar-color-text)] - Couleur du texte (labels et lien actif). À surcharger localement pour un fond sombre ponctuel, indépendamment du thème global.
  * @cssprop [--ar-breadcrumb-separator-color=var(--ar-color-neutral-80)] - Couleur du séparateur entre les items (desktop).
  * @cssprop [--ar-breadcrumb-bullet-color=var(--ar-color-neutral-80)] - Couleur des puces de la liste mobile.
  * @cssprop [--ar-breadcrumb-panel-min-width=var(--ar-panel-min-width)] - Largeur min du panel mobile (cascade vers --ar-panel-min-width).

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -345,6 +345,7 @@
         /* breadcrumb */
         --ar-breadcrumb-distance: var(--ar-anchor-distance);
         --ar-breadcrumb-offset: var(--ar-anchor-offset);
+        --ar-breadcrumb-color: var(--ar-color-text);
         --ar-breadcrumb-separator-color: var(--ar-color-neutral-80);
         --ar-breadcrumb-bullet-color: var(--ar-color-neutral-80);
         --ar-breadcrumb-panel-min-width: var(--ar-panel-min-width);


### PR DESCRIPTION
## Résumé

- Retire l'attribut `dark` documenté dans `ar-breadcrumb.mdx` — jamais lu par le composant (vestige mARIAnne, antérieur au refacto CSS tokens).
- Retire les 4 sélecteurs `.high-contrast` de `breadcrumb.styles.ts` — classe jamais posée nulle part dans le projet, CSS mort.
- Ajoute le token `--ar-breadcrumb-color` (défaut `var(--ar-color-text)`) pour couvrir le besoin d'origine derrière `dark` : permettre de forcer la couleur du texte sur un fond sombre ponctuel, indépendamment du thème global `[data-theme="dark"]`. Documenté dans `ar-breadcrumb.mdx`.

## Test plan

- [x] `npx vitest run` (packages/core) — 658 tests passent
- [x] `npx tsc --noEmit` — propre
- [x] `npx prettier --check` sur les fichiers modifiés — propre
- [x] `npm run build:manifest` — `--ar-breadcrumb-color` apparaît correctement dans le manifest CEM