### PR TITLE
chore(core): passe de cohérence sur le style des tests

### DIFF
--- a/packages/core/src/autoloader.test.ts
+++ b/packages/core/src/autoloader.test.ts
@@ -45,7 +45,7 @@ describe('autoloader', () => {
         appendElement('ar-alert');
         await tick();
 
-        expect(mockAlertImport).toHaveBeenCalledTimes(1);
+        expect(mockAlertImport).toHaveBeenCalledOnce();
     });
 
     it('ne recharge pas le module si ar-alert est ajouté une seconde fois (loaded Set)', async () => {

--- a/packages/core/src/components/alert/alert.ts
+++ b/packages/core/src/components/alert/alert.ts
@@ -56,9 +56,6 @@ export type ArAlertVariant = 'success' | 'warning' | 'error' | 'info';
 export class ArAlert extends LitElement {
     static override styles = [styles];
 
-    /** Nom du composant affiché dans les logs */
-    // @ignore
-    static readonly NAME = 'ArAlert';
     // @ignore
     static readonly DEFAULT_VARIANT: ArAlertVariant = 'error';
     // @ignore
@@ -194,7 +191,7 @@ export class ArAlert extends LitElement {
         );
         if (!$focusableElement) {
             warn(
-                ArAlert.NAME,
+                'ar-alert',
                 `L'id "${this.nextFocus}" spécifié via 'next-focus' n'est pas présent dans la page.`,
             );
             return;

--- a/packages/core/src/components/breadcrumb/breadcrumb.test.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.test.ts
@@ -259,44 +259,6 @@ describe('ArBreadcrumb', () => {
             expect(hideHandler).toHaveBeenCalledOnce();
         });
 
-        it('émet ar-breadcrumb-show au premier clic sur le bouton', async () => {
-            el = await fixture(`
-                <ar-breadcrumb>
-                    <ar-breadcrumb-item label="Accueil" href="/"></ar-breadcrumb-item>
-                    <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
-                </ar-breadcrumb>
-            `);
-            let fired = false;
-            el.addEventListener('ar-breadcrumb-show', () => {
-                fired = true;
-            });
-            const btn = getShadow(el).querySelector('#breadcrumb-dropdown') as HTMLButtonElement;
-            btn.click();
-            await waitForUpdate(el);
-
-            expect(fired).toBe(true);
-        });
-
-        it('émet ar-breadcrumb-hide au deuxième clic sur le bouton', async () => {
-            el = await fixture(`
-                <ar-breadcrumb>
-                    <ar-breadcrumb-item label="Accueil" href="/"></ar-breadcrumb-item>
-                    <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
-                </ar-breadcrumb>
-            `);
-            let fired = false;
-            el.addEventListener('ar-breadcrumb-hide', () => {
-                fired = true;
-            });
-            const btn = getShadow(el).querySelector('#breadcrumb-dropdown') as HTMLButtonElement;
-            btn.click();
-            await waitForUpdate(el);
-            btn.click();
-            await waitForUpdate(el);
-
-            expect(fired).toBe(true);
-        });
-
         it('open vaut false par défaut', async () => {
             el = await fixture(`
                 <ar-breadcrumb>

--- a/packages/core/src/components/charcounter/charcounter.ts
+++ b/packages/core/src/components/charcounter/charcounter.ts
@@ -36,7 +36,6 @@ function pluralize(count: number, label: string): string {
  */
 export class ArCharcounter extends LitElement {
     static override styles = [styles];
-    static readonly NAME = 'ArCharcounter';
     private static _idCounter = 0;
 
     /** ID du champ observé. Requis. */

--- a/packages/core/src/components/collapse/collapse.ts
+++ b/packages/core/src/components/collapse/collapse.ts
@@ -32,7 +32,6 @@ export type ArCollapseEvents =
  */
 export class ArCollapse extends LitElement {
     static override styles = [styles];
-    static readonly NAME = 'ArCollapse';
     private static _idCounter = 0;
 
     /** Ouvre ou ferme le panel. */

--- a/packages/core/src/components/datepicker/datepicker.test.ts
+++ b/packages/core/src/components/datepicker/datepicker.test.ts
@@ -75,21 +75,21 @@ describe('ArDatepicker', () => {
         });
 
         it("émet ar-datepicker-show à l'ouverture", async () => {
-            let fired = false;
-            el.addEventListener('ar-datepicker-show', () => (fired = true));
+            const handler = vi.fn();
+            el.addEventListener('ar-datepicker-show', handler);
             el.open = true;
             await waitForUpdate(el);
-            expect(fired).toBe(true);
+            expect(handler).toHaveBeenCalledOnce();
         });
 
         it('émet ar-datepicker-hide à la fermeture', async () => {
             el.open = true;
             await waitForUpdate(el);
-            let fired = false;
-            el.addEventListener('ar-datepicker-hide', () => (fired = true));
+            const handler = vi.fn();
+            el.addEventListener('ar-datepicker-hide', handler);
             el.open = false;
             await waitForUpdate(el);
-            expect(fired).toBe(true);
+            expect(handler).toHaveBeenCalledOnce();
         });
 
         it("disabled bloque l'ouverture", async () => {
@@ -190,12 +190,12 @@ describe('ArDatepicker', () => {
 
         it('émet ar-datepicker-input-change au blur', async () => {
             el = await fixture('<ar-datepicker></ar-datepicker>');
-            let fired = false;
-            el.addEventListener('ar-datepicker-input-change', () => (fired = true));
+            const handler = vi.fn();
+            el.addEventListener('ar-datepicker-input-change', handler);
             el.inputElement.value = '12/06/2026';
             el.inputElement.dispatchEvent(new Event('blur'));
             await waitForUpdate(el);
-            expect(fired).toBe(true);
+            expect(handler).toHaveBeenCalledOnce();
         });
     });
 

--- a/packages/core/src/components/dialog/dialog.test.ts
+++ b/packages/core/src/components/dialog/dialog.test.ts
@@ -566,7 +566,7 @@ describe('ArDialog', () => {
             el = await fixture('<ar-dialog></ar-dialog>');
             el.appendChild(document.createTextNode(' '));
             await waitForUpdate(el);
-            expect(spy).toHaveBeenCalledTimes(1);
+            expect(spy).toHaveBeenCalledOnce();
         });
     });
 

--- a/packages/core/src/components/dropdown/dropdown.test.ts
+++ b/packages/core/src/components/dropdown/dropdown.test.ts
@@ -400,7 +400,7 @@ describe('ArDropdown', () => {
             await waitForUpdate(el);
             await new Promise((resolve) => setTimeout(resolve, 0));
 
-            expect(shownHandler).toHaveBeenCalledTimes(1);
+            expect(shownHandler).toHaveBeenCalledOnce();
             const event = shownHandler.mock.calls[0][0] as CustomEvent;
             expect(event.detail).toEqual({ id: 'my-dropdown' });
         });

--- a/packages/core/src/components/progressbar/progressbar.ts
+++ b/packages/core/src/components/progressbar/progressbar.ts
@@ -34,9 +34,6 @@ export class ArProgressbarConfig {
 export class ArProgressbar extends LitElement {
     static override styles: CSSResultGroup = [utilitiesStyles, styles];
 
-    /** Nom du composant affiché dans les logs */
-    static readonly NAME = 'ArProgressbar';
-
     /**
      * Pourcentage de complétion. Automatiquement borné entre 0 et 100.
      * @attr percent

--- a/packages/core/src/components/spinner/spinner.ts
+++ b/packages/core/src/components/spinner/spinner.ts
@@ -20,8 +20,6 @@ import { warn } from '../../utils/warn.js';
  */
 export class ArSpinner extends LitElement {
     static override styles: CSSResultGroup = [utilitiesStyles, animationsStyles, styles];
-
-    static readonly NAME = 'ArSpinner';
     static readonly DEFAULT_DONE: boolean = false;
     static readonly DEFAULT_LOADING_LABEL: string = 'Contenu en cours de chargement';
     static readonly DEFAULT_DONE_LABEL: string = 'Chargement terminé';

--- a/packages/core/src/components/stepper/stepper.test.ts
+++ b/packages/core/src/components/stepper/stepper.test.ts
@@ -141,7 +141,7 @@ describe('ArStepper', () => {
             const link = shadow(el).querySelector<HTMLAnchorElement>('a.stepper-link');
             if (link) {
                 link.click();
-                expect(handler).toHaveBeenCalledTimes(1);
+                expect(handler).toHaveBeenCalledOnce();
                 const event = handler.mock.calls[0][0] as CustomEvent;
                 expect(event.detail).toHaveProperty('path');
             }
@@ -317,7 +317,7 @@ describe('ArStepper', () => {
             );
             el.remove();
 
-            expect(removeListenerSpy).toHaveBeenCalledTimes(1);
+            expect(removeListenerSpy).toHaveBeenCalledOnce();
         });
     });
 

--- a/packages/core/src/controllers/navigation-tree.controller.test.ts
+++ b/packages/core/src/controllers/navigation-tree.controller.test.ts
@@ -86,7 +86,7 @@ describe('NavigationTreeController', () => {
         ctrl.setCurrentPath('/b');
 
         expect(ctrl.currentNode?.path).toBe('/b');
-        expect(host.requestUpdate).toHaveBeenCalledTimes(1); // setCurrentPath seulement
+        expect(host.requestUpdate).toHaveBeenCalledOnce(); // setCurrentPath seulement
     });
 
     it('setCurrentPath() ne fait rien si le path est identique', () => {

--- a/packages/core/src/utils/deprecated.test.ts
+++ b/packages/core/src/utils/deprecated.test.ts
@@ -11,7 +11,7 @@ describe('warnDeprecated', () => {
 
         warnDeprecated('ar-alert', 'links', 'Utilisez des slots.');
 
-        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledOnce();
         expect(spy).toHaveBeenCalledWith(expect.stringContaining('ar-alert'));
         expect(spy).toHaveBeenCalledWith(expect.stringContaining('links'));
         expect(spy).toHaveBeenCalledWith(expect.stringContaining('Utilisez des slots.'));
@@ -24,7 +24,7 @@ describe('warnDeprecated', () => {
         warnDeprecated('ar-breadcrumb', 'dark', 'Message.');
         warnDeprecated('ar-breadcrumb', 'dark', 'Message.');
 
-        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledOnce();
     });
 
     it('affiche des warnings distincts pour des paires tag:member différentes', () => {

--- a/packages/core/src/utils/when-all-defined.test.ts
+++ b/packages/core/src/utils/when-all-defined.test.ts
@@ -62,7 +62,7 @@ describe('whenAllDefined', () => {
 
         await whenAllDefined();
 
-        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledOnce();
         expect(spy).toHaveBeenCalledWith('ar-alert');
         expect(spy).not.toHaveBeenCalledWith('my-button');
     });
@@ -78,7 +78,7 @@ describe('whenAllDefined', () => {
 
         await whenAllDefined();
 
-        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledOnce();
         expect(spy).toHaveBeenCalledWith('acme-alert');
         expect(spy).not.toHaveBeenCalledWith('ar-alert');
     });
@@ -93,7 +93,7 @@ describe('whenAllDefined', () => {
 
         await whenAllDefined('my-');
 
-        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledOnce();
         expect(spy).toHaveBeenCalledWith('my-button');
         expect(spy).not.toHaveBeenCalledWith('ar-alert');
     });


### PR DESCRIPTION
## Résumé

Traite le backlog de 6 points relevés lors d'une relecture manuelle des PR #103/#104 (voir mémoire projet `project_test_style_consistency_backlog`).

**Corrections de code :**
- **`NAME` mort + bug de format `warn()`** : `collapse`/`spinner`/`progressbar`/`charcounter` déclaraient un `static readonly NAME` jamais référencé nulle part (dead code). `alert.ts` était le seul à l'utiliser dans un `warn()`, mais avec la valeur PascalCase (`'ArAlert'`) — produisant `[ArAlert] ...` au lieu du format `[ar-alert] ...` utilisé par tous les autres composants. Les 5 constantes supprimées, `alert.ts` aligné sur le littéral `'ar-alert'`.

**Corrections de tests :**
- `toHaveBeenCalledTimes(1)` → `toHaveBeenCalledOnce()` uniformisé sur tout `packages/core/src` (pas seulement les composants).
- Pattern booléen `let fired = false` remplacé par `vi.fn()` dans les fichiers Vitest (`breadcrumb.test.ts`, `datepicker.test.ts`) — deux tests `breadcrumb.test.ts` étaient en fait des doublons stricts d'un test juste au-dessus avec une assertion plus faible, supprimés plutôt que reformatés. Ce pattern reste légitime dans les fichiers `*.browser.test.ts`/`*.a11y.test.ts` (Web Test Runner, pas d'accès à `vi.fn()`).

**Points investigués, aucun changement nécessaire :**
- `_emit()` vs `dispatchEvent()` inline : pattern déjà cohérent — `_emit` factorise plusieurs events partageant la même forme, les composants à un seul event n'en ont pas besoin.
- Tests de custom properties CSS (`datepicker`/`dialog`) : deux gardes ciblées et justifiées indépendamment (régression thème, câblage fonctionnel), pas une convention à généraliser.

## Test plan

- [x] `npm run test` complet vert (669/669)
- [x] `npm run test:browser` vert (220/220)
- [x] `tsc --noEmit` propre