### PR TITLE
feat(core): tokens scopés par composant pour les boutons partagés

### DIFF
--- a/packages/core/src/components/breadcrumb/breadcrumb.styles.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.styles.ts
@@ -146,4 +146,31 @@ export default css`
         min-width: var(--ar-breadcrumb-panel-min-width);
         max-width: var(--ar-breadcrumb-panel-max-width);
     }
+
+    /* ── Boutons trigger/home mobile (tokens scopés au composant) ──────────
+     * #mobile-home-btn gagne la cascade par spécificité d'ID. [part='trigger']
+     * reçoit .btn + l'attribut pour dépasser .btn-tertiary dans
+     * button.styles.ts, indépendamment de l'ordre des styles. */
+
+    #mobile-home-btn,
+    [part='trigger'].btn.btn-tertiary {
+        background-color: var(--ar-breadcrumb-toggle-bg);
+    }
+
+    #mobile-home-btn:hover,
+    [part='trigger'].btn.btn-tertiary:hover {
+        background-color: var(--ar-breadcrumb-toggle-bg-hover);
+    }
+
+    #mobile-home-btn:not(:disabled):not(.disabled):not([aria-disabled='true']):active,
+    [part='trigger'].btn.btn-tertiary:not(:disabled):not(.disabled):not(
+            [aria-disabled='true']
+        ):active {
+        background-color: var(--ar-breadcrumb-toggle-bg-pressed);
+    }
+
+    #mobile-home-btn:focus,
+    [part='trigger'].btn.btn-tertiary:focus {
+        background-color: var(--ar-breadcrumb-toggle-bg-focus);
+    }
 `;

--- a/packages/core/src/components/breadcrumb/breadcrumb.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.ts
@@ -41,6 +41,10 @@ import { AnchoredController } from '../../controllers/anchored.controller.js';
  * @cssprop [--ar-breadcrumb-panel-max-width=var(--ar-panel-max-width)] - Largeur max du panel mobile (cascade vers --ar-panel-max-width).
  * @cssprop [--ar-breadcrumb-distance=var(--ar-anchor-distance)] - Espacement entre le trigger et le panel mobile.
  * @cssprop [--ar-breadcrumb-offset=var(--ar-anchor-offset)] - Décalage latéral du panel mobile.
+ * @cssprop [--ar-breadcrumb-toggle-bg=var(--ar-button-tertiary-bg)] - Fond du bouton retour/trigger mobile.
+ * @cssprop [--ar-breadcrumb-toggle-bg-hover=var(--ar-button-tertiary-bg-hover)] - Fond du bouton retour/trigger mobile au survol.
+ * @cssprop [--ar-breadcrumb-toggle-bg-pressed=var(--ar-button-tertiary-bg-active)] - Fond du bouton retour/trigger mobile pressé.
+ * @cssprop [--ar-breadcrumb-toggle-bg-focus=var(--ar-button-tertiary-bg-focus)] - Fond du bouton retour/trigger mobile au focus.
  *
  * @event {CustomEvent} ar-breadcrumb-open  - Émis à l'ouverture du dropdown mobile.
  * @event {CustomEvent} ar-breadcrumb-close - Émis à la fermeture du dropdown mobile.

--- a/packages/core/src/components/dialog/dialog.styles.ts
+++ b/packages/core/src/components/dialog/dialog.styles.ts
@@ -187,6 +187,29 @@ export default [
             flex-shrink: 0;
         }
 
