### PR TITLE
fix(docs): corrige la hiérarchie de titres des pages composant

### DIFF
--- a/apps/docs/CONTRIBUTING.md
+++ b/apps/docs/CONTRIBUTING.md
@@ -172,8 +172,9 @@ apps/docs/
 ├── src/
 │   ├── components/
 │   │   ├── ComponentApi.astro      ← Tables de référence API (attributs, events, slots…)
-│   │   ├── NarrativeHeading.astro  ← Composant MDX custom : h2 avec id slugifié (ancres TOC)
-│   │   ├── NarrativeList.astro     ← Composant MDX custom : ul avec classe .narrative-list
+│   │   ├── NarrativeHeading.astro    ← Composant MDX custom : h2 MDX → <h3> avec id slugifié (ancres TOC)
+│   │   ├── NarrativeSubheading.astro ← Composant MDX custom : h3 MDX → <h4> avec id slugifié (ancres TOC)
+│   │   ├── NarrativeList.astro       ← Composant MDX custom : ul avec classe .narrative-list
 │   │   ├── Playground.astro        ← Variantes + playground + controls
 │   │   ├── SiteNav.astro           ← Navigation gauche (auto-générée depuis CEM + MDX)
 │   │   └── TableOfContents.astro   ← TOC sticky droite + collapse mobile
@@ -208,14 +209,14 @@ apps/docs/
   │     └── getCustomElements()  → liste de tous les custom elements
   ├── getCollection('components') → données MDX (titre, variantes, description)
   ├── render(mdx)                 → { Content, headings[] }
-  │     └── headings (depth=2)   → narrativeTocEntries (ancres depuis les h2 MDX)
+  │     └── headings (depth=2/3) → narrativeTocEntries (ancres depuis les h2/h3 MDX)
   ├── buildControls()             → contrôles playground depuis les membres CEM
   └── tocEntries[]                → narrativeTocEntries + Exemples + Playground + API
         ↓
   Layout.astro (3 colonnes)
     ├── SiteNav.astro             ← nav gauche
     ├── <section class="narrative">
-    │     └── <Content components={{ h2: NarrativeHeading, ul: NarrativeList }} />
+    │     └── <Content components={{ h2: NarrativeHeading, h3: NarrativeSubheading, ul: NarrativeList }} />
     ├── Playground.astro          ← variantes + playground + ComponentApi
     └── TableOfContents           ← TOC droite (slot="toc")
 ```
@@ -325,35 +326,39 @@ entre le header de la page et les exemples. C'est l'endroit pour documenter l'us
 Certains éléments HTML générés par le MDX sont remplacés par des composants Astro afin de contrôler
 précisément le rendu. Le mapping est déclaré dans `[slug].astro` via la prop `components` de `<Content>` :
 
-| Élément MDX | Composant Astro          | Rôle                                                       |
-| ----------- | ------------------------ | ---------------------------------------------------------- |
-| `ul`        | `NarrativeList.astro`    | Ajoute la classe `.narrative-list` pour le ciblage CSS     |
-| `h2`        | `NarrativeHeading.astro` | Génère un `id` slugifié automatiquement (ancre TOC + lien) |
+| Élément MDX | Composant Astro             | Rôle                                                                        |
+| ----------- | --------------------------- | --------------------------------------------------------------------------- |
+| `ul`        | `NarrativeList.astro`       | Ajoute la classe `.narrative-list` pour le ciblage CSS                      |
+| `h2`        | `NarrativeHeading.astro`    | Rendu en `<h3>` (sections, sous `.page-title` en `<h2>`), id slugifié (TOC) |
+| `h3`        | `NarrativeSubheading.astro` | Rendu en `<h4>` (sous-sections), même mécanisme d'id slugifié (TOC)         |
 
 **Ajouter un nouveau composant custom :** créer `src/components/Narrative<Nom>.astro`, l'importer
 dans `[slug].astro` et l'ajouter dans le spread `components={{ … }}`.
 
-### TOC automatique depuis les `h2`
+### TOC automatique depuis les `h2`/`h3`
 
-Les titres `## Titre` du MDX sont **automatiquement ajoutés à la TOC** — il n'y a rien à déclarer
-dans le frontmatter. Le mécanisme fonctionne ainsi :
+Les titres `## Titre` et `### Sous-titre` du MDX sont **automatiquement ajoutés à la TOC** — il
+n'y a rien à déclarer dans le frontmatter. Le mécanisme fonctionne ainsi :
 
 1. `render(mdx)` retourne un tableau `headings` (fourni par Astro/remark)
