### PR TITLE
feat(pagination)!: retire variant au profit de tokens purs

### DIFF
--- a/packages/core/src/components/pagination/pagination.styles.ts
+++ b/packages/core/src/components/pagination/pagination.styles.ts
@@ -46,26 +46,30 @@ export default css`
     }
 
     /* ── Boutons prev/next/page (tokens scopés au composant) ──────────────────
-     * Sélecteurs volontairement plus spécifiques que a.btn-tertiary.light dans
+     * Sélecteurs volontairement plus spécifiques que a.btn-tertiary dans
      * button.styles.ts (ajout de .pagination + .btn) pour gagner la cascade
      * indépendamment de l'ordre des styles. Ne cible que les <a> (prev/next/
      * page non active) — la page courante est un <span>, gérée séparément par
-     * --ar-pagination-active-color ci-dessous. */
+     * --ar-pagination-active-color ci-dessous. --ar-pagination-color et
+     * --ar-pagination-bg permettent de rendre la pagination lisible sur un
+     * fond sombre ponctuel, indépendamment du thème global (ex-variant="dark",
+     * retiré au profit de tokens purs — cf. --ar-breadcrumb-color). */
 
-    .pagination a.btn.btn-tertiary.light {
+    .pagination a.btn.btn-tertiary {
+        color: var(--ar-pagination-color);
         background-color: var(--ar-pagination-bg);
     }
 
-    .pagination a.btn.btn-tertiary.light:hover {
+    .pagination a.btn.btn-tertiary:hover {
         background-color: var(--ar-pagination-bg-hover);
     }
 
     .pagination
-        a.btn.btn-tertiary.light:not(:disabled):not(.disabled):not([aria-disabled='true']):active {
+        a.btn.btn-tertiary:not(:disabled):not(.disabled):not([aria-disabled='true']):active {
         background-color: var(--ar-pagination-bg-pressed);
     }
 
-    .pagination a.btn.btn-tertiary.light:focus {
+    .pagination a.btn.btn-tertiary:focus {
         background-color: var(--ar-pagination-bg-focus);
     }
 
@@ -83,6 +87,6 @@ export default css`
         box-shadow: none !important;
         cursor: default !important;
         border-color: transparent !important;