+        /* ── Bouton de fermeture (tokens scopés au composant) ────────────────────
+         * Sélecteurs volontairement plus spécifiques que .btn-tertiary.light dans
+         * button.styles.ts (ajout de [part='close'].btn) pour gagner la cascade
+         * indépendamment de l'ordre des styles. */
+
+        [part='close'].btn.btn-tertiary.light {
+            background-color: var(--ar-dialog-close-bg);
+        }
+
+        [part='close'].btn.btn-tertiary.light:hover {
+            background-color: var(--ar-dialog-close-bg-hover);
+        }
+
+        [part='close'].btn.btn-tertiary.light:not(:disabled):not(.disabled):not(
+                [aria-disabled='true']
+            ):active {
+            background-color: var(--ar-dialog-close-bg-pressed);
+        }
+
+        [part='close'].btn.btn-tertiary.light:focus {
+            background-color: var(--ar-dialog-close-bg-focus);
+        }
+
         /* ── Shake (fermeture bloquée) ────────────────────────────────────────── */
 
         dialog.shake {

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -65,6 +65,10 @@ if (typeof document !== 'undefined') {
  * @cssprop [--spacing=1.25rem] - Padding interne (block et inline) de la zone de contenu.
  * @cssprop [--spacing-block] - Padding haut/bas. Prend le pas sur `--spacing` si défini.
  * @cssprop [--spacing-inline] - Padding gauche/droite. Prend le pas sur `--spacing` si défini.
+ * @cssprop [--ar-dialog-close-bg=var(--ar-button-tertiary-bg)] - Fond du bouton de fermeture.
+ * @cssprop [--ar-dialog-close-bg-hover=var(--ar-button-tertiary-bg-hover)] - Fond du bouton de fermeture au survol.
+ * @cssprop [--ar-dialog-close-bg-pressed=var(--ar-button-tertiary-bg-active)] - Fond du bouton de fermeture pressé.
+ * @cssprop [--ar-dialog-close-bg-focus=var(--ar-button-tertiary-bg-focus)] - Fond du bouton de fermeture au focus.
  *
  * @event {CustomEvent} ar-dialog-show - Émis avant l'ouverture. Annulable.
  * @event {CustomEvent} ar-dialog-shown - Émis après l'ouverture (après updateComplete).

--- a/packages/core/src/components/pagination/pagination.styles.ts
+++ b/packages/core/src/components/pagination/pagination.styles.ts
@@ -45,6 +45,30 @@ export default css`
         }
     }
 
+    /* ── Boutons prev/next/page (tokens scopés au composant) ──────────────────
+     * Sélecteurs volontairement plus spécifiques que a.btn-tertiary.light dans
+     * button.styles.ts (ajout de .pagination + .btn) pour gagner la cascade
+     * indépendamment de l'ordre des styles. Ne cible que les <a> (prev/next/
+     * page non active) — la page courante est un <span>, gérée séparément par
+     * --ar-pagination-active-color ci-dessous. */
+
+    .pagination a.btn.btn-tertiary.light {
+        background-color: var(--ar-pagination-bg);
+    }
+
+    .pagination a.btn.btn-tertiary.light:hover {
+        background-color: var(--ar-pagination-bg-hover);
+    }
+
+    .pagination
+        a.btn.btn-tertiary.light:not(:disabled):not(.disabled):not([aria-disabled='true']):active {
+        background-color: var(--ar-pagination-bg-pressed);
+    }
+
+    .pagination a.btn.btn-tertiary.light:focus {
+        background-color: var(--ar-pagination-bg-focus);
+    }
+
     .pagination-item.active .btn-tertiary {
         z-index: 3;
         color: var(--ar-pagination-active-color);

--- a/packages/core/src/components/pagination/pagination.ts
+++ b/packages/core/src/components/pagination/pagination.ts
@@ -43,6 +43,10 @@ export interface ArPaginationPageChangeDetail {
  * @csspart next     - Le bouton "Page suivante".
  *
  * @cssprop [--ar-pagination-active-color=var(--ar-color-interactive)] - Couleur de la page active (texte + bordure).
+ * @cssprop [--ar-pagination-bg=var(--ar-button-tertiary-bg)] - Fond des boutons prev/next/page (non actifs).
+ * @cssprop [--ar-pagination-bg-hover=var(--ar-button-tertiary-bg-hover)] - Fond des boutons prev/next/page au survol.
+ * @cssprop [--ar-pagination-bg-pressed=var(--ar-button-tertiary-bg-active)] - Fond des boutons prev/next/page pressés.
+ * @cssprop [--ar-pagination-bg-focus=var(--ar-button-tertiary-bg-focus)] - Fond des boutons prev/next/page au focus.
  *
  * @event {CustomEvent<{from: number, to: number}>} ar-pagination-page-change - Émis à chaque changement de page. Contient `from` et `to`.
  */

--- a/packages/core/src/components/stepper/stepper.styles.ts
+++ b/packages/core/src/components/stepper/stepper.styles.ts
@@ -31,6 +31,16 @@ export default css`
         text-align: left;
     }
 
+    /* Tokens scopés au composant — .btn + [part='trigger'] pour dépasser
+     * .btn-secondary dans button.styles.ts, indépendamment de l'ordre des styles. */
+    [part='trigger'].btn.btn-secondary {
+        background-color: var(--ar-stepper-trigger-bg);
+    }
+
+    [part='trigger'].btn.btn-secondary:hover {
+        background-color: var(--ar-stepper-trigger-bg-hover);
+    }
+
     [part='panel'] {
         padding: 0.75rem;
         min-width: var(--ar-stepper-panel-min-width);

--- a/packages/core/src/components/stepper/stepper.ts
+++ b/packages/core/src/components/stepper/stepper.ts
@@ -69,6 +69,8 @@ export interface ArStepperStepChangeDetail {
  * @cssprop [--ar-stepper-active-label-color=var(--ar-color-interactive)]                     - Couleur du label de l'étape active.
  * @cssprop [--ar-stepper-distance=var(--ar-anchor-distance)]                                 - Espacement entre le trigger et le panel mobile.
  * @cssprop [--ar-stepper-offset=var(--ar-anchor-offset)]                                     - Décalage latéral du panel mobile.
+ * @cssprop [--ar-stepper-trigger-bg=var(--ar-button-secondary-bg)]                             - Fond du bouton trigger mobile.
+ * @cssprop [--ar-stepper-trigger-bg-hover=var(--ar-button-secondary-bg-hover)]                 - Fond du bouton trigger mobile au survol.
  *
  * @event {CustomEvent<{ path: string }>} ar-stepper-step-changed - Émis au clic sur une étape.
  */

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -345,6 +345,10 @@
         --ar-breadcrumb-bullet-color: var(--ar-color-neutral-80);
         --ar-breadcrumb-panel-min-width: var(--ar-panel-min-width);
         --ar-breadcrumb-panel-max-width: var(--ar-panel-max-width);
+        --ar-breadcrumb-toggle-bg: var(--ar-button-tertiary-bg);
+        --ar-breadcrumb-toggle-bg-hover: var(--ar-button-tertiary-bg-hover);
+        --ar-breadcrumb-toggle-bg-pressed: var(--ar-button-tertiary-bg-active);
+        --ar-breadcrumb-toggle-bg-focus: var(--ar-button-tertiary-bg-focus);
 
         /* stepper */
         --ar-stepper-distance: var(--ar-anchor-distance);
@@ -365,6 +369,8 @@
         --ar-stepper-connector-color: var(--ar-color-neutral-80);
         --ar-stepper-panel-min-width: var(--ar-panel-min-width);
         --ar-stepper-panel-max-width: var(--ar-panel-max-width);
+        --ar-stepper-trigger-bg: var(--ar-button-secondary-bg);
+        --ar-stepper-trigger-bg-hover: var(--ar-button-secondary-bg-hover);
 
         /* progressbar */
         --ar-progressbar-track-color: var(--ar-color-bg-subtle);
@@ -373,6 +379,10 @@
 
         /* pagination */
         --ar-pagination-active-color: var(--ar-color-interactive);
+        --ar-pagination-bg: var(--ar-button-tertiary-bg);
+        --ar-pagination-bg-hover: var(--ar-button-tertiary-bg-hover);
+        --ar-pagination-bg-pressed: var(--ar-button-tertiary-bg-active);
+        --ar-pagination-bg-focus: var(--ar-button-tertiary-bg-focus);
 
         /* spinner */
         --ar-spinner-stroke-color: currentColor;
@@ -416,6 +426,10 @@
 
         /* dialog */
         --ar-dialog-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 20px 50px -8px rgba(0, 0, 0, 0.2);
+        --ar-dialog-close-bg: var(--ar-button-tertiary-bg);
+        --ar-dialog-close-bg-hover: var(--ar-button-tertiary-bg-hover);
+        --ar-dialog-close-bg-pressed: var(--ar-button-tertiary-bg-active);
+        --ar-dialog-close-bg-focus: var(--ar-button-tertiary-bg-focus);
 
         /* table */
         --ar-table-padding-x: 1rem;


### PR DESCRIPTION
## Résumé

Suite de la réflexion sur l'usage des custom properties par un consommateur de Design System qui souhaite restyler les boutons internes des composants (dialog, pagination, breadcrumb, stepper) — voir discussion en amont sur les conventions Shoelace/Vaadin (tokens scopés par composant + `::part()`, déjà en place pour `--ar-panel-*`).

`button.styles.ts` est un module CSS partagé par 4 composants via des classes génériques (`.btn-tertiary`, `.btn-secondary`). Jusqu'ici, surcharger `--ar-button-tertiary-bg` pour restyler par exemple le bouton de fermeture d'un dialog changeait aussi, sans le vouloir, les boutons de pagination et le toggle mobile du breadcrumb — même token, même valeur, partout, sans découplage possible.

Ajoute par composant un jeu de tokens qui pointent par défaut vers le token générique correspondant, posés dans le propre stylesheet du composant (après `buttonStyles` dans la cascade, avec une spécificité volontairement supérieure pour gagner indépendamment de l'ordre des styles) :

- `--ar-dialog-close-bg(-hover|-pressed|-focus)` sur le bouton de fermeture
- `--ar-pagination-bg(-hover|-pressed|-focus)` sur les boutons prev/next/page non actifs (la page courante reste gérée par `--ar-pagination-active-color`)
- `--ar-breadcrumb-toggle-bg(-hover|-pressed|-focus)` sur le bouton retour mobile et le trigger du dropdown
- `--ar-stepper-trigger-bg(-hover)` sur le trigger du dropdown mobile

Chaque `@cssprop` est documenté en JSDoc sur le composant concerné.

## Test plan

- [x] `npm run test` — 659 tests unitaires passent
- [x] `npm run test:browser` — 220 tests Chromium passent
- [x] `npm run build` — build propre
- [x] Vérification Playwright : rendu par défaut inchangé sur les 4 composants
- [x] Vérification Playwright : surcharger `--ar-pagination-bg` (magenta) n'affecte pas le bouton de fermeture de `ar-dialog`, et surcharger `--ar-dialog-close-bg`/`-focus` (vert) ne change que ce bouton précis

🤖 Generated with [Claude Code](https://claude.com/claude-code)