-2. `[slug].astro` filtre les `depth === 2` et les injecte dans `tocEntries` avant les exemples
-3. `NarrativeHeading.astro` pose le même `id` sur le `h2` rendu, via `github-slugger` — le même
-   algorithme qu'Astro, ce qui garantit que l'ancre et l'entrée TOC sont toujours synchronisées
+2. `[slug].astro` filtre les `depth === 2 || depth === 3` et les injecte dans `tocEntries` avant
+   les exemples (`depth === 2` en entrée de premier niveau, `depth === 3` en sous-menu)
+3. `NarrativeHeading.astro`/`NarrativeSubheading.astro` posent le même `id` sur le `h3`/`h4` rendu,
+   via `github-slugger` — le même algorithme qu'Astro, ce qui garantit que l'ancre et l'entrée TOC
+   sont toujours synchronisées
 
-**Conséquence :** renommer un `h2` dans le MDX met à jour l'ancre et la TOC simultanément, sans
-aucune intervention manuelle.
+**Conséquence :** renommer un `h2`/`h3` dans le MDX met à jour l'ancre et la TOC simultanément,
+sans aucune intervention manuelle.
 
 ### Flux de données narratif
 
 ```text
 ar-alert.mdx (corps)
   → render(mdx) → { Content, headings[] }
-  → headings filtrés depth=2 → narrativeTocEntries → tocEntries[]
-  → <Content components={{ ul: NarrativeList, h2: NarrativeHeading }} />
-      → h2 "Accessibilité" → <NarrativeHeading> → <h2 id="accessibilité">
+  → headings filtrés depth=2/3 → narrativeTocEntries → tocEntries[]
+  → <Content components={{ ul: NarrativeList, h2: NarrativeHeading, h3: NarrativeSubheading }} />
+      → h2 "Accessibilité" → <NarrativeHeading> → <h3 id="accessibilité">
+      → h3 "Pris en charge automatiquement" → <NarrativeSubheading> → <h4 id="pris-en-charge-automatiquement">
       → ul → <NarrativeList> → <ul class="narrative-list">
 ```
 

--- a/apps/docs/src/components/NarrativeHeading.astro
+++ b/apps/docs/src/components/NarrativeHeading.astro
@@ -2,7 +2,9 @@
 /**
  * NarrativeHeading.astro
  *
- * Composant MDX custom pour les titres h2 du contenu narratif des pages composant.
+ * Composant MDX custom pour les titres h2 (source MDX) du contenu narratif des
+ * pages composant — rendu en <h3>, car .page-title (le titre de page) occupe le
+ * niveau h2. Le niveau MDX (##) reste inchangé : seul le tag HTML rendu diffère.
  *
  * Rôle : générer un `id` slugifié depuis le texte du titre, afin que chaque h2
  * du MDX soit accessible comme ancre et apparaisse correctement dans la TOC.
@@ -26,4 +28,4 @@ const text = await Astro.slots.render('default');
 const plainText = text.replace(/<[^>]+>/g, '').trim();
 const slug = id ?? new GithubSlugger().slug(plainText);
 ---
-<h2 id={slug} {...rest}><slot /></h2>
+<h3 id={slug} {...rest}><slot /></h3>

--- a/apps/docs/src/components/NarrativeSubheading.astro
+++ b/apps/docs/src/components/NarrativeSubheading.astro
@@ -1,0 +1,31 @@
+---
+/**
+ * NarrativeSubheading.astro
+ *
+ * Composant MDX custom pour les titres h3 (source MDX) du contenu narratif des
+ * pages composant — rendu en <h4>, enfant des sections NarrativeHeading (<h3>).
+ *
+ * Rôle : générer un `id` slugifié depuis le texte du titre, sur le même principe
+ * que NarrativeHeading.astro, afin que les entrées de TOC de niveau 2
+ * (narrativeTocEntries dans [slug].astro, depth MDX === 3) pointent vers une
+ * ancre réellement présente dans le DOM — sans ce composant, le h3 MDX natif
+ * n'a aucun id et ces liens de TOC ne mènent nulle part.
+ *
+ * L'algorithme de slugification utilise `github-slugger` — le même qu'Astro/remark
+ * utilise pour construire le tableau `headings` retourné par `render()`.
+ *
+ * Usage : injecté via <Content components={{ h3: NarrativeSubheading }} /> dans [slug].astro.
+ * Ne pas utiliser directement dans les templates Astro.
+ */
+import GithubSlugger from 'github-slugger';
+
+interface Props {
+    id?: string;
+}
+
+const { id, ...rest } = Astro.props as Props & Record<string, unknown>;
+const text = await Astro.slots.render('default');
+const plainText = text.replace(/<[^>]+>/g, '').trim();
+const slug = id ?? new GithubSlugger().slug(plainText);
+---
+<h4 id={slug} {...rest}><slot /></h4>