-        color: var(--ar-color-text) !important;
+        color: var(--ar-pagination-color) !important;
     }
 `;

--- a/packages/core/src/components/pagination/pagination.test.ts
+++ b/packages/core/src/components/pagination/pagination.test.ts
@@ -50,10 +50,6 @@ describe('ArPagination', () => {
         it('total vaut DEFAULT_TOTAL (5)', () => {
             expect(el.total).toBe(ArPagination.DEFAULT_TOTAL);
         });
-
-        it('variant vaut DEFAULT_VARIANT ("light")', () => {
-            expect(el.variant).toBe(ArPagination.DEFAULT_VARIANT);
-        });
     });
 
     // ── Réflexion des attributs ───────────────────────────────────────────────
@@ -73,23 +69,12 @@ describe('ArPagination', () => {
             expect(el.getAttribute('total')).toBe('20');
         });
 
-        it('reflète variant en attribut HTML', async () => {
+        it('ne pose pas de classe light/dark sur prev/next (variant retiré au profit de tokens)', async () => {
             el = await fixture('<ar-pagination></ar-pagination>');
-            el.variant = 'dark';
-            await waitForUpdate(el);
-            expect(el.getAttribute('variant')).toBe('dark');
-        });
-
-        it('prev suit variant="dark"', async () => {
-            el = await fixture('<ar-pagination variant="dark"></ar-pagination>');
-            expect(requirePart(el, 'prev').classList.contains('dark')).toBe(true);
             expect(requirePart(el, 'prev').classList.contains('light')).toBe(false);
-        });
-
-        it('next suit variant="dark"', async () => {
-            el = await fixture('<ar-pagination variant="dark"></ar-pagination>');
-            expect(requirePart(el, 'next').classList.contains('dark')).toBe(true);
+            expect(requirePart(el, 'prev').classList.contains('dark')).toBe(false);
             expect(requirePart(el, 'next').classList.contains('light')).toBe(false);
+            expect(requirePart(el, 'next').classList.contains('dark')).toBe(false);
         });
     });
 

--- a/packages/core/src/components/pagination/pagination.ts
+++ b/packages/core/src/components/pagination/pagination.ts
@@ -13,11 +13,7 @@ import { warn } from '../../utils/warn.js';
 export class ArPaginationConfig {
     current?: number = 1;
     total?: number = 5;
-    variant?: ArPaginationVariant = 'light';
 }
-
-/** Variantes de style disponibles */
-export type ArPaginationVariant = 'light' | 'dark';
 
 /** Détail de l'événement émis lors d'un changement de page */
 export interface ArPaginationPageChangeDetail {
@@ -43,6 +39,7 @@ export interface ArPaginationPageChangeDetail {
  * @csspart next     - Le bouton "Page suivante".
  *
  * @cssprop [--ar-pagination-active-color=var(--ar-color-interactive)] - Couleur de la page active (texte + bordure).
+ * @cssprop [--ar-pagination-color=var(--ar-color-text)] - Couleur du texte des boutons prev/next/page (non actifs). À surcharger localement pour un fond sombre ponctuel, indépendamment du thème global.
  * @cssprop [--ar-pagination-bg=var(--ar-button-tertiary-bg)] - Fond des boutons prev/next/page (non actifs).
  * @cssprop [--ar-pagination-bg-hover=var(--ar-button-tertiary-bg-hover)] - Fond des boutons prev/next/page au survol.
  * @cssprop [--ar-pagination-bg-pressed=var(--ar-button-tertiary-bg-active)] - Fond des boutons prev/next/page pressés.
@@ -55,7 +52,6 @@ export class ArPagination extends LitElement {
 
     static readonly DEFAULT_CURRENT: number = 1;
     static readonly DEFAULT_TOTAL: number = 5;
-    static readonly DEFAULT_VARIANT: ArPaginationVariant = 'light';
 
     /**
      * Numéro de la page courante (commence à 1).
@@ -72,14 +68,6 @@ export class ArPagination extends LitElement {
      */
     @property({ reflect: true, type: Number, useDefault: true })
     total: number = ArPagination.DEFAULT_TOTAL;
-
-    /**
-     * Variante de style. Adapter selon la couleur de fond de la page.
-     * @attr variant
-     * @default 'light'
-     */
-    @property({ reflect: true, type: String, useDefault: true })
-    variant: 'light' | 'dark' = ArPagination.DEFAULT_VARIANT;
 
     override updated(changed: Map<string, unknown>): void {
         if (changed.has('total') && this.total < 1) {
@@ -114,7 +102,7 @@ export class ArPagination extends LitElement {
                 <li part="item" class="pagination-item">
                     <a
                         part="prev"
-                        class="btn btn-tertiary ${this.variant} btn-ratio-square"
+                        class="btn btn-tertiary btn-ratio-square"
                         href="javascript:;"
                         .ariaDisabled=${isPreviousDisabled}
                         aria-disabled=${isPreviousDisabled}
@@ -132,16 +120,16 @@ export class ArPagination extends LitElement {
                         // -1 et -2 sont des sentinelles représentant les ellipses
                         return page === -1 || page === -2
                             ? html` <li part="item" class="pagination-item" aria-hidden="true">
-                                  <span class="btn btn-tertiary ${this.variant}">...</span>
+                                  <span class="btn btn-tertiary">...</span>
                               </li>`
-                            : this.renderPage(page, page === current, this.variant);
+                            : this.renderPage(page, page === current);
                     },
                 )}
 
                 <li part="item" class="pagination-item">
                     <a
                         part="next"
-                        class="btn btn-tertiary ${this.variant} btn-ratio-square"
+                        class="btn btn-tertiary btn-ratio-square"
                         href="javascript:;"
                         .ariaDisabled=${isNextDisabled}
                         aria-disabled=${isNextDisabled}
@@ -156,27 +144,19 @@ export class ArPagination extends LitElement {
     }
 
     /** Génère le `<li>` d'une page. Surcharger en sous-classe si besoin. */
-    protected renderPage(
-        page: number,
-        active: boolean,
-        variant: ArPaginationVariant = 'light',
-    ): TemplateResult {
+    protected renderPage(page: number, active: boolean): TemplateResult {
         return html` <li part="item" class="pagination-item${active ? ' active' : ''}">
