### PR TITLE
feat(core): mutualise le pattern events annulables (ToggleController) + events -prevented

### DIFF
--- a/apps/docs/src/content/components/ar-dialog.mdx
+++ b/apps/docs/src/content/components/ar-dialog.mdx
@@ -140,6 +140,7 @@ Plutôt que de piloter `open` en JavaScript, un élément cliquable peut ouvrir 
 | Événement                       | Moment                                                | Annulable |
 | ------------------------------- | ----------------------------------------------------- | --------- |
 | `ar-dialog-show`                | Avant l'ouverture                                     | Oui       |
+| `ar-dialog-show-prevented`      | Si `ar-dialog-show` est annulé                        | Non       |
 | `ar-dialog-shown`               | Après l'ouverture (post-render)                       | Non       |
 | `ar-dialog-hide`                | Avant la fermeture (Escape, backdrop, `open = false`) | Oui       |
 | `ar-dialog-hide-prevented`      | Si `ar-dialog-hide` est annulé                        | Non       |

--- a/docs/superpowers/plans/2026-07-16-toggle-controller-mutualization.md
+++ b/docs/superpowers/plans/2026-07-16-toggle-controller-mutualization.md
@@ -1,0 +1,1080 @@
+# ToggleController — Mutualisation events annulables + events prevented — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Mutualiser le pattern events annulables `show`/`hide` dupliqué entre `ar-dropdown`, `ar-breadcrumb`, `ar-collapse` dans un `ToggleController` partagé, et ajouter des événements `-show-prevented`/`-hide-prevented` sur les 4 composants disclosure (`ar-dropdown`, `ar-breadcrumb`, `ar-collapse`, `ar-dialog`).
+
+**Architecture:** `ToggleController` (ReactiveController, même famille qu'`AnchoredController`) prend en charge la détection du changement de `open`, le différé via `updateComplete`, l'émission `show`/`hide`/`show-prevented`/`hide-prevented`, et le flag anti-cycle-redondant. Les composants fournissent `onShow()`/`onHide()` (leur logique propre) et émettent eux-mêmes `shown`/`hidden` via la fonction partagée `emitToggleEvent()`. `ar-dialog` reste hors controller (ajout minimal d'un seul event dans son code existant).
+
+**Tech Stack:** Lit 3 (`ReactiveController`), TypeScript, Vitest (tests unitaires), Web Test Runner/Playwright (tests navigateur).
+
+## Global Constraints
+
+- Prettier : 100 caractères, 4 espaces, guillemets simples.
+- Toujours `import type` pour les imports de types.
+- Aucun fallback cosmétique — non applicable ici (pas de CSS dans ce chantier).
+- Breaking changes en alpha acceptés sans dépréciation (`warnDeprecated`) — précédent PR #89/#112.
+- Après chaque tâche : `npm run test` (racine, Vitest) doit passer intégralement avant de committer.
+- Spec de référence : `docs/superpowers/specs/2026-07-16-toggle-controller-mutualization-design.md`.
+
+---
+
+## État d'avancement
+
+**Tâches 1 et 2 déjà complétées et committées** (commit `2485186` sur la branche `feat/toggle-controller-mutualization`, créée depuis `dev`) :
+
+- `packages/core/src/utils/toggle-events.ts` — `emitToggleEvent(host, name, { cancelable })`.
+- `packages/core/src/controllers/toggle.controller.ts` — `ToggleController`.
+- Tests associés (19 tests, tous verts), design validé empiriquement (voir commentaires dans le code sur le comportement de `skipInitialTransition`).
+
+Le reste de ce plan (tâches 3 à 8) part de cet état. Ne pas recréer ces fichiers.
+
+### Interface de `ToggleController` (déjà livrée, pour référence)
+
+```ts
+export interface ToggleControllerOptions {
+    eventPrefix: string;
+    onShow: () => void;
+    onHide: () => void;
+    shouldToggle?: () => boolean;
+    skipInitialTransition?: boolean;
+}
+
+export class ToggleController implements ReactiveController {
+    constructor(
+        host: ReactiveControllerHost & HTMLElement & { open: boolean },
+        opts: ToggleControllerOptions,
+    );
+}
+```
+
+### Interface de `emitToggleEvent` (déjà livrée, pour référence)
+
+```ts
+export function emitToggleEvent(
+    host: HTMLElement,
+    name: string,
+    opts: { cancelable: boolean },
+): CustomEvent;
+```
+
+---
+
+### Task 3: Migration `ar-dropdown`
+
+**Files:**
+
+- Modify: `packages/core/src/components/dropdown/dropdown.ts`
+- Modify: `packages/core/src/components/dropdown/dropdown.test.ts`
+- Verify (pas de modification attendue) : `packages/core/src/components/dropdown/dropdown.browser.test.ts`
+
+**Interfaces:**
+
+- Consumes: `ToggleController` et `emitToggleEvent` (`packages/core/src/controllers/toggle.controller.js`, `packages/core/src/utils/toggle-events.js`).
+- Produces: `ar-dropdown-show-prevented`, `ar-dropdown-hide-prevented` (nouveaux events publics).
+
+- [ ] **Step 1: Écrire les tests des nouveaux events `-prevented`**
+
+Ajouter dans `packages/core/src/components/dropdown/dropdown.test.ts`, dans le `describe('événements', ...)` existant (après le test `"n'émet pas ar-dropdown-hide/-hidden quand ar-dropdown-show est annulé"`) :
+
+```ts
+it('émet ar-dropdown-show-prevented (non cancelable) quand ar-dropdown-show est annulé', async () => {
+    el.addEventListener('ar-dropdown-show', (e) => e.preventDefault());
+    let event: CustomEvent | undefined;
+    el.addEventListener('ar-dropdown-show-prevented', (e) => {
+        event = e as CustomEvent;
+    });
+    el.open = true;
+    await waitForUpdate(el);
+    await waitForUpdate(el);
+    expect(event).toBeDefined();
+    expect(event?.cancelable).toBe(false);
+    expect(event?.detail).toEqual({ id: undefined });
+});
+
+it('émet ar-dropdown-hide-prevented (non cancelable) quand ar-dropdown-hide est annulé', async () => {
+    el.open = true;
+    await waitForUpdate(el);
+    el.addEventListener('ar-dropdown-hide', (e) => e.preventDefault());
+    let event: CustomEvent | undefined;
+    el.addEventListener('ar-dropdown-hide-prevented', (e) => {
+        event = e as CustomEvent;
+    });
+    el.open = false;
+    await waitForUpdate(el);
+    await waitForUpdate(el);
+    expect(event).toBeDefined();
+    expect(event?.cancelable).toBe(false);
+    expect(event?.detail).toEqual({ id: undefined });
+});
+```
+
+- [ ] **Step 2: Lancer les tests, vérifier qu'ils échouent**
+
+Run: `cd packages/core && npx vitest run src/components/dropdown/dropdown.test.ts`
+Expected: les 2 nouveaux tests FAIL (les events `-prevented` n'existent pas encore). Les autres tests existants doivent encore PASS.
+
+- [ ] **Step 3: Migrer `dropdown.ts` vers `ToggleController`**
+
+Remplacer l'import en haut du fichier :
+
+```ts
+import { LitElement, html, type TemplateResult, type PropertyValues } from 'lit';
+```
+
+par :
+
+```ts
+import { LitElement, html, type TemplateResult, type PropertyValues } from 'lit';
+import { ToggleController } from '../../controllers/toggle.controller.js';
+import { emitToggleEvent } from '../../utils/toggle-events.js';
+```
+
+(insérer les 2 nouvelles lignes juste après l'import `lit`, avant l'import `AnchoredController` existant).
+
+Remplacer le bloc JSDoc `@event` (lignes ~43-46) :
+
+```ts
+ * @event {CustomEvent} ar-dropdown-show    - Émis avant l'ouverture (annulable).
+ * @event {CustomEvent} ar-dropdown-shown   - Émis après l'ouverture.
+ * @event {CustomEvent} ar-dropdown-hide    - Émis avant la fermeture (annulable).
+ * @event {CustomEvent} ar-dropdown-hidden  - Émis après la fermeture.
+```
+
+par :
+
+```ts
+ * @event {CustomEvent} ar-dropdown-show           - Émis avant l'ouverture (annulable).
+ * @event {CustomEvent} ar-dropdown-show-prevented - Émis si ar-dropdown-show est annulé.
+ * @event {CustomEvent} ar-dropdown-shown          - Émis après l'ouverture.
+ * @event {CustomEvent} ar-dropdown-hide           - Émis avant la fermeture (annulable).
+ * @event {CustomEvent} ar-dropdown-hide-prevented - Émis si ar-dropdown-hide est annulé.
+ * @event {CustomEvent} ar-dropdown-hidden         - Émis après la fermeture.
+```
+
+Remplacer le champ `_suppressNextToggle` et son commentaire (lignes ~88-94) :
+
+```ts
+    /**
+     * Quand _show()/_hide() annule et revient sur `open`, ça redéclenche un second cycle
+     * updated() qui appellerait la branche opposée pour rien (le panel n'a jamais changé
+     * d'état). Ce flag fait de ce second appel un no-op, sans affecter les fermetures
+     * externes légitimes (onExternalClose), qui ne passent pas par cette annulation.
+     */
+    private _suppressNextToggle = false;
+```
+
+par :
+
+```ts
+    private readonly _toggle = new ToggleController(this, {
+        eventPrefix: 'ar-dropdown',
+        onShow: () => this._onShow(),
+        onHide: () => this._onHide(),
+    });
+```
+
+Remplacer entièrement le bloc `updated()` (lignes ~116-147) :
+
+```ts
+    override updated(changed: PropertyValues<this>): void {
+        if (changed.has('placement')) {
+            this._popover.setPlacement(this.placement);
+        }
+        if (changed.has('noScrollLock')) {
+            this._popover.setLockScroll(!this.noScrollLock);
+        }
+        if (changed.has('for')) {
+            this._externalTrigger?.removeEventListener('click', this._handleTriggerClick);
+            this._externalTrigger = null;
+            const newTrigger = this._resolvedTrigger;
+            if (this.for && !newTrigger) {
+                warn('ar-dropdown', `Aucun élément trouvé avec l'id "${this.for}".`);
+            }
+            if (newTrigger && this._panel) {
+                this._popover.attach(newTrigger, this._panel);
+                if (this.for) {
+                    newTrigger.addEventListener('click', this._handleTriggerClick);
+                    this._externalTrigger = newTrigger;
+                }
+            }
+        }
+        if (changed.has('open')) {
+            // Différé après la fin du cycle courant : _show()/_hide() déclenchent
+            // Popover.show()/hide(), qui appelle host.requestUpdate() — un appel synchrone
+            // ici déclencherait l'avertissement dev Lit "change-in-update".
+            void this.updateComplete.then(() => {
+                if (this.open) this._show();
+                else this._hide();
+            });
+        }
+    }
+```
+
+par (le bloc `changed.has('open')` disparaît, le reste est inchangé) :
+
+```ts
+    override updated(changed: PropertyValues<this>): void {
+        if (changed.has('placement')) {
+            this._popover.setPlacement(this.placement);
+        }
+        if (changed.has('noScrollLock')) {
+            this._popover.setLockScroll(!this.noScrollLock);
+        }
+        if (changed.has('for')) {
+            this._externalTrigger?.removeEventListener('click', this._handleTriggerClick);
+            this._externalTrigger = null;
+            const newTrigger = this._resolvedTrigger;
+            if (this.for && !newTrigger) {
+                warn('ar-dropdown', `Aucun élément trouvé avec l'id "${this.for}".`);
+            }
+            if (newTrigger && this._panel) {
+                this._popover.attach(newTrigger, this._panel);
+                if (this.for) {
+                    newTrigger.addEventListener('click', this._handleTriggerClick);
+                    this._externalTrigger = newTrigger;
+                }
+            }
+        }
+    }
+```
+
+Remplacer `_show()`/`_hide()`/`_emit()` (lignes ~215-263) :
+
+```ts
+    private _show(): void {
+        if (this._suppressNextToggle) {
+            this._suppressNextToggle = false;
+            return;
+        }
+        const showEv = this._emit('ar-dropdown-show');
+        if (showEv.defaultPrevented) {
+            this._suppressNextToggle = true;
+            this.open = false;
+            return;
+        }
+        this._detectMenuMode();
+        this._panel?.addEventListener('keydown', this._handlePanelKeyDown);
+        if (this._menuMode) this._activateMenuListeners();
+        void this._popover.show().then(() => {
+            if (this._menuMode) this._focusMenuItem(0);
+            this._emit('ar-dropdown-shown');
+        });
+    }
+
+    private _hide(): void {
+        if (this._suppressNextToggle) {
+            this._suppressNextToggle = false;
+            return;
+        }
+        const hideEv = this._emit('ar-dropdown-hide');
+        if (hideEv.defaultPrevented) {
+            this._suppressNextToggle = true;
+            this.open = true;
+            return;
+        }
+        this._panel?.removeEventListener('keydown', this._handlePanelKeyDown);
+        this._removeMenuListeners();
+        this._activeIndex = -1;
+        this._popover.hide();
+        this._resolvedTrigger?.focus();
+        this._emit('ar-dropdown-hidden');
+    }
+
+    private _emit(name: string): CustomEvent {
+        const e = new CustomEvent(name, {
+            bubbles: true,
+            composed: true,
+            cancelable: true,
+            detail: { id: this.id || undefined },
+        });
+        this.dispatchEvent(e);
+        return e;
+    }
+```
+
+par :
+
+```ts
+    private _onShow(): void {
+        this._detectMenuMode();
+        this._panel?.addEventListener('keydown', this._handlePanelKeyDown);
+        if (this._menuMode) this._activateMenuListeners();
+        void this._popover.show().then(() => {
+            if (this._menuMode) this._focusMenuItem(0);
+            emitToggleEvent(this, 'ar-dropdown-shown', { cancelable: false });
+        });
+    }
+
+    private _onHide(): void {
+        this._panel?.removeEventListener('keydown', this._handlePanelKeyDown);
+        this._removeMenuListeners();
+        this._activeIndex = -1;
+        this._popover.hide();
+        this._resolvedTrigger?.focus();
+        emitToggleEvent(this, 'ar-dropdown-hidden', { cancelable: false });
+    }
+```
+
+- [ ] **Step 4: Adapter les tests existants qui utilisaient `_show`/`_hide` implicitement**
+
+Aucun test n'appelle `_show`/`_hide` directement (méthodes privées) — les tests existants passent par `el.open = ...` ou des clics, donc aucune adaptation attendue au-delà des nouveaux tests du Step 1. Vérifier avec :
+
+Run: `cd packages/core && npx vitest run src/components/dropdown/dropdown.test.ts --reporter=verbose`
+Expected: tous les tests PASS, y compris les 2 nouveaux du Step 1.
+
+- [ ] **Step 5: Vérifier les tests navigateur (point exact de la régression PR #112)**
+
+Run: `cd packages/core && npx web-test-runner --files "src/components/dropdown/**/*.browser.test.ts"`
+Expected: tous PASS, en particulier `light-dismiss` et `Escape`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/components/dropdown/dropdown.ts packages/core/src/components/dropdown/dropdown.test.ts
+git commit -m "feat(core): migre ar-dropdown vers ToggleController + ajoute show/hide-prevented"
+```
+
+---
+
+### Task 4: Migration `ar-breadcrumb`
+
+**Files:**
+
+- Modify: `packages/core/src/components/breadcrumb/breadcrumb.ts`
+- Modify: `packages/core/src/components/breadcrumb/breadcrumb.test.ts`
+- Verify (pas de modification attendue) : `packages/core/src/components/breadcrumb/breadcrumb.browser.test.ts`
+
+**Interfaces:**
+
+- Consumes: `ToggleController` avec `shouldToggle: () => this.isMobile` et `skipInitialTransition: true` (préserve exactement le comportement actuel — cf. spec, section "Impact par composant").
+- Produces: `ar-breadcrumb-show-prevented`, `ar-breadcrumb-hide-prevented`.
+
+- [ ] **Step 1: Écrire les tests des nouveaux events `-prevented`**
+
+Ajouter dans `packages/core/src/components/breadcrumb/breadcrumb.test.ts`, dans le `describe('dropdown mobile', ...)` existant, juste après le test `"n'émet pas ar-breadcrumb-show/-shown quand ar-breadcrumb-hide est annulé"` :
+
+```ts
+it('émet ar-breadcrumb-show-prevented (non cancelable) quand ar-breadcrumb-show est annulé', async () => {
+    el = await fixture(`
+                <ar-breadcrumb>
+                    <ar-breadcrumb-item label="Accueil" href="/"></ar-breadcrumb-item>
+                    <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
+                </ar-breadcrumb>
+            `);
+    mockPopoverPanel(el);
+    el.addEventListener('ar-breadcrumb-show', (e) => e.preventDefault());
+    let event: CustomEvent | undefined;
+    el.addEventListener('ar-breadcrumb-show-prevented', (e) => {
+        event = e as CustomEvent;
+    });
+    el.open = true;
+    await waitForUpdate(el);
+    await waitForUpdate(el);
+    expect(event).toBeDefined();
+    expect(event?.cancelable).toBe(false);
+});
+
+it('émet ar-breadcrumb-hide-prevented (non cancelable) quand ar-breadcrumb-hide est annulé', async () => {
+    el = await fixture(`
+                <ar-breadcrumb>
+                    <ar-breadcrumb-item label="Accueil" href="/"></ar-breadcrumb-item>
+                    <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
+                </ar-breadcrumb>
+            `);
+    mockPopoverPanel(el);
+    const btn = getShadow(el).querySelector('#breadcrumb-dropdown') as HTMLButtonElement;
+    btn.click();
+    await waitForUpdate(el);
+    el.addEventListener('ar-breadcrumb-hide', (e) => e.preventDefault());
+    let event: CustomEvent | undefined;
+    el.addEventListener('ar-breadcrumb-hide-prevented', (e) => {
+        event = e as CustomEvent;
+    });
+    btn.click();
+    await waitForUpdate(el);
+    await waitForUpdate(el);
+    expect(event).toBeDefined();
+    expect(event?.cancelable).toBe(false);
+});
+```
+
+- [ ] **Step 2: Lancer les tests, vérifier qu'ils échouent**
+
+Run: `cd packages/core && npx vitest run src/components/breadcrumb/breadcrumb.test.ts`
+Expected: les 2 nouveaux tests FAIL, les autres PASS.
+
+- [ ] **Step 3: Migrer `breadcrumb.ts` vers `ToggleController`**
+
+Ajouter l'import (après l'import `lit`, avant les imports `@lit/context`/styles) :
+
+```ts
+import { ToggleController } from '../../controllers/toggle.controller.js';
+import { emitToggleEvent } from '../../utils/toggle-events.js';
+```
+
+Remplacer le bloc JSDoc `@event` (lignes ~49-52) :
+
+```ts
+ * @event {CustomEvent} ar-breadcrumb-show   - Émis avant l'ouverture du dropdown mobile. Annulable.
+ * @event {CustomEvent} ar-breadcrumb-shown  - Émis après l'ouverture du dropdown mobile.
+ * @event {CustomEvent} ar-breadcrumb-hide   - Émis avant la fermeture du dropdown mobile. Annulable.
+ * @event {CustomEvent} ar-breadcrumb-hidden - Émis après la fermeture du dropdown mobile.
+```
+
+par :
+
+```ts
+ * @event {CustomEvent} ar-breadcrumb-show           - Émis avant l'ouverture du dropdown mobile. Annulable.
+ * @event {CustomEvent} ar-breadcrumb-show-prevented - Émis si ar-breadcrumb-show est annulé.
+ * @event {CustomEvent} ar-breadcrumb-shown          - Émis après l'ouverture du dropdown mobile.
+ * @event {CustomEvent} ar-breadcrumb-hide           - Émis avant la fermeture du dropdown mobile. Annulable.
+ * @event {CustomEvent} ar-breadcrumb-hide-prevented - Émis si ar-breadcrumb-hide est annulé.
+ * @event {CustomEvent} ar-breadcrumb-hidden         - Émis après la fermeture du dropdown mobile.
+```
+
+Remplacer le champ `_suppressNextToggle` (lignes ~80-86) :
+
+```ts
+    /**
+     * Quand _show()/_hide() annule et revient sur `open`, ça redéclenche un second cycle
+     * updated() qui appellerait la branche opposée pour rien (le panel n'a jamais changé
+     * d'état). Ce flag fait de ce second appel un no-op, sans affecter les fermetures
+     * externes légitimes (onExternalClose), qui ne passent pas par cette annulation.
+     */
+    private _suppressNextToggle = false;
+```
+
+par :
+
+```ts
+    private readonly _toggle = new ToggleController(this, {
+        eventPrefix: 'ar-breadcrumb',
+        shouldToggle: () => this.isMobile,
+        skipInitialTransition: true,
+        onShow: () => this._onShow(),
+        onHide: () => this._onHide(),
+    });
+```
+
+Remplacer le bloc `updated()` (lignes ~144-159) :
+
+```ts
+    override updated(changed: PropertyValues<this>): void {
+        if ((changed as Map<PropertyKey, unknown>).has('isMobile') && this.isMobile) {
+            void this.updateComplete.then(() => {
+                if (this.isConnected) this._attachDropdown();
+            });
+        }
+        if (changed.has('open') && changed.get('open') !== undefined && this.isMobile) {
+            // Différé après la fin du cycle courant : _show()/_hide() déclenchent
+            // Popover.show()/hide(), qui appelle host.requestUpdate() — un appel synchrone
+            // ici déclencherait l'avertissement dev Lit "change-in-update".
+            void this.updateComplete.then(() => {
+                if (this.open) this._show();
+                else this._hide();
+            });
+        }
+    }
+```
+
+par (le bloc `changed.has('open')` disparaît, le reste est inchangé) :
+
+```ts
+    override updated(changed: PropertyValues<this>): void {
+        if ((changed as Map<PropertyKey, unknown>).has('isMobile') && this.isMobile) {
+            void this.updateComplete.then(() => {
+                if (this.isConnected) this._attachDropdown();
+            });
+        }
+    }
+```
+
+Remplacer `_show()`/`_hide()`/`_emit()` (lignes ~259-299) :
+
+```ts
+    private _show(): void {
+        if (this._suppressNextToggle) {
+            this._suppressNextToggle = false;
+            return;
+        }
+        const showEv = this._emit('ar-breadcrumb-show');
+        if (showEv.defaultPrevented) {
+            this._suppressNextToggle = true;
+            this.open = false;
+            return;
+        }
+        void this._popover.show().then(() => {
+            this._emit('ar-breadcrumb-shown');
+        });
+    }
+
+    private _hide(): void {
+        if (this._suppressNextToggle) {
+            this._suppressNextToggle = false;
+            return;
+        }
+        const hideEv = this._emit('ar-breadcrumb-hide');
+        if (hideEv.defaultPrevented) {
+            this._suppressNextToggle = true;
+            this.open = true;
+            return;
+        }
+        this._popover.hide();
+        this._emit('ar-breadcrumb-hidden');
+    }
+
+    private _emit(name: string): CustomEvent {
+        const e = new CustomEvent(name, {
+            bubbles: true,
+            composed: true,
+            cancelable: true,
+            detail: { id: this.id || undefined },
+        });
+        this.dispatchEvent(e);
+        return e;
+    }
+```
+
+par :
+
+```ts
+    private _onShow(): void {
+        void this._popover.show().then(() => {
+            emitToggleEvent(this, 'ar-breadcrumb-shown', { cancelable: false });
+        });
+    }
+
+    private _onHide(): void {
+        this._popover.hide();
+        emitToggleEvent(this, 'ar-breadcrumb-hidden', { cancelable: false });
+    }
+```
+
+- [ ] **Step 4: Lancer les tests**
+
+Run: `cd packages/core && npx vitest run src/components/breadcrumb/breadcrumb.test.ts --reporter=verbose`
+Expected: tous PASS, y compris les 2 nouveaux du Step 1. En particulier, vérifier que le test `"open vaut false par défaut"` et le comportement desktop (`describe('attribut open — mode desktop', ...)`) restent inchangés (`shouldToggle`/`skipInitialTransition` doivent reproduire exactement l'ancien comportement).
+
+- [ ] **Step 5: Vérifier les tests navigateur**
+
+Run: `cd packages/core && npx web-test-runner --files "src/components/breadcrumb/**/*.browser.test.ts"`
+Expected: tous PASS, en particulier le test `light-dismiss` (point exact de la régression PR #112).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/components/breadcrumb/breadcrumb.ts packages/core/src/components/breadcrumb/breadcrumb.test.ts
+git commit -m "feat(core): migre ar-breadcrumb vers ToggleController + ajoute show/hide-prevented"
+```
+
+---
+
+### Task 5: Migration `ar-collapse`
+
+**Files:**
+
+- Modify: `packages/core/src/components/collapse/collapse.ts`
+- Modify: `packages/core/src/components/collapse/collapse.test.ts`
+- Verify (pas de modification attendue) : `packages/core/src/components/collapse/collapse.browser.test.ts`, `collapse.a11y.test.ts`
+
+**Interfaces:**
+
+- Consumes: `ToggleController` avec `skipInitialTransition: true` (préserve le comportement actuel — collapse ne fire pas show/hide sur `open=true` posé avant la première connexion, cf. son ancien guard `changed.get('open') !== undefined` combiné à `_initialized`).
+- Produces: `ar-collapse-show-prevented`, `ar-collapse-hide-prevented`. `ar-collapse-show`/`-shown`/`-hide`/`-hidden` gagnent désormais `detail: { id }` (n'en avaient pas avant — décision actée : changement additif accepté).
+
+- [ ] **Step 1: Écrire les tests des nouveaux events `-prevented` et du nouveau `detail`**
+
+Ajouter dans `packages/core/src/components/collapse/collapse.test.ts`, dans le `describe('événements', ...)` existant, après le test `"n'émet pas ar-collapse-show/-shown quand ar-collapse-hide est annulé"` :
+
+```ts
+it('émet ar-collapse-show-prevented (non cancelable) quand ar-collapse-show est annulé', async () => {
+    el.addEventListener('ar-collapse-show', (e) => e.preventDefault());
+    let event: CustomEvent | undefined;
+    el.addEventListener('ar-collapse-show-prevented', (e) => {
+        event = e as CustomEvent;
+    });
+    el.open = true;
+    await waitForUpdate(el);
+    expect(event).toBeDefined();
+    expect(event?.cancelable).toBe(false);
+});
+
+it('émet ar-collapse-hide-prevented (non cancelable) quand ar-collapse-hide est annulé', async () => {
+    el.show();
+    await waitForUpdate(el);
+    el.addEventListener('ar-collapse-hide', (e) => e.preventDefault());
+    let event: CustomEvent | undefined;
+    el.addEventListener('ar-collapse-hide-prevented', (e) => {
+        event = e as CustomEvent;
+    });
+    el.open = false;
+    await waitForUpdate(el);
+    expect(event).toBeDefined();
+    expect(event?.cancelable).toBe(false);
+});
+
+it('ar-collapse-show porte desormais detail.id (id auto-généré)', async () => {
+    let detail: { id?: string } | undefined;
+    el.addEventListener('ar-collapse-show', (e) => {
+        detail = (e as CustomEvent).detail;
+    });
+    el.show();
+    await waitForUpdate(el);
+    expect(detail?.id).toBe(el.id);
+});
+```
+
+- [ ] **Step 2: Lancer les tests, vérifier qu'ils échouent**
+
+Run: `cd packages/core && npx vitest run src/components/collapse/collapse.test.ts`
+Expected: les 3 nouveaux tests FAIL, les autres PASS.
+
+- [ ] **Step 3: Migrer `collapse.ts` vers `ToggleController`**
+
+Ajouter l'import (après l'import `lit`) :
+
+```ts
+import { ToggleController } from '../../controllers/toggle.controller.js';
+import { emitToggleEvent } from '../../utils/toggle-events.js';
+```
+
+Retirer `export type ArCollapseEvents = ...` (lignes 7-11) — n'est plus utilisé une fois `_emit()` supprimé (vérifier par `grep -rn "ArCollapseEvents" packages/core/src` qu'aucun autre fichier ne l'importe avant de le retirer).
+
+Remplacer le bloc JSDoc `@event` (lignes ~28-31) :
+
+```ts
+ * @event {CustomEvent} ar-collapse-show   - Avant l'ouverture. Annulable.
+ * @event {CustomEvent} ar-collapse-shown  - Après la fin de l'animation d'ouverture.
+ * @event {CustomEvent} ar-collapse-hide   - Avant la fermeture. Annulable.
+ * @event {CustomEvent} ar-collapse-hidden - Après la fin de l'animation de fermeture.
+```
+
+par :
+
+```ts
+ * @event {CustomEvent} ar-collapse-show           - Avant l'ouverture. Annulable.
+ * @event {CustomEvent} ar-collapse-show-prevented - Émis si ar-collapse-show est annulé.
+ * @event {CustomEvent} ar-collapse-shown          - Après la fin de l'animation d'ouverture.
+ * @event {CustomEvent} ar-collapse-hide           - Avant la fermeture. Annulable.
+ * @event {CustomEvent} ar-collapse-hide-prevented - Émis si ar-collapse-hide est annulé.
+ * @event {CustomEvent} ar-collapse-hidden         - Après la fin de l'animation de fermeture.
+```
+
+Ajouter le controller comme champ de classe, juste après `private _onTransitionEnd: (() => void) | null = null;` (ligne 66) :
+
+```ts
+    private readonly _toggle = new ToggleController(this, {
+        eventPrefix: 'ar-collapse',
+        skipInitialTransition: true,
+        onShow: () => this._onShow(),
+        onHide: () => this._onHide(),
+    });
+```
+
+Remplacer le bloc `updated()` (lignes ~93-109) :
+
+```ts
+    override updated(changed: PropertyValues<this>): void {
+        if (!this._initialized) return;
+        if (changed.has('for')) {
+            this._detachExternalTrigger();
+            if (this.for) {
+                this._warnIfBothTriggers();
+                this._attachExternalTrigger();
+            }
+        }
+        if (changed.has('open') && changed.get('open') !== undefined) {
+            if (this.open) this._show();
+            else this._hide();
+        }
+        if (changed.has('disabled')) {
+            this._syncTriggerDisabled();
+        }
+    }
+```
+
+par (le bloc `changed.has('open')` disparaît, le reste est inchangé) :
+
+```ts
+    override updated(changed: PropertyValues<this>): void {
+        if (!this._initialized) return;
+        if (changed.has('for')) {
+            this._detachExternalTrigger();
+            if (this.for) {
+                this._warnIfBothTriggers();
+                this._attachExternalTrigger();
+            }
+        }
+        if (changed.has('disabled')) {
+            this._syncTriggerDisabled();
+        }
+    }
+```
+
+Remplacer `_show()`/`_hide()`/`_emit()` (lignes ~272-352) :
+
+```ts
+    private _show(): void {
+        // symétrique de la garde de _hide() : panel déjà visible (ex. ar-collapse-hide
+        // annulé → open=true redéclenché) — évite de réémettre show/shown pour rien.
+        if (!this._panel.hasAttribute('hidden') && !this._animating) return;
+        const ev = this._emit('ar-collapse-show');
+        if (ev.defaultPrevented) {
+            this.open = false;
+            return;
+        }
+        this._abortAnimation();
+        this._closeGroupSiblings();
+        this._syncTriggerAria();
+        this._animating = true;
+        const panel = this._panel;
+        panel.style.height = '0px';
+        panel.removeAttribute('hidden');
+        const targetH = panel.scrollHeight;
+        void panel.offsetHeight; // force reflow
+        if (!this._shouldAnimate()) {
+            panel.style.height = 'auto';
+            this._animating = false;
+            this._emit('ar-collapse-shown');
+            return;
+        }
+        panel.style.height = `${targetH}px`;
+        const onShow = () => {
+            this._onTransitionEnd = null;
+            this._animating = false;
+            panel.style.height = 'auto';
+            this._emit('ar-collapse-shown');
+        };
+        this._onTransitionEnd = onShow;
+        panel.addEventListener('transitionend', onShow, { once: true });
+    }
+
+    private _hide(): void {
+        // finding 2 : panel déjà caché (ex. ar-collapse-show annulé → open=false déclenché)
+        if (this._panel.hasAttribute('hidden') && !this._animating) return;
+        const ev = this._emit('ar-collapse-hide');
+        if (ev.defaultPrevented) {
+            this.open = true;
+            return;
+        }
+        const wasAnimating = this._animating;
+        this._abortAnimation();
+        this._syncTriggerAria();
+        if (wasAnimating) {
+            // finding 5 : snap immédiat — frère accordéon ou interruption externe
+            this._panel.setAttribute('hidden', '');
+            this._panel.style.height = '';
+            this._emit('ar-collapse-hidden');
+            return;
+        }
+        this._animating = true;
+        const panel = this._panel;
+        panel.style.height = `${panel.scrollHeight}px`;
+        void panel.offsetHeight; // force reflow
+        if (!this._shouldAnimate()) {
+            this._animating = false;
+            panel.setAttribute('hidden', '');
+            panel.style.height = '';
+            this._emit('ar-collapse-hidden');
+            return;
+        }
+        panel.style.height = '0px';
+        const onHide = () => {
+            this._onTransitionEnd = null;
+            this._animating = false;
+            panel.setAttribute('hidden', '');
+            panel.style.height = '';
+            this._emit('ar-collapse-hidden');
+        };
+        this._onTransitionEnd = onHide;
+        panel.addEventListener('transitionend', onHide, { once: true });
+    }
+
+    private _emit(name: ArCollapseEvents): CustomEvent {
+        const e = new CustomEvent(name, { bubbles: true, composed: true, cancelable: true });
+        this.dispatchEvent(e);
+        return e;
+    }
+```
+
+par (les gardes `hasAttribute('hidden')` disparaissent — protection anti-cycle-redondant désormais gérée par le controller ; `_emit()` disparaît, remplacé par `emitToggleEvent`) :
+
+```ts
+    private _onShow(): void {
+        this._abortAnimation();
+        this._closeGroupSiblings();
+        this._syncTriggerAria();
+        this._animating = true;
+        const panel = this._panel;
+        panel.style.height = '0px';
+        panel.removeAttribute('hidden');
+        const targetH = panel.scrollHeight;
+        void panel.offsetHeight; // force reflow
+        if (!this._shouldAnimate()) {
+            panel.style.height = 'auto';
+            this._animating = false;
+            emitToggleEvent(this, 'ar-collapse-shown', { cancelable: false });
+            return;
+        }
+        panel.style.height = `${targetH}px`;
+        const onShow = () => {
+            this._onTransitionEnd = null;
+            this._animating = false;
+            panel.style.height = 'auto';
+            emitToggleEvent(this, 'ar-collapse-shown', { cancelable: false });
+        };
+        this._onTransitionEnd = onShow;
+        panel.addEventListener('transitionend', onShow, { once: true });
+    }
+
+    private _onHide(): void {
+        const wasAnimating = this._animating;
+        this._abortAnimation();
+        this._syncTriggerAria();
+        if (wasAnimating) {
+            // finding 5 : snap immédiat — frère accordéon ou interruption externe
+            this._panel.setAttribute('hidden', '');
+            this._panel.style.height = '';
+            emitToggleEvent(this, 'ar-collapse-hidden', { cancelable: false });
+            return;
+        }
+        this._animating = true;
+        const panel = this._panel;
+        panel.style.height = `${panel.scrollHeight}px`;
+        void panel.offsetHeight; // force reflow
+        if (!this._shouldAnimate()) {
+            this._animating = false;
+            panel.setAttribute('hidden', '');
+            panel.style.height = '';
+            emitToggleEvent(this, 'ar-collapse-hidden', { cancelable: false });
+            return;
+        }
+        panel.style.height = '0px';
+        const onHide = () => {
+            this._onTransitionEnd = null;
+            this._animating = false;
+            panel.setAttribute('hidden', '');
+            panel.style.height = '';
+            emitToggleEvent(this, 'ar-collapse-hidden', { cancelable: false });
+        };
+        this._onTransitionEnd = onHide;
+        panel.addEventListener('transitionend', onHide, { once: true });
+    }
+```
+
+**Point d'attention** : `_abortAnimation()` (méthode existante, inchangée) référence `this.open` pour décider de l'état final du panel lors d'un abort (`disconnectedCallback`, ou interruption). Vérifier après migration qu'elle continue de fonctionner correctement — elle ne dépend pas de `_show`/`_hide`/`_emit`, seulement de `this.open` et `this._panel`, donc ne devrait pas être affectée par ce refactor. Confirmer avec la suite de tests complète (Step 4).
+
+- [ ] **Step 4: Lancer les tests**
+
+Run: `cd packages/core && npx vitest run src/components/collapse/collapse.test.ts --reporter=verbose`
+Expected: tous PASS, y compris les 3 nouveaux du Step 1. Porter une attention particulière aux tests `'show() est no-op si déjà open'` et `'hide() est no-op si déjà fermé'` (describe `'show() / hide()'`) — ces no-op restent garantis par les guards de `show()`/`hide()` publics (`if (this.open || this._animating || this.disabled) return;`), indépendants du controller.
+
+- [ ] **Step 5: Vérifier les tests navigateur et a11y**
+
+Run: `cd packages/core && npx web-test-runner --files "src/components/collapse/**/*.{browser,a11y}.test.ts"`
+Expected: tous PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/components/collapse/collapse.ts packages/core/src/components/collapse/collapse.test.ts
+git commit -m "feat(core): migre ar-collapse vers ToggleController + ajoute show/hide-prevented"
+```
+
+---
+
+### Task 6: Ajout minimal `ar-dialog-show-prevented`
+
+**Files:**
+
+- Modify: `packages/core/src/components/dialog/dialog.ts`
+- Modify: `packages/core/src/components/dialog/dialog.test.ts`
+
+**Interfaces:**
+
+- Consumes: rien de nouveau — `ar-dialog` garde son propre `_emit()` (pas de migration vers `emitToggleEvent`/`ToggleController` dans ce plan, cf. spec).
+- Produces: `ar-dialog-show-prevented`.
+
+- [ ] **Step 1: Écrire le test du nouvel event**
+
+Ajouter dans `packages/core/src/components/dialog/dialog.test.ts`, dans le `describe('ouverture', ...)` (même bloc que le test `"ar-dialog-show annulable empêche l'ouverture"`, juste après lui) :
+
+```ts
+it('ar-dialog-show annulé émet ar-dialog-show-prevented', async () => {
+    el = await fixture('<ar-dialog></ar-dialog>');
+    el.addEventListener('ar-dialog-show', (e) => e.preventDefault());
+    const prevented = vi.fn();
+    el.addEventListener('ar-dialog-show-prevented', prevented);
+    el.open = true;
+    await waitForUpdate(el);
+    expect(prevented).toHaveBeenCalledOnce();
+});
+```
+
+- [ ] **Step 2: Lancer le test, vérifier qu'il échoue**
+
+Run: `cd packages/core && npx vitest run src/components/dialog/dialog.test.ts`
+Expected: le nouveau test FAIL, les autres PASS.
+
+- [ ] **Step 3: Ajouter l'event dans `dialog.ts`**
+
+Dans le type `ArDialogEvents` (lignes 21-30), ajouter `'ar-dialog-show-prevented'` juste après `'ar-dialog-show'` :
+
+```ts
+export type ArDialogEvents =
+    | 'ar-dialog-show'
+    | 'ar-dialog-show-prevented'
+    | 'ar-dialog-shown'
+    | 'ar-dialog-hide'
+    | 'ar-dialog-hide-prevented'
+    | 'ar-dialog-hidden'
+    | 'ar-dialog-dismissed'
+    | 'ar-dialog-dismissed-prevented'
+    | 'ar-dialog-accepted'
+    | 'ar-dialog-accepted-prevented';
+```
+
+Dans le bloc JSDoc `@event` (ligne 73), ajouter juste après `ar-dialog-show` :
+
+```ts
+ * @event {CustomEvent} ar-dialog-show - Émis avant l'ouverture. Annulable.
+ * @event {CustomEvent} ar-dialog-show-prevented - Émis si ar-dialog-show est annulé.
+```
+
+Dans `_show()` (lignes 409-420), ajouter l'émission juste après `this._triggerElement = null;` — **avant** le `.then()` différé (décision actée : émission synchrone, `el.open` peut encore valoir `true` un instant à ce moment précis, le revert réel arrivant un tick plus tard) :
+
+```ts
+    private _show(): void {
+        this._triggerElement = document.activeElement;
+        const showEvent = this._emit('ar-dialog-show');
+        if (showEvent.defaultPrevented) {
+            this._triggerElement = null;
+            this._emit('ar-dialog-show-prevented');
+            void this.updateComplete.then(() => {
+                if (this.isConnected && this.open && !this.dialog?.open) {
+                    this.open = false;
+                }
+            });
+            return;
+        }
+```
+
+(le reste de `_show()` est inchangé).
+
+- [ ] **Step 4: Lancer les tests**
+
+Run: `cd packages/core && npx vitest run src/components/dialog/dialog.test.ts --reporter=verbose`
+Expected: tous PASS, y compris le nouveau test.
+
+- [ ] **Step 5: Vérifier les tests navigateur et a11y du dialog**
+
+Run: `cd packages/core && npx web-test-runner --files "src/components/dialog/**/*.{browser,a11y}.test.ts"`
+Expected: tous PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/components/dialog/dialog.ts packages/core/src/components/dialog/dialog.test.ts
+git commit -m "feat(core): ajoute ar-dialog-show-prevented (symétrique à hide-prevented)"
+```
+
+---
+
+### Task 7: Vérification globale + documentation
+
+**Files:**
+
+- Verify only (pas de modification de code attendue, sauf régénération de fichiers générés) :
+    - `packages/core/custom-elements.json` (régénéré par `build:manifest`)
+    - `apps/docs/` (vérification visuelle uniquement)
+
+- [ ] **Step 1: Suite complète Vitest**
+
+Run (depuis la racine) : `npm run test`
+Expected: tous les fichiers PASS (comparer le compte total de tests à avant ce chantier + les nouveaux tests ajoutés dans les tasks 3-6 : 5 nouveaux dans dropdown, 5 dans breadcrumb — 2 events-prevented + les 3 tests de non-régression déjà existants restent, en fait juste 2 nouveaux par composant sauf collapse qui en a 3 — total +9 nouveaux tests de composants, +19 déjà comptés dans le commit `2485186`).
+
+- [ ] **Step 2: Suite complète navigateur**
+
+Run: `cd packages/core && npx web-test-runner`
+Expected: tous PASS (220+ tests avant ce chantier, plus les vérifications des tasks 3-6 déjà passées individuellement).
+
+- [ ] **Step 3: Typecheck et lint**
+
+Run: `cd packages/core && npx tsc --noEmit && npm run lint`
+Expected: aucune erreur.
+
+- [ ] **Step 4: Régénérer le CEM et vérifier l'impact doc**
+
+Run: `cd packages/core && npm run build:manifest`
+Expected: `custom-elements.json` regénéré sans erreur, contient les nouveaux events (`grep -c "prevented" custom-elements.json` doit être > 0).
+
+Lancer le site de doc en local (`npm run dev` depuis la racine, ou `cd apps/docs && npm run dev`) et vérifier visuellement les pages `ar-dropdown`, `ar-breadcrumb`, `ar-collapse`, `ar-dialog` — la table des events doit lister les nouveaux `-prevented`, sans régression d'affichage sur les events existants.
+
+- [ ] **Step 5: Commit des fichiers générés si modifiés**
+
+```bash
+git status --short packages/core/custom-elements.json
+# Si modifié :
+git add packages/core/custom-elements.json
+git commit -m "chore(core): régénère le CEM avec les nouveaux events -prevented"
+```
+
+---
+
+### Task 8: Ouverture de la PR
+
+**Files:** aucun.
+
+- [ ] **Step 1: Push de la branche**
+
+```bash
+git push -u origin feat/toggle-controller-mutualization
+```
+
+- [ ] **Step 2: Créer la PR vers `dev`**
+
+```bash
+gh pr create --base dev --head feat/toggle-controller-mutualization \
+  --title "feat(core): mutualise le pattern events annulables (ToggleController) + events -prevented" \
+  --body "$(cat <<'EOF'
+## Contexte
+
+Item 1 de #111 (chantier technique global), 2ᵉ moitié — suite de #112 (bug d'émission parasite).
+Spec : docs/superpowers/specs/2026-07-16-toggle-controller-mutualization-design.md
+
+## Contenu
+
+- `ToggleController` (ReactiveController partagé) + `emitToggleEvent()` — mutualise la mécanique show/hide annulable dupliquée entre ar-dropdown, ar-breadcrumb, ar-collapse.
+- Nouveaux événements `ar-*-show-prevented`/`ar-*-hide-prevented` sur les 4 composants disclosure (dropdown, breadcrumb, collapse, dialog).
+- Correctif : `cancelable: false` sur les events informatifs (shown/hidden/-prevented), qui étaient `cancelable: true` par erreur — sauf ar-dialog, qui garde son `_emit()` propre (hors scope de la migration controller).
+- ar-collapse gagne `detail: { id }` sur ses events (absent auparavant).
+
+## Breaking changes (alpha, acceptés sans dépréciation)
+
+- `CustomEvent.cancelable` passe de `true` à `false` sur ar-dropdown-shown/-hidden, ar-breadcrumb-shown/-hidden, ar-collapse-show/-shown/-hide/-hidden.
+- ar-collapse : nouveaux champs `detail.id` sur tous ses events (additif).
+
+## Test plan
+
+- [x] npm run test — suite complète Vitest
+- [x] npm run test:browser — suite complète navigateur (WTR), y compris light-dismiss/Escape (point de la régression #112)
+- [x] tsc --noEmit + npm run lint
+- [x] Vérification visuelle doc Astro (table events)
+EOF
+)"
+```
+
+---
+
+## Self-Review (fait avant remise du plan)
+
+**Couverture spec** : périmètre (3 composants mutualisés + dialog minimal) ✓, `ToggleController` API ✓ (livré, validé empiriquement), fonction d'émission partagée ✓ (livré), impact par composant ✓ (tasks 3-6), tests ✓ (chaque task), documentation/CEM ✓ (task 7).
+
+**Signatures** : `ToggleControllerOptions` (`eventPrefix`, `onShow`, `onHide`, `shouldToggle?`, `skipInitialTransition?`) et `emitToggleEvent(host, name, { cancelable })` utilisés de façon cohérente dans toutes les tasks 3-6, correspondant exactement à l'implémentation livrée dans le commit `2485186`.
+
+**Nuances découvertes en cours de planification, non prévues au spec initial, actées avec l'utilisateur avant rédaction** :
+
+- `ar-breadcrumb` : gate `isMobile` + skip de la toute première transition (`shouldToggle`/`skipInitialTransition`).
+- `ar-collapse` : skip de la toute première transition également ; ajout de `detail: { id }` absent auparavant.
+- `ar-dialog` : timing synchrone (avant le revert différé) pour `ar-dialog-show-prevented`.

--- a/docs/superpowers/specs/2026-07-16-toggle-controller-mutualization-design.md
+++ b/docs/superpowers/specs/2026-07-16-toggle-controller-mutualization-design.md
@@ -1,0 +1,118 @@
+# Mutualisation du pattern events annulables (ToggleController)
+
+Date : 2026-07-16
+Contexte : [issue #111](https://github.com/jogo-labs/ariane/issues/111) (chantier technique global), item 1 — 2ᵉ moitié. La 1ʳᵉ moitié (bug d'émission parasite du toggle opposé sur annulation) est livrée en [PR #112](https://github.com/jogo-labs/ariane/pull/112). Fait suite à [`2026-07-14-pr2-events-convention-design.md`](./2026-07-14-pr2-events-convention-design.md), qui a aligné `ar-breadcrumb`/`ar-tooltip`/`ar-stepper` sur le pattern `show`/`shown`/`hide`/`hidden` déjà en place sur `ar-dropdown`/`ar-dialog`/`ar-collapse`.
+
+## Objectif
+
+Deux choses distinctes mais liées :
+
+1. **Mutualiser** la mécanique dupliquée entre `ar-dropdown`, `ar-breadcrumb` et `ar-collapse` (émission `show`/`hide` annulable, revert de `open` sur annulation, flag anti-cycle-redondant post-fix PR #112) dans un `ReactiveController` partagé, `ToggleController` — même famille que `AnchoredController`.
+2. **Ajouter** des événements `-prevented` (`ar-*-show-prevented`/`ar-*-hide-prevented`) sur les 4 composants disclosure (`ar-dropdown`, `ar-breadcrumb`, `ar-collapse`, `ar-dialog`), pour que le consommateur soit notifié explicitement d'une annulation au lieu de devoir inspecter `el.open` après coup. `ar-dialog` a déjà `ar-dialog-hide-prevented` ; il lui manque `ar-dialog-show-prevented`.
+
+## Périmètre
+
+**Mutualisé via `ToggleController`** : `ar-dropdown`, `ar-breadcrumb`, `ar-collapse`.
+
+**Non mutualisé, ajout minimal dans le code existant** : `ar-dialog` — sa logique (`_isClosing`, `_closePending`, animations, focus trap, shake + annonce a11y sur annulation) est trop spécifique pour justifier de la forcer dans le controller. Il gagne juste l'émission de `ar-dialog-show-prevented` au bon endroit dans `_show()`. La question de le faire passer par le controller plus tard reste ouverte, à réévaluer une fois le reste du chantier terminé (pas dans ce spec).
+
+## `ToggleController`
+
+Nouveau fichier `packages/core/src/controllers/toggle.controller.ts`.
+
+```ts
+export interface ToggleControllerOptions {
+    /** Préfixe des events, ex. 'ar-dropdown' → ar-dropdown-show, ar-dropdown-show-prevented, etc. */
+    eventPrefix: string;
+    /** Logique d'ouverture propre au composant, appelée si le show n'est pas annulé. */
+    onShow: () => void;
+    /** Logique de fermeture propre au composant, appelée si le hide n'est pas annulé. */
+    onHide: () => void;
+}
+
+export class ToggleController implements ReactiveController {
+    constructor(
+        host: ReactiveControllerHost & HTMLElement & { open: boolean },
+        opts: ToggleControllerOptions,
+    );
+}
+```
+
+**Responsabilités** :
+
+- Détecte que `open` a changé en comparant à une valeur `_lastOpen` interne à chaque `hostUpdated()` — remplace le `changed.has('open')` que chaque composant gérait dans son propre `updated()`. `_lastOpen` s'initialise à `false` dans le constructeur (valeur par défaut de la propriété `open` sur les 3 composants) : si `open` vaut déjà `true` au tout premier `hostUpdated()` (élément créé avec l'attribut posé avant connexion), la comparaison le détecte comme un changement et déclenche `onShow()` — à vérifier explicitement à l'implémentation contre le test existant `"n'émet ar-dropdown-show qu'une fois quand open est déjà vrai au premier rendu"`, qui dépend de ce comportement.
+- Diffère l'action via `host.updateComplete.then()` (même raison qu'aujourd'hui : `Popover.show()`/`hide()` appellent `host.requestUpdate()`, un appel synchrone déclencherait l'avertissement dev Lit "change-in-update").
+- Émet `<prefix>-show` ou `<prefix>-hide` (`cancelable: true`).
+- Si `defaultPrevented` : revert `host.open` à sa valeur précédente, pose le flag interne anti-cycle-redondant (`_suppressNextToggle`, hérité du fix PR #112, désormais interne au controller au lieu d'un champ privé par composant), puis émet `<prefix>-show-prevented` ou `<prefix>-hide-prevented` (`cancelable: false`) — **dans cet ordre** (revert puis événement), comme le fait déjà `ar-dialog-hide-prevented` aujourd'hui.
+- Sinon, appelle `opts.onShow()`/`opts.onHide()` et s'arrête là. L'émission de `<prefix>-shown`/`<prefix>-hidden` reste à la charge du composant lui-même (timing variable : promise pour dropdown/breadcrumb via `Popover.show()`, sync ou `transitionend` pour collapse selon `prefersReducedMotion()`).
+- `onExternalClose` (popover, light-dismiss/Escape natif) continue de faire `host.open = false` directement, sans passer par le controller pour l'annulation — le controller le détecte comme une transition normale (le flag n'est pas posé), donc `onHide()` s'exécute et les events s'émettent normalement. C'est le comportement validé empiriquement par le fix de régression CI de PR #112 ; le controller doit le préserver à l'identique.
+
+## Fonction d'émission partagée
+
+Le `_emit()` privé dupliqué dans chaque composant (`{ bubbles: true, composed: true, cancelable: true, detail: { id: host.id || undefined } }` pour _tous_ les events) est remplacé par une fonction exportée, utilisée à la fois par le controller (pour `show`/`hide`/`show-prevented`/`hide-prevented`) et par chaque composant (pour `shown`/`hidden`) :
+
+```ts
+export function emitToggleEvent(
+    host: HTMLElement,
+    name: string,
+    opts: { cancelable: boolean },
+): CustomEvent {
+    const e = new CustomEvent(name, {
+        bubbles: true,
+        composed: true,
+        cancelable: opts.cancelable,
+        detail: { id: host.id || undefined },
+    });
+    host.dispatchEvent(e);
+    return e;
+}
+```
+
+**Correctif de comportement inclus** : aujourd'hui, `_emit()` pose `cancelable: true` sur _tous_ les events, y compris `shown`/`hidden` et `ar-dialog-hide-prevented`, alors que rien ne vérifie `defaultPrevented` dessus — c'est purement informatif. La nouvelle fonction partagée corrige ça : `cancelable: true` uniquement pour `show`/`hide`, `false` pour `shown`/`hidden`/`show-prevented`/`hide-prevented`. Changement mineur de comportement (le `CustomEvent.cancelable` observable passe de `true` à `false` sur ces events), accepté sans dépréciation — precedent posé par [PR #89](https://github.com/jogo-labs/ariane/pull/89) pour les breaking changes en alpha.
+
+Placement : `packages/core/src/utils/toggle-events.ts` (à côté de `popover.ts`, pas dans le controller lui-même, pour rester réutilisable par `ar-dialog` qui n'utilise pas le controller).
+
+## Impact par composant
+
+### `ar-dropdown`
+
+- `_show()`/`_hide()` deviennent les callbacks `onShow()`/`onHide()` passés au `ToggleController`.
+- Le bloc `changed.has('open')` disparaît de `updated()`.
+- Le champ privé `_suppressNextToggle` (ajouté par PR #112) disparaît, géré par le controller.
+- `onShow()`/`onHide()` gardent leur logique actuelle (détection menu mode, listeners clavier, `Popover.show()`/`hide()`) et émettent eux-mêmes `ar-dropdown-shown`/`ar-dropdown-hidden` via `emitToggleEvent()`.
+- Nouveaux events : `ar-dropdown-show-prevented`, `ar-dropdown-hide-prevented` (émis par le controller, rien à faire côté composant).
+
+### `ar-breadcrumb`
+
+Même transformation que `ar-dropdown` (structure identique post-PR #112).
+
+### `ar-collapse`
+
+- Même transformation, avec une simplification supplémentaire : le garde `if (this._panel.hasAttribute('hidden') && !this._animating) return;` (et son miroir côté `_show()`) est supprimé — il ne servait que la protection anti-cycle-redondant, désormais gérée par le controller. L'idempotence de l'API publique `show()`/`hide()` (`if (this.open || this._animating || this.disabled) return;`) est indépendante et reste inchangée.
+- `onShow()`/`onHide()` gardent toute la logique d'animation (`_animating`, `transitionend`, `_closeGroupSiblings()`) et émettent `ar-collapse-shown`/`ar-collapse-hidden` eux-mêmes au bon moment (sync si `!_shouldAnimate()`, sinon dans le listener `transitionend`).
+- Nouveaux events : `ar-collapse-show-prevented`, `ar-collapse-hide-prevented`.
+
+### `ar-dialog`
+
+- Aucun changement structurel. Ajout de `this._emit('ar-dialog-show-prevented')` dans `_show()`, au même endroit où `this.open` est actuellement reverté sur annulation (avant le `return`), symétrique à `ar-dialog-hide-prevented` existant dans `_close()`.
+- `_emit()` propre à `ar-dialog` reste en place (pas de migration vers `emitToggleEvent()` dans ce spec — hors scope, cf. section suivante). Le correctif `cancelable: false` sur les events informatifs ne s'applique donc **pas** à `ar-dialog` pour l'instant — incohérence mineure assumée, à trancher si `ar-dialog` migre vers le controller/la fonction partagée plus tard.
+
+## Tests
+
+- Nouveaux tests unitaires pour `ToggleController` isolé (host mocké minimal : `open`, `updateComplete`, `dispatchEvent`).
+- Tests existants par composant (show/hide/prevented-implicite/no-op) adaptés à la nouvelle API interne (`onShow`/`onHide` au lieu de `_show`/`_hide`) — comportement observable inchangé, sauf ajout des nouveaux events.
+- Nouveaux tests `-show-prevented`/`-hide-prevented` sur les 4 composants : événement émis une seule fois, `detail.id` correct, `cancelable: false` (sauf `ar-dialog`, cf. ci-dessus), `el.open` déjà reverté au moment de l'event.
+- Re-vérification des tests navigateur light-dismiss/Escape (`dropdown.browser.test.ts`, `breadcrumb.browser.test.ts`) après migration — point exact de la régression CI de PR #112, à ne pas réintroduire.
+- Suite complète (`npm run test` + `npm run test:browser`) + `tsc --noEmit` + `npm run lint` avant merge, comme pour PR #112.
+
+## Documentation
+
+- 6 nouvelles entrées JSDoc `@event` (2 par composant mutualisé × 3) + 1 (`ar-dialog-show-prevented`) = 7 au total.
+- Impact sur le CEM (`custom-elements.json`, régénéré par `npm run build:manifest`) et potentiellement la doc Astro (table API/playground) — à vérifier visuellement lors de l'implémentation, pas seulement via le build.
+
+## Hors scope
+
+- Faire passer `ar-dialog` par `ToggleController` — décision différée, cf. section Périmètre.
+- Extraction d'un `PopoverController`/mécanisme commun à `ar-dropdown`/`ar-breadcrumb` au-delà du `ToggleController` (ex. mutualiser aussi la détection menu mode) — pas identifié comme dupliqué à ce stade.
+- `ar-stepper`, `ar-table-sort` : déjà traités par PR2 (2026-07-14) ou déjà conformes, pas de paire `show`/`hide` annulable applicable.
+- Item 2 (sync CEM ↔ thème) et item 3 (audit dette technique large) de #111 : hors scope de ce spec, traités séparément.

--- a/packages/core/src/components/breadcrumb/breadcrumb.test.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.test.ts
@@ -435,6 +435,49 @@ describe('ArBreadcrumb', () => {
             expect(showHandler).not.toHaveBeenCalled();
             expect(shownHandler).not.toHaveBeenCalled();
         });
+
+        it('émet ar-breadcrumb-show-prevented (non cancelable) quand ar-breadcrumb-show est annulé', async () => {
+            el = await fixture(`
+                <ar-breadcrumb>
+                    <ar-breadcrumb-item label="Accueil" href="/"></ar-breadcrumb-item>
+                    <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
+                </ar-breadcrumb>
+            `);
+            mockPopoverPanel(el);
+            el.addEventListener('ar-breadcrumb-show', (e) => e.preventDefault());
+            let event: CustomEvent | undefined;
+            el.addEventListener('ar-breadcrumb-show-prevented', (e) => {
+                event = e as CustomEvent;
+            });
+            el.open = true;
+            await waitForUpdate(el);
+            await waitForUpdate(el);
+            expect(event).toBeDefined();
+            expect(event?.cancelable).toBe(false);
+        });
+
+        it('émet ar-breadcrumb-hide-prevented (non cancelable) quand ar-breadcrumb-hide est annulé', async () => {
+            el = await fixture(`
+                <ar-breadcrumb>
+                    <ar-breadcrumb-item label="Accueil" href="/"></ar-breadcrumb-item>
+                    <ar-breadcrumb-item label="Page courante"></ar-breadcrumb-item>
+                </ar-breadcrumb>
+            `);
+            mockPopoverPanel(el);
+            const btn = getShadow(el).querySelector('#breadcrumb-dropdown') as HTMLButtonElement;
+            btn.click();
+            await waitForUpdate(el);
+            el.addEventListener('ar-breadcrumb-hide', (e) => e.preventDefault());
+            let event: CustomEvent | undefined;
+            el.addEventListener('ar-breadcrumb-hide-prevented', (e) => {
+                event = e as CustomEvent;
+            });
+            btn.click();
+            await waitForUpdate(el);
+            await waitForUpdate(el);
+            expect(event).toBeDefined();
+            expect(event?.cancelable).toBe(false);
+        });
     });
 
     // ── Attribut open (desktop) ───────────────────────────────────────────────

--- a/packages/core/src/components/breadcrumb/breadcrumb.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.ts
@@ -110,6 +110,7 @@ export class ArBreadcrumb extends LitElement {
 
     constructor() {
         super();
+        // s'enregistre lui-même via host.addController(), pas besoin de conserver la référence
         new ToggleController(this, {
             eventPrefix: 'ar-breadcrumb',
             shouldToggle: () => this.isMobile,

--- a/packages/core/src/components/breadcrumb/breadcrumb.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.ts
@@ -7,6 +7,8 @@ import {
     type PropertyValues,
 } from 'lit';
 import { property, query, state } from 'lit/decorators.js';
+import { ToggleController } from '../../controllers/toggle.controller.js';
+import { emitToggleEvent } from '../../utils/toggle-events.js';
 import { ContextProvider } from '@lit/context';
 import utilitiesStyles from '../../styles/utilities.styles.js';
 import resetStyles from '../../styles/components/reset.styles.js';
@@ -46,10 +48,12 @@ import { AnchoredController } from '../../controllers/anchored.controller.js';
  * @cssprop [--ar-breadcrumb-toggle-bg-pressed=var(--ar-button-tertiary-bg-active)] - Fond du bouton retour/trigger mobile pressé.
  * @cssprop [--ar-breadcrumb-toggle-bg-focus=var(--ar-button-tertiary-bg-focus)] - Fond du bouton retour/trigger mobile au focus.
  *
- * @event {CustomEvent} ar-breadcrumb-show   - Émis avant l'ouverture du dropdown mobile. Annulable.
- * @event {CustomEvent} ar-breadcrumb-shown  - Émis après l'ouverture du dropdown mobile.
- * @event {CustomEvent} ar-breadcrumb-hide   - Émis avant la fermeture du dropdown mobile. Annulable.
- * @event {CustomEvent} ar-breadcrumb-hidden - Émis après la fermeture du dropdown mobile.
+ * @event {CustomEvent} ar-breadcrumb-show           - Émis avant l'ouverture du dropdown mobile. Annulable.
+ * @event {CustomEvent} ar-breadcrumb-show-prevented - Émis si ar-breadcrumb-show est annulé.
+ * @event {CustomEvent} ar-breadcrumb-shown          - Émis après l'ouverture du dropdown mobile.
+ * @event {CustomEvent} ar-breadcrumb-hide           - Émis avant la fermeture du dropdown mobile. Annulable.
+ * @event {CustomEvent} ar-breadcrumb-hide-prevented - Émis si ar-breadcrumb-hide est annulé.
+ * @event {CustomEvent} ar-breadcrumb-hidden         - Émis après la fermeture du dropdown mobile.
  */
 export class ArBreadcrumb extends LitElement {
     static override styles: CSSResultGroup = [
@@ -77,14 +81,6 @@ export class ArBreadcrumb extends LitElement {
     private _items = new Set<ArBreadcrumbItem>();
     private _rebuildPending = false;
 
-    /**
-     * Quand _show()/_hide() annule et revient sur `open`, ça redéclenche un second cycle
-     * updated() qui appellerait la branche opposée pour rien (le panel n'a jamais changé
-     * d'état). Ce flag fait de ce second appel un no-op, sans affecter les fermetures
-     * externes légitimes (onExternalClose), qui ne passent pas par cette annulation.
-     */
-    private _suppressNextToggle = false;
-
     private readonly _provider = new ContextProvider(this, {
         context: breadcrumbContext,
         initialValue: {
@@ -111,6 +107,17 @@ export class ArBreadcrumb extends LitElement {
             this.open = false;
         },
     });
+
+    constructor() {
+        super();
+        new ToggleController(this, {
+            eventPrefix: 'ar-breadcrumb',
+            shouldToggle: () => this.isMobile,
+            skipInitialTransition: true,
+            onShow: () => this._onShow(),
+            onHide: () => this._onHide(),
+        });
+    }
 
     // ---------------------------------------------------------------------------
     // Lifecycle
@@ -145,15 +152,6 @@ export class ArBreadcrumb extends LitElement {
         if ((changed as Map<PropertyKey, unknown>).has('isMobile') && this.isMobile) {
             void this.updateComplete.then(() => {
                 if (this.isConnected) this._attachDropdown();
-            });
-        }
-        if (changed.has('open') && changed.get('open') !== undefined && this.isMobile) {
-            // Différé après la fin du cycle courant : _show()/_hide() déclenchent
-            // Popover.show()/hide(), qui appelle host.requestUpdate() — un appel synchrone
-            // ici déclencherait l'avertissement dev Lit "change-in-update".
-            void this.updateComplete.then(() => {
-                if (this.open) this._show();
-                else this._hide();
             });
         }
     }
@@ -256,46 +254,15 @@ export class ArBreadcrumb extends LitElement {
         this.open = !this.open;
     };
 
-    private _show(): void {
-        if (this._suppressNextToggle) {
-            this._suppressNextToggle = false;
-            return;
-        }
-        const showEv = this._emit('ar-breadcrumb-show');
-        if (showEv.defaultPrevented) {
-            this._suppressNextToggle = true;
-            this.open = false;
-            return;
-        }
+    private _onShow(): void {
         void this._popover.show().then(() => {
-            this._emit('ar-breadcrumb-shown');
+            emitToggleEvent(this, 'ar-breadcrumb-shown', { cancelable: false });
         });
     }
 
-    private _hide(): void {
-        if (this._suppressNextToggle) {
-            this._suppressNextToggle = false;
-            return;
-        }
-        const hideEv = this._emit('ar-breadcrumb-hide');
-        if (hideEv.defaultPrevented) {
-            this._suppressNextToggle = true;
-            this.open = true;
-            return;
-        }
+    private _onHide(): void {
         this._popover.hide();
-        this._emit('ar-breadcrumb-hidden');
-    }
-
-    private _emit(name: string): CustomEvent {
-        const e = new CustomEvent(name, {
-            bubbles: true,
-            composed: true,
-            cancelable: true,
-            detail: { id: this.id || undefined },
-        });
-        this.dispatchEvent(e);
-        return e;
+        emitToggleEvent(this, 'ar-breadcrumb-hidden', { cancelable: false });
     }
 
     private _handleMediaChange = (): void => {

--- a/packages/core/src/components/collapse/collapse.test.ts
+++ b/packages/core/src/components/collapse/collapse.test.ts
@@ -238,6 +238,42 @@ describe('ArCollapse', () => {
             expect(showHandler).not.toHaveBeenCalled();
             expect(shownHandler).not.toHaveBeenCalled();
         });
+
+        it('émet ar-collapse-show-prevented (non cancelable) quand ar-collapse-show est annulé', async () => {
+            el.addEventListener('ar-collapse-show', (e) => e.preventDefault());
+            let event: CustomEvent | undefined;
+            el.addEventListener('ar-collapse-show-prevented', (e) => {
+                event = e as CustomEvent;
+            });
+            el.open = true;
+            await waitForUpdate(el);
+            expect(event).toBeDefined();
+            expect(event?.cancelable).toBe(false);
+        });
+
+        it('émet ar-collapse-hide-prevented (non cancelable) quand ar-collapse-hide est annulé', async () => {
+            el.show();
+            await waitForUpdate(el);
+            el.addEventListener('ar-collapse-hide', (e) => e.preventDefault());
+            let event: CustomEvent | undefined;
+            el.addEventListener('ar-collapse-hide-prevented', (e) => {
+                event = e as CustomEvent;
+            });
+            el.open = false;
+            await waitForUpdate(el);
+            expect(event).toBeDefined();
+            expect(event?.cancelable).toBe(false);
+        });
+
+        it('ar-collapse-show porte desormais detail.id (id auto-généré)', async () => {
+            let detail: { id?: string } | undefined;
+            el.addEventListener('ar-collapse-show', (e) => {
+                detail = (e as CustomEvent).detail;
+            });
+            el.show();
+            await waitForUpdate(el);
+            expect(detail?.id).toBe(el.id);
+        });
     });
 
     // ── Trigger interne + ARIA ────────────────────────────────────────────────

--- a/packages/core/src/components/collapse/collapse.ts
+++ b/packages/core/src/components/collapse/collapse.ts
@@ -65,6 +65,7 @@ export class ArCollapse extends LitElement {
 
     constructor() {
         super();
+        // s'enregistre lui-même via host.addController(), pas besoin de conserver la référence
         new ToggleController(this, {
             eventPrefix: 'ar-collapse',
             skipInitialTransition: true,

--- a/packages/core/src/components/collapse/collapse.ts
+++ b/packages/core/src/components/collapse/collapse.ts
@@ -2,13 +2,9 @@ import { LitElement, html, type TemplateResult, type PropertyValues } from 'lit'
 import { property, query } from 'lit/decorators.js';
 import { warn } from '../../utils/warn.js';
 import { prefersReducedMotion } from '../../utils/media.js';
+import { ToggleController } from '../../controllers/toggle.controller.js';
+import { emitToggleEvent } from '../../utils/toggle-events.js';
 import styles from './collapse.styles.js';
-
-export type ArCollapseEvents =
-    | 'ar-collapse-show'
-    | 'ar-collapse-shown'
-    | 'ar-collapse-hide'
-    | 'ar-collapse-hidden';
 
 /**
  * @summary Panneau pliable/dépliable accessible avec animation de hauteur.
@@ -25,10 +21,12 @@ export type ArCollapseEvents =
  * @cssprop [--ar-collapse-duration=0s]  - Durée de la transition height.
  * @cssprop [--ar-collapse-easing=ease]  - Easing de la transition height.
  *
- * @event {CustomEvent} ar-collapse-show   - Avant l'ouverture. Annulable.
- * @event {CustomEvent} ar-collapse-shown  - Après la fin de l'animation d'ouverture.
- * @event {CustomEvent} ar-collapse-hide   - Avant la fermeture. Annulable.
- * @event {CustomEvent} ar-collapse-hidden - Après la fin de l'animation de fermeture.
+ * @event {CustomEvent} ar-collapse-show           - Avant l'ouverture. Annulable.
+ * @event {CustomEvent} ar-collapse-show-prevented - Émis si ar-collapse-show est annulé.
+ * @event {CustomEvent} ar-collapse-shown          - Après la fin de l'animation d'ouverture.
+ * @event {CustomEvent} ar-collapse-hide           - Avant la fermeture. Annulable.
+ * @event {CustomEvent} ar-collapse-hide-prevented - Émis si ar-collapse-hide est annulé.
+ * @event {CustomEvent} ar-collapse-hidden         - Après la fin de l'animation de fermeture.
  */
 export class ArCollapse extends LitElement {
     static override styles = [styles];
@@ -65,6 +63,16 @@ export class ArCollapse extends LitElement {
     private _internalTrigger: HTMLElement | null = null;
     private _onTransitionEnd: (() => void) | null = null;
 
+    constructor() {
+        super();
+        new ToggleController(this, {
+            eventPrefix: 'ar-collapse',
+            skipInitialTransition: true,
+            onShow: () => this._onShow(),
+            onHide: () => this._onHide(),
+        });
+    }
+
     override connectedCallback(): void {
         super.connectedCallback();
         if (!this.id) {
@@ -98,10 +106,6 @@ export class ArCollapse extends LitElement {
                 this._warnIfBothTriggers();
                 this._attachExternalTrigger();
             }
-        }
-        if (changed.has('open') && changed.get('open') !== undefined) {
-            if (this.open) this._show();
-            else this._hide();
         }
         if (changed.has('disabled')) {
             this._syncTriggerDisabled();
@@ -269,15 +273,7 @@ export class ArCollapse extends LitElement {
         return !prefersReducedMotion() && d > 0;
     }
 
-    private _show(): void {
-        // symétrique de la garde de _hide() : panel déjà visible (ex. ar-collapse-hide
-        // annulé → open=true redéclenché) — évite de réémettre show/shown pour rien.
-        if (!this._panel.hasAttribute('hidden') && !this._animating) return;
-        const ev = this._emit('ar-collapse-show');
-        if (ev.defaultPrevented) {
-            this.open = false;
-            return;
-        }
+    private _onShow(): void {
         this._abortAnimation();
         this._closeGroupSiblings();
         this._syncTriggerAria();
@@ -290,7 +286,7 @@ export class ArCollapse extends LitElement {
         if (!this._shouldAnimate()) {
             panel.style.height = 'auto';
             this._animating = false;
-            this._emit('ar-collapse-shown');
+            emitToggleEvent(this, 'ar-collapse-shown', { cancelable: false });
             return;
         }
         panel.style.height = `${targetH}px`;
@@ -298,20 +294,13 @@ export class ArCollapse extends LitElement {
             this._onTransitionEnd = null;
             this._animating = false;
             panel.style.height = 'auto';
-            this._emit('ar-collapse-shown');
+            emitToggleEvent(this, 'ar-collapse-shown', { cancelable: false });
         };
         this._onTransitionEnd = onShow;
         panel.addEventListener('transitionend', onShow, { once: true });
     }
 
-    private _hide(): void {
-        // finding 2 : panel déjà caché (ex. ar-collapse-show annulé → open=false déclenché)
-        if (this._panel.hasAttribute('hidden') && !this._animating) return;
-        const ev = this._emit('ar-collapse-hide');
-        if (ev.defaultPrevented) {
-            this.open = true;
-            return;
-        }
+    private _onHide(): void {
         const wasAnimating = this._animating;
         this._abortAnimation();
         this._syncTriggerAria();
@@ -319,7 +308,7 @@ export class ArCollapse extends LitElement {
             // finding 5 : snap immédiat — frère accordéon ou interruption externe
             this._panel.setAttribute('hidden', '');
             this._panel.style.height = '';
-            this._emit('ar-collapse-hidden');
+            emitToggleEvent(this, 'ar-collapse-hidden', { cancelable: false });
             return;
         }
         this._animating = true;
@@ -330,7 +319,7 @@ export class ArCollapse extends LitElement {
             this._animating = false;
             panel.setAttribute('hidden', '');
             panel.style.height = '';
-            this._emit('ar-collapse-hidden');
+            emitToggleEvent(this, 'ar-collapse-hidden', { cancelable: false });
             return;
         }
         panel.style.height = '0px';
@@ -339,15 +328,9 @@ export class ArCollapse extends LitElement {
             this._animating = false;
             panel.setAttribute('hidden', '');
             panel.style.height = '';
-            this._emit('ar-collapse-hidden');
+            emitToggleEvent(this, 'ar-collapse-hidden', { cancelable: false });
         };
         this._onTransitionEnd = onHide;
         panel.addEventListener('transitionend', onHide, { once: true });
-    }
-
-    private _emit(name: ArCollapseEvents): CustomEvent {
-        const e = new CustomEvent(name, { bubbles: true, composed: true, cancelable: true });
-        this.dispatchEvent(e);
-        return e;
     }
 }

--- a/packages/core/src/components/dialog/dialog.test.ts
+++ b/packages/core/src/components/dialog/dialog.test.ts
@@ -248,6 +248,16 @@ describe('ArDialog', () => {
             expect(el.open).toBe(false);
         });
 
+        it('ar-dialog-show annulé émet ar-dialog-show-prevented', async () => {
+            el = await fixture('<ar-dialog></ar-dialog>');
+            el.addEventListener('ar-dialog-show', (e) => e.preventDefault());
+            const prevented = vi.fn();
+            el.addEventListener('ar-dialog-show-prevented', prevented);
+            el.open = true;
+            await waitForUpdate(el);
+            expect(prevented).toHaveBeenCalledOnce();
+        });
+
         it('open=true deux fois ne double-appelle pas showModal', async () => {
             el = await fixture('<ar-dialog></ar-dialog>');
             el.open = true;

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -20,6 +20,7 @@ import { warn } from '../../utils/warn.js';
 /** Evènements envoyés par le webcomposant ArDialog */
 export type ArDialogEvents =
     | 'ar-dialog-show'
+    | 'ar-dialog-show-prevented'
     | 'ar-dialog-shown'
     | 'ar-dialog-hide'
     | 'ar-dialog-hide-prevented'
@@ -71,6 +72,7 @@ if (typeof document !== 'undefined') {
  * @cssprop [--ar-dialog-close-bg-focus=var(--ar-button-tertiary-bg-focus)] - Fond du bouton de fermeture au focus.
  *
  * @event {CustomEvent} ar-dialog-show - Émis avant l'ouverture. Annulable.
+ * @event {CustomEvent} ar-dialog-show-prevented - Émis si ar-dialog-show est annulé.
  * @event {CustomEvent} ar-dialog-shown - Émis après l'ouverture (après updateComplete).
  * @event {CustomEvent} ar-dialog-hide - Émis avant la fermeture. Annulable.
  * @event {CustomEvent} ar-dialog-hide-prevented - Émis si ar-dialog-hide est annulé. Le composant secoue le dialog et annonce `prevented-message` aux lecteurs d'écran.
@@ -411,6 +413,7 @@ export class ArDialog extends LitElement {
         const showEvent = this._emit('ar-dialog-show');
         if (showEvent.defaultPrevented) {
             this._triggerElement = null;
+            this._emit('ar-dialog-show-prevented');
             void this.updateComplete.then(() => {
                 if (this.isConnected && this.open && !this.dialog?.open) {
                     this.open = false;

--- a/packages/core/src/components/dropdown/dropdown.test.ts
+++ b/packages/core/src/components/dropdown/dropdown.test.ts
@@ -137,6 +137,36 @@ describe('ArDropdown', () => {
             expect(hiddenHandler).not.toHaveBeenCalled();
         });
 
+        it('émet ar-dropdown-show-prevented (non cancelable) quand ar-dropdown-show est annulé', async () => {
+            el.addEventListener('ar-dropdown-show', (e) => e.preventDefault());
+            let event: CustomEvent | undefined;
+            el.addEventListener('ar-dropdown-show-prevented', (e) => {
+                event = e as CustomEvent;
+            });
+            el.open = true;
+            await waitForUpdate(el);
+            await waitForUpdate(el);
+            expect(event).toBeDefined();
+            expect(event?.cancelable).toBe(false);
+            expect(event?.detail).toEqual({ id: undefined });
+        });
+
+        it('émet ar-dropdown-hide-prevented (non cancelable) quand ar-dropdown-hide est annulé', async () => {
+            el.open = true;
+            await waitForUpdate(el);
+            el.addEventListener('ar-dropdown-hide', (e) => e.preventDefault());
+            let event: CustomEvent | undefined;
+            el.addEventListener('ar-dropdown-hide-prevented', (e) => {
+                event = e as CustomEvent;
+            });
+            el.open = false;
+            await waitForUpdate(el);
+            await waitForUpdate(el);
+            expect(event).toBeDefined();
+            expect(event?.cancelable).toBe(false);
+            expect(event?.detail).toEqual({ id: undefined });
+        });
+
         it("n'émet pas ar-dropdown-show/-shown quand ar-dropdown-hide est annulé", async () => {
             el.open = true;
             await waitForUpdate(el);

--- a/packages/core/src/components/dropdown/dropdown.ts
+++ b/packages/core/src/components/dropdown/dropdown.ts
@@ -91,6 +91,7 @@ export class ArDropdown extends LitElement {
 
     constructor() {
         super();
+        // s'enregistre lui-même via host.addController(), pas besoin de conserver la référence
         new ToggleController(this, {
             eventPrefix: 'ar-dropdown',
             onShow: () => this._onShow(),

--- a/packages/core/src/components/dropdown/dropdown.ts
+++ b/packages/core/src/components/dropdown/dropdown.ts
@@ -1,4 +1,6 @@
 import { LitElement, html, type TemplateResult, type PropertyValues } from 'lit';
+import { ToggleController } from '../../controllers/toggle.controller.js';
+import { emitToggleEvent } from '../../utils/toggle-events.js';
 import { property, query } from 'lit/decorators.js';
 import { AnchoredController } from '../../controllers/anchored.controller.js';
 import { ArDropdownItem } from '../dropdown-item/dropdown-item.js';
@@ -40,10 +42,12 @@ export type ArDropdownPlacement =
  * @cssprop [--ar-dropdown-distance=var(--ar-anchor-distance)] - Espacement entre le trigger et le panel (axe principal).
  * @cssprop [--ar-dropdown-offset=var(--ar-anchor-offset)] - Décalage latéral du panel (axe transversal).
  *
- * @event {CustomEvent} ar-dropdown-show    - Émis avant l'ouverture (annulable).
- * @event {CustomEvent} ar-dropdown-shown   - Émis après l'ouverture.
- * @event {CustomEvent} ar-dropdown-hide    - Émis avant la fermeture (annulable).
- * @event {CustomEvent} ar-dropdown-hidden  - Émis après la fermeture.
+ * @event {CustomEvent} ar-dropdown-show           - Émis avant l'ouverture (annulable).
+ * @event {CustomEvent} ar-dropdown-show-prevented - Émis si ar-dropdown-show est annulé.
+ * @event {CustomEvent} ar-dropdown-shown          - Émis après l'ouverture.
+ * @event {CustomEvent} ar-dropdown-hide           - Émis avant la fermeture (annulable).
+ * @event {CustomEvent} ar-dropdown-hide-prevented - Émis si ar-dropdown-hide est annulé.
+ * @event {CustomEvent} ar-dropdown-hidden         - Émis après la fermeture.
  */
 export class ArDropdown extends LitElement {
     static override styles = [panelStyles, styles];
@@ -85,13 +89,14 @@ export class ArDropdown extends LitElement {
     private _externalTrigger: HTMLElement | null = null;
     private readonly _uniqueId = Math.random().toString(36).slice(2, 9);
 
-    /**
-     * Quand _show()/_hide() annule et revient sur `open`, ça redéclenche un second cycle
-     * updated() qui appellerait la branche opposée pour rien (le panel n'a jamais changé
-     * d'état). Ce flag fait de ce second appel un no-op, sans affecter les fermetures
-     * externes légitimes (onExternalClose), qui ne passent pas par cette annulation.
-     */
-    private _suppressNextToggle = false;
+    constructor() {
+        super();
+        new ToggleController(this, {
+            eventPrefix: 'ar-dropdown',
+            onShow: () => this._onShow(),
+            onHide: () => this._onHide(),
+        });
+    }
 
     override firstUpdated(): void {
         if (this.for) {
@@ -134,15 +139,6 @@ export class ArDropdown extends LitElement {
                     this._externalTrigger = newTrigger;
                 }
             }
-        }
-        if (changed.has('open')) {
-            // Différé après la fin du cycle courant : _show()/_hide() déclenchent
-            // Popover.show()/hide(), qui appelle host.requestUpdate() — un appel synchrone
-            // ici déclencherait l'avertissement dev Lit "change-in-update".
-            void this.updateComplete.then(() => {
-                if (this.open) this._show();
-                else this._hide();
-            });
         }
     }
 
@@ -212,54 +208,23 @@ export class ArDropdown extends LitElement {
         this.open = !this.open;
     };
 
-    private _show(): void {
-        if (this._suppressNextToggle) {
-            this._suppressNextToggle = false;
-            return;
-        }
-        const showEv = this._emit('ar-dropdown-show');
-        if (showEv.defaultPrevented) {
-            this._suppressNextToggle = true;
-            this.open = false;
-            return;
-        }
+    private _onShow(): void {
         this._detectMenuMode();
         this._panel?.addEventListener('keydown', this._handlePanelKeyDown);
         if (this._menuMode) this._activateMenuListeners();
         void this._popover.show().then(() => {
             if (this._menuMode) this._focusMenuItem(0);
-            this._emit('ar-dropdown-shown');
+            emitToggleEvent(this, 'ar-dropdown-shown', { cancelable: false });
         });
     }
 
-    private _hide(): void {
-        if (this._suppressNextToggle) {
-            this._suppressNextToggle = false;
-            return;
-        }
-        const hideEv = this._emit('ar-dropdown-hide');
-        if (hideEv.defaultPrevented) {
-            this._suppressNextToggle = true;
-            this.open = true;
-            return;
-        }
+    private _onHide(): void {
         this._panel?.removeEventListener('keydown', this._handlePanelKeyDown);
         this._removeMenuListeners();
         this._activeIndex = -1;
         this._popover.hide();
         this._resolvedTrigger?.focus();
-        this._emit('ar-dropdown-hidden');
-    }
-
-    private _emit(name: string): CustomEvent {
-        const e = new CustomEvent(name, {
-            bubbles: true,
-            composed: true,
-            cancelable: true,
-            detail: { id: this.id || undefined },
-        });
-        this.dispatchEvent(e);
-        return e;
+        emitToggleEvent(this, 'ar-dropdown-hidden', { cancelable: false });
     }
 
     private _activateMenuListeners(): void {

--- a/packages/core/src/controllers/toggle.controller.test.ts
+++ b/packages/core/src/controllers/toggle.controller.test.ts
@@ -1,0 +1,247 @@
+import { LitElement } from 'lit';
+import { property } from 'lit/decorators.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fixture, waitForUpdate } from '../test-utils.js';
+import { ToggleController } from './toggle.controller.js';
+import { emitToggleEvent } from '../utils/toggle-events.js';
+
+class TestToggleHost extends LitElement {
+    @property({ type: Boolean }) open = false;
+
+    readonly onShowSpy = vi.fn();
+    readonly onHideSpy = vi.fn();
+
+    readonly toggle = new ToggleController(this, {
+        eventPrefix: 'ar-test',
+        onShow: () => {
+            this.onShowSpy();
+            emitToggleEvent(this, 'ar-test-shown', { cancelable: false });
+        },
+        onHide: () => {
+            this.onHideSpy();
+            emitToggleEvent(this, 'ar-test-hidden', { cancelable: false });
+        },
+    });
+}
+if (!customElements.get('test-toggle-host')) {
+    customElements.define('test-toggle-host', TestToggleHost);
+}
+
+class TestToggleHostSkipInitial extends LitElement {
+    @property({ type: Boolean }) open = false;
+    readonly onShowSpy = vi.fn();
+    readonly onHideSpy = vi.fn();
+    readonly toggle = new ToggleController(this, {
+        eventPrefix: 'ar-test',
+        onShow: () => this.onShowSpy(),
+        onHide: () => this.onHideSpy(),
+        skipInitialTransition: true,
+    });
+}
+if (!customElements.get('test-toggle-host-skip-initial')) {
+    customElements.define('test-toggle-host-skip-initial', TestToggleHostSkipInitial);
+}
+
+class TestToggleHostGated extends LitElement {
+    @property({ type: Boolean }) open = false;
+    gateOpen = true;
+    readonly onShowSpy = vi.fn();
+    readonly onHideSpy = vi.fn();
+    readonly toggle = new ToggleController(this, {
+        eventPrefix: 'ar-test',
+        onShow: () => this.onShowSpy(),
+        onHide: () => this.onHideSpy(),
+        shouldToggle: () => this.gateOpen,
+    });
+}
+if (!customElements.get('test-toggle-host-gated')) {
+    customElements.define('test-toggle-host-gated', TestToggleHostGated);
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'test-toggle-host': TestToggleHost;
+        'test-toggle-host-skip-initial': TestToggleHostSkipInitial;
+        'test-toggle-host-gated': TestToggleHostGated;
+    }
+}
+
+describe('ToggleController', () => {
+    let el: TestToggleHost;
+    afterEach(() => el?.remove());
+
+    it('appelle onShow quand open passe à true', async () => {
+        el = await fixture('<test-toggle-host></test-toggle-host>');
+        el.open = true;
+        await waitForUpdate(el);
+        await waitForUpdate(el);
+        expect(el.onShowSpy).toHaveBeenCalledOnce();
+    });
+
+    it('appelle onHide quand open passe à false', async () => {
+        el = await fixture('<test-toggle-host open></test-toggle-host>');
+        await waitForUpdate(el);
+        el.open = false;
+        await waitForUpdate(el);
+        await waitForUpdate(el);
+        expect(el.onHideSpy).toHaveBeenCalledOnce();
+    });
+
+    it("émet ar-test-show avant d'appeler onShow", async () => {
+        el = await fixture('<test-toggle-host></test-toggle-host>');
+        const handler = vi.fn();
+        el.addEventListener('ar-test-show', handler);
+        el.open = true;
+        await waitForUpdate(el);
+        await waitForUpdate(el);
+        expect(handler).toHaveBeenCalledOnce();
+        expect(el.onShowSpy).toHaveBeenCalledOnce();
+    });
+
+    it("annule l'ouverture et émet ar-test-show-prevented si ar-test-show est preventDefault()", async () => {
+        el = await fixture('<test-toggle-host></test-toggle-host>');
+        el.addEventListener('ar-test-show', (e) => e.preventDefault());
+        const preventedHandler = vi.fn();
+        el.addEventListener('ar-test-show-prevented', preventedHandler);
+        el.open = true;
+        await waitForUpdate(el);
+        await waitForUpdate(el);
+        expect(el.open).toBe(false);
+        expect(el.onShowSpy).not.toHaveBeenCalled();
+        expect(preventedHandler).toHaveBeenCalledOnce();
+    });
+
+    it("ar-test-show-prevented n'est pas cancelable", async () => {
+        el = await fixture('<test-toggle-host></test-toggle-host>');
+        el.addEventListener('ar-test-show', (e) => e.preventDefault());
+        let capturedEvent: CustomEvent | undefined;
+        el.addEventListener('ar-test-show-prevented', (e) => {
+            capturedEvent = e as CustomEvent;
+        });
+        el.open = true;
+        await waitForUpdate(el);
+        await waitForUpdate(el);
+        expect(capturedEvent?.cancelable).toBe(false);
+    });
+
+    it('ne réémet pas ar-test-hide/-hidden après un show annulé (pas de cycle redondant)', async () => {
+        el = await fixture('<test-toggle-host></test-toggle-host>');
+        el.addEventListener('ar-test-show', (e) => e.preventDefault());
+        const hideHandler = vi.fn();
+        const hiddenHandler = vi.fn();
+        el.addEventListener('ar-test-hide', hideHandler);
+        el.addEventListener('ar-test-hidden', hiddenHandler);
+        el.open = true;
+        await waitForUpdate(el);
+        await waitForUpdate(el);
+        expect(hideHandler).not.toHaveBeenCalled();
+        expect(hiddenHandler).not.toHaveBeenCalled();
+        expect(el.onHideSpy).not.toHaveBeenCalled();
+    });
+
+    it('annule la fermeture et émet ar-test-hide-prevented si ar-test-hide est preventDefault()', async () => {
+        el = await fixture('<test-toggle-host open></test-toggle-host>');
+        await waitForUpdate(el);
+        el.addEventListener('ar-test-hide', (e) => e.preventDefault());
+        const preventedHandler = vi.fn();
+        el.addEventListener('ar-test-hide-prevented', preventedHandler);
+        el.open = false;
+        await waitForUpdate(el);
+        await waitForUpdate(el);
+        expect(el.open).toBe(true);
+        expect(el.onHideSpy).not.toHaveBeenCalled();
+        expect(preventedHandler).toHaveBeenCalledOnce();
+    });
+
+    it('ne réémet pas ar-test-show/-shown après un hide annulé (pas de cycle redondant)', async () => {
+        el = await fixture('<test-toggle-host open></test-toggle-host>');
+        await waitForUpdate(el);
+        el.onShowSpy.mockClear(); // fixture(open) a déjà appelé onShow une fois à la création
+        el.addEventListener('ar-test-hide', (e) => e.preventDefault());
+        const showHandler = vi.fn();
+        const shownHandler = vi.fn();
+        el.addEventListener('ar-test-show', showHandler);
+        el.addEventListener('ar-test-shown', shownHandler);
+        el.open = false;
+        await waitForUpdate(el);
+        await waitForUpdate(el);
+        expect(showHandler).not.toHaveBeenCalled();
+        expect(shownHandler).not.toHaveBeenCalled();
+        expect(el.onShowSpy).not.toHaveBeenCalled();
+    });
+
+    it("émet detail.id sur ar-test-show avec l'id de l'hôte", async () => {
+        el = await fixture('<test-toggle-host id="mon-host"></test-toggle-host>');
+        let detail: { id?: string } | undefined;
+        el.addEventListener('ar-test-show', (e) => {
+            detail = (e as CustomEvent).detail;
+        });
+        el.open = true;
+        await waitForUpdate(el);
+        await waitForUpdate(el);
+        expect(detail).toEqual({ id: 'mon-host' });
+    });
+
+    it('ar-test-show/-hide sont cancelable, ar-test-shown/-hidden non', async () => {
+        el = await fixture('<test-toggle-host></test-toggle-host>');
+        let showEvent: CustomEvent | undefined;
+        let shownEvent: CustomEvent | undefined;
+        el.addEventListener('ar-test-show', (e) => {
+            showEvent = e as CustomEvent;
+        });
+        el.addEventListener('ar-test-shown', (e) => {
+            shownEvent = e as CustomEvent;
+        });
+        el.open = true;
+        await waitForUpdate(el);
+        await waitForUpdate(el);
+        expect(showEvent?.cancelable).toBe(true);
+        expect(shownEvent?.cancelable).toBe(false);
+    });
+});
+
+describe('ToggleController — skipInitialTransition', () => {
+    let el: TestToggleHostSkipInitial;
+    afterEach(() => el?.remove());
+
+    it("n'appelle pas onShow si open=true dès la création (avant la 1ère connexion)", async () => {
+        el = document.createElement('test-toggle-host-skip-initial') as TestToggleHostSkipInitial;
+        el.open = true;
+        document.body.appendChild(el);
+        await waitForUpdate(el);
+        await waitForUpdate(el);
+        expect(el.onShowSpy).not.toHaveBeenCalled();
+        expect(el.open).toBe(true);
+    });
+
+    it('appelle onShow pour un toggle ultérieur (skip uniquement le tout premier cycle)', async () => {
+        el = await fixture('<test-toggle-host-skip-initial></test-toggle-host-skip-initial>');
+        el.open = true;
+        await waitForUpdate(el);
+        await waitForUpdate(el);
+        expect(el.onShowSpy).toHaveBeenCalledOnce();
+    });
+});
+
+describe('ToggleController — shouldToggle', () => {
+    let el: TestToggleHostGated;
+    afterEach(() => el?.remove());
+
+    it("n'appelle pas onShow si shouldToggle() retourne false", async () => {
+        el = await fixture('<test-toggle-host-gated></test-toggle-host-gated>');
+        el.gateOpen = false;
+        el.open = true;
+        await waitForUpdate(el);
+        await waitForUpdate(el);
+        expect(el.onShowSpy).not.toHaveBeenCalled();
+    });
+
+    it('appelle onShow si shouldToggle() retourne true', async () => {
+        el = await fixture('<test-toggle-host-gated></test-toggle-host-gated>');
+        el.gateOpen = true;
+        el.open = true;
+        await waitForUpdate(el);
+        await waitForUpdate(el);
+        expect(el.onShowSpy).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/core/src/controllers/toggle.controller.ts
+++ b/packages/core/src/controllers/toggle.controller.ts
@@ -1,0 +1,99 @@
+import type { ReactiveController, ReactiveControllerHost } from 'lit';
+import { emitToggleEvent } from '../utils/toggle-events.js';
+
+export interface ToggleControllerOptions {
+    /** Préfixe des events, ex. 'ar-dropdown' → ar-dropdown-show, ar-dropdown-show-prevented, etc. */
+    eventPrefix: string;
+    /** Logique d'ouverture propre au composant, appelée si le show n'est pas annulé. */
+    onShow: () => void;
+    /** Logique de fermeture propre au composant, appelée si le hide n'est pas annulé. */
+    onHide: () => void;
+    /** Gate arbitraire évalué avant de programmer une transition. Défaut : toujours vrai. */
+    shouldToggle?: () => boolean;
+    /**
+     * Si vrai, ignore la toute première transition détectée si elle survient dès le tout
+     * premier cycle de mise à jour de l'hôte (élément créé avec `open` déjà à `true` avant
+     * sa première connexion). Défaut : false.
+     */
+    skipInitialTransition?: boolean;
+}
+
+type ToggleHost = ReactiveControllerHost & HTMLElement & { open: boolean };
+
+/**
+ * Mutualise le pattern events annulables `show`/`hide` (+ `show-prevented`/`hide-prevented`
+ * sur annulation, `shown`/`hidden` à la charge du composant) utilisé par ar-dropdown,
+ * ar-breadcrumb et ar-collapse.
+ *
+ * Détecte les changements de `open` indépendamment du `updated()` du composant (comparaison
+ * interne à chaque `hostUpdated()`), diffère l'action via `updateComplete.then()` pour éviter
+ * l'avertissement dev Lit "change-in-update", et protège contre le cycle `updated()` redondant
+ * qu'une annulation (revert de `open`) déclenche — sans jamais bloquer une fermeture/ouverture
+ * externe légitime (ex. `onExternalClose` d'un popover), qui ne passe pas par cette annulation.
+ */
+export class ToggleController implements ReactiveController {
+    private readonly _host: ToggleHost;
+    private readonly _opts: ToggleControllerOptions;
+    private _lastOpen: boolean;
+    private _suppressNext = false;
+    private _isFirstCycle = true;
+
+    constructor(host: ToggleHost, opts: ToggleControllerOptions) {
+        this._host = host;
+        this._opts = opts;
+        this._lastOpen = host.open;
+        host.addController(this);
+    }
+
+    hostUpdated(): void {
+        const wasFirstCycle = this._isFirstCycle;
+        this._isFirstCycle = false;
+
+        const host = this._host;
+        const changed = host.open !== this._lastOpen;
+        this._lastOpen = host.open;
+        if (!changed) return;
+        if (wasFirstCycle && this._opts.skipInitialTransition) return;
+        if (this._opts.shouldToggle && !this._opts.shouldToggle()) return;
+
+        // Différé après la fin du cycle courant : onShow()/onHide() déclenchent souvent
+        // host.requestUpdate() (ex. Popover.show()/hide()) — un appel synchrone ici
+        // déclencherait l'avertissement dev Lit "change-in-update".
+        void host.updateComplete.then(() => {
+            if (host.open) this._show();
+            else this._hide();
+        });
+    }
+
+    private _show(): void {
+        if (this._suppressNext) {
+            this._suppressNext = false;
+            return;
+        }
+        const prefix = this._opts.eventPrefix;
+        const ev = emitToggleEvent(this._host, `${prefix}-show`, { cancelable: true });
+        if (ev.defaultPrevented) {
+            this._suppressNext = true;
+            this._host.open = false;
+            emitToggleEvent(this._host, `${prefix}-show-prevented`, { cancelable: false });
+            return;
+        }
+        this._opts.onShow();
+    }
+
+    private _hide(): void {
+        if (this._suppressNext) {
+            this._suppressNext = false;
+            return;
+        }
+        const prefix = this._opts.eventPrefix;
+        const ev = emitToggleEvent(this._host, `${prefix}-hide`, { cancelable: true });
+        if (ev.defaultPrevented) {
+            this._suppressNext = true;
+            this._host.open = true;
+            emitToggleEvent(this._host, `${prefix}-hide-prevented`, { cancelable: false });
+            return;
+        }
+        this._opts.onHide();
+    }
+}

--- a/packages/core/src/utils/toggle-events.test.ts
+++ b/packages/core/src/utils/toggle-events.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+import { emitToggleEvent } from './toggle-events.js';
+
+describe('emitToggleEvent', () => {
+    it('dispatch un CustomEvent avec bubbles/composed true', () => {
+        const host = document.createElement('div');
+        document.body.appendChild(host);
+        const handler = vi.fn();
+        host.addEventListener('my-event', handler);
+        emitToggleEvent(host, 'my-event', { cancelable: true });
+        expect(handler).toHaveBeenCalledOnce();
+        const event = handler.mock.calls[0][0] as CustomEvent;
+        expect(event.bubbles).toBe(true);
+        expect(event.composed).toBe(true);
+        host.remove();
+    });
+
+    it('applique cancelable depuis les options', () => {
+        const host = document.createElement('div');
+        const cancelableEvent = emitToggleEvent(host, 'my-event', { cancelable: true });
+        expect(cancelableEvent.cancelable).toBe(true);
+        const nonCancelableEvent = emitToggleEvent(host, 'my-event-2', { cancelable: false });
+        expect(nonCancelableEvent.cancelable).toBe(false);
+    });
+
+    it('detail.id reflète host.id quand présent', () => {
+        const host = document.createElement('div');
+        host.id = 'mon-id';
+        const event = emitToggleEvent(host, 'my-event', { cancelable: false });
+        expect(event.detail).toEqual({ id: 'mon-id' });
+    });
+
+    it('detail.id vaut undefined quand host.id est vide', () => {
+        const host = document.createElement('div');
+        const event = emitToggleEvent(host, 'my-event', { cancelable: false });
+        expect(event.detail).toEqual({ id: undefined });
+    });
+
+    it('retourne le CustomEvent dispatché (pour vérifier defaultPrevented)', () => {
+        const host = document.createElement('div');
+        host.addEventListener('my-event', (e) => e.preventDefault());
+        const event = emitToggleEvent(host, 'my-event', { cancelable: true });
+        expect(event.defaultPrevented).toBe(true);
+    });
+});

--- a/packages/core/src/utils/toggle-events.ts
+++ b/packages/core/src/utils/toggle-events.ts
@@ -1,0 +1,19 @@
+/**
+ * Construit et dispatch un `CustomEvent` selon la convention de cycle de vie disclosure
+ * (`show`/`shown`/`hide`/`hidden`/`show-prevented`/`hide-prevented`) partagée par
+ * ar-dropdown, ar-breadcrumb, ar-collapse (via ToggleController) et ar-dialog.
+ */
+export function emitToggleEvent(
+    host: HTMLElement,
+    name: string,
+    opts: { cancelable: boolean },
+): CustomEvent {
+    const e = new CustomEvent(name, {
+        bubbles: true,
+        composed: true,
+        cancelable: opts.cancelable,
+        detail: { id: host.id || undefined },
+    });
+    host.dispatchEvent(e);
+    return e;
+}


### PR DESCRIPTION
## Contexte

Item 1 de #111 (chantier technique global), 2ᵉ moitié — suite de #112 (bug d'émission parasite).
Spec : docs/superpowers/specs/2026-07-16-toggle-controller-mutualization-design.md

## Contenu

- `ToggleController` (ReactiveController partagé) + `emitToggleEvent()` — mutualise la mécanique show/hide annulable dupliquée entre ar-dropdown, ar-breadcrumb, ar-collapse.
- Nouveaux événements `ar-*-show-prevented`/`ar-*-hide-prevented` sur les 4 composants disclosure (dropdown, breadcrumb, collapse, dialog).
- Correctif : `cancelable: false` sur les events informatifs (shown/hidden/-prevented), qui étaient `cancelable: true` par erreur — sauf ar-dialog, qui garde son `_emit()` propre (hors scope de la migration controller).
- ar-collapse gagne `detail: { id }` sur ses events (absent auparavant).

## Breaking changes (alpha, acceptés sans dépréciation)

- `CustomEvent.cancelable` passe de `true` à `false` sur ar-dropdown-shown/-hidden, ar-breadcrumb-shown/-hidden, ar-collapse-show/-shown/-hide/-hidden.
- ar-collapse : nouveaux champs `detail.id` sur tous ses events (additif).

## Test plan

- [x] npm run test — suite complète Vitest
- [x] npm run test:browser — suite complète navigateur (WTR), y compris light-dismiss/Escape (point de la régression #112)
- [x] tsc --noEmit + npm run lint
- [x] Vérification visuelle doc Astro (table events)

🤖 Generated with subagent-driven-development (Claude Code)