--- a/apps/docs/src/components/Playground.astro
+++ b/apps/docs/src/components/Playground.astro
@@ -47,11 +47,11 @@ const showPlayground = displayMode === 'demo';
 {/* ── Exemples (variantes) ── */}
 {variants.length > 0 && (
     <section id="exemples">
-        <h4 class="section-title">Exemples</h4>
+        <h3 class="section-title">Exemples</h3>
         <div class="main-section">
             {variants.map((variant) => (
                 <section id={`exemple-${variant.name}`}>
-                    <h5 class="subsection-title">{variant.label ?? variant.name}</h5>
+                    <h4 class="subsection-title">{variant.label ?? variant.name}</h4>
                     {variant.description && (
                         <p class="variant-description">{variant.description}</p>
                     )}
@@ -155,7 +155,7 @@ const showPlayground = displayMode === 'demo';
 
 {/* ── Référence API ── */}
 <section id="reference-api">
-    <h4 class="section-title">Référence API</h4>
+    <h3 class="section-title">Référence API</h3>
     <ComponentApi component={component} />
 </section>
 

--- a/apps/docs/src/pages/components/[slug].astro
+++ b/apps/docs/src/pages/components/[slug].astro
@@ -5,6 +5,7 @@ import Playground from '../../components/Playground.astro';
 import TableOfContents from '../../components/TableOfContents.astro';
 import NarrativeList from '../../components/NarrativeList.astro';
 import NarrativeHeading from '../../components/NarrativeHeading.astro';
+import NarrativeSubheading from '../../components/NarrativeSubheading.astro';
 import manifest from '@cem';
 import { getSlug } from '../../utils/tag-name.ts';
 import { type CemDeclaration, getCustomElements, buildControls } from '../../utils/cem-types.ts';
@@ -107,7 +108,7 @@ const tocEntries = [
 
     <div class="page-container">
         <div class="page-header">
-            <h3 class="page-title">{pageTitle}</h3>
+            <h2 class="page-title">{pageTitle}</h2>
 
             <div class="meta">
                 <code>&lt;{component.tagName}&gt;</code>
@@ -119,13 +120,21 @@ const tocEntries = [
         {/*
           * Contenu narratif du MDX (usage, accessibilité…).
           * Les composants custom remplacent les éléments HTML natifs générés par le MDX :
-          *   - h2 → NarrativeHeading : pose un id slugifié pour les ancres TOC
-          *   - ul → NarrativeList    : ajoute .narrative-list pour le ciblage CSS sans sélecteur de tag
+          *   - h2 → NarrativeHeading   : rendu en <h3> (sections, enfant de .page-title en h2),
+          *                               pose un id slugifié pour les ancres TOC
+          *   - h3 → NarrativeSubheading : rendu en <h4> (sous-sections), même mécanisme d'id
+          *   - ul → NarrativeList      : ajoute .narrative-list pour le ciblage CSS sans sélecteur de tag
           * Voir apps/docs/CONTRIBUTING.md § "Contenu narratif MDX" pour la documentation complète.
           */}
         {Content && (
             <section class="narrative">
-                <Content components={{ ul: NarrativeList, h2: NarrativeHeading }} />
+                <Content
+                    components={{
+                        ul: NarrativeList,
+                        h2: NarrativeHeading,
+                        h3: NarrativeSubheading,
+                    }}
+                />
             </section>
         )}
 
@@ -152,7 +161,7 @@ const tocEntries = [
         .toc-mobile-inline { display: block; }
     }
 
-    .narrative :global(h2) {
+    .narrative :global(h3) {
         font-size: 1.25rem;
         font-weight: 600;
         border-bottom: 2px solid var(--doc-border, #e5e7eb);
@@ -161,9 +170,9 @@ const tocEntries = [
         color: var(--doc-text, #111827);
     }
 
-    .narrative :global(h2:first-child) { margin-top: 0; }
+    .narrative :global(h3:first-child) { margin-top: 0; }
 
-    .narrative :global(h3) {
+    .narrative :global(h4) {
         font-size: 1.05rem;
         font-weight: 600;
         color: var(--doc-text-subtle, #374151);


### PR DESCRIPTION
## Contexte

Issue #109 (audit fond/forme/a11y de la documentation), constat majeur identifié via un audit exploratoire : sur les 18 pages composant, le titre de page était rendu en `<h3>` alors que `Layout.astro` pose déjà un `<h1>` (marque, sur toutes les pages) et que les autres gabarits de page (`foundations/tokens.astro`, `getting-started/*.astro`) utilisent déjà `<h2>` pour leur titre. En aval, `Playground.astro` sautait directement de `<h2>` (sections narratives) à `<h4>` ("Exemples"/"Référence API"), et les sous-sections de `ComponentApi.astro` restaient `<h4>` — sœurs de leur parent plutôt qu'enfants. Violation WCAG 1.3.1/2.4.6 sur un site qui documente par ailleurs l'accessibilité des composants.

## Changements

Nouvelle hiérarchie, alignée sur les autres gabarits de page du site :

```
h1 (marque, Layout)
  h2 (.page-title — nom du composant)
    h3 (sections narratives MDX ## + "Exemples" + "Référence API")
      h4 (sous-sections MDX ### + labels de variante + sous-sections ComponentApi)
```

- `[slug].astro` : `.page-title` passe de `h3` à `h2` ; ajoute le composant `h3` (`NarrativeSubheading`) au mapping MDX ; styles scoped `.narrative` décalés en conséquence.
- `NarrativeHeading.astro` : les `h2` MDX (`##`) sont désormais rendus en `<h3>` (au lieu de `<h2>`).
- `NarrativeSubheading.astro` (nouveau) : même mécanisme que `NarrativeHeading` pour les `h3` MDX (`###`), rendus en `<h4>` avec id slugifié. Corrige au passage un bug latent : les entrées de TOC de niveau 2 (`narrativeTocEntries`, `depth MDX === 3`) pointaient vers une ancre qui n'a jamais existé, faute d'id sur le `<h3>` natif MDX.
- `Playground.astro` : "Exemples"/"Référence API" passent de `h4` à `h3` ; les labels de variante de `h5` à `h4`.
- `ComponentApi.astro` : aucun changement — ses sous-sections `h4` étaient déjà au bon niveau, il ne manquait qu'un parent `h3` correct.
- `CONTRIBUTING.md` : documentation mise à jour (architecture des fichiers, flux de données narratif, tableau des composants MDX custom, section TOC).

## Test plan

- [x] `npm run lint --workspace=apps/docs` (`astro check`) — 0 erreur
- [x] `npm run test --workspace=apps/docs` — 47/47 verts
- [x] `npm run build --workspace=apps/docs` — build complet OK, 23 pages générées
- [x] Vérification automatisée sur les 18 pages composant générées : aucun saut de niveau de titre dans le contenu principal
- [x] Vérifié manuellement sur `dialog/index.html` que les ancres de TOC (`#pris-en-charge-automatiquement`, etc.) correspondent bien à un id réel dans le DOM généré

🤖 Generated with [Claude Code](https://claude.com/claude-code)