### PR TITLE
fix(core): évite l'émission parasite du toggle opposé sur annulation

### DIFF
--- a/packages/core/src/components/breadcrumb/breadcrumb.test.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.test.ts
@@ -39,6 +39,17 @@ function mockMediaQuery(matches: boolean): MediaQueryList {
     } as unknown as MediaQueryList;
 }
 
+// happy-dom does not implement the Popover API — mock showPopover/hidePopover on the panel
+// (même pattern que dropdown.test.ts), nécessaire pour que Popover.isOpen reflète l'état réel.
+function mockPanelPopover(el: ArBreadcrumb): void {
+    const panel = getPart(el, 'panel') as HTMLElement | null;
+    if (!panel) return;
+    (panel as HTMLElement & { showPopover: () => void; hidePopover: () => void }).showPopover =
+        vi.fn();
+    (panel as HTMLElement & { showPopover: () => void; hidePopover: () => void }).hidePopover =
+        vi.fn();
+}
+
 describe('ArBreadcrumb', () => {
     let el: ArBreadcrumb;
 
@@ -227,6 +238,7 @@ describe('ArBreadcrumb', () => {
                     <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
                 </ar-breadcrumb>
             `);
+            mockPanelPopover(el);
             const handler = vi.fn();
             el.addEventListener('ar-breadcrumb-show', handler);
 
@@ -244,6 +256,7 @@ describe('ArBreadcrumb', () => {
                     <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
                 </ar-breadcrumb>
             `);
+            mockPanelPopover(el);
             const showHandler = vi.fn();
             const hideHandler = vi.fn();
             el.addEventListener('ar-breadcrumb-show', showHandler);
@@ -266,6 +279,7 @@ describe('ArBreadcrumb', () => {
                     <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
                 </ar-breadcrumb>
             `);
+            mockPanelPopover(el);
             expect(el.open).toBe(false);
             expect(el.hasAttribute('open')).toBe(false);
         });
@@ -277,6 +291,7 @@ describe('ArBreadcrumb', () => {
                     <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
                 </ar-breadcrumb>
             `);
+            mockPanelPopover(el);
             const btn = getShadow(el).querySelector('#breadcrumb-dropdown') as HTMLButtonElement;
             btn.click();
             await waitForUpdate(el);
@@ -292,6 +307,7 @@ describe('ArBreadcrumb', () => {
                     <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
                 </ar-breadcrumb>
             `);
+            mockPanelPopover(el);
             const handler = vi.fn();
             el.addEventListener('ar-breadcrumb-show', handler);
 
@@ -308,6 +324,7 @@ describe('ArBreadcrumb', () => {
                     <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
                 </ar-breadcrumb>
             `);
+            mockPanelPopover(el);
             const btn = getShadow(el).querySelector('#breadcrumb-dropdown') as HTMLButtonElement;
             btn.click();
             await waitForUpdate(el);
@@ -327,6 +344,7 @@ describe('ArBreadcrumb', () => {
                     <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
                 </ar-breadcrumb>
             `);
+            mockPanelPopover(el);
             const order: string[] = [];
             el.addEventListener('ar-breadcrumb-show', () => order.push('show'));
             const shownHandler = vi.fn(() => order.push('shown'));
@@ -352,6 +370,7 @@ describe('ArBreadcrumb', () => {
                     <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
                 </ar-breadcrumb>
             `);
+            mockPanelPopover(el);
             el.addEventListener('ar-breadcrumb-show', (e) => e.preventDefault());
 
             const btn = getShadow(el).querySelector('#breadcrumb-dropdown') as HTMLButtonElement;
@@ -368,6 +387,7 @@ describe('ArBreadcrumb', () => {
                     <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
                 </ar-breadcrumb>
             `);
+            mockPanelPopover(el);
             const btn = getShadow(el).querySelector('#breadcrumb-dropdown') as HTMLButtonElement;
             btn.click();
             await waitForUpdate(el);
@@ -377,6 +397,56 @@ describe('ArBreadcrumb', () => {
             await waitForUpdate(el);
 
             expect(el.open).toBe(true);
+        });
+
+        it("n'émet pas ar-breadcrumb-hide/-hidden quand ar-breadcrumb-show est annulé", async () => {
+            el = await fixture(`
+                <ar-breadcrumb>
+                    <ar-breadcrumb-item label="Accueil" href="/"></ar-breadcrumb-item>
+                    <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
+                </ar-breadcrumb>
+            `);
+            mockPanelPopover(el);
+            el.addEventListener('ar-breadcrumb-show', (e) => e.preventDefault());
+            const hideHandler = vi.fn();
+            const hiddenHandler = vi.fn();
+            el.addEventListener('ar-breadcrumb-hide', hideHandler);
+            el.addEventListener('ar-breadcrumb-hidden', hiddenHandler);
+
+            el.open = true;
+            await waitForUpdate(el);
+            await waitForUpdate(el);
+            await waitForUpdate(el);
+
+            expect(hideHandler).not.toHaveBeenCalled();
+            expect(hiddenHandler).not.toHaveBeenCalled();
+        });
+
+        it("n'émet pas ar-breadcrumb-show/-shown quand ar-breadcrumb-hide est annulé", async () => {
+            el = await fixture(`
+                <ar-breadcrumb>
+                    <ar-breadcrumb-item label="Accueil" href="/"></ar-breadcrumb-item>
+                    <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
+                </ar-breadcrumb>
+            `);
+            mockPanelPopover(el);
+            const btn = getShadow(el).querySelector('#breadcrumb-dropdown') as HTMLButtonElement;
+            btn.click();
+            await waitForUpdate(el);
+
+            el.addEventListener('ar-breadcrumb-hide', (e) => e.preventDefault());
+            const showHandler = vi.fn();
+            const shownHandler = vi.fn();
+            el.addEventListener('ar-breadcrumb-show', showHandler);
+            el.addEventListener('ar-breadcrumb-shown', shownHandler);
+
+            el.open = false;
+            await waitForUpdate(el);
+            await waitForUpdate(el);
+            await waitForUpdate(el);
+
+            expect(showHandler).not.toHaveBeenCalled();
+            expect(shownHandler).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/core/src/components/breadcrumb/breadcrumb.test.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ArBreadcrumb } from './breadcrumb.js';
-import { getPart } from '../../test-utils.js';
+import { getPart, mockPopoverPanel } from '../../test-utils.js';
 import './index.js';
 import '../breadcrumb-item/index.js';
 
@@ -37,17 +37,6 @@ function mockMediaQuery(matches: boolean): MediaQueryList {
         addEventListener: vi.fn(),
         removeEventListener: vi.fn(),
     } as unknown as MediaQueryList;
-}
-
-// happy-dom does not implement the Popover API — mock showPopover/hidePopover on the panel
-// (même pattern que dropdown.test.ts), nécessaire pour que Popover.isOpen reflète l'état réel.
-function mockPanelPopover(el: ArBreadcrumb): void {
-    const panel = getPart(el, 'panel') as HTMLElement | null;
-    if (!panel) return;
-    (panel as HTMLElement & { showPopover: () => void; hidePopover: () => void }).showPopover =
-        vi.fn();
-    (panel as HTMLElement & { showPopover: () => void; hidePopover: () => void }).hidePopover =
-        vi.fn();
 }
 
 describe('ArBreadcrumb', () => {
@@ -238,7 +227,7 @@ describe('ArBreadcrumb', () => {
                     <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
                 </ar-breadcrumb>
             `);
-            mockPanelPopover(el);
+            mockPopoverPanel(el);
             const handler = vi.fn();
             el.addEventListener('ar-breadcrumb-show', handler);
 
@@ -256,7 +245,7 @@ describe('ArBreadcrumb', () => {
                     <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
                 </ar-breadcrumb>
             `);
-            mockPanelPopover(el);
+            mockPopoverPanel(el);
             const showHandler = vi.fn();
             const hideHandler = vi.fn();
             el.addEventListener('ar-breadcrumb-show', showHandler);
@@ -279,7 +268,7 @@ describe('ArBreadcrumb', () => {
                     <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
                 </ar-breadcrumb>
             `);
-            mockPanelPopover(el);
+            mockPopoverPanel(el);
             expect(el.open).toBe(false);
             expect(el.hasAttribute('open')).toBe(false);
         });
@@ -291,7 +280,7 @@ describe('ArBreadcrumb', () => {
                     <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
                 </ar-breadcrumb>
             `);
-            mockPanelPopover(el);
+            mockPopoverPanel(el);
             const btn = getShadow(el).querySelector('#breadcrumb-dropdown') as HTMLButtonElement;
             btn.click();
             await waitForUpdate(el);
@@ -307,7 +296,7 @@ describe('ArBreadcrumb', () => {
                     <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
                 </ar-breadcrumb>
             `);
-            mockPanelPopover(el);
+            mockPopoverPanel(el);
             const handler = vi.fn();
             el.addEventListener('ar-breadcrumb-show', handler);
 
@@ -324,7 +313,7 @@ describe('ArBreadcrumb', () => {
                     <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
                 </ar-breadcrumb>
             `);
-            mockPanelPopover(el);
+            mockPopoverPanel(el);
             const btn = getShadow(el).querySelector('#breadcrumb-dropdown') as HTMLButtonElement;
             btn.click();
             await waitForUpdate(el);
@@ -344,7 +333,7 @@ describe('ArBreadcrumb', () => {
                     <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
                 </ar-breadcrumb>
             `);
-            mockPanelPopover(el);
+            mockPopoverPanel(el);
             const order: string[] = [];
             el.addEventListener('ar-breadcrumb-show', () => order.push('show'));
             const shownHandler = vi.fn(() => order.push('shown'));
@@ -370,7 +359,7 @@ describe('ArBreadcrumb', () => {
                     <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
                 </ar-breadcrumb>
             `);
-            mockPanelPopover(el);
+            mockPopoverPanel(el);
             el.addEventListener('ar-breadcrumb-show', (e) => e.preventDefault());
 
             const btn = getShadow(el).querySelector('#breadcrumb-dropdown') as HTMLButtonElement;
@@ -387,7 +376,7 @@ describe('ArBreadcrumb', () => {
                     <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
                 </ar-breadcrumb>
             `);
-            mockPanelPopover(el);
+            mockPopoverPanel(el);
             const btn = getShadow(el).querySelector('#breadcrumb-dropdown') as HTMLButtonElement;
             btn.click();
             await waitForUpdate(el);
@@ -406,7 +395,7 @@ describe('ArBreadcrumb', () => {
                     <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
                 </ar-breadcrumb>
             `);
-            mockPanelPopover(el);
+            mockPopoverPanel(el);
             el.addEventListener('ar-breadcrumb-show', (e) => e.preventDefault());
             const hideHandler = vi.fn();
             const hiddenHandler = vi.fn();
@@ -414,7 +403,6 @@ describe('ArBreadcrumb', () => {
             el.addEventListener('ar-breadcrumb-hidden', hiddenHandler);
 
             el.open = true;
-            await waitForUpdate(el);
             await waitForUpdate(el);
             await waitForUpdate(el);
 
@@ -429,7 +417,7 @@ describe('ArBreadcrumb', () => {
                     <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
                 </ar-breadcrumb>
             `);
-            mockPanelPopover(el);
+            mockPopoverPanel(el);
             const btn = getShadow(el).querySelector('#breadcrumb-dropdown') as HTMLButtonElement;
             btn.click();
             await waitForUpdate(el);
@@ -441,7 +429,6 @@ describe('ArBreadcrumb', () => {
             el.addEventListener('ar-breadcrumb-shown', shownHandler);
 
             el.open = false;
-            await waitForUpdate(el);
             await waitForUpdate(el);
             await waitForUpdate(el);
 

--- a/packages/core/src/components/breadcrumb/breadcrumb.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.ts
@@ -77,6 +77,14 @@ export class ArBreadcrumb extends LitElement {
     private _items = new Set<ArBreadcrumbItem>();
     private _rebuildPending = false;
 
+    /**
+     * Quand _show()/_hide() annule et revient sur `open`, ça redéclenche un second cycle
+     * updated() qui appellerait la branche opposée pour rien (le panel n'a jamais changé
+     * d'état). Ce flag fait de ce second appel un no-op, sans affecter les fermetures
+     * externes légitimes (onExternalClose), qui ne passent pas par cette annulation.
+     */
+    private _suppressNextToggle = false;
+
     private readonly _provider = new ContextProvider(this, {
         context: breadcrumbContext,
         initialValue: {
@@ -249,9 +257,13 @@ export class ArBreadcrumb extends LitElement {
     };
 
     private _show(): void {
-        if (this._popover.isOpen) return;
+        if (this._suppressNextToggle) {
+            this._suppressNextToggle = false;
+            return;
+        }
         const showEv = this._emit('ar-breadcrumb-show');
         if (showEv.defaultPrevented) {
+            this._suppressNextToggle = true;
             this.open = false;
             return;
         }
@@ -261,9 +273,13 @@ export class ArBreadcrumb extends LitElement {
     }
 
     private _hide(): void {
-        if (!this._popover.isOpen) return;
+        if (this._suppressNextToggle) {
+            this._suppressNextToggle = false;
+            return;
+        }
         const hideEv = this._emit('ar-breadcrumb-hide');
         if (hideEv.defaultPrevented) {
+            this._suppressNextToggle = true;
             this.open = true;
             return;
         }

--- a/packages/core/src/components/breadcrumb/breadcrumb.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.ts
@@ -249,6 +249,7 @@ export class ArBreadcrumb extends LitElement {
     };
 
     private _show(): void {
+        if (this._popover.isOpen) return;
         const showEv = this._emit('ar-breadcrumb-show');
         if (showEv.defaultPrevented) {
             this.open = false;
@@ -260,6 +261,7 @@ export class ArBreadcrumb extends LitElement {
     }
 
     private _hide(): void {
+        if (!this._popover.isOpen) return;
         const hideEv = this._emit('ar-breadcrumb-hide');
         if (hideEv.defaultPrevented) {
             this.open = true;

--- a/packages/core/src/components/collapse/collapse.test.ts
+++ b/packages/core/src/components/collapse/collapse.test.ts
@@ -205,6 +205,41 @@ describe('ArCollapse', () => {
             await waitForUpdate(el);
             expect(el.open).toBe(true);
         });
+
+        it("n'émet pas ar-collapse-hide/-hidden quand ar-collapse-show est annulé", async () => {
+            el.addEventListener('ar-collapse-show', (e) => e.preventDefault());
+            const hideHandler = vi.fn();
+            const hiddenHandler = vi.fn();
+            el.addEventListener('ar-collapse-hide', hideHandler);
+            el.addEventListener('ar-collapse-hidden', hiddenHandler);
+
+            el.open = true;
+            await waitForUpdate(el);
+            await waitForUpdate(el);
+            await waitForUpdate(el);
+
+            expect(hideHandler).not.toHaveBeenCalled();
+            expect(hiddenHandler).not.toHaveBeenCalled();
+        });
+
+        it("n'émet pas ar-collapse-show/-shown quand ar-collapse-hide est annulé", async () => {
+            el.show();
+            await waitForUpdate(el);
+
+            el.addEventListener('ar-collapse-hide', (e) => e.preventDefault());
+            const showHandler = vi.fn();
+            const shownHandler = vi.fn();
+            el.addEventListener('ar-collapse-show', showHandler);
+            el.addEventListener('ar-collapse-shown', shownHandler);
+
+            el.open = false;
+            await waitForUpdate(el);
+            await waitForUpdate(el);
+            await waitForUpdate(el);
+
+            expect(showHandler).not.toHaveBeenCalled();
+            expect(shownHandler).not.toHaveBeenCalled();
+        });
     });
 
     // ── Trigger interne + ARIA ────────────────────────────────────────────────

--- a/packages/core/src/components/collapse/collapse.test.ts
+++ b/packages/core/src/components/collapse/collapse.test.ts
@@ -216,7 +216,6 @@ describe('ArCollapse', () => {
             el.open = true;
             await waitForUpdate(el);
             await waitForUpdate(el);
-            await waitForUpdate(el);
 
             expect(hideHandler).not.toHaveBeenCalled();
             expect(hiddenHandler).not.toHaveBeenCalled();
@@ -233,7 +232,6 @@ describe('ArCollapse', () => {
             el.addEventListener('ar-collapse-shown', shownHandler);
 
             el.open = false;
-            await waitForUpdate(el);
             await waitForUpdate(el);
             await waitForUpdate(el);
 

--- a/packages/core/src/components/collapse/collapse.ts
+++ b/packages/core/src/components/collapse/collapse.ts
@@ -270,6 +270,9 @@ export class ArCollapse extends LitElement {
     }
 
     private _show(): void {
+        // symétrique de la garde de _hide() : panel déjà visible (ex. ar-collapse-hide
+        // annulé → open=true redéclenché) — évite de réémettre show/shown pour rien.
+        if (!this._panel.hasAttribute('hidden') && !this._animating) return;
         const ev = this._emit('ar-collapse-show');
         if (ev.defaultPrevented) {
             this.open = false;

--- a/packages/core/src/components/dropdown/dropdown.test.ts
+++ b/packages/core/src/components/dropdown/dropdown.test.ts
@@ -1,18 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ArDropdown } from './dropdown.js';
-import { fixture, waitForUpdate, getPart } from '../../test-utils.js';
+import { fixture, waitForUpdate, getPart, mockPopoverPanel } from '../../test-utils.js';
 import './index.js';
 import '../dropdown-item/index.js';
-
-// happy-dom does not implement the Popover API — mock showPopover/hidePopover on the panel.
-function mockPanelPopover(el: ArDropdown): void {
-    const panel = getPart(el, 'panel') as HTMLElement | null;
-    if (!panel) return;
-    (panel as HTMLElement & { showPopover: () => void; hidePopover: () => void }).showPopover =
-        vi.fn();
-    (panel as HTMLElement & { showPopover: () => void; hidePopover: () => void }).hidePopover =
-        vi.fn();
-}
 
 describe('ArDropdown', () => {
     let el: ArDropdown;
@@ -57,7 +47,7 @@ describe('ArDropdown', () => {
         });
 
         it('open reflète en attribut', async () => {
-            mockPanelPopover(el);
+            mockPopoverPanel(el);
             el.open = true;
             await waitForUpdate(el);
             expect(el.hasAttribute('open')).toBe(true);
@@ -95,7 +85,7 @@ describe('ArDropdown', () => {
             el = await fixture(
                 '<ar-dropdown><button slot="trigger">Trigger</button></ar-dropdown>',
             );
-            mockPanelPopover(el);
+            mockPopoverPanel(el);
         });
 
         it('émet ar-dropdown-show avant ouverture', async () => {
@@ -142,7 +132,6 @@ describe('ArDropdown', () => {
             el.open = true;
             await waitForUpdate(el);
             await waitForUpdate(el);
-            await waitForUpdate(el);
 
             expect(hideHandler).not.toHaveBeenCalled();
             expect(hiddenHandler).not.toHaveBeenCalled();
@@ -159,7 +148,6 @@ describe('ArDropdown', () => {
             el.addEventListener('ar-dropdown-shown', shownHandler);
 
             el.open = false;
-            await waitForUpdate(el);
             await waitForUpdate(el);
             await waitForUpdate(el);
 
@@ -189,7 +177,7 @@ describe('ArDropdown', () => {
             el = await fixture(
                 '<ar-dropdown disabled><button slot="trigger">Trigger</button></ar-dropdown>',
             );
-            mockPanelPopover(el);
+            mockPopoverPanel(el);
             const trigger = el.querySelector<HTMLButtonElement>('button');
             trigger?.click();
             await waitForUpdate(el);
@@ -213,7 +201,7 @@ describe('ArDropdown', () => {
         it("bloque overflowY des ancêtres scroll à l'ouverture", async () => {
             el = await fixture('<ar-dropdown><button slot="trigger">T</button></ar-dropdown>');
             container.appendChild(el);
-            mockPanelPopover(el);
+            mockPopoverPanel(el);
 
             el.open = true;
             await waitForUpdate(el);
@@ -224,7 +212,7 @@ describe('ArDropdown', () => {
         it('restaure overflowY des ancêtres à la fermeture', async () => {
             el = await fixture('<ar-dropdown><button slot="trigger">T</button></ar-dropdown>');
             container.appendChild(el);
-            mockPanelPopover(el);
+            mockPopoverPanel(el);
 
             el.open = true;
             await waitForUpdate(el);
@@ -241,7 +229,7 @@ describe('ArDropdown', () => {
             );
             await waitForUpdate(el);
             container.appendChild(el);
-            mockPanelPopover(el);
+            mockPopoverPanel(el);
 
             el.open = true;
             await waitForUpdate(el);
@@ -271,7 +259,7 @@ describe('ArDropdown', () => {
 
         it('le clic sur le trigger externe ouvre le dropdown', async () => {
             el = await fixture('<ar-dropdown for="test-ext-trigger"></ar-dropdown>');
-            mockPanelPopover(el);
+            mockPopoverPanel(el);
 
             externalBtn.click();
             await waitForUpdate(el);
@@ -306,7 +294,7 @@ describe('ArDropdown', () => {
                     <button slot="trigger">Menu</button>
                 </ar-dropdown>
             `);
-            mockPanelPopover(el);
+            mockPopoverPanel(el);
             // Append items after fixture to trigger slotchange
             const item1 = document.createElement('ar-dropdown-item');
             item1.innerHTML = '<button>Item 1</button>';
@@ -326,7 +314,7 @@ describe('ArDropdown', () => {
                     <p>Contenu libre</p>
                 </ar-dropdown>
             `);
-            mockPanelPopover(el);
+            mockPopoverPanel(el);
             await waitForUpdate(el);
             const panel = getPart(el, 'panel');
             expect(panel?.getAttribute('role')).toBeNull();
@@ -338,7 +326,7 @@ describe('ArDropdown', () => {
                     <button slot="trigger">Menu</button>
                 </ar-dropdown>
             `);
-            mockPanelPopover(el);
+            mockPopoverPanel(el);
             const item1 = document.createElement('ar-dropdown-item');
             item1.innerHTML = '<button>Item 1</button>';
             const hr = document.createElement('hr');
@@ -423,7 +411,7 @@ describe('ArDropdown', () => {
             document.body.appendChild(host);
 
             const dropdown = host.shadowRoot!.querySelector('ar-dropdown') as ArDropdown;
-            mockPanelPopover(dropdown);
+            mockPopoverPanel(dropdown);
             await waitForUpdate(dropdown);
 
             const trigger = host.shadowRoot!.getElementById(
@@ -441,7 +429,7 @@ describe('ArDropdown', () => {
     describe('detail des events de cycle de vie', () => {
         it('ar-dropdown-shown porte detail.id', async () => {
             el = await fixture('<ar-dropdown id="my-dropdown"><div>Contenu</div></ar-dropdown>');
-            mockPanelPopover(el);
+            mockPopoverPanel(el);
             const shownHandler = vi.fn();
             el.addEventListener('ar-dropdown-shown', shownHandler);
 

--- a/packages/core/src/components/dropdown/dropdown.test.ts
+++ b/packages/core/src/components/dropdown/dropdown.test.ts
@@ -132,6 +132,41 @@ describe('ArDropdown', () => {
             expect(el.open).toBe(true);
         });
 
+        it("n'émet pas ar-dropdown-hide/-hidden quand ar-dropdown-show est annulé", async () => {
+            el.addEventListener('ar-dropdown-show', (e) => e.preventDefault());
+            const hideHandler = vi.fn();
+            const hiddenHandler = vi.fn();
+            el.addEventListener('ar-dropdown-hide', hideHandler);
+            el.addEventListener('ar-dropdown-hidden', hiddenHandler);
+
+            el.open = true;
+            await waitForUpdate(el);
+            await waitForUpdate(el);
+            await waitForUpdate(el);
+
+            expect(hideHandler).not.toHaveBeenCalled();
+            expect(hiddenHandler).not.toHaveBeenCalled();
+        });
+
+        it("n'émet pas ar-dropdown-show/-shown quand ar-dropdown-hide est annulé", async () => {
+            el.open = true;
+            await waitForUpdate(el);
+
+            el.addEventListener('ar-dropdown-hide', (e) => e.preventDefault());
+            const showHandler = vi.fn();
+            const shownHandler = vi.fn();
+            el.addEventListener('ar-dropdown-show', showHandler);
+            el.addEventListener('ar-dropdown-shown', shownHandler);
+
+            el.open = false;
+            await waitForUpdate(el);
+            await waitForUpdate(el);
+            await waitForUpdate(el);
+
+            expect(showHandler).not.toHaveBeenCalled();
+            expect(shownHandler).not.toHaveBeenCalled();
+        });
+
         it("n'émet ar-dropdown-show qu'une fois quand open est déjà vrai au premier rendu", async () => {
             // Écoute posée avant connexion : fixture() connecte puis résout après le premier
             // rendu, trop tard pour capter un événement émis dès firstUpdated()/updated().

--- a/packages/core/src/components/dropdown/dropdown.ts
+++ b/packages/core/src/components/dropdown/dropdown.ts
@@ -85,6 +85,14 @@ export class ArDropdown extends LitElement {
     private _externalTrigger: HTMLElement | null = null;
     private readonly _uniqueId = Math.random().toString(36).slice(2, 9);
 
+    /**
+     * Quand _show()/_hide() annule et revient sur `open`, ça redéclenche un second cycle
+     * updated() qui appellerait la branche opposée pour rien (le panel n'a jamais changé
+     * d'état). Ce flag fait de ce second appel un no-op, sans affecter les fermetures
+     * externes légitimes (onExternalClose), qui ne passent pas par cette annulation.
+     */
+    private _suppressNextToggle = false;
+
     override firstUpdated(): void {
         if (this.for) {
             const slot = this.shadowRoot?.querySelector<HTMLSlotElement>('slot[name="trigger"]');
@@ -205,9 +213,13 @@ export class ArDropdown extends LitElement {
     };
 
     private _show(): void {
-        if (this._popover.isOpen) return;
+        if (this._suppressNextToggle) {
+            this._suppressNextToggle = false;
+            return;
+        }
         const showEv = this._emit('ar-dropdown-show');
         if (showEv.defaultPrevented) {
+            this._suppressNextToggle = true;
             this.open = false;
             return;
         }
@@ -221,9 +233,13 @@ export class ArDropdown extends LitElement {
     }
 
     private _hide(): void {
-        if (!this._popover.isOpen) return;
+        if (this._suppressNextToggle) {
+            this._suppressNextToggle = false;
+            return;
+        }
         const hideEv = this._emit('ar-dropdown-hide');
         if (hideEv.defaultPrevented) {
+            this._suppressNextToggle = true;
             this.open = true;
             return;
         }

--- a/packages/core/src/components/dropdown/dropdown.ts
+++ b/packages/core/src/components/dropdown/dropdown.ts
@@ -205,6 +205,7 @@ export class ArDropdown extends LitElement {
     };
 
     private _show(): void {
+        if (this._popover.isOpen) return;
         const showEv = this._emit('ar-dropdown-show');
         if (showEv.defaultPrevented) {
             this.open = false;
@@ -220,6 +221,7 @@ export class ArDropdown extends LitElement {
     }
 
     private _hide(): void {
+        if (!this._popover.isOpen) return;
         const hideEv = this._emit('ar-dropdown-hide');
         if (hideEv.defaultPrevented) {
             this.open = true;

--- a/packages/core/src/components/tooltip/tooltip.test.ts
+++ b/packages/core/src/components/tooltip/tooltip.test.ts
@@ -1,15 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { fixture, waitForUpdate, getPart } from '../../test-utils.js';
+import { fixture, waitForUpdate, getPart, mockPopoverPanel } from '../../test-utils.js';
 import type { ArTooltip } from './tooltip.js';
 import './index.js';
-
-// happy-dom ne supporte pas l'API Popover — on mock showPopover/hidePopover sur la bulle.
-function mockBubblePopover(el: ArTooltip): void {
-    const bubble = getPart(el, 'bubble') as HTMLElement | null;
-    if (!bubble) return;
-    (bubble as any).showPopover = vi.fn();
-    (bubble as any).hidePopover = vi.fn();
-}
 
 describe('ArTooltip', () => {
     let el: ArTooltip;
@@ -20,7 +12,7 @@ describe('ArTooltip', () => {
         beforeEach(async () => {
             document.body.innerHTML = '<button id="btn">x</button>';
             el = await fixture<ArTooltip>('<ar-tooltip for="btn">Aide</ar-tooltip>');
-            mockBubblePopover(el);
+            mockPopoverPanel(el, 'bubble');
         });
 
         it('monte un shadow DOM', () => {
@@ -122,7 +114,7 @@ describe('ArTooltip', () => {
             el = await fixture<ArTooltip>(
                 '<ar-tooltip for="btn" disabled show-delay="0">Aide</ar-tooltip>',
             );
-            mockBubblePopover(el);
+            mockPopoverPanel(el, 'bubble');
             document.getElementById('btn')!.dispatchEvent(new Event('mouseenter'));
             await new Promise((r) => setTimeout(r, 10));
             expect((getPart(el, 'bubble') as any).showPopover).not.toHaveBeenCalled();
@@ -135,7 +127,7 @@ describe('ArTooltip', () => {
             el = await fixture<ArTooltip>(
                 '<ar-tooltip id="my-tooltip" for="btn" show-delay="0">Aide</ar-tooltip>',
             );
-            mockBubblePopover(el);
+            mockPopoverPanel(el, 'bubble');
         });
 
         it('émet ar-tooltip-shown avec detail.id après affichage', async () => {

--- a/packages/core/src/test-utils.ts
+++ b/packages/core/src/test-utils.ts
@@ -11,6 +11,8 @@
  * le cast fourni à l'appel (ex: `fixture<ArAlert>(...)`).
  */
 
+import { vi } from 'vitest';
+
 /** Alias pour contourner le protected de `updateComplete` dans LitElement. */
 type LitEl = { updateComplete: Promise<boolean> };
 
@@ -81,4 +83,23 @@ export function requirePart(el: Element, part: string): Element {
     if (!found)
         throw new Error(`Part "${part}" not found in shadow DOM of <${el.tagName.toLowerCase()}>`);
     return found;
+}
+
+/**
+ * happy-dom n'implémente pas l'API Popover native (`showPopover`/`hidePopover`) — mock ces
+ * méthodes sur le part flottant d'un composant (`ar-dropdown`, `ar-breadcrumb`, `ar-tooltip`…)
+ * pour que `Popover.isOpen` (utils/popover.ts) reflète un état réel dans les tests unitaires.
+ *
+ * Le comportement natif complet (`:popover-open`, light-dismiss, événement `toggle`) reste
+ * couvert par les tests navigateur (`*.browser.test.ts`, WTR) — ne pas chercher à le simuler ici.
+ *
+ * @param part - Nom du `part` shadow DOM portant `popover="auto"` (défaut : "panel").
+ */
+export function mockPopoverPanel(el: Element, part = 'panel'): void {
+    const target = getPart(el, part) as
+        | (HTMLElement & { showPopover?: () => void; hidePopover?: () => void })
+        | null;
+    if (!target) return;
+    target.showPopover = vi.fn();
+    target.hidePopover = vi.fn();
 }


### PR DESCRIPTION
## Contexte

Item 1 de [#111](https://github.com/jogo-labs/ariane/issues/111) (chantier technique global).

## Root cause

Quand un consommateur annule `ar-*-show`/`ar-*-hide` via `preventDefault()`, le composant revient sur `this.open`, ce qui redéclenche un second cycle `updated()` de Lit et exécute la branche opposée (`_show()`/`_hide()`) sans garde, sur un panel qui n'a en réalité jamais changé d'état. Reproduit empiriquement (tests avant fix) avant toute correction.

## Fix

- `ar-dropdown` et `ar-breadcrumb` : `_show()`/`_hide()` gardés par `this._popover.isOpen` (pattern déjà utilisé par `ar-tooltip`).
- `ar-collapse` : garde symétrique ajoutée côté `_show()` (celle côté `_hide()` existait déjà, cf. commentaire "finding 2").
- `ar-dialog` : non concerné, garde déjà via l'état natif du `<dialog>`.

## Tests

- 6 tests de non-régression ajoutés (2 par composant touché).
- Mutualisation du mock Popover (`mockPanelPopover`/`mockBubblePopover`, dupliqué 3x) en `mockPopoverPanel(el, part)` dans `test-utils.ts`.
- Nombre d'`await waitForUpdate` vérifié empiriquement (2 cycles nécessaires et suffisants, pas 3).

## Test plan

- [x] `npm run test` — 684/684 passent
- [x] `tsc --noEmit` propre
- [x] `npm run lint` propre