-            ${this.renderPageLink(page, active, variant)}
+            ${this.renderPageLink(page, active)}
         </li>`;
     }
 
     /** Génère le lien ou le span (si page active) d'une page */
-    protected renderPageLink(
-        page: number,
-        active: boolean,
-        variant: ArPaginationVariant = 'light',
-    ): TemplateResult {
+    protected renderPageLink(page: number, active: boolean): TemplateResult {
         if (active) {
             return html` <span
                 part="current"
                 aria-current="true"
-                class="btn btn-tertiary ${variant}"
+                class="btn btn-tertiary"
                 data-ar-pagination-page="${page}"
             >
                 ${this.renderPageLabel(page)}
@@ -184,7 +164,7 @@ export class ArPagination extends LitElement {
         }
         return html` <a
             part="link"
-            class="btn btn-tertiary ${variant}"
+            class="btn btn-tertiary"
             data-ar-pagination-page="${page}"
             href="javascript:;"
         >

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -379,6 +379,7 @@
 
         /* pagination */
         --ar-pagination-active-color: var(--ar-color-interactive);
+        --ar-pagination-color: var(--ar-color-text);
         --ar-pagination-bg: var(--ar-button-tertiary-bg);
         --ar-pagination-bg-hover: var(--ar-button-tertiary-bg-hover);
         --ar-pagination-bg-pressed: var(--ar-button-tertiary-bg-active);


### PR DESCRIPTION
## Résumé

Suite de la discussion sur la cohérence de `variant` avec la philosophie headless.

`variant="light"|"dark"` mélangeait deux besoins différents :
- le mode sombre **global** du thème (`[data-theme='dark']`, qui flip automatiquement tous les tokens sémantiques) ;
- le besoin **ponctuel** de rendre un composant lisible sur un fond sombre local, indépendamment du thème global.

Le second besoin est légitime — c'est exactement ce que `--ar-breadcrumb-color` résout pour `ar-breadcrumb` (#91). Mais ici, l'implémentation reposait sur un attribut HTML doublé d'un jeu de couleurs `.btn-tertiary.dark` **codées en dur** dans `button.styles.ts` (jamais tokenisées, donc non surchargeables) — en plus d'être buguée (prev/next ignoraient `variant` jusqu'à #96).

### Changements

- Retire l'attribut/propriété `variant`, le type `ArPaginationVariant` et `ArPaginationConfig.variant`.
- Les boutons prev/next/page rendent désormais toujours `class="btn btn-tertiary"`, sans modificateur.
- Ajoute `--ar-pagination-color` (texte) en complément des `--ar-pagination-bg(-hover|-pressed|-focus)` déjà scopés (#95).
- Un consommateur reproduit l'ancien effet "dark" en surchargeant ces tokens sur une seule instance, sans attribut ni JS — même mécanisme que `--ar-breadcrumb-color`.

### ⚠️ BREAKING CHANGE

L'attribut/propriété `variant` de `ar-pagination` est retiré. Projet en alpha, aucun consommateur connu — remplacer par une surcharge de `--ar-pagination-color`/`--ar-pagination-bg(-hover|-pressed|-focus)` sur l'instance concernée.

## Test plan

- [x] `npm run test` — 658 tests unitaires passent
- [x] `npm run test:browser` — 220 tests Chromium passent
- [x] `npm run build` — build propre
- [x] Vérification visuelle Playwright : rendu par défaut inchangé, et l'ancien rendu "dark" reproduit à l'identique via les tokens seuls (sans attribut)

🤖 Generated with [Claude Code](https://claude.com/claude-code)