### PR TITLE
docs: fusionne le tableau Événements généré et le tableau manuel de ar-dialog

### DIFF
--- a/apps/docs/src/components/ComponentApi.astro
+++ b/apps/docs/src/components/ComponentApi.astro
@@ -10,6 +10,7 @@ import { readFileSync } from 'fs';
 import { resolve } from 'path';
 import { type CemDeclaration } from '../utils/cem-types.ts';
 import { buildTokenMap, resolveColor } from '../utils/parse-tokens.ts';
+import { isCancelableEvent, stripCancelableMarker } from '../utils/events.ts';
 
 interface Props {
     component: CemDeclaration;
@@ -70,16 +71,16 @@ const publicMethods = (component.members ?? []).filter(
                     <thead>
                         <tr>
                             <th>Nom</th>
-                            <th>Type</th>
                             <th>Description</th>
+                            <th>Annulable</th>
                         </tr>
                     </thead>
                     <tbody>
                         {component.events.map((event) => (
                             <tr>
                                 <td><code>{event.name}</code></td>
-                                <td><code>{event.type?.text ?? 'CustomEvent'}</code></td>
-                                <td>{event.description ?? ''}</td>
+                                <td>{stripCancelableMarker(event.description)}</td>
+                                <td>{isCancelableEvent(event.description) ? 'Oui' : 'Non'}</td>
                             </tr>
                         ))}
                     </tbody>

--- a/apps/docs/src/content/components/ar-dialog.mdx
+++ b/apps/docs/src/content/components/ar-dialog.mdx
@@ -137,20 +137,7 @@ Plutôt que de piloter `open` en JavaScript, un élément cliquable peut ouvrir 
 
 ### Cycle d'événements
 
-| Événement                       | Moment                                                | Annulable |
-| ------------------------------- | ----------------------------------------------------- | --------- |
-| `ar-dialog-show`                | Avant l'ouverture                                     | Oui       |
-| `ar-dialog-show-prevented`      | Si `ar-dialog-show` est annulé                        | Non       |
-| `ar-dialog-shown`               | Après l'ouverture (post-render)                       | Non       |
-| `ar-dialog-hide`                | Avant la fermeture (Escape, backdrop, `open = false`) | Oui       |
-| `ar-dialog-hide-prevented`      | Si `ar-dialog-hide` est annulé                        | Non       |
-| `ar-dialog-hidden`              | Après la fermeture (post-animation)                   | Non       |
-| `ar-dialog-dismissed`           | Clic sur un élément `data-ar-dismiss`                 | Oui       |
-| `ar-dialog-dismissed-prevented` | Si `ar-dialog-dismissed` est annulé                   | Non       |
-| `ar-dialog-accepted`            | Clic sur un élément `data-ar-accept`                  | Oui       |
-| `ar-dialog-accepted-prevented`  | Si `ar-dialog-accepted` est annulé                    | Non       |
-
-Tous portent `detail: { id }` (l'id du dialog). `data-ar-dismiss` et `data-ar-accept` sont deux conventions distinctes de `ar-dialog-hide` : elles permettent de distinguer une annulation ("Annuler") d'une confirmation ("Confirmer") sur le même geste de fermeture.
+Tous les événements portent `detail: { id }` (l'id du dialog). `data-ar-dismiss` et `data-ar-accept` sont deux conventions distinctes de `ar-dialog-hide` : elles permettent de distinguer une annulation ("Annuler") d'une confirmation ("Confirmer") sur le même geste de fermeture. La liste complète des événements, avec leur annulabilité, est dans la [Référence API](#reference-api) ci-dessous.
 
 ```js
 document.getElementById('confirm-dialog').addEventListener('ar-dialog-accepted', (e) => {

--- a/apps/docs/src/content/components/ar-table-sort.mdx
+++ b/apps/docs/src/content/components/ar-table-sort.mdx
@@ -167,3 +167,18 @@ Voir la variante **Multi-colonnes** ci-dessous pour un exemple complet. Pour per
 ### Localisation
 
 Les labels sont en français par défaut. Une infrastructure de localisation (`setLocale()`) est prévue — voir l'issue GitHub correspondante.
+
+## Utilisation
+
+### Détail de l'événement
+
+L'événement `ar-table-sort-change` porte un objet `detail` structuré ainsi :
+
+| Champ            | Type                             | Description                                                   |
+| ---------------- | -------------------------------- | ------------------------------------------------------------- |
+| `type`           | `'alpha' \| 'numeric' \| 'date'` | Type de tri du composant qui a émis l'événement.              |
+| `currentOrder`   | `'none' \| 'asc' \| 'desc'`      | Ordre de tri actuel avant le clic.                            |
+| `requestedOrder` | `'none' \| 'asc' \| 'desc'`      | Ordre demandé — le cycle suivant dans la séquence.            |
+| `columnLabel`    | `string`                         | Libellé textuel de la colonne (contenu du slot du composant). |
+
+Consulter les variantes **Alphabétique**, **Numérique** et **Date** ci-dessus pour voir comment accéder à `e.detail` dans un écouteur `ar-table-sort-change`.

--- a/apps/docs/src/content/components/ar-table-sort.mdx
+++ b/apps/docs/src/content/components/ar-table-sort.mdx
@@ -181,4 +181,4 @@ L'événement `ar-table-sort-change` porte un objet `detail` structuré ainsi :
 | `requestedOrder` | `'none' \| 'asc' \| 'desc'`      | Ordre demandé — le cycle suivant dans la séquence.            |
 | `columnLabel`    | `string`                         | Libellé textuel de la colonne (contenu du slot du composant). |
 
-Consulter les variantes **Alphabétique**, **Numérique** et **Date** ci-dessus pour voir comment accéder à `e.detail` dans un écouteur `ar-table-sort-change`.
+Consulter les variantes **Alphabétique**, **Numérique** et **Date** ci-dessous pour un exemple d'écouteur `ar-table-sort-change`.

--- a/apps/docs/src/utils/events.test.ts
+++ b/apps/docs/src/utils/events.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { isCancelableEvent, stripCancelableMarker } from './events.js';
+
+describe('isCancelableEvent', () => {
+    it('détecte le marqueur "@cancelable" en fin de description', () => {
+        expect(isCancelableEvent("Émis avant l'ouverture. @cancelable")).toBe(true);
+    });
+
+    it('détecte le marqueur même sur une description sans point avant', () => {
+        expect(isCancelableEvent('Avant fermeture. @cancelable')).toBe(true);
+    });
+
+    it('retourne false sans le marqueur', () => {
+        expect(isCancelableEvent('Émis si ar-dialog-show est annulé.')).toBe(false);
+    });
+
+    it('retourne false si "cancelable" apparaît sans le marqueur exact', () => {
+        expect(isCancelableEvent("Ceci n'est pas cancelable.")).toBe(false);
+    });
+
+    it('retourne false pour une description undefined', () => {
+        expect(isCancelableEvent(undefined)).toBe(false);
+    });
+
+    it('retourne false pour une chaîne vide', () => {
+        expect(isCancelableEvent('')).toBe(false);
+    });
+});
+
+describe('stripCancelableMarker', () => {
+    it('retire le marqueur "@cancelable" et l\'espace précédent', () => {
+        expect(stripCancelableMarker("Émis avant l'ouverture. @cancelable")).toBe(
+            "Émis avant l'ouverture.",
+        );
+    });
+
+    it('laisse la description inchangée sans marqueur', () => {
+        expect(stripCancelableMarker('Émis si ar-dialog-show est annulé.')).toBe(
+            'Émis si ar-dialog-show est annulé.',
+        );
+    });
+
+    it('retourne une chaîne vide pour une description undefined', () => {
+        expect(stripCancelableMarker(undefined)).toBe('');
+    });
+});

--- a/apps/docs/src/utils/events.ts
+++ b/apps/docs/src/utils/events.ts
@@ -1,0 +1,26 @@
+/**
+ * events.ts
+ *
+ * Dérive l'annulabilité d'un événement CEM depuis la convention JSDoc `@event` : toute
+ * description qui se termine par le marqueur "@cancelable" (précédé d'un espace, en fin de
+ * ligne — jamais un tag JSDoc séparé) décrit un événement
+ * `dispatchEvent(..., { cancelable: true })`.
+ *
+ * Convention appliquée dans tous les composants Lit concernés — cf.
+ * packages/core/src/components/dialog/dialog.ts, collapse.ts, breadcrumb.ts, dropdown.ts,
+ * datepicker.ts.
+ */
+
+const CANCELABLE_MARKER_RE = /\s*@cancelable\s*$/;
+
+/** Retourne true si la description JSDoc d'un event se termine par le marqueur "@cancelable". */
+export function isCancelableEvent(description: string | undefined): boolean {
+    if (description === undefined) return false;
+    return CANCELABLE_MARKER_RE.test(description);
+}
+
+/** Retire le marqueur "@cancelable" (et l'espace précédent) d'une description, si présent. */
+export function stripCancelableMarker(description: string | undefined): string {
+    if (description === undefined) return '';
+    return description.replace(CANCELABLE_MARKER_RE, '');
+}

--- a/packages/core/src/components/breadcrumb/breadcrumb.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.ts
@@ -48,10 +48,10 @@ import { AnchoredController } from '../../controllers/anchored.controller.js';
  * @cssprop [--ar-breadcrumb-toggle-bg-pressed=var(--ar-button-tertiary-bg-active)] - Fond du bouton retour/trigger mobile pressé.
  * @cssprop [--ar-breadcrumb-toggle-bg-focus=var(--ar-button-tertiary-bg-focus)] - Fond du bouton retour/trigger mobile au focus.
  *
- * @event {CustomEvent} ar-breadcrumb-show           - Émis avant l'ouverture du dropdown mobile. Annulable.
+ * @event {CustomEvent} ar-breadcrumb-show           - Émis avant l'ouverture du dropdown mobile. @cancelable
  * @event {CustomEvent} ar-breadcrumb-show-prevented - Émis si ar-breadcrumb-show est annulé.
  * @event {CustomEvent} ar-breadcrumb-shown          - Émis après l'ouverture du dropdown mobile.
- * @event {CustomEvent} ar-breadcrumb-hide           - Émis avant la fermeture du dropdown mobile. Annulable.
+ * @event {CustomEvent} ar-breadcrumb-hide           - Émis avant la fermeture du dropdown mobile. @cancelable
  * @event {CustomEvent} ar-breadcrumb-hide-prevented - Émis si ar-breadcrumb-hide est annulé.
  * @event {CustomEvent} ar-breadcrumb-hidden         - Émis après la fermeture du dropdown mobile.
  */

--- a/packages/core/src/components/collapse/collapse.ts
+++ b/packages/core/src/components/collapse/collapse.ts
@@ -21,10 +21,10 @@ import styles from './collapse.styles.js';
  * @cssprop [--ar-collapse-duration=0s]  - Durée de la transition height.
  * @cssprop [--ar-collapse-easing=ease]  - Easing de la transition height.
  *
- * @event {CustomEvent} ar-collapse-show           - Avant l'ouverture. Annulable.
+ * @event {CustomEvent} ar-collapse-show           - Avant l'ouverture. @cancelable
  * @event {CustomEvent} ar-collapse-show-prevented - Émis si ar-collapse-show est annulé.
  * @event {CustomEvent} ar-collapse-shown          - Après la fin de l'animation d'ouverture.
- * @event {CustomEvent} ar-collapse-hide           - Avant la fermeture. Annulable.
+ * @event {CustomEvent} ar-collapse-hide           - Avant la fermeture. @cancelable
  * @event {CustomEvent} ar-collapse-hide-prevented - Émis si ar-collapse-hide est annulé.
  * @event {CustomEvent} ar-collapse-hidden         - Après la fin de l'animation de fermeture.
  */

--- a/packages/core/src/components/datepicker/datepicker.ts
+++ b/packages/core/src/components/datepicker/datepicker.ts
@@ -93,9 +93,9 @@ import { warn } from '../../utils/warn.js';
  *
  * @event {CustomEvent} ar-datepicker-input-change   - Valeur commitée (blur ou sélection calendrier).
  * @event {CustomEvent} ar-datepicker-input-complete - Saisie texte complète (valide ou non).
- * @event {CustomEvent} ar-datepicker-show           - Avant ouverture du popover.
+ * @event {CustomEvent} ar-datepicker-show           - Avant ouverture du popover. @cancelable
  * @event {CustomEvent} ar-datepicker-shown          - Après ouverture.
- * @event {CustomEvent} ar-datepicker-hide           - Avant fermeture.
+ * @event {CustomEvent} ar-datepicker-hide           - Avant fermeture. @cancelable
  * @event {CustomEvent} ar-datepicker-hidden         - Après fermeture.
  */
 export class ArDatepicker extends LitElement {

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -79,15 +79,15 @@ if (typeof document !== 'undefined') {
  * @cssprop [--ar-dialog-close-bg-pressed=var(--ar-button-tertiary-bg-active)] - Fond du bouton de fermeture pressé.
  * @cssprop [--ar-dialog-close-bg-focus=var(--ar-button-tertiary-bg-focus)] - Fond du bouton de fermeture au focus.
  *
- * @event {CustomEvent} ar-dialog-show - Émis avant l'ouverture. Annulable.
+ * @event {CustomEvent} ar-dialog-show - Émis avant l'ouverture. @cancelable
  * @event {CustomEvent} ar-dialog-show-prevented - Émis si ar-dialog-show est annulé.
  * @event {CustomEvent} ar-dialog-shown - Émis après l'ouverture (après updateComplete).
- * @event {CustomEvent} ar-dialog-hide - Émis avant la fermeture. Annulable.
+ * @event {CustomEvent} ar-dialog-hide - Émis avant la fermeture. @cancelable
  * @event {CustomEvent} ar-dialog-hide-prevented - Émis si ar-dialog-hide est annulé. Le composant secoue le dialog et annonce `prevented-message` aux lecteurs d'écran.
  * @event {CustomEvent} ar-dialog-hidden - Émis après la fermeture (après animation).
- * @event {CustomEvent} ar-dialog-dismissed - Émis lors d'un clic sur data-ar-dismiss. Annulable.
+ * @event {CustomEvent} ar-dialog-dismissed - Émis lors d'un clic sur data-ar-dismiss. @cancelable
  * @event {CustomEvent} ar-dialog-dismissed-prevented - Émis si ar-dialog-dismissed est annulé.
- * @event {CustomEvent} ar-dialog-accepted - Émis lors d'un clic sur data-ar-accept. Annulable.
+ * @event {CustomEvent} ar-dialog-accepted - Émis lors d'un clic sur data-ar-accept. @cancelable
  * @event {CustomEvent} ar-dialog-accepted-prevented - Émis si ar-dialog-accepted est annulé.
  */
 export class ArDialog extends LitElement {

--- a/packages/core/src/components/dropdown/dropdown.ts
+++ b/packages/core/src/components/dropdown/dropdown.ts
@@ -42,10 +42,10 @@ export type ArDropdownPlacement =
  * @cssprop [--ar-dropdown-distance=var(--ar-anchor-distance)] - Espacement entre le trigger et le panel (axe principal).
  * @cssprop [--ar-dropdown-offset=var(--ar-anchor-offset)] - Décalage latéral du panel (axe transversal).
  *
- * @event {CustomEvent} ar-dropdown-show           - Émis avant l'ouverture (annulable).
+ * @event {CustomEvent} ar-dropdown-show           - Émis avant l'ouverture. @cancelable
  * @event {CustomEvent} ar-dropdown-show-prevented - Émis si ar-dropdown-show est annulé.
  * @event {CustomEvent} ar-dropdown-shown          - Émis après l'ouverture.
- * @event {CustomEvent} ar-dropdown-hide           - Émis avant la fermeture (annulable).
+ * @event {CustomEvent} ar-dropdown-hide           - Émis avant la fermeture. @cancelable
  * @event {CustomEvent} ar-dropdown-hide-prevented - Émis si ar-dropdown-hide est annulé.
  * @event {CustomEvent} ar-dropdown-hidden         - Émis après la fermeture.
  */


### PR DESCRIPTION
## Contexte

Repéré en marge de la revue de la PR #116 (issue #109) : `ar-dialog.mdx` avait une section narrative "Utilisation > Cycle d'événements" (tableau manuel Événement/Moment/Annulable) qui faisait doublon avec le tableau "Référence API > Événements" auto-généré depuis le JSDoc `@event` — pas les mêmes colonnes, information partiellement redondante, aucun garde-fou ne les comparait.

## Changements

- **Marqueur JSDoc `@cancelable`** (nouveau) : ajouté en fin de description `@event`, sur la même ligne (jamais un tag séparé — vérifié empiriquement qu'un `@mot` au milieu d'un commentaire JSDoc n'est jamais interprété comme un nouveau tag par TypeScript ni par l'analyseur CEM). Introduit sur les 5 composants concernés : `dialog.ts`/`collapse.ts`/`breadcrumb.ts` (remplacent leur `"Annulable."` textuel existant), `dropdown.ts` (remplace `"(annulable)"` inline), `datepicker.ts` (l'ajoute — ses events `show`/`hide` sont `cancelable: true` en code mais ne le mentionnaient pas en JSDoc).
- `apps/docs/src/utils/events.ts` (nouveau) : `isCancelableEvent()`/`stripCancelableMarker()`, fonctions pures testées (9 tests).
- `ComponentApi.astro` : le tableau Événements généré affiche désormais `Nom | Description | Annulable` (colonne "Type" retirée, toujours `CustomEvent`, sans valeur informative).
- `ar-dialog.mdx` : le tableau manuel "Cycle d'événements" est retiré ; la prose explicative (`detail: { id }`, distinction `data-ar-dismiss`/`data-ar-accept`, exemple de code) est conservée avec un renvoi vers la Référence API.

Choix délibéré (discuté avant l'implémentation) : le marqueur vit dans la description `@event` elle-même plutôt que dans un tag `@cancelable <event>` séparé, pour éviter d'avoir deux sources à synchroniser par événement.

## Test plan

- [x] `npm run test` (racine) — core 756/756, docs 56/56
- [x] `npm run lint` (racine) — 0 erreur
- [x] `npm run build --workspace=packages/core && npm run build --workspace=apps/docs` — les deux builds passent
- [x] Vérifié sur `dialog/index.html` généré : colonne Annulable correcte (Oui/Non), marqueur `@cancelable` absent du texte affiché, ancre `#reference-api` fonctionnelle, hiérarchie de titres non régressée (PR #116)
- [x] Aucun autre fichier MDX ne contient de tableau événements dupliqué

Exécuté en subagent-driven-development (4 tâches, revue indépendante après chaque tâche, 0 Critical/Important sur l'ensemble).

🤖 Generated with [Claude Code](https://claude.com/claude-code)