### PR TITLE
docs(headless): retire la colonne Défaut des CSS custom properties

### DIFF
--- a/apps/docs/src/components/ComponentApi.astro
+++ b/apps/docs/src/components/ComponentApi.astro
@@ -6,10 +6,7 @@
  * Toutes les sections (attributs, events, CSS parts, CSS props, slots) sont auto-générées.
  * Ajouter une annotation JSDoc dans le composant TS → apparaît ici automatiquement.
  */
-import { readFileSync } from 'fs';
-import { resolve } from 'path';
 import { type CemDeclaration } from '../utils/cem-types.ts';
-import { buildTokenMap, resolveColor } from '../utils/parse-tokens.ts';
 import { isCancelableEvent, stripCancelableMarker } from '../utils/events.ts';
 
 interface Props {
@@ -17,14 +14,6 @@ interface Props {
 }
 
 const { component } = Astro.props;
-
-const themePath = resolve(process.cwd(), '../../packages/core/src/styles/themes/default.css');
-const tokenMap = buildTokenMap(readFileSync(themePath, 'utf-8'));
-
-function swatchColor(value: string | undefined): string | undefined {
-    if (!value) return undefined;
-    return resolveColor(value, tokenMap);
-}
 
 const publicMethods = (component.members ?? []).filter(
     (m) => m.kind === 'method' && m.privacy !== 'private' && m.privacy !== 'protected',
@@ -167,31 +156,16 @@ const publicMethods = (component.members ?? []).filter(
                     <thead>
                         <tr>
                             <th>Nom</th>
-                            <th>Défaut</th>
                             <th>Description</th>
                         </tr>
                     </thead>
                     <tbody>
-                        {component.cssProperties.map((prop) => {
-                            const color = swatchColor(prop.default);
-                            return (
-                                <tr>
-                                    <td><code>{prop.name}</code></td>
-                                    <td>
-                                        {color ? (
-                                            <span
-                                                class="swatch"
-                                                style={`background: var(${prop.name})`}
-                                                aria-hidden="true"
-                                            />
-                                        ) : (
-                                            <code>{prop.default ?? '—'}</code>
-                                        )}
-                                    </td>
-                                    <td>{prop.description ?? ''}</td>
-                                </tr>
-                            );
-                        })}
+                        {component.cssProperties.map((prop) => (
+                            <tr>
+                                <td><code>{prop.name}</code></td>
+                                <td>{prop.description ?? ''}</td>
+                            </tr>
+                        ))}
                     </tbody>
                 </table>
             </div>

--- a/apps/docs/src/components/Playground.astro
+++ b/apps/docs/src/components/Playground.astro
@@ -44,6 +44,16 @@ const {
 const showPlayground = displayMode === 'demo';
 ---
 
+{/* ── Encart thème de démo ── */}
+{/* Ariane est headless : aucun style n'est intégré au composant. Les previews
+    ci-dessous chargent le thème de démo `default.css` fourni avec la librairie —
+    à ne pas confondre avec un style par défaut intrinsèque au composant. */}
+<div class="theme-notice">
+    Les exemples ci-dessous sont affichés avec le thème de démo
+    <code>default.css</code> fourni par Ariane. Un composant headless n'a
+    aucun style intégré — remplacez ce thème par le vôtre pour un rendu différent.
+</div>
+
 {/* ── Exemples (variantes) ── */}
 {variants.length > 0 && (
     <section id="exemples">
@@ -378,6 +388,22 @@ const showPlayground = displayMode === 'demo';
         height:     1.1rem;
         cursor:     pointer;
         margin-top: 0.2rem;
+    }
+
+    /* ── Encart thème de démo ────────────────────────── */
+
+    .theme-notice {
+        padding:       0.75rem 1rem;
+        background:    color-mix(in srgb, var(--ar-color-interactive, #2563eb) 8%, transparent);
+        border:        1px solid color-mix(in srgb, var(--ar-color-interactive, #2563eb) 20%, transparent);
+        border-radius: 0.5rem;
+        font-size:     0.875rem;
+        color:         var(--doc-text, #374151);
+        margin:        0 0 1rem;
+    }
+
+    .theme-notice code {
+        font-size: 0.85em;
     }
 
     /* ── Encart parent ───────────────────────────────── */

--- a/apps/docs/src/components/Playground.astro
+++ b/apps/docs/src/components/Playground.astro
@@ -44,20 +44,18 @@ const {
 const showPlayground = displayMode === 'demo';
 ---
 
-{/* ── Encart thème de démo ── */}
-{/* Ariane est headless : aucun style n'est intégré au composant. Les previews
-    ci-dessous chargent le thème de démo `default.css` fourni avec la librairie —
-    à ne pas confondre avec un style par défaut intrinsèque au composant. */}
-<div class="theme-notice">
-    Les exemples ci-dessous sont affichés avec le thème de démo
-    <code>default.css</code> fourni par Ariane. Un composant headless n'a
-    aucun style intégré — remplacez ce thème par le vôtre pour un rendu différent.
-</div>
-
 {/* ── Exemples (variantes) ── */}
 {variants.length > 0 && (
     <section id="exemples">
         <h3 class="section-title">Exemples</h3>
+        {/* ── Encart thème de démo ── */}
+        {/* Ariane est headless : aucun style n'est intégré au composant. Les previews
+            ci-dessous chargent le thème de démo `default.css` fourni avec la librairie —
+            à ne pas confondre avec un style par défaut intrinsèque au composant. */}
+        <ar-alert variant="info" style="margin-bottom: 1rem">
+            <p style="margin: 0">Les exemples ci-dessous sont affichés avec le thème de démo <code>default.css</code> fourni par Ariane.<br>
+            Un composant headless n'a aucun style intégré — remplacez ce thème par le vôtre pour un rendu différent.</p>
+        </ar-alert>
         <div class="main-section">
             {variants.map((variant) => (
                 <section id={`exemple-${variant.name}`}>
@@ -171,6 +169,12 @@ const showPlayground = displayMode === 'demo';
 
 <style>
     @import '../styles/doc-prose.css';
+
+    /* Évite le flash non-stylé le temps de l'hydratation du custom element
+       (Lit n'applique son shadow DOM/style qu'une fois défini côté client). */
+    ar-alert:not(:defined) {
+        visibility: hidden;
+    }
 
     /* ── Variantes ─────────────────────────────────────── */
 
@@ -388,22 +392,6 @@ const showPlayground = displayMode === 'demo';
         height:     1.1rem;
         cursor:     pointer;
         margin-top: 0.2rem;
-    }
-
-    /* ── Encart thème de démo ────────────────────────── */
-
-    .theme-notice {
-        padding:       0.75rem 1rem;
-        background:    color-mix(in srgb, var(--ar-color-interactive, #2563eb) 8%, transparent);
-        border:        1px solid color-mix(in srgb, var(--ar-color-interactive, #2563eb) 20%, transparent);
-        border-radius: 0.5rem;
-        font-size:     0.875rem;
-        color:         var(--doc-text, #374151);
-        margin:        0 0 1rem;
-    }
-
-    .theme-notice code {
-        font-size: 0.85em;
     }
 
     /* ── Encart parent ───────────────────────────────── */

--- a/apps/docs/src/styles/doc-table.css
+++ b/apps/docs/src/styles/doc-table.css
@@ -35,6 +35,16 @@ td {
     color: var(--doc-text, #111827);
 }
 
+/* La première colonne (Nom) se cale sur son contenu (nom de token/attribut,
+   généralement court et sans espace) au lieu de rétrécir sous la pression
+   d'une colonne Description longue — les colonnes suivantes se partagent
+   l'espace restant. */
+th:first-child,
+td:first-child {
+    width: 1%;
+    white-space: nowrap;
+}
+
 code {
     font-family: 'Fira Code', 'Cascadia Code', monospace;
     font-size: 0.8rem;

--- a/packages/core/cem.config.js
+++ b/packages/core/cem.config.js
@@ -14,7 +14,6 @@ import { resolve } from 'node:path';
 import { customElementVsCodePlugin } from 'custom-element-vs-code-integration';
 import {
     extractThemeTokens,
-    validateCssPropertyDefaults,
     validateCssPropertyCoverage,
 } from './scripts/validate-cssprop-defaults.js';
 import {
@@ -177,18 +176,14 @@ export default {
                     }
                 }
 
-                // Valide que les @cssprop [--nom=valeur] écrits à la main dans le JSDoc
-                // des composants correspondent aux valeurs réelles de default.css —
+                // Valide que chaque token --ar-* de default.css appartenant à un composant
+                // a bien une entrée @cssprop dans son JSDoc (trou de documentation) —
                 // cf. docs/superpowers/specs/2026-07-16-cem-theme-default-sync-design.md
                 const themeCss = readFileSync(
                     resolve(process.cwd(), 'src/styles/themes/default.css'),
                     'utf-8',
                 );
                 const themeTokens = extractThemeTokens(themeCss);
-                const cssPropDefaultErrors = validateCssPropertyDefaults(
-                    customElementsManifest,
-                    themeTokens,
-                );
                 const cssPropCoverageErrors = validateCssPropertyCoverage(
                     customElementsManifest,
                     themeTokens,
@@ -203,16 +198,8 @@ export default {
                     findHardcodedTokenAssignments(filePath, readFileSync(filePath, 'utf-8')),
                 );
 
-                const allErrors = [
-                    ...cssPropDefaultErrors,
-                    ...cssPropCoverageErrors,
-                    ...hardcodedErrors,
-                ];
+                const allErrors = [...cssPropCoverageErrors, ...hardcodedErrors];
                 if (allErrors.length > 0) {
-                    const defaultErrorsMsg =
-                        cssPropDefaultErrors.length > 0
-                            ? `\n  désynchronisé(s) :\n${cssPropDefaultErrors.map((e) => `    - ${e}`).join('\n')}`
-                            : '';
                     const coverageErrorsMsg =
                         cssPropCoverageErrors.length > 0
                             ? `\n  non documenté(s) :\n${cssPropCoverageErrors.map((e) => `    - ${e}`).join('\n')}`
@@ -222,7 +209,7 @@ export default {
                             ? `\n  codé(s) en dur :\n${hardcodedErrors.map((e) => `    - ${e}`).join('\n')}`
                             : '';
                     throw new Error(
-                        `[CEM] ${allErrors.length} @cssprop erreur(s) avec default.css :${defaultErrorsMsg}${coverageErrorsMsg}${hardcodedErrorsMsg}`,
+                        `[CEM] ${allErrors.length} @cssprop erreur(s) avec default.css :${coverageErrorsMsg}${hardcodedErrorsMsg}`,
                     );
                 }
             },

--- a/packages/core/scripts/validate-cssprop-defaults.js
+++ b/packages/core/scripts/validate-cssprop-defaults.js
@@ -1,10 +1,10 @@
 /**
- * Extrait et valide les valeurs par défaut des CSS custom properties (`@cssprop`)
- * documentées à la main dans le JSDoc des composants, en les comparant à leur
- * définition réelle dans le thème par défaut (`src/styles/themes/default.css`).
+ * Extrait les tokens du thème par défaut (`src/styles/themes/default.css`) et
+ * vérifie que chaque token appartenant à un composant a bien une entrée
+ * `@cssprop` dans son JSDoc — un trou de documentation silencieux.
  *
  * Utilisé par `cem.config.js` (hook `packageLinkPhase`) pour faire échouer
- * `npm run build:manifest` en cas de désaccord — cf. docs/superpowers/specs/2026-07-16-cem-theme-default-sync-design.md
+ * `npm run build:manifest` en cas de trou — cf. docs/superpowers/specs/2026-07-16-cem-theme-default-sync-design.md
  */
 
 const TOKEN_RE = /(--ar[\w-]+)\s*:\s*([^;]+)/g;
@@ -45,40 +45,12 @@ export function extractThemeTokens(css) {
 }
 
 /**
- * Compare les `@cssprop [--nom=valeur]` déjà résolus dans le manifest CEM
- * aux valeurs réelles du thème par défaut. Ne modifie rien : retourne la liste
- * des désaccords trouvés (tableau vide si tout est cohérent).
- *
- * @param {{ modules?: Array<{ declarations?: Array<{ name: string, cssProperties?: Array<{ name: string, default?: string }> }> }> }} customElementsManifest
- * @param {Map<string, string>} themeTokens
- * @returns {string[]}
- */
-export function validateCssPropertyDefaults(customElementsManifest, themeTokens) {
-    const errors = [];
-    for (const mod of customElementsManifest.modules ?? []) {
-        for (const decl of mod.declarations ?? []) {
-            for (const prop of decl.cssProperties ?? []) {
-                if (prop.default === undefined) continue;
-                const themeValue = themeTokens.get(prop.name);
-                if (themeValue === undefined) continue;
-                const jsdocValue = prop.default.trim().replace(/\s+/g, ' ');
-                if (jsdocValue !== themeValue) {
-                    errors.push(
-                        `${decl.name} : ${prop.name} déclare [default=${jsdocValue}] dans le JSDoc mais default.css définit "${themeValue}"`,
-                    );
-                }
-            }
-        }
-    }
-    return errors;
-}
-
-/**
  * Détecte les tokens de default.css qui appartiennent à un composant (par
  * préfixe de tag, ex. --ar-alert-* pour <ar-alert>) mais qui n'ont aucune
  * entrée @cssprop dans le JSDoc de ce composant — un trou de documentation
- * silencieux. Ne vérifie pas la valeur (cf. validateCssPropertyDefaults pour
- * ça), seulement la présence d'une entrée cssProperties portant ce nom.
+ * silencieux. Seule la présence d'une entrée cssProperties portant ce nom est
+ * vérifiée (aucun concept de valeur par défaut à comparer : ni le JSDoc ni la
+ * doc générée n'en documentent, cf. suppression de la colonne « Défaut »).
  *
  * L'appartenance à un composant se détermine par préfixe de tag le plus long
  * (ex. --ar-tab-group-active-shadow appartient à <ar-tab-group>, pas à

--- a/packages/core/scripts/validate-cssprop-defaults.test.js
+++ b/packages/core/scripts/validate-cssprop-defaults.test.js
@@ -1,9 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-    extractThemeTokens,
-    validateCssPropertyDefaults,
-    validateCssPropertyCoverage,
-} from './validate-cssprop-defaults.js';
+import { extractThemeTokens, validateCssPropertyCoverage } from './validate-cssprop-defaults.js';
 
 describe('extractThemeTokens', () => {
     it('extrait un token simple', () => {
@@ -95,95 +91,6 @@ describe('extractThemeTokens', () => {
         const tokens = extractThemeTokens(css);
         expect(tokens.get('--ar-test-shadow')).toBe('0 1px 2px rgba(0,0,0,0.1)');
         expect(tokens.get('--ar-test-gradient')).toBe('linear-gradient( 90deg, red, blue )');
-    });
-});
-
-describe('validateCssPropertyDefaults', () => {
-    function manifestWith(cssProperties) {
-        return {
-            modules: [{ declarations: [{ name: 'ArPagination', cssProperties }] }],
-        };
-    }
-
-    it('ne retourne aucune erreur quand la valeur JSDoc correspond au thème', () => {
-        const themeTokens = new Map([['--ar-pagination-radius', '0.75rem']]);
-        const manifest = manifestWith([{ name: '--ar-pagination-radius', default: '0.75rem' }]);
-        expect(validateCssPropertyDefaults(manifest, themeTokens)).toEqual([]);
-    });
-
-    it('retourne une erreur détaillée quand la valeur JSDoc diverge du thème', () => {
-        const themeTokens = new Map([['--ar-pagination-radius', '0.75rem']]);
-        const manifest = manifestWith([{ name: '--ar-pagination-radius', default: '1rem' }]);
-        const errors = validateCssPropertyDefaults(manifest, themeTokens);
-        expect(errors).toHaveLength(1);
-        expect(errors[0]).toContain('ArPagination');
-        expect(errors[0]).toContain('--ar-pagination-radius');
-        expect(errors[0]).toContain('1rem');
-        expect(errors[0]).toContain('0.75rem');
-    });
-
-    it('ignore les cssProperties sans default (rien à comparer)', () => {
-        const themeTokens = new Map([['--ar-charcounter-color', '#171717']]);
-        const manifest = manifestWith([{ name: '--ar-charcounter-color' }]);
-        expect(validateCssPropertyDefaults(manifest, themeTokens)).toEqual([]);
-    });
-
-    it('ignore les tokens absents du thème (props hors thème, ex. --ar-dialog-width)', () => {
-        const themeTokens = new Map();
-        const manifest = manifestWith([{ name: '--ar-dialog-width', default: '500px' }]);
-        expect(validateCssPropertyDefaults(manifest, themeTokens)).toEqual([]);
-    });
-
-    it('agrège les erreurs sur plusieurs déclarations', () => {
-        const themeTokens = new Map([
-            ['--ar-pagination-radius', '0.75rem'],
-            ['--ar-alert-padding', '1rem'],
-        ]);
-        const manifest = {
-            modules: [
-                {
-                    declarations: [
-                        {
-                            name: 'ArPagination',
-                            cssProperties: [{ name: '--ar-pagination-radius', default: '1rem' }],
-                        },
-                        {
-                            name: 'ArAlert',
-                            cssProperties: [{ name: '--ar-alert-padding', default: '2rem' }],
-                        },
-                    ],
-                },
-            ],
-        };
-        expect(validateCssPropertyDefaults(manifest, themeTokens)).toHaveLength(2);
-    });
-
-    it('accepte une valeur JSDoc single-line qui correspond à une valeur thème multi-ligne après normalisation', () => {
-        const themeTokens = new Map([['--ar-test-shadow', '0 1px 2px rgba(0,0,0,0.1)']]);
-        const manifest = manifestWith([
-            {
-                name: '--ar-test-shadow',
-                default: '0 1px 2px rgba(0,0,0,0.1)',
-            },
-        ]);
-        expect(validateCssPropertyDefaults(manifest, themeTokens)).toEqual([]);
-    });
-
-    it('normalise aussi la valeur JSDoc avant comparaison (ex. espaces multiples → single)', () => {
-        const themeTokens = new Map([['--ar-test-shadow', '0 1px 2px rgba(0,0,0,0.1)']]);
-        const manifest = manifestWith([
-            {
-                name: '--ar-test-shadow',
-                default: '0  1px   2px\n            rgba(0,0,0,0.1)',
-            },
-        ]);
-        expect(validateCssPropertyDefaults(manifest, themeTokens)).toEqual([]);
-    });
-
-    it('accepte une valeur JSDoc avec espaces leading/trailing qui correspond à la valeur thème après trim', () => {
-        const themeTokens = new Map([['--ar-pagination-radius', '0.75rem']]);
-        const manifest = manifestWith([{ name: '--ar-pagination-radius', default: '  0.75rem  ' }]);
-        expect(validateCssPropertyDefaults(manifest, themeTokens)).toEqual([]);
     });
 });
 
@@ -291,10 +198,8 @@ describe('validateCssPropertyCoverage', () => {
         expect(validateCssPropertyCoverage(manifest, themeTokens)).toEqual([]);
     });
 
-    it('documente un token avec default optionnel (la présence suffit, pas la valeur)', () => {
-        const manifest = manifestWithTag('ar-alert', [
-            { name: '--ar-alert-padding', default: '1rem' },
-        ]);
+    it("ne compare pas la valeur du token, seule la présence de l'entrée @cssprop compte", () => {
+        const manifest = manifestWithTag('ar-alert', [{ name: '--ar-alert-padding' }]);
         const themeTokens = new Map([['--ar-alert-padding', '0.75rem']]);
         expect(validateCssPropertyCoverage(manifest, themeTokens)).toEqual([]);
     });

--- a/packages/core/src/components/alert/alert.ts
+++ b/packages/core/src/components/alert/alert.ts
@@ -29,26 +29,26 @@ export type ArAlertVariant = 'success' | 'warning' | 'error' | 'info';
  * @csspart body      - Le conteneur du titre et du contenu.
  * @csspart close     - Le bouton de fermeture (présent uniquement si `next-focus` est défini).
  *
- * @cssprop [--ar-alert-border-radius=0.75rem]                     - Arrondi des alertes.
- * @cssprop [--ar-alert-padding=1rem]                              - Marge interne des alertes.
- * @cssprop [--ar-alert-border-width=1px]                          - Epaisseur des bordures.
- * @cssprop [--ar-alert-border-style=solid]                        - Style des bordures.
- * @cssprop [--ar-alert-close-size=2rem]                           - Taille (width/height) du bouton de fermeture.
- * @cssprop [--ar-alert-close-radius=7px]                          - Arrondi du bouton de fermeture.
- * @cssprop [--ar-alert-close-bg=color-mix(in srgb, currentColor 8%, transparent)]    - Fond du bouton de fermeture au repos.
- * @cssprop [--ar-alert-close-hover-bg=color-mix(in srgb, currentColor 20%, transparent)] - Fond du bouton de fermeture au survol.
- * @cssprop [--ar-alert-info-bg=var(--ar-color-info-bg)]           - Fond de l'alerte "info".
- * @cssprop [--ar-alert-info-border=var(--ar-color-info-bg)]       - Bordure de l'alerte "info".
- * @cssprop [--ar-alert-info-icon=var(--ar-color-info-text)]       - Couleur de l'icône "info".
- * @cssprop [--ar-alert-warning-bg=var(--ar-color-warning-bg)]     - Fond de l'alerte "warning".
- * @cssprop [--ar-alert-warning-border=var(--ar-color-warning-bg)] - Bordure de l'alerte "warning".
- * @cssprop [--ar-alert-warning-icon=var(--ar-color-warning-text)] - Couleur de l'icône "warning".
- * @cssprop [--ar-alert-error-bg=var(--ar-color-danger-bg)]        - Fond de l'alerte "error".
- * @cssprop [--ar-alert-error-border=var(--ar-color-danger-bg)]    - Bordure de l'alerte "error".
- * @cssprop [--ar-alert-error-icon=var(--ar-color-danger-text)]    - Couleur de l'icône "error".
- * @cssprop [--ar-alert-success-bg=var(--ar-color-success-bg)]     - Fond de l'alerte "success".
- * @cssprop [--ar-alert-success-border=var(--ar-color-success-bg)] - Bordure de l'alerte "success".
- * @cssprop [--ar-alert-success-icon=var(--ar-color-success-text)] - Couleur de l'icône "success".
+ * @cssprop --ar-alert-border-radius - Arrondi des alertes.
+ * @cssprop --ar-alert-padding - Marge interne des alertes.
+ * @cssprop --ar-alert-border-width - Epaisseur des bordures.
+ * @cssprop --ar-alert-border-style - Style des bordures.
+ * @cssprop --ar-alert-close-size - Taille (width/height) du bouton de fermeture.
+ * @cssprop --ar-alert-close-radius - Arrondi du bouton de fermeture.
+ * @cssprop --ar-alert-close-bg - Fond du bouton de fermeture au repos.
+ * @cssprop --ar-alert-close-hover-bg - Fond du bouton de fermeture au survol.
+ * @cssprop --ar-alert-info-bg - Fond de l'alerte "info".
+ * @cssprop --ar-alert-info-border - Bordure de l'alerte "info".
+ * @cssprop --ar-alert-info-icon - Couleur de l'icône "info".
+ * @cssprop --ar-alert-warning-bg - Fond de l'alerte "warning".
+ * @cssprop --ar-alert-warning-border - Bordure de l'alerte "warning".
+ * @cssprop --ar-alert-warning-icon - Couleur de l'icône "warning".
+ * @cssprop --ar-alert-error-bg - Fond de l'alerte "error".
+ * @cssprop --ar-alert-error-border - Bordure de l'alerte "error".
+ * @cssprop --ar-alert-error-icon - Couleur de l'icône "error".
+ * @cssprop --ar-alert-success-bg - Fond de l'alerte "success".
+ * @cssprop --ar-alert-success-border - Bordure de l'alerte "success".
+ * @cssprop --ar-alert-success-icon - Couleur de l'icône "success".
 
  *
  * @event {CustomEvent} ar-alert-close - Émis après la fermeture de l'alerte (fin de transition).

--- a/packages/core/src/components/breadcrumb/breadcrumb.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.ts
@@ -36,17 +36,17 @@ import { AnchoredController } from '../../controllers/anchored.controller.js';
  * @csspart trigger    - Le bouton d'ouverture du panel mobile.
  * @csspart panel      - Le panel mobile flottant.
  *
- * @cssprop [--ar-breadcrumb-color=var(--ar-color-text)] - Couleur du texte (labels et lien actif). À surcharger localement pour un fond sombre ponctuel, indépendamment du thème global.
- * @cssprop [--ar-breadcrumb-separator-color=var(--ar-color-neutral-80)] - Couleur du séparateur entre les items (desktop).
- * @cssprop [--ar-breadcrumb-bullet-color=var(--ar-color-neutral-80)] - Couleur des puces de la liste mobile.
- * @cssprop [--ar-breadcrumb-panel-min-width=var(--ar-panel-min-width)] - Largeur min du panel mobile (cascade vers --ar-panel-min-width).
- * @cssprop [--ar-breadcrumb-panel-max-width=var(--ar-panel-max-width)] - Largeur max du panel mobile (cascade vers --ar-panel-max-width).
- * @cssprop [--ar-breadcrumb-distance=var(--ar-anchor-distance)] - Espacement entre le trigger et le panel mobile.
- * @cssprop [--ar-breadcrumb-offset=var(--ar-anchor-offset)] - Décalage latéral du panel mobile.
- * @cssprop [--ar-breadcrumb-toggle-bg=var(--ar-button-tertiary-bg)] - Fond du bouton retour/trigger mobile.
- * @cssprop [--ar-breadcrumb-toggle-bg-hover=var(--ar-button-tertiary-bg-hover)] - Fond du bouton retour/trigger mobile au survol.
- * @cssprop [--ar-breadcrumb-toggle-bg-pressed=var(--ar-button-tertiary-bg-active)] - Fond du bouton retour/trigger mobile pressé.
- * @cssprop [--ar-breadcrumb-toggle-bg-focus=var(--ar-button-tertiary-bg-focus)] - Fond du bouton retour/trigger mobile au focus.
+ * @cssprop --ar-breadcrumb-color - Couleur du texte (labels et lien actif). À surcharger localement pour un fond sombre ponctuel, indépendamment du thème global.
+ * @cssprop --ar-breadcrumb-separator-color - Couleur du séparateur entre les items (desktop).
+ * @cssprop --ar-breadcrumb-bullet-color - Couleur des puces de la liste mobile.
+ * @cssprop --ar-breadcrumb-panel-min-width - Largeur min du panel mobile (cascade vers --ar-panel-min-width).
+ * @cssprop --ar-breadcrumb-panel-max-width - Largeur max du panel mobile (cascade vers --ar-panel-max-width).
+ * @cssprop --ar-breadcrumb-distance - Espacement entre le trigger et le panel mobile.
+ * @cssprop --ar-breadcrumb-offset - Décalage latéral du panel mobile.
+ * @cssprop --ar-breadcrumb-toggle-bg - Fond du bouton retour/trigger mobile.
+ * @cssprop --ar-breadcrumb-toggle-bg-hover - Fond du bouton retour/trigger mobile au survol.
+ * @cssprop --ar-breadcrumb-toggle-bg-pressed - Fond du bouton retour/trigger mobile pressé.
+ * @cssprop --ar-breadcrumb-toggle-bg-focus - Fond du bouton retour/trigger mobile au focus.
  *
  * @event {CustomEvent} ar-breadcrumb-show           - Émis avant l'ouverture du dropdown mobile. @cancelable
  * @event {CustomEvent} ar-breadcrumb-show-prevented - Émis si ar-breadcrumb-show est annulé.

--- a/packages/core/src/components/charcounter/charcounter.ts
+++ b/packages/core/src/components/charcounter/charcounter.ts
@@ -27,12 +27,12 @@ function pluralize(count: number, label: string): string {
  * @csspart remaining - Le chiffre des caractères restants.
  * @csspart label     - Le texte après le chiffre (ex: "restants").
  *
- * @cssprop [--ar-charcounter-color]                - Couleur état normal.
- * @cssprop [--ar-charcounter-warning-color]         - Couleur état warning.
- * @cssprop [--ar-charcounter-error-color]           - Couleur état error.
- * @cssprop [--ar-charcounter-font-size=0.875rem]    - Taille de police.
- * @cssprop [--ar-charcounter-warning-weight=600]    - Graisse du texte en état warning.
- * @cssprop [--ar-charcounter-error-weight=700]      - Graisse du texte en état error.
+ * @cssprop --ar-charcounter-color - Couleur état normal.
+ * @cssprop --ar-charcounter-warning-color - Couleur état warning.
+ * @cssprop --ar-charcounter-error-color - Couleur état error.
+ * @cssprop --ar-charcounter-font-size - Taille de police.
+ * @cssprop --ar-charcounter-warning-weight - Graisse du texte en état warning.
+ * @cssprop --ar-charcounter-error-weight - Graisse du texte en état error.
  */
 export class ArCharcounter extends LitElement {
     static override styles = [styles];

--- a/packages/core/src/components/collapse/collapse.ts
+++ b/packages/core/src/components/collapse/collapse.ts
@@ -18,8 +18,8 @@ import styles from './collapse.styles.js';
  * @csspart panel             - Zone animée (overflow hidden, height 0 → auto).
  * @csspart content           - Wrapper interne du contenu.
  *
- * @cssprop [--ar-collapse-duration=0s]  - Durée de la transition height.
- * @cssprop [--ar-collapse-easing=ease]  - Easing de la transition height.
+ * @cssprop --ar-collapse-duration - Durée de la transition height.
+ * @cssprop --ar-collapse-easing - Easing de la transition height.
  *
  * @event {CustomEvent} ar-collapse-show           - Avant l'ouverture. @cancelable
  * @event {CustomEvent} ar-collapse-show-prevented - Émis si ar-collapse-show est annulé.

--- a/packages/core/src/components/datepicker/datepicker.ts
+++ b/packages/core/src/components/datepicker/datepicker.ts
@@ -42,54 +42,54 @@ import { warn } from '../../utils/warn.js';
  * @csspart today-btn  - Bouton « Aujourd'hui ».
  * @csspart close-btn  - Bouton « Fermer ».
  *
- * @cssprop [--ar-datepicker-panel-width]        - Largeur du popover.
- * @cssprop [--ar-datepicker-distance=var(--ar-anchor-distance)] - Espacement entre le trigger et le panel.
- * @cssprop [--ar-datepicker-offset=var(--ar-anchor-offset)] - Décalage latéral du panel.
- * @cssprop [--ar-datepicker-header-font-size]         - Taille de police de l'en-tête.
- * @cssprop [--ar-datepicker-header-padding]           - Padding de l'en-tête.
- * @cssprop [--ar-datepicker-header-margin]            - Margin de l'en-tête.
- * @cssprop [--ar-datepicker-header-radius]            - Border-radius de l'en-tête.
- * @cssprop [--ar-datepicker-header-bg=transparent]     - Fond de l'en-tête.
- * @cssprop [--ar-datepicker-nav-btn-size]                  - Taille (width = height) des boutons nav.
- * @cssprop [--ar-datepicker-nav-btn-bg]                    - Fond des boutons de navigation.
- * @cssprop [--ar-datepicker-nav-btn-border-width]          - Épaisseur de bordure des boutons nav.
- * @cssprop [--ar-datepicker-nav-btn-border-color]          - Couleur de bordure des boutons nav.
- * @cssprop [--ar-datepicker-nav-btn-color]                 - Couleur texte des boutons nav.
- * @cssprop [--ar-datepicker-nav-btn-radius]                - Border-radius des boutons nav.
- * @cssprop [--ar-datepicker-nav-btn-hover-bg]              - Fond au survol des boutons nav.
- * @cssprop [--ar-datepicker-nav-btn-active-bg]             - Fond à l'état actif des boutons nav.
- * @cssprop [--ar-datepicker-footer-padding]                - Padding du footer.
- * @cssprop [--ar-datepicker-footer-bg=transparent]          - Fond du footer.
- * @cssprop [--ar-datepicker-footer-margin]                 - Margin du footer.
- * @cssprop [--ar-datepicker-footer-btn-bg]                 - Fond des boutons du footer.
- * @cssprop [--ar-datepicker-footer-btn-border-width]       - Épaisseur de bordure des boutons footer.
- * @cssprop [--ar-datepicker-footer-btn-border-color]       - Couleur de bordure des boutons footer.
- * @cssprop [--ar-datepicker-footer-btn-color]              - Couleur texte des boutons footer.
- * @cssprop [--ar-datepicker-footer-btn-radius]             - Border-radius des boutons footer.
- * @cssprop [--ar-datepicker-footer-btn-padding]            - Padding des boutons footer.
- * @cssprop [--ar-datepicker-footer-btn-hover-bg]           - Fond au survol des boutons footer.
- * @cssprop [--ar-datepicker-footer-btn-hover-border-color] - Couleur de bordure au survol des boutons footer.
- * @cssprop [--ar-datepicker-footer-btn-active-bg]          - Fond à l'état actif des boutons footer.
- * @cssprop [--ar-datepicker-weekday-color]            - Couleur des abréviations de jours.
- * @cssprop [--ar-datepicker-weekday-font-size]        - Taille de police des abréviations de jours.
- * @cssprop [--ar-datepicker-day-size]                 - Taille des cellules jour.
- * @cssprop [--ar-datepicker-day-font-size]            - Taille de police des jours.
- * @cssprop [--ar-datepicker-day-radius]               - Border-radius des cellules jour.
- * @cssprop [--ar-datepicker-day-bg=transparent]        - Fond des cellules jour.
- * @cssprop [--ar-datepicker-day-border-width]         - Épaisseur de bordure des cellules jour.
- * @cssprop [--ar-datepicker-day-border-color]         - Couleur de bordure par défaut des cellules jour.
- * @cssprop [--ar-datepicker-day-other-month-color]    - Couleur des jours hors du mois affiché.
- * @cssprop [--ar-datepicker-day-today-bg]             - Fond du jour actuel.
- * @cssprop [--ar-datepicker-day-today-color]          - Couleur texte du jour actuel.
- * @cssprop [--ar-datepicker-day-today-border]         - Couleur de bordure du jour actuel.
- * @cssprop [--ar-datepicker-day-hover-bg]             - Fond au survol d'un jour.
- * @cssprop [--ar-datepicker-day-hover-color]          - Couleur texte au survol d'un jour.
- * @cssprop [--ar-datepicker-day-focus-ring-color]     - Couleur du focus ring des jours.
- * @cssprop [--ar-datepicker-day-focus-ring-width]     - Épaisseur du focus ring des jours.
- * @cssprop [--ar-datepicker-day-focus-ring-offset]    - Décalage du focus ring des jours.
- * @cssprop [--ar-datepicker-day-selected-bg]          - Fond du jour sélectionné.
- * @cssprop [--ar-datepicker-day-selected-color]       - Couleur texte du jour sélectionné.
- * @cssprop [--ar-datepicker-input-error-border-color] - Bordure input en état d'erreur.
+ * @cssprop --ar-datepicker-panel-width - Largeur du popover.
+ * @cssprop --ar-datepicker-distance - Espacement entre le trigger et le panel.
+ * @cssprop --ar-datepicker-offset - Décalage latéral du panel.
+ * @cssprop --ar-datepicker-header-font-size - Taille de police de l'en-tête.
+ * @cssprop --ar-datepicker-header-padding - Padding de l'en-tête.
+ * @cssprop --ar-datepicker-header-margin - Margin de l'en-tête.
+ * @cssprop --ar-datepicker-header-radius - Border-radius de l'en-tête.
+ * @cssprop --ar-datepicker-header-bg - Fond de l'en-tête.
+ * @cssprop --ar-datepicker-nav-btn-size - Taille (width = height) des boutons nav.
+ * @cssprop --ar-datepicker-nav-btn-bg - Fond des boutons de navigation.
+ * @cssprop --ar-datepicker-nav-btn-border-width - Épaisseur de bordure des boutons nav.
+ * @cssprop --ar-datepicker-nav-btn-border-color - Couleur de bordure des boutons nav.
+ * @cssprop --ar-datepicker-nav-btn-color - Couleur texte des boutons nav.
+ * @cssprop --ar-datepicker-nav-btn-radius - Border-radius des boutons nav.
+ * @cssprop --ar-datepicker-nav-btn-hover-bg - Fond au survol des boutons nav.
+ * @cssprop --ar-datepicker-nav-btn-active-bg - Fond à l'état actif des boutons nav.
+ * @cssprop --ar-datepicker-footer-padding - Padding du footer.
+ * @cssprop --ar-datepicker-footer-bg - Fond du footer.
+ * @cssprop --ar-datepicker-footer-margin - Margin du footer.
+ * @cssprop --ar-datepicker-footer-btn-bg - Fond des boutons du footer.
+ * @cssprop --ar-datepicker-footer-btn-border-width - Épaisseur de bordure des boutons footer.
+ * @cssprop --ar-datepicker-footer-btn-border-color - Couleur de bordure des boutons footer.
+ * @cssprop --ar-datepicker-footer-btn-color - Couleur texte des boutons footer.
+ * @cssprop --ar-datepicker-footer-btn-radius - Border-radius des boutons footer.
+ * @cssprop --ar-datepicker-footer-btn-padding - Padding des boutons footer.
+ * @cssprop --ar-datepicker-footer-btn-hover-bg - Fond au survol des boutons footer.
+ * @cssprop --ar-datepicker-footer-btn-hover-border-color - Couleur de bordure au survol des boutons footer.
+ * @cssprop --ar-datepicker-footer-btn-active-bg - Fond à l'état actif des boutons footer.
+ * @cssprop --ar-datepicker-weekday-color - Couleur des abréviations de jours.
+ * @cssprop --ar-datepicker-weekday-font-size - Taille de police des abréviations de jours.
+ * @cssprop --ar-datepicker-day-size - Taille des cellules jour.
+ * @cssprop --ar-datepicker-day-font-size - Taille de police des jours.
+ * @cssprop --ar-datepicker-day-radius - Border-radius des cellules jour.
+ * @cssprop --ar-datepicker-day-bg - Fond des cellules jour.
+ * @cssprop --ar-datepicker-day-border-width - Épaisseur de bordure des cellules jour.
+ * @cssprop --ar-datepicker-day-border-color - Couleur de bordure par défaut des cellules jour.
+ * @cssprop --ar-datepicker-day-other-month-color - Couleur des jours hors du mois affiché.
+ * @cssprop --ar-datepicker-day-today-bg - Fond du jour actuel.
+ * @cssprop --ar-datepicker-day-today-color - Couleur texte du jour actuel.
+ * @cssprop --ar-datepicker-day-today-border - Couleur de bordure du jour actuel.
+ * @cssprop --ar-datepicker-day-hover-bg - Fond au survol d'un jour.
+ * @cssprop --ar-datepicker-day-hover-color - Couleur texte au survol d'un jour.
+ * @cssprop --ar-datepicker-day-focus-ring-color - Couleur du focus ring des jours.
+ * @cssprop --ar-datepicker-day-focus-ring-width - Épaisseur du focus ring des jours.
+ * @cssprop --ar-datepicker-day-focus-ring-offset - Décalage du focus ring des jours.
+ * @cssprop --ar-datepicker-day-selected-bg - Fond du jour sélectionné.
+ * @cssprop --ar-datepicker-day-selected-color - Couleur texte du jour sélectionné.
+ * @cssprop --ar-datepicker-input-error-border-color - Bordure input en état d'erreur.
  *
  * @event {CustomEvent} ar-datepicker-input-change   - Valeur commitée (blur ou sélection calendrier).
  * @event {CustomEvent} ar-datepicker-input-complete - Saisie texte complète (valide ou non).

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -62,22 +62,22 @@ if (typeof document !== 'undefined') {
  * @csspart body - La zone de contenu principale.
  * @csspart footer - La zone d'actions (absente du DOM si slot non utilisé).
  *
- * @cssprop [--ar-dialog-width=500px (modal) ou 720px (drawer)] - Largeur du dialog. Prend le pas sur les tailles prédéfinies.
- * @cssprop [--ar-dialog-width-sm=360px] - Largeur du dialog modal, taille `sm`.
- * @cssprop [--ar-dialog-width-md=500px] - Largeur du dialog modal, taille `md`.
- * @cssprop [--ar-dialog-width-lg=800px] - Largeur du dialog modal, taille `lg`.
- * @cssprop [--ar-dialog-width-xl=1140px] - Largeur du dialog modal, taille `xl`.
- * @cssprop [--ar-dialog-drawer-width-sm=360px] - Largeur du drawer, taille `sm`.
- * @cssprop [--ar-dialog-drawer-width-md=720px] - Largeur du drawer, taille `md`.
- * @cssprop [--ar-dialog-drawer-width-lg=960px] - Largeur du drawer, taille `lg`.
- * @cssprop [--ar-dialog-drawer-width-xl=1440px] - Largeur du drawer, taille `xl`.
- * @cssprop [--ar-dialog-spacing=1.25rem] - Padding interne (block et inline) de la zone de contenu.
- * @cssprop [--ar-dialog-spacing-block] - Padding haut/bas. Prend le pas sur `--ar-dialog-spacing` si défini.
- * @cssprop [--ar-dialog-spacing-inline] - Padding gauche/droite. Prend le pas sur `--ar-dialog-spacing` si défini.
- * @cssprop [--ar-dialog-close-bg=var(--ar-button-tertiary-bg)] - Fond du bouton de fermeture.
- * @cssprop [--ar-dialog-close-bg-hover=var(--ar-button-tertiary-bg-hover)] - Fond du bouton de fermeture au survol.
- * @cssprop [--ar-dialog-close-bg-pressed=var(--ar-button-tertiary-bg-active)] - Fond du bouton de fermeture pressé.
- * @cssprop [--ar-dialog-close-bg-focus=var(--ar-button-tertiary-bg-focus)] - Fond du bouton de fermeture au focus.
+ * @cssprop --ar-dialog-width - Largeur du dialog. Prend le pas sur les tailles prédéfinies.
+ * @cssprop --ar-dialog-width-sm - Largeur du dialog modal, taille `sm`.
+ * @cssprop --ar-dialog-width-md - Largeur du dialog modal, taille `md`.
+ * @cssprop --ar-dialog-width-lg - Largeur du dialog modal, taille `lg`.
+ * @cssprop --ar-dialog-width-xl - Largeur du dialog modal, taille `xl`.
+ * @cssprop --ar-dialog-drawer-width-sm - Largeur du drawer, taille `sm`.
+ * @cssprop --ar-dialog-drawer-width-md - Largeur du drawer, taille `md`.
+ * @cssprop --ar-dialog-drawer-width-lg - Largeur du drawer, taille `lg`.
+ * @cssprop --ar-dialog-drawer-width-xl - Largeur du drawer, taille `xl`.
+ * @cssprop --ar-dialog-spacing - Padding interne (block et inline) de la zone de contenu.
+ * @cssprop --ar-dialog-spacing-block - Padding haut/bas. Prend le pas sur `--ar-dialog-spacing` si défini.
+ * @cssprop --ar-dialog-spacing-inline - Padding gauche/droite. Prend le pas sur `--ar-dialog-spacing` si défini.
+ * @cssprop --ar-dialog-close-bg - Fond du bouton de fermeture.
+ * @cssprop --ar-dialog-close-bg-hover - Fond du bouton de fermeture au survol.
+ * @cssprop --ar-dialog-close-bg-pressed - Fond du bouton de fermeture pressé.
+ * @cssprop --ar-dialog-close-bg-focus - Fond du bouton de fermeture au focus.
  *
  * @event {CustomEvent} ar-dialog-show - Émis avant l'ouverture. @cancelable
  * @event {CustomEvent} ar-dialog-show-prevented - Émis si ar-dialog-show est annulé.

--- a/packages/core/src/components/dropdown/dropdown.ts
+++ b/packages/core/src/components/dropdown/dropdown.ts
@@ -31,16 +31,16 @@ export type ArDropdownPlacement =
  *
  * @csspart panel - Le panel flottant.
  *
- * @cssprop [--ar-dropdown-min-width=10rem] - Largeur minimale du panel.
- * @cssprop [--ar-dropdown-color=var(--ar-panel-text)] - Couleur du texte (cascade vers --ar-panel-text).
- * @cssprop [--ar-dropdown-max-width=var(--ar-panel-max-width)] - Largeur maximale (cascade vers --ar-panel-max-width).
- * @cssprop [--ar-dropdown-padding=var(--ar-panel-padding)] - Marge interne (cascade vers --ar-panel-padding).
- * @cssprop [--ar-dropdown-bg=var(--ar-panel-bg)] - Fond du panel (cascade vers --ar-panel-bg).
- * @cssprop [--ar-dropdown-border-color=var(--ar-panel-border-color)] - Bordure (cascade vers --ar-panel-border-color).
- * @cssprop [--ar-dropdown-border-radius=var(--ar-panel-radius)] - Arrondi (cascade vers --ar-panel-radius).
- * @cssprop [--ar-dropdown-shadow=var(--ar-panel-shadow)] - Ombre (cascade vers --ar-panel-shadow).
- * @cssprop [--ar-dropdown-distance=var(--ar-anchor-distance)] - Espacement entre le trigger et le panel (axe principal).
- * @cssprop [--ar-dropdown-offset=var(--ar-anchor-offset)] - Décalage latéral du panel (axe transversal).
+ * @cssprop --ar-dropdown-min-width - Largeur minimale du panel.
+ * @cssprop --ar-dropdown-color - Couleur du texte (cascade vers --ar-panel-text).
+ * @cssprop --ar-dropdown-max-width - Largeur maximale (cascade vers --ar-panel-max-width).
+ * @cssprop --ar-dropdown-padding - Marge interne (cascade vers --ar-panel-padding).
+ * @cssprop --ar-dropdown-bg - Fond du panel (cascade vers --ar-panel-bg).
+ * @cssprop --ar-dropdown-border-color - Bordure (cascade vers --ar-panel-border-color).
+ * @cssprop --ar-dropdown-border-radius - Arrondi (cascade vers --ar-panel-radius).
+ * @cssprop --ar-dropdown-shadow - Ombre (cascade vers --ar-panel-shadow).
+ * @cssprop --ar-dropdown-distance - Espacement entre le trigger et le panel (axe principal).
+ * @cssprop --ar-dropdown-offset - Décalage latéral du panel (axe transversal).
  *
  * @event {CustomEvent} ar-dropdown-show           - Émis avant l'ouverture. @cancelable
  * @event {CustomEvent} ar-dropdown-show-prevented - Émis si ar-dropdown-show est annulé.

--- a/packages/core/src/components/pagination/pagination.ts
+++ b/packages/core/src/components/pagination/pagination.ts
@@ -38,13 +38,13 @@ export interface ArPaginationPageChangeDetail {
  * @csspart prev     - Le bouton "Page précédente".
  * @csspart next     - Le bouton "Page suivante".
  *
- * @cssprop [--ar-pagination-radius=var(--ar-border-radius-lg)] - Arrondi du conteneur de pagination.
- * @cssprop [--ar-pagination-active-color=var(--ar-color-interactive)] - Couleur de la page active (texte + bordure).
- * @cssprop [--ar-pagination-color=var(--ar-color-text)] - Couleur du texte des boutons prev/next/page (non actifs). À surcharger localement pour un fond sombre ponctuel, indépendamment du thème global.
- * @cssprop [--ar-pagination-bg=var(--ar-button-tertiary-bg)] - Fond des boutons prev/next/page (non actifs).
- * @cssprop [--ar-pagination-bg-hover=var(--ar-button-tertiary-bg-hover)] - Fond des boutons prev/next/page au survol.
- * @cssprop [--ar-pagination-bg-pressed=var(--ar-button-tertiary-bg-active)] - Fond des boutons prev/next/page pressés.
- * @cssprop [--ar-pagination-bg-focus=var(--ar-button-tertiary-bg-focus)] - Fond des boutons prev/next/page au focus.
+ * @cssprop --ar-pagination-radius - Arrondi du conteneur de pagination.
+ * @cssprop --ar-pagination-active-color - Couleur de la page active (texte + bordure).
+ * @cssprop --ar-pagination-color - Couleur du texte des boutons prev/next/page (non actifs). À surcharger localement pour un fond sombre ponctuel, indépendamment du thème global.
+ * @cssprop --ar-pagination-bg - Fond des boutons prev/next/page (non actifs).
+ * @cssprop --ar-pagination-bg-hover - Fond des boutons prev/next/page au survol.
+ * @cssprop --ar-pagination-bg-pressed - Fond des boutons prev/next/page pressés.
+ * @cssprop --ar-pagination-bg-focus - Fond des boutons prev/next/page au focus.
  *
  * @event {CustomEvent<{from: number, to: number}>} ar-pagination-page-change - Émis à chaque changement de page. Contient `from` et `to`.
  */

--- a/packages/core/src/components/progressbar/progressbar.ts
+++ b/packages/core/src/components/progressbar/progressbar.ts
@@ -27,9 +27,9 @@ export class ArProgressbarConfig {
  * @csspart track        - Le `<div>` représentant le fond de la barre (rail).
  * @csspart bar          - Le `<div>` représentant la progression (la partie remplie).
  *
- * @cssprop [--ar-progressbar-track-color=var(--ar-color-bg-subtle)]   - Couleur du rail (fond).
- * @cssprop [--ar-progressbar-fill-color=var(--ar-color-interactive)]  - Couleur de la progression.
- * @cssprop [--ar-progressbar-percent-color=var(--ar-color-text-muted)] - Couleur du texte du pourcentage.
+ * @cssprop --ar-progressbar-track-color - Couleur du rail (fond).
+ * @cssprop --ar-progressbar-fill-color - Couleur de la progression.
+ * @cssprop --ar-progressbar-percent-color - Couleur du texte du pourcentage.
  */
 export class ArProgressbar extends LitElement {
     static override styles: CSSResultGroup = [utilitiesStyles, styles];

--- a/packages/core/src/components/spinner/spinner.ts
+++ b/packages/core/src/components/spinner/spinner.ts
@@ -16,7 +16,7 @@ import { warn } from '../../utils/warn.js';
  * @csspart spinner   - L'élément `<svg>` du spinner (visible quand `done` est false).
  * @csspart status    - Le `<div role="alert">` lu par les lecteurs d'écran.
  *
- * @cssprop [--ar-spinner-stroke-color=currentColor] - Couleur du trait SVG. Hérite de `currentColor` par défaut.
+ * @cssprop --ar-spinner-stroke-color - Couleur du trait SVG. Hérite de `currentColor` par défaut.
  */
 export class ArSpinner extends LitElement {
     static override styles: CSSResultGroup = [utilitiesStyles, animationsStyles, styles];

--- a/packages/core/src/components/stepper/stepper.ts
+++ b/packages/core/src/components/stepper/stepper.ts
@@ -52,27 +52,27 @@ export interface ArStepperStepChangeDetail {
  * @csspart trigger      - Le bouton d'ouverture du panel mobile.
  * @csspart panel        - Le panel mobile flottant.
  *
- * @cssprop [--ar-stepper-panel-min-width=var(--ar-panel-min-width)]                         - Largeur min du panel mobile (cascade vers --ar-panel-min-width).
- * @cssprop [--ar-stepper-panel-max-width=var(--ar-panel-max-width)]                         - Largeur max du panel mobile (cascade vers --ar-panel-max-width).
- * @cssprop [--ar-stepper-gap=1.5rem]                                                         - Hauteur du connecteur entre les étapes principales.
- * @cssprop [--ar-stepper-substep-gap=1rem]                                                   - Hauteur du connecteur entre les sous-étapes.
- * @cssprop [--ar-stepper-connector-color=var(--ar-color-neutral-80)]                         - Couleur du connecteur pointillé entre les étapes.
- * @cssprop [--ar-stepper-active-bullet-bg=var(--ar-color-interactive)]                       - Fond de la puce de l'étape active.
- * @cssprop [--ar-stepper-active-bullet-color=var(--ar-color-text-inverse)]                   - Couleur du numéro dans la puce active.
- * @cssprop [--ar-stepper-bullet-bg=var(--ar-color-primary-80)]                               - Fond des puces des étapes visitables.
- * @cssprop [--ar-stepper-bullet-color=var(--ar-color-interactive)]                           - Couleur du numéro dans les puces visitables.
- * @cssprop [--ar-stepper-bullet-border-color=var(--ar-color-neutral-80)]                     - Bordure des puces des étapes suivantes.
- * @cssprop [--ar-stepper-bullet-hover-bg=var(--ar-color-text-muted)]                         - Fond de la puce au survol.
- * @cssprop [--ar-stepper-link-hover-color=var(--ar-color-text-muted)]                       - Couleur du texte du lien au survol.
- * @cssprop [--ar-stepper-bullet-radius=0.75rem]                                              - Border-radius de la puce.
- * @cssprop [--ar-stepper-link-focus-radius=0.125rem]                                         - Border-radius de l'anneau de focus du lien.
- * @cssprop [--ar-stepper-label-color=var(--ar-color-text-muted)]                             - Couleur des labels des étapes inactives.
- * @cssprop [--ar-stepper-active-label-color=var(--ar-color-interactive)]                     - Couleur du label de l'étape active.
- * @cssprop [--ar-stepper-distance=var(--ar-anchor-distance)]                                 - Espacement entre le trigger et le panel mobile.
- * @cssprop [--ar-stepper-offset=var(--ar-anchor-offset)]                                     - Décalage latéral du panel mobile.
- * @cssprop [--ar-stepper-trigger-bg=var(--ar-button-secondary-bg)]                             - Fond du bouton trigger mobile.
- * @cssprop [--ar-stepper-trigger-bg-hover=var(--ar-button-secondary-bg-hover)]                 - Fond du bouton trigger mobile au survol.
- * @cssprop [--ar-stepper-trigger-radius=0.75rem]                                              - Border-radius du bouton trigger mobile.
+ * @cssprop --ar-stepper-panel-min-width - Largeur min du panel mobile (cascade vers --ar-panel-min-width).
+ * @cssprop --ar-stepper-panel-max-width - Largeur max du panel mobile (cascade vers --ar-panel-max-width).
+ * @cssprop --ar-stepper-gap - Hauteur du connecteur entre les étapes principales.
+ * @cssprop --ar-stepper-substep-gap - Hauteur du connecteur entre les sous-étapes.
+ * @cssprop --ar-stepper-connector-color - Couleur du connecteur pointillé entre les étapes.
+ * @cssprop --ar-stepper-active-bullet-bg - Fond de la puce de l'étape active.
+ * @cssprop --ar-stepper-active-bullet-color - Couleur du numéro dans la puce active.
+ * @cssprop --ar-stepper-bullet-bg - Fond des puces des étapes visitables.
+ * @cssprop --ar-stepper-bullet-color - Couleur du numéro dans les puces visitables.
+ * @cssprop --ar-stepper-bullet-border-color - Bordure des puces des étapes suivantes.
+ * @cssprop --ar-stepper-bullet-hover-bg - Fond de la puce au survol.
+ * @cssprop --ar-stepper-link-hover-color - Couleur du texte du lien au survol.
+ * @cssprop --ar-stepper-bullet-radius - Border-radius de la puce.
+ * @cssprop --ar-stepper-link-focus-radius - Border-radius de l'anneau de focus du lien.
+ * @cssprop --ar-stepper-label-color - Couleur des labels des étapes inactives.
+ * @cssprop --ar-stepper-active-label-color - Couleur du label de l'étape active.
+ * @cssprop --ar-stepper-distance - Espacement entre le trigger et le panel mobile.
+ * @cssprop --ar-stepper-offset - Décalage latéral du panel mobile.
+ * @cssprop --ar-stepper-trigger-bg - Fond du bouton trigger mobile.
+ * @cssprop --ar-stepper-trigger-bg-hover - Fond du bouton trigger mobile au survol.
+ * @cssprop --ar-stepper-trigger-radius - Border-radius du bouton trigger mobile.
  *
  * @event {CustomEvent<{ path: string }>} ar-stepper-step-change - Émis au clic sur une étape.
  */

--- a/packages/core/src/components/table-sort/table-sort.ts
+++ b/packages/core/src/components/table-sort/table-sort.ts
@@ -59,11 +59,11 @@ function getActionLabel(type: TableSortType, order: TableSortOrder, pending: boo
  * @csspart button    - Le bouton déclencheur.
  * @csspart indicator - L'icône de direction de tri.
  *
- * @cssprop --ar-table-sort-gap                     - Espacement label / indicateur.
- * @cssprop --ar-table-sort-indicator-gap           - Espacement entre les icônes indicateurs asc / desc.
- * @cssprop --ar-table-sort-indicator-size          - Taille de l'icône indicateur asc / desc.
- * @cssprop --ar-table-sort-indicator-color         - Couleur état neutre.
- * @cssprop --ar-table-sort-indicator-active-color  - Couleur état actif (asc/desc).
+ * @cssprop --ar-table-sort-gap - Espacement label / indicateur.
+ * @cssprop --ar-table-sort-indicator-gap - Espacement entre les icônes indicateurs asc / desc.
+ * @cssprop --ar-table-sort-indicator-size - Taille de l'icône indicateur asc / desc.
+ * @cssprop --ar-table-sort-indicator-color - Couleur état neutre.
+ * @cssprop --ar-table-sort-indicator-active-color - Couleur état actif (asc/desc).
  * @cssprop --ar-table-sort-indicator-pending-color - Couleur état pending.
  *
  * @event {CustomEvent<{ type: TableSortType; currentOrder: TableSortOrder; requestedOrder: TableSortOrder; columnLabel: string }>} ar-table-sort-change - Émis au clic quand pending est false.

--- a/packages/core/src/components/tooltip/tooltip.ts
+++ b/packages/core/src/components/tooltip/tooltip.ts
@@ -32,15 +32,15 @@ export type ArTooltipPlacement =
  * @csspart bubble - Le panel flottant.
  * @csspart arrow  - Le caret directionnel.
  *
- * @cssprop --ar-tooltip-bg                  - Fond de la bulle.
- * @cssprop --ar-tooltip-color                  - Couleur du texte.
- * @cssprop --ar-tooltip-border-radius        - Arrondi.
- * @cssprop --ar-tooltip-padding    - Marge interne.
- * @cssprop --ar-tooltip-font-size          - Taille de police.
- * @cssprop --ar-tooltip-max-width              - Largeur maximale.
- * @cssprop --ar-tooltip-arrow-size               - Taille du caret.
- * @cssprop [--ar-tooltip-distance=10px] - Espacement entre le trigger et la bulle.
- * @cssprop [--ar-tooltip-offset=var(--ar-anchor-offset)] - Décalage latéral de la bulle.
+ * @cssprop --ar-tooltip-bg - Fond de la bulle.
+ * @cssprop --ar-tooltip-color - Couleur du texte.
+ * @cssprop --ar-tooltip-border-radius - Arrondi.
+ * @cssprop --ar-tooltip-padding - Marge interne.
+ * @cssprop --ar-tooltip-font-size - Taille de police.
+ * @cssprop --ar-tooltip-max-width - Largeur maximale.
+ * @cssprop --ar-tooltip-arrow-size - Taille du caret.
+ * @cssprop --ar-tooltip-distance - Espacement entre le trigger et la bulle.
+ * @cssprop --ar-tooltip-offset - Décalage latéral de la bulle.
  *
  * Pas d'events show/hide annulables : un tooltip n'a pas de raison métier de bloquer
  * son affichage (contrairement à un dialog ou un menu), contrairement à


### PR DESCRIPTION
## Contexte

Dans le cadre de #109 (audit doc), un audit précédent avait noté que la colonne « Défaut » du tableau CSS Custom Properties était très incohérente selon les composants (68 valeurs manquantes sur tab/tab-group/table-sort/datepicker, vérifié comme oubli de rédaction JSDoc systématique).

En creusant, on s'est rendu compte que le vrai problème n'était pas l'incohérence mais la colonne elle-même : afficher la valeur de `default.css` sous le libellé « Défaut » laisse croire qu'elle est intrinsèque au composant, contraire à la philosophie headless d'Ariane (aucun style intégré, `default.css` est un thème de démo remplaçable parmi d'autres).

## Changements

- `ComponentApi.astro` : retire la colonne « Défaut » (et le calcul de swatch couleur associé, devenu mort) du tableau CSS Custom Properties. Ne touche pas à la colonne « Défaut » du tableau Attributs & Propriétés (défauts JS réels, légitimes).
- `Playground.astro` : ajoute un bandeau (`<ar-alert variant="info">`, dogfooding) au-dessus des sections Exemples/Playground de chaque page composant, précisant explicitement que les previews chargent le thème de démo `default.css`. Masque le composant avant son hydratation (`ar-alert:not(:defined)`) pour éviter un flash de contenu non stylé.
- `doc-table.css` : la colonne « Nom » de toutes les tables partagées (Attributs, Events, CSS Parts, Slots, CSS Custom Properties, Methods, Design Tokens) se cale sur son contenu (`width:1%; white-space:nowrap`) au lieu de rétrécir sous la pression d'une colonne Description longue.
- `packages/core` : retire le `=valeur` du JSDoc `@cssprop [--nom=valeur]` sur les 12 composants concernés (plus aucun consommateur — ni la doc, ni les données vscode.css-custom-data.json générées) ; retire en conséquence `validateCssPropertyDefaults` (devenu no-op) et son branchement dans `cem.config.js`. `validateCssPropertyCoverage` (présence de l'entrée @cssprop, indépendante de la valeur) reste en place.

Referme la partie « colonne Défaut incohérente » de #109 — la colonne n'a plus lieu d'être plutôt que d'être complétée.

Chantier plus large identifié en discussion (page dédiée au thème + outil de config/export) : ouvert séparément en #120, hors scope beta.

## Test plan

- [x] `npm run build --workspace=apps/docs` : build OK, 23 pages générées
- [x] `npm run test --workspace=apps/docs` : 56/56 tests passent
- [x] `npm run build:manifest --workspace=packages/core` : OK, aucune erreur de coverage
- [x] `npm run test --workspace=packages/core` : 748/748 tests passent
- [x] `npm run lint --workspace=packages/core` : clean
- [x] Vérifié en dev server : bandeau affiché correctement sur `/components/alert/`, plus aucune occurrence de « Défaut » sur le tableau CSS custom properties (seules restent les occurrences légitimes : tableau Attributs, variante nommée « Défaut » d'ar-alert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)