### PR TITLE
fix(core): raccorde --ar-collapse-duration/-easing au thème + comble des trous de tests

### DIFF
--- a/packages/core/src/controllers/tooltip.controller.test.ts
+++ b/packages/core/src/controllers/tooltip.controller.test.ts
@@ -1,0 +1,134 @@
+import { LitElement, html } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { afterEach, describe, expect, it } from 'vitest';
+import { TooltipController } from './tooltip.controller.js';
+import { fixture, mockPopoverPanel } from '../test-utils.js';
+
+// ── Fixture component ──────────────────────────────────────────────────────────
+
+@customElement('test-tooltip-controller')
+class TestTooltipHost extends LitElement {
+    readonly tooltip = new TooltipController(this, { cssVarPrefix: 'tooltip' });
+
+    override render() {
+        return html`
+            <button part="trigger">Trigger</button>
+            <div part="panel">Contenu</div>
+        `;
+    }
+}
+
+@customElement('test-tooltip-controller-no-prefix')
+class TestTooltipHostNoPrefix extends LitElement {
+    readonly tooltip = new TooltipController(this);
+
+    override render() {
+        return html`
+            <button part="trigger">Trigger</button>
+            <div part="panel">Contenu</div>
+        `;
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'test-tooltip-controller': TestTooltipHost;
+        'test-tooltip-controller-no-prefix': TestTooltipHostNoPrefix;
+    }
+}
+
+type ControllerInternals = { _readCssVar(kind: 'distance' | 'offset'): number };
+
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('TooltipController', () => {
+    let el: TestTooltipHost;
+
+    afterEach(() => {
+        el?.remove();
+    });
+
+    describe('attach()', () => {
+        it('ajoute role="tooltip" sur le panel et aria-describedby sur le trigger', async () => {
+            el = await fixture('<test-tooltip-controller></test-tooltip-controller>');
+            const trigger = el.shadowRoot?.querySelector('[part="trigger"]') as HTMLElement;
+            const panel = el.shadowRoot?.querySelector('[part="panel"]') as HTMLElement;
+            el.tooltip.attach(trigger, panel);
+
+            expect(panel.getAttribute('role')).toBe('tooltip');
+            expect(trigger.getAttribute('aria-describedby')).toBe(el.id);
+        });
+
+        it("génère un id sur l'hôte si absent", async () => {
+            el = await fixture('<test-tooltip-controller></test-tooltip-controller>');
+            expect(el.id).toBe('');
+            const trigger = el.shadowRoot?.querySelector('[part="trigger"]') as HTMLElement;
+            const panel = el.shadowRoot?.querySelector('[part="panel"]') as HTMLElement;
+            el.tooltip.attach(trigger, panel);
+
+            expect(el.id).toMatch(/^ar-tooltip-/);
+        });
+
+        it("conserve l'id existant s'il est déjà défini", async () => {
+            el = await fixture(
+                '<test-tooltip-controller id="custom-id"></test-tooltip-controller>',
+            );
+            const trigger = el.shadowRoot?.querySelector('[part="trigger"]') as HTMLElement;
+            const panel = el.shadowRoot?.querySelector('[part="panel"]') as HTMLElement;
+            el.tooltip.attach(trigger, panel);
+
+            expect(el.id).toBe('custom-id');
+            expect(trigger.getAttribute('aria-describedby')).toBe('custom-id');
+        });
+    });
+
+    describe('isOpen / show() / hide()', () => {
+        it('reflète le cycle show() → hide() une fois attaché', async () => {
+            el = await fixture('<test-tooltip-controller></test-tooltip-controller>');
+            const trigger = el.shadowRoot?.querySelector('[part="trigger"]') as HTMLElement;
+            const panel = el.shadowRoot?.querySelector('[part="panel"]') as HTMLElement;
+            el.tooltip.attach(trigger, panel);
+            mockPopoverPanel(el, 'panel');
+
+            expect(el.tooltip.isOpen).toBe(false);
+
+            await el.tooltip.show();
+            expect(el.tooltip.isOpen).toBe(true);
+
+            el.tooltip.hide();
+            expect(el.tooltip.isOpen).toBe(false);
+        });
+    });
+
+    describe('_readCssVar (lecture --ar-<prefix>-distance/offset)', () => {
+        it("résout les valeurs numériques définies sur l'hôte", async () => {
+            el = await fixture('<test-tooltip-controller></test-tooltip-controller>');
+            el.style.setProperty('--ar-tooltip-distance', '12px');
+            el.style.setProperty('--ar-tooltip-offset', '4px');
+
+            const internals = el.tooltip as unknown as ControllerInternals;
+            expect(internals._readCssVar('distance')).toBe(12);
+            expect(internals._readCssVar('offset')).toBe(4);
+        });
+
+        it('retombe à 0 quand la custom property est absente', async () => {
+            el = await fixture('<test-tooltip-controller></test-tooltip-controller>');
+
+            const internals = el.tooltip as unknown as ControllerInternals;
+            expect(internals._readCssVar('distance')).toBe(0);
+            expect(internals._readCssVar('offset')).toBe(0);
+        });
+
+        it('retombe à 0 sans cssVarPrefix configuré', async () => {
+            const noPrefixEl = await fixture<TestTooltipHostNoPrefix>(
+                '<test-tooltip-controller-no-prefix></test-tooltip-controller-no-prefix>',
+            );
+            noPrefixEl.style.setProperty('--ar-tooltip-distance', '12px');
+
+            const internals = noPrefixEl.tooltip as unknown as ControllerInternals;
+            expect(internals._readCssVar('distance')).toBe(0);
+
+            noPrefixEl.remove();
+        });
+    });
+});

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -450,6 +450,10 @@
         --ar-dialog-close-bg-pressed: var(--ar-button-tertiary-bg-active);
         --ar-dialog-close-bg-focus: var(--ar-button-tertiary-bg-focus);
 
