### PR TITLE
fix(pagination): retire le clone Bootstrap mort et les règles dupliquées

### DIFF
--- a/packages/core/src/components/pagination/pagination.styles.ts
+++ b/packages/core/src/components/pagination/pagination.styles.ts
@@ -5,101 +5,11 @@ export default css`
         display: block;
         box-sizing: border-box;
     }
-    /* Pagination */
+
     .pagination {
         padding-left: 0;
         list-style: none;
         border-radius: 0.5rem;
-    }
-
-    .page-link {
-        position: relative;
-        display: block;
-        padding: 0.5rem 0.75rem;
-        margin-left: -1px;
-        line-height: 1.25;
-        background-color: var(--ar-color-bg);
-        border: 1px solid var(--ar-color-border);
-    }
-
-    .page-link,
-    .page-link:hover {
-        color: var(--ar-color-interactive);
-        text-decoration: none;
-    }
-
-    .page-link:hover {
-        z-index: 2;
-        background-color: var(--ar-color-bg-subtle);
-        border-color: var(--ar-color-border);
-    }
-
-    .page-link:focus {
-        z-index: 3;
-        outline: 0;
-        -webkit-box-shadow: 0 0 0 0.2rem rgba(40, 50, 118, 0.25);
-        box-shadow: 0 0 0 0.2rem rgba(40, 50, 118, 0.25);
-    }
-
-    .page-item:first-child .page-link {
-        margin-left: 0;
-        border-top-left-radius: 0.5rem;
-        border-bottom-left-radius: 0.5rem;
-    }
-
-    .page-item:last-child .page-link {
-        border-top-right-radius: 0.5rem;
-        border-bottom-right-radius: 0.5rem;
-    }
-
-    .page-item.active .page-link {
-        z-index: 3;
-        color: var(--ar-color-text-inverse);
-        background-color: var(--ar-color-interactive);
-        border-color: var(--ar-color-interactive);
-    }
-
-    .page-item.disabled .page-link {
-        color: var(--ar-color-text-muted);
-        pointer-events: none;
-        cursor: auto;
-        background-color: var(--ar-color-bg);
-        border-color: var(--ar-color-border);
-    }
-
-    .pagination-lg .page-link {
-        padding: 0.75rem 1.5rem;
-        font-size: 1.25rem;
-        line-height: 1.5;
-    }
-
-    .pagination-lg .page-item:first-child .page-link {
-        border-top-left-radius: 0.75rem;
-        border-bottom-left-radius: 0.75rem;
-    }
-
-    .pagination-lg .page-item:last-child .page-link {
-        border-top-right-radius: 0.75rem;
-        border-bottom-right-radius: 0.75rem;
-    }
-
-    .pagination-sm .page-link {
-        padding: 0.25rem 0.5rem;
-        font-size: 0.875rem;
-        line-height: 1.5;
-    }
-
-    .pagination-sm .page-item:first-child .page-link {
-        border-top-left-radius: 0.25rem;
-        border-bottom-left-radius: 0.25rem;
-    }
-
-    .pagination-sm .page-item:last-child .page-link {
-        border-top-right-radius: 0.25rem;
-        border-bottom-right-radius: 0.25rem;
-    }
-
-    .pagination {
         display: -webkit-box;
         display: -ms-flexbox;
         display: flex;
@@ -110,6 +20,7 @@ export default css`
         flex-wrap: wrap;
         margin-bottom: 0;
     }
+
     .pagination .btn-tertiary {
         aspect-ratio: 1/1;
         padding: 0;
@@ -122,46 +33,6 @@ export default css`
         -webkit-box-pack: center;
         -ms-flex-pack: center;
         justify-content: center;
-        margin: 0 0.125rem;
-    }
-    @media only screen and (max-width: 640px) {
-        .pagination
-            li:not(.active):not([aria-hidden='true']):not(:first-child):not(:last-child):not(
-                :nth-child(2)
-            ):not(:nth-last-child(2)) {
-            display: none;
-        }
-    }
-
-    .pagination-item.active .btn-tertiary {
-        z-index: 3;
-        color: var(--ar-color-text-inverse);
-        background-color: var(--ar-color-interactive);
-        font-weight: 700;
-    }
-    .pagination-item[aria-hidden='true'] .btn-tertiary:not([aria-disabled='true']) {
-        background: none !important;
-        -webkit-box-shadow: none !important;
-        box-shadow: none !important;
-        cursor: default !important;
-        border-color: transparent !important;
-    }
-    .pagination,
-    .pagination .btn-tertiary {
-        display: -webkit-box;
-        display: -ms-flexbox;
-        display: flex;
-        -webkit-box-pack: center;
-        -ms-flex-pack: center;
-        justify-content: center;
-    }
-
-    .pagination .btn-tertiary {
-        aspect-ratio: 1/1;
-        padding: 0;
-        -webkit-box-align: center;
-        -ms-flex-align: center;
-        align-items: center;
         margin: 0 0.125rem;
     }
 
@@ -188,9 +59,6 @@ export default css`
         box-shadow: none !important;
         cursor: default !important;
         border-color: transparent !important;
-    }
-
-    .pagination-item[aria-hidden='true'] .btn-tertiary:not([aria-disabled='true']) {
         color: var(--ar-color-text) !important;
     }
 `;


### PR DESCRIPTION
## Résumé

Suite de l'audit CSS entamé sur button.styles.ts (#91, #92) et reset.styles.ts (#93).

- `pagination.styles.ts` contenait un clone Bootstrap complet (`.page-link`, `.page-item`, `.pagination-lg`, `.pagination-sm`) jamais utilisé — `ar-pagination` rend `.pagination-item`/`.btn-tertiary`, pas ces classes. Ces ~90 lignes mortes emportaient avec elles le seul `box-shadow` non tokenisé du fichier (`rgba(40, 50, 118, 0.25)`).
- Le reste était dupliqué : `.pagination` et `.pagination .btn-tertiary` définis 2-3 fois, la media query 640px répétée à l'identique, et `.pagination-item.active .btn-tertiary` défini deux fois avec des valeurs **contradictoires** — la version sans token (`background-color: var(--ar-color-interactive)`) était silencieusement morte, écrasée en cascade par la version avec le token documenté `--ar-pagination-active-color`. Seule cette dernière est conservée.
- 197 → 60 lignes.

## Test plan

- [x] `npm run test` — 659 tests unitaires passent
- [x] `npm run test:browser` — 220 tests Chromium passent
- [x] `npm run build` — build propre
- [x] Vérification visuelle (Playwright + docs dev server) : rendu de `ar-pagination` (page active encerclée, prev/next désactivés) identique avant/après

🤖 Generated with [Claude Code](https://claude.com/claude-code)