### PR TITLE
fix(pagination): applique variant aux boutons prev/next

### DIFF
--- a/packages/core/src/components/pagination/pagination.test.ts
+++ b/packages/core/src/components/pagination/pagination.test.ts
@@ -79,6 +79,18 @@ describe('ArPagination', () => {
             await waitForUpdate(el);
             expect(el.getAttribute('variant')).toBe('dark');
         });
+
+        it('prev suit variant="dark"', async () => {
+            el = await fixture('<ar-pagination variant="dark"></ar-pagination>');
+            expect(requirePart(el, 'prev').classList.contains('dark')).toBe(true);
+            expect(requirePart(el, 'prev').classList.contains('light')).toBe(false);
+        });
+
+        it('next suit variant="dark"', async () => {
+            el = await fixture('<ar-pagination variant="dark"></ar-pagination>');
+            expect(requirePart(el, 'next').classList.contains('dark')).toBe(true);
+            expect(requirePart(el, 'next').classList.contains('light')).toBe(false);
+        });
     });
 
     // ── Accessibilité ─────────────────────────────────────────────────────────

--- a/packages/core/src/components/pagination/pagination.ts
+++ b/packages/core/src/components/pagination/pagination.ts
@@ -114,7 +114,7 @@ export class ArPagination extends LitElement {
                 <li part="item" class="pagination-item">
                     <a
                         part="prev"
-                        class="btn btn-tertiary light btn-ratio-square"
+                        class="btn btn-tertiary ${this.variant} btn-ratio-square"
                         href="javascript:;"
                         .ariaDisabled=${isPreviousDisabled}
                         aria-disabled=${isPreviousDisabled}
@@ -141,7 +141,7 @@ export class ArPagination extends LitElement {
                 <li part="item" class="pagination-item">
                     <a
                         part="next"
-                        class="btn btn-tertiary light btn-ratio-square"
+                        class="btn btn-tertiary ${this.variant} btn-ratio-square"
                         href="javascript:;"
                         .ariaDisabled=${isNextDisabled}
                         aria-disabled=${isNextDisabled}


### PR DESCRIPTION
## Résumé

Suivi de la remarque : le paramètre `variant` de `ar-pagination` semblait ne pas être appliqué partout.

Les boutons prev/next étaient codés en dur sur la classe `light`, contrairement aux liens de page et à l'ellipse qui suivent déjà `this.variant`. Avec `variant="dark"` (pensé pour un fond sombre), les liens de page basculaient correctement en `dark` tandis que prev/next restaient en `light` — quasi invisibles sur fond sombre, contraste cassé.

Contrairement au cas de l'attribut `dark` mort de `ar-breadcrumb` (#91, aucune CSS derrière), ici le CSS `.btn-tertiary.dark` existe déjà et fonctionne (confirmé par capture) — il manquait juste le branchement sur ces deux boutons. Correction : `class="btn btn-tertiary ${this.variant} btn-ratio-square"` au lieu de `"btn btn-tertiary light btn-ratio-square"` en dur.

## Test plan

- [x] `npm run test` — 661 tests unitaires passent (+2 nouveaux : prev/next suivent `variant="dark"`)
- [x] `npm run test:browser` — 220 tests Chromium passent
- [x] `npm run build` — build propre
- [x] Vérification visuelle Playwright : avant/après sur fond sombre, plus de régression sur le variant `light` par défaut

🤖 Generated with [Claude Code](https://claude.com/claude-code)