### PR TITLE
chore(core): documente l'intention de --ar-dropdown-min-width non cascadé

### DIFF
--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -430,6 +430,9 @@
         --ar-dropdown-border-radius: var(--ar-panel-radius);
         --ar-dropdown-shadow: var(--ar-panel-shadow);
         --ar-dropdown-padding: var(--ar-panel-padding);
+        /* Valeur propre, volontairement non cascadée depuis --ar-panel-min-width : un menu
+           dropdown reste lisible plus étroit qu'un panel de disclosure générique (breadcrumb,
+           stepper). */
         --ar-dropdown-min-width: 10rem;
         --ar-dropdown-max-width: var(--ar-panel-max-width);
 


### PR DESCRIPTION
## Contexte

Suite à l'audit "lot A - couche flottante" (dropdown/tooltip/dialog), 3 points restaient non tranchés. Vérification empirique avant correctif :

1. **`_handleTriggerSlotChange` — listener dupliqué sur double `slotchange`** : reproduit avec un spy `addEventListener`, mais `_handleTriggerClick` étant une référence de fonction stable (champ de classe), le DOM déduplique nativement l'enregistrement. Un clic après un second `slotchange` ne déclenche qu'un seul toggle. **Pas un bug** — aucun changement de code.
2. **`--ar-dropdown-min-width` non cascadé vers `--ar-panel-min-width`** : différence de valeur réelle (10rem vs 18rem), pas un oubli de câblage — un dropdown reste lisible plus étroit qu'un panel de disclosure générique. Documenté ici plutôt qu'harmonisé (changement visuel non demandé).
3. **`DEFAULT_DIALOG_LABEL` en dur en français** : déjà cohérent avec la décision actée de rester français jusqu'au chantier i18n (#80). Aucune action.

## Changement

Ajoute un commentaire dans `default.css` expliquant pourquoi `--ar-dropdown-min-width` a sa propre valeur plutôt que de cascader — évite de re-signaler ce point à chaque futur audit.

## Test plan

- [x] `npm run build:manifest` (vérifie que la doc `@cssprop` reste alignée avec `default.css`, garde-fou #114)
- [x] Aucun changement de comportement/valeur — commentaire uniquement

🤖 Generated with [Claude Code](https://claude.com/claude-code)