### PR TITLE
fix(core): élimine les avertissements dev Lit (change-in-update, expression-in-textarea)

### DIFF
--- a/packages/core/src/components/breadcrumb/breadcrumb.test.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.test.ts
@@ -368,11 +368,14 @@ describe('ArBreadcrumb', () => {
             const order: string[] = [];
             el.addEventListener('ar-breadcrumb-show', () => order.push('show'));
             const shownHandler = vi.fn(() => order.push('shown'));
+            const shownPromise = new Promise<void>((resolve) => {
+                el.addEventListener('ar-breadcrumb-shown', () => resolve(), { once: true });
+            });
             el.addEventListener('ar-breadcrumb-shown', shownHandler);
 
             const btn = getShadow(el).querySelector('#breadcrumb-dropdown') as HTMLButtonElement;
             btn.click();
-            await waitForUpdate(el);
+            await shownPromise;
 
             expect(order).toEqual(['show', 'shown']);
             expect(shownHandler).toHaveBeenCalledOnce();

--- a/packages/core/src/components/breadcrumb/breadcrumb.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.ts
@@ -140,8 +140,13 @@ export class ArBreadcrumb extends LitElement {
             });
         }
         if (changed.has('open') && changed.get('open') !== undefined && this.isMobile) {
-            if (this.open) this._show();
-            else this._hide();
+            // Différé après la fin du cycle courant : _show()/_hide() déclenchent
+            // Popover.show()/hide(), qui appelle host.requestUpdate() — un appel synchrone
+            // ici déclencherait l'avertissement dev Lit "change-in-update".
+            void this.updateComplete.then(() => {
+                if (this.open) this._show();
+                else this._hide();
+            });
         }
     }
 

--- a/packages/core/src/components/charcounter/charcounter.a11y.test.ts
+++ b/packages/core/src/components/charcounter/charcounter.a11y.test.ts
@@ -33,10 +33,18 @@ describe('ar-charcounter — accessibilité', () => {
             const container = await fixture(html`
                 <div>
                     <label for="field2">Commentaire</label>
-                    <textarea id="field2">${'x'.repeat(165)}</textarea>
+                    <textarea id="field2"></textarea>
                     <ar-charcounter for="field2" max="200"></ar-charcounter>
                 </div>
             `);
+            // Interpoler dans <textarea> n'est pas supporté par lit-html (contenu raw-text) —
+            // on fixe la valeur après coup et on déclenche 'input' pour que ar-charcounter
+            // (qui ne recalcule que sur cet événement) recalcule bien son état "warning".
+            const counter = container.querySelector<ArCharcounter>('ar-charcounter')!;
+            const field = container.querySelector<HTMLTextAreaElement>('#field2')!;
+            field.value = 'x'.repeat(165);
+            field.dispatchEvent(new Event('input'));
+            await counter.updateComplete;
             await expect(container).to.be.accessible();
         });
     });