+        /* collapse */
+        --ar-collapse-duration: 0s;
+        --ar-collapse-easing: ease;
+
         /* table */
         --ar-table-padding-x: 1rem;
 
@@ -791,6 +795,6 @@
     }
 
     ar-collapse::part(panel) {
-        transition: height var(--ar-collapse-duration, 0s) var(--ar-collapse-easing, ease);
+        transition: height var(--ar-collapse-duration) var(--ar-collapse-easing);
     }
 }

--- a/packages/core/src/utils/media.test.ts
+++ b/packages/core/src/utils/media.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { prefersReducedMotion } from './media.js';
+
+describe('prefersReducedMotion', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('retourne true quand la media query correspond', () => {
+        vi.spyOn(window, 'matchMedia').mockReturnValue({
+            matches: true,
+        } as MediaQueryList);
+
+        expect(prefersReducedMotion()).toBe(true);
+    });
+
+    it('retourne false quand la media query ne correspond pas', () => {
+        vi.spyOn(window, 'matchMedia').mockReturnValue({
+            matches: false,
+        } as MediaQueryList);
+
+        expect(prefersReducedMotion()).toBe(false);
+    });
+
+    it('interroge la media query prefers-reduced-motion: reduce', () => {
+        const spy = vi
+            .spyOn(window, 'matchMedia')
+            .mockReturnValue({ matches: false } as MediaQueryList);
+
+        prefersReducedMotion();
+
+        expect(spy).toHaveBeenCalledWith('(prefers-reduced-motion: reduce)');
+    });
+
+    it('retourne false si window.matchMedia est indisponible', () => {
+        const original = window.matchMedia;
+        // @ts-expect-error - simule un environnement sans matchMedia
+        delete window.matchMedia;
+
+        expect(prefersReducedMotion()).toBe(false);
+
+        window.matchMedia = original;
+    });
+});

--- a/packages/core/src/utils/warn.test.ts
+++ b/packages/core/src/utils/warn.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { warn } from './warn.js';
+
+describe('warn', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('affiche un warning console préfixé par le tag', () => {
+        const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        warn('ar-collapse', 'for et slot="trigger" sont tous les deux définis.');
+
+        expect(spy).toHaveBeenCalledOnce();
+        expect(spy).toHaveBeenCalledWith(
+            '[ar-collapse] for et slot="trigger" sont tous les deux définis.',
+        );
+    });
+
+    it('logue un message distinct à chaque appel, sans déduplication', () => {
+        const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        warn('ar-dialog', 'Message A.');
+        warn('ar-dialog', 'Message A.');
+
+        expect(spy).toHaveBeenCalledTimes(2);
+    });
+});


### PR DESCRIPTION
## Contexte

Suite à l'audit exploratoire de l'item 3 de l'issue #111 (« Audit dette technique large »), deux constats actionnables retenus :

1. `collapse.ts` documente `@cssprop [--ar-collapse-duration=0s]` et `@cssprop [--ar-collapse-easing=ease]`, mais ces deux valeurs n'existaient nulle part comme tokens `:root` de `default.css` — elles n'étaient utilisées qu'en fallback inline (`var(--ar-collapse-duration, 0s)`) dans la règle `ar-collapse::part(panel)`. Ce pattern rend les deux tokens invisibles au garde-fou automatique `validate-cssprop-defaults.js` (PR #114) : la valeur documentée en JSDoc et la valeur réellement appliquée pouvaient dériver silencieusement sans jamais faire échouer le build.
2. `tooltip.controller.ts`, `utils/warn.ts` et `utils/media.ts` étaient les seuls fichiers non-composant du repo sans test dédié.

## Changements

- `default.css` : ajout de `--ar-collapse-duration: 0s;` et `--ar-collapse-easing: ease;` dans le bloc `:root` de base, section `/* collapse */`. La règle `ar-collapse::part(panel)` consomme désormais ces tokens sans fallback inline (`var(--ar-collapse-duration) var(--ar-collapse-easing)`), cohérent avec le pattern établi par ADR-005. Comportement runtime inchangé (mêmes valeurs par défaut).
- `tooltip.controller.test.ts` (nouveau) : couvre `attach()` (role, aria-describedby, génération/préservation d'id), le cycle `isOpen`/`show()`/`hide()`, et `_readCssVar()` (résolution, absence de valeur, absence de `cssVarPrefix`).
- `utils/warn.test.ts` (nouveau) : format du message, absence de déduplication.
- `utils/media.test.ts` (nouveau) : `prefersReducedMotion()` sur les deux branches de `matches`, la media query interrogée, et le cas `matchMedia` indisponible.

## Test plan

- [x] `npm run test` (racine) — 756/756 verts
- [x] `npm run build:manifest --workspace=packages/core` — pas de régression du garde-fou @cssprop/default.css
- [x] `npm run lint` — 0 erreur (warnings docs préexistants, non liés)
- [x] `npm run build --workspace=packages/core` — build complet OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)