--- a/packages/core/src/components/datepicker/datepicker.ts
+++ b/packages/core/src/components/datepicker/datepicker.ts
@@ -201,12 +201,19 @@ export class ArDatepicker extends LitElement {
         if (changed.has('open')) {
             if (this._skipNextOpenChange) {
                 this._skipNextOpenChange = false;
-            } else if (this.open) {
-                void this._show().catch((e: unknown) => {
-                    warn('ar-datepicker', String(e));
-                });
             } else {
-                this._hide();
+                // Différé après la fin du cycle courant : _show()/_hide() déclenchent
+                // AnchoredController.show()/hide(), qui appelle host.requestUpdate() — un appel
+                // synchrone ici déclencherait l'avertissement dev Lit "change-in-update".
+                void this.updateComplete.then(() => {
+                    if (this.open) {
+                        void this._show().catch((e: unknown) => {
+                            warn('ar-datepicker', String(e));
+                        });
+                    } else {
+                        this._hide();
+                    }
+                });
             }
         }
 

--- a/packages/core/src/components/dropdown/dropdown.test.ts
+++ b/packages/core/src/components/dropdown/dropdown.test.ts
@@ -131,6 +131,20 @@ describe('ArDropdown', () => {
             await waitForUpdate(el);
             expect(el.open).toBe(true);
         });
+
+        it("n'émet ar-dropdown-show qu'une fois quand open est déjà vrai au premier rendu", async () => {
+            // Écoute posée avant connexion : fixture() connecte puis résout après le premier
+            // rendu, trop tard pour capter un événement émis dès firstUpdated()/updated().
+            const openEl = document.createElement('ar-dropdown') as ArDropdown;
+            openEl.innerHTML = '<button slot="trigger">Trigger</button>';
+            openEl.open = true;
+            const handler = vi.fn();
+            openEl.addEventListener('ar-dropdown-show', handler);
+            document.body.appendChild(openEl);
+            await waitForUpdate(openEl);
+            expect(handler).toHaveBeenCalledOnce();
+            openEl.remove();
+        });
     });
 
     // ── Disabled ─────────────────────────────────────────────────────────────

--- a/packages/core/src/components/dropdown/dropdown.ts
+++ b/packages/core/src/components/dropdown/dropdown.ts
@@ -103,7 +103,6 @@ export class ArDropdown extends LitElement {
                 this._externalTrigger = trigger;
             }
         }
-        if (this.open) this._show();
     }
 
     override updated(changed: PropertyValues<this>): void {
@@ -129,8 +128,13 @@ export class ArDropdown extends LitElement {
             }
         }
         if (changed.has('open')) {
-            if (this.open) this._show();
-            else this._hide();
+            // Différé après la fin du cycle courant : _show()/_hide() déclenchent
+            // Popover.show()/hide(), qui appelle host.requestUpdate() — un appel synchrone
+            // ici déclencherait l'avertissement dev Lit "change-in-update".
+            void this.updateComplete.then(() => {
+                if (this.open) this._show();
+                else this._hide();
+            });
         }
     }
 


### PR DESCRIPTION
## Résumé

Root-cause de deux catégories d'avertissements dev repérés lors d'une revue manuelle post-merge des PR #103/#104 :

- **`change-in-update`** (breadcrumb, dropdown, datepicker) : `_show()`/`_hide()` déclenchent `Popover.show()`/`hide()`, qui appelle `host.requestUpdate()` de façon synchrone. Ces méthodes étaient invoquées directement depuis `updated()` en réaction au changement de la propriété `open` — le `requestUpdate()` survenait donc pendant le cycle de mise à jour en cours, l'anti-pattern exact que Lit signale. Différé via `updateComplete.then()`, à l'image du pattern déjà en place pour `_attachDropdown()` sur `ar-breadcrumb`.
- **`expression-in-textarea`** (charcounter) : un test a11y interpolait une expression lit-html dans un `<textarea>` — non supporté par lit-html (contenu raw-text). Fixe la valeur après le rendu et déclenche `input` au lieu d'interpoler.

**Bug réel découvert en cours de route (pas juste du bruit dev-mode)** : `ar-dropdown` appelait `_show()` à la fois dans `firstUpdated()` et dans `updated()` au tout premier rendu quand `open` était déjà vrai à la création — doublant l'émission de `ar-dropdown-show`/`shown` et l'enregistrement du listener `keydown` du panel (jamais retiré une fois, donc potentiellement déclenché deux fois par frappe). Corrigé + test de régression ajouté (vérifié qu'il échoue sans le correctif).

## Test plan

- [x] `npm run test` complet (672/672)
- [x] `npm run test:browser` — 3 runs consécutifs, 220/220, 0 avertissement `change-in-update`/`expression-in-textarea`
- [x] `tsc --noEmit` propre
- [x] Test de régression `ar-dropdown` vérifié en échec sur le code non corrigé avant d'être validé sur le correctif