### PR TITLE
fix(docs): corrige les écarts d'accessibilité relevés dans l'audit #109

### DIFF
--- a/apps/docs/src/components/ComponentApi.astro
+++ b/apps/docs/src/components/ComponentApi.astro
@@ -30,10 +30,10 @@ const publicMethods = (component.members ?? []).filter(
                 <table>
                     <thead>
                         <tr>
-                            <th>Nom</th>
-                            <th>Type</th>
-                            <th>Défaut</th>
-                            <th>Description</th>
+                            <th scope="col">Nom</th>
+                            <th scope="col">Type</th>
+                            <th scope="col">Défaut</th>
+                            <th scope="col">Description</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -59,9 +59,9 @@ const publicMethods = (component.members ?? []).filter(
                 <table>
                     <thead>
                         <tr>
-                            <th>Nom</th>
-                            <th>Description</th>
-                            <th>Annulable</th>
+                            <th scope="col">Nom</th>
+                            <th scope="col">Description</th>
+                            <th scope="col">Annulable</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -86,10 +86,10 @@ const publicMethods = (component.members ?? []).filter(
                 <table>
                     <thead>
                         <tr>
-                            <th>Nom</th>
-                            <th>Paramètres</th>
-                            <th>Retour</th>
-                            <th>Description</th>
+                            <th scope="col">Nom</th>
+                            <th scope="col">Paramètres</th>
+                            <th scope="col">Retour</th>
+                            <th scope="col">Description</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -130,8 +130,8 @@ const publicMethods = (component.members ?? []).filter(
                 <table>
                     <thead>
                         <tr>
-                            <th>Nom</th>
-                            <th>Description</th>
+                            <th scope="col">Nom</th>
+                            <th scope="col">Description</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -155,8 +155,8 @@ const publicMethods = (component.members ?? []).filter(
                 <table>
                     <thead>
                         <tr>
-                            <th>Nom</th>
-                            <th>Description</th>
+                            <th scope="col">Nom</th>
+                            <th scope="col">Description</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -180,8 +180,8 @@ const publicMethods = (component.members ?? []).filter(
                 <table>
                     <thead>
                         <tr>
-                            <th>Nom</th>
-                            <th>Description</th>
+                            <th scope="col">Nom</th>
+                            <th scope="col">Description</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/apps/docs/src/components/PaletteGrid.astro
+++ b/apps/docs/src/components/PaletteGrid.astro
@@ -29,9 +29,9 @@ function needsBorder(value: string): boolean {
     <table class="palette-table">
         <thead>
             <tr>
-                <th class="hue-label"></th>
+                <th class="hue-label" scope="col"></th>
                 {displayStops.map((stop) => (
-                    <th class="stop-header">{stop}</th>
+                    <th class="stop-header" scope="col">{stop}</th>
                 ))}
             </tr>
         </thead>

--- a/apps/docs/src/components/SiteNav.astro
+++ b/apps/docs/src/components/SiteNav.astro
@@ -195,7 +195,7 @@ const componentItems: NavItem[] = allComponents
         font-weight:    600;
         text-transform: uppercase;
         letter-spacing: 0.08em;
-        color:          #6b7280;
+        color:          var(--doc-text-muted, #6b7280);
         padding:        0 0.75rem;
         margin:         0 0 0.4rem;
     }

--- a/apps/docs/src/components/TableOfContents.astro
+++ b/apps/docs/src/components/TableOfContents.astro
@@ -106,7 +106,7 @@ const { entries, mobileOnly = false } = Astro.props;
         font-weight:    600;
         text-transform: uppercase;
         letter-spacing: 0.08em;
-        color:          #6b7280;
+        color:          var(--doc-text-muted, #6b7280);
         margin:         0 0 0.5rem;
     }
 

--- a/apps/docs/src/content/components/ar-stepper-item.mdx
+++ b/apps/docs/src/content/components/ar-stepper-item.mdx
@@ -4,4 +4,4 @@ title: Stepper Item
 description: Représentation des étapes et sous étapes du composant Stepper.
 ---
 
-Documentation narrative du composant `ar-stepper`.
+Documentation narrative du composant `ar-stepper-item`.

--- a/apps/docs/src/layouts/Layout.astro
+++ b/apps/docs/src/layouts/Layout.astro
@@ -57,6 +57,16 @@ const {
         <script src="/js/playground.js" is:inline></script>
 
         <style is:global>
+            a:focus-visible,
+            button:focus-visible,
+            input:focus-visible,
+            select:focus-visible,
+            summary:focus-visible {
+                outline: 2px solid var(--doc-accent, #7c3aed);
+                outline-offset: 2px;
+                border-radius: 2px;
+            }
+
             .sr-only {
                 position: absolute;
                 width: 1px;
@@ -300,7 +310,10 @@ const {
             .header-version {
                 font-size:     0.7rem;
                 font-weight:   500;
-                color:         var(--doc-text-muted, #6b7280);
+                /* var(--doc-text-muted) échoue le contraste AA (4.28:1) sur ce fond en
+                   thème clair — même paire que .badge (var(--doc-accent)/-bg), conforme
+                   dans les deux thèmes (5.05:1 clair, 5.54:1 sombre). */
+                color:         var(--doc-accent, #7c3aed);
                 background:    var(--doc-accent-bg, #f3efff);
                 border:        1px solid var(--doc-accent-border, #e0d0ff);
                 padding:       1px 8px;
@@ -443,7 +456,7 @@ const {
         <a href="#main-content" class="skip-link">Aller au contenu principal</a>
         {showToc && <a href="#toc" class="skip-link">Aller au sommaire</a>}
 
-        <div class="alpha-banner" role="banner">
+        <div class="alpha-banner" role="status">
             Librairie en cours de développement — API instable, ne pas utiliser en production.
             <a href="https://github.com/jogo-labs/ariane/issues" target="_blank" rel="noopener noreferrer">Signaler un problème</a>
         </div>
@@ -454,7 +467,7 @@ const {
                 <!-- Burger : visible uniquement en mobile, et seulement si nav présente -->
                 {showNav && (
                     <button class="icon-btn" id="burger-btn" aria-label="Ouvrir la navigation" aria-expanded="false" aria-controls="site-nav-column">
-                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
                             <line x1="3" y1="6" x2="21" y2="6"/>
                             <line x1="3" y1="12" x2="21" y2="12"/>
                             <line x1="3" y1="18" x2="21" y2="18"/>
@@ -478,7 +491,7 @@ const {
                     aria-label="Code source sur GitHub (nouvel onglet)"
                     title="Code source sur GitHub (nouvel onglet)"
                 >
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .3a12 12 0 0 0-3.79 23.4c.6.1.82-.26.82-.57v-2.2c-3.34.72-4.04-1.61-4.04-1.61-.54-1.38-1.33-1.75-1.33-1.75-1.08-.74.08-.73.08-.73 1.2.09 1.83 1.24 1.83 1.24 1.07 1.83 2.8 1.3 3.48 1 .1-.78.42-1.3.76-1.6-2.67-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.14-.3-.54-1.52.1-3.18 0 0 1.01-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.28-1.55 3.29-1.23 3.29-1.23.65 1.66.24 2.88.12 3.18.77.84 1.23 1.91 1.23 3.22 0 4.61-2.8 5.63-5.48 5.92.43.37.81 1.1.81 2.22v3.29c0 .32.21.69.82.57A12 12 0 0 0 12 .3"/></svg>
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .3a12 12 0 0 0-3.79 23.4c.6.1.82-.26.82-.57v-2.2c-3.34.72-4.04-1.61-4.04-1.61-.54-1.38-1.33-1.75-1.33-1.75-1.08-.74.08-.73.08-.73 1.2.09 1.83 1.24 1.83 1.24 1.07 1.83 2.8 1.3 3.48 1 .1-.78.42-1.3.76-1.6-2.67-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.14-.3-.54-1.52.1-3.18 0 0 1.01-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.28-1.55 3.29-1.23 3.29-1.23.65 1.66.24 2.88.12 3.18.77.84 1.23 1.91 1.23 3.22 0 4.61-2.8 5.63-5.48 5.92.43.37.81 1.1.81 2.22v3.29c0 .32.21.69.82.57A12 12 0 0 0 12 .3"/></svg>
                 </a>
                 <!-- Trigger thème -->
                 <button class="icon-btn" id="theme-trigger" aria-label="Thème : Automatique" title="Thème : Automatique">
@@ -519,7 +532,7 @@ const {
             {showNav && (
                 <div class="nav-column" id="site-nav-column" tabindex="-1">
                     <button class="icon-btn" id="nav-close-btn" aria-label="Fermer la navigation">
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                             <line x1="18" y1="6" x2="6" y2="18"/>
                             <line x1="6" y1="6" x2="18" y2="18"/>
                         </svg>

--- a/apps/docs/src/pages/foundations/tokens.astro
+++ b/apps/docs/src/pages/foundations/tokens.astro
@@ -79,8 +79,8 @@ const tocEntries = [
                             <table>
                                 <thead>
                                     <tr>
-                                        <th>Token</th>
-                                        <th>Valeur</th>
+                                        <th scope="col">Token</th>
+                                        <th scope="col">Valeur</th>
                                     </tr>
                                 </thead>
                                 <tbody>

--- a/apps/docs/src/pages/index.astro
+++ b/apps/docs/src/pages/index.astro
@@ -53,17 +53,17 @@ const firstComponentHref = rootComponents[0]?.tagName
 
         <div class="selling-grid">
             <div class="selling-card">
-                <div class="selling-icon">♿</div>
+                <div class="selling-icon" aria-hidden="true">♿</div>
                 <h3>Accessible par défaut</h3>
                 <p>ARIA, navigation clavier et rôles sémantiques intégrés dans chaque composant. Pas une option — une exigence de base.</p>
             </div>
             <div class="selling-card">
-                <div class="selling-icon">⚡</div>
+                <div class="selling-icon" aria-hidden="true">⚡</div>
                 <h3>Indépendant du framework</h3>
                 <p>Custom Elements natifs : ça fonctionne avec React, Vue, Svelte, Angular ou du HTML pur. Une seule librairie, partout.</p>
             </div>
             <div class="selling-card">
-                <div class="selling-icon">🏗</div>
+                <div class="selling-icon" aria-hidden="true">🏗</div>
                 <h3>Fondation pour ton Design System</h3>
                 <p>CSS Custom Properties exposés sur chaque composant. Ariane pose les fondations ; toi tu définis l'identité visuelle.</p>
             </div>


### PR DESCRIPTION
## Contexte

Suite à la discussion sur #109 : les axes Fond et Forme sont traités (PR #116, #117, #121). Il restait l'axe Accessibilité, jamais audité concrètement jusqu'ici (seule la structure de titres avait été vérifiée en PR #116). Cette PR couvre l'accessibilité du **site de doc lui-même** (pas des composants qu'il documente).

Audit mené via agent Explore (lecture de code + calcul de ratios de contraste WCAG, pas d'estimation à l'œil).

## Changements

**Contraste (AA)**
- `.header-version` (`Layout.astro`) : `var(--doc-text-muted)` sur `--doc-accent-bg` échouait en thème clair (4.28:1, sous le seuil 4.5:1) — bascule sur la paire `var(--doc-accent)`/`-accent-bg` déjà utilisée par `.badge`, conforme dans les deux thèmes (5.05:1 clair, 5.54:1 sombre).
- `SiteNav.astro` `.nav-section h2` et `TableOfContents.astro` `.toc-title` : `#6b7280` codé en dur ne basculait pas en dark mode (3.58:1 sur fond sombre, sous le seuil) — remplacé par `var(--doc-text-muted, #6b7280)` comme les usages équivalents ailleurs dans le site.

**Structure sémantique**
- `alpha-banner` : `role="banner"` dupliquait le landmark du `<header>` natif (qui a déjà ce rôle implicite) et était sémantiquement incorrect pour un message d'avertissement — passé à `role="status"`.
- `<th>` des tables générées (`ComponentApi.astro`, `PaletteGrid.astro`, `tokens.astro`) : ajout de `scope="col"`.

**Clavier**
- Ajout d'un style `:focus-visible` global (absent de tout le site jusqu'ici) sur les éléments interactifs standards (`a`, `button`, `input`, `select`, `summary`).

**Alt text / décoratif**
- SVG burger/GitHub/fermeture-nav (`Layout.astro`) : `aria-hidden="true"` manquant, contrairement aux autres icônes du même fichier qui l'ont déjà.
- Emojis décoratifs de la page d'accueil (♿⚡🏗) : `aria-hidden="true"`.

**Forme (même audit)**
- `ar-stepper-item.mdx` référençait « ar-stepper » au lieu de « ar-stepper-item » dans son texte narratif (copié-collé).

## Hors scope de cette PR

- Points non vérifiables sans navigateur réel (rendu `backdrop-filter`/`color-mix()`, anneau de focus visuellement rogné) — à vérifier visuellement séparément si besoin.
- Focus trap absent dans le drawer nav mobile (mineur, l'overlay + Escape limitent déjà l'impact).
- `ar-charcounter.mdx` : relu en entier, sa longueur (96 lignes) est justifiée par une documentation a11y réellement non triviale (aria-live, WCAG 1.3.1/4.1.3/4.1.1) — pas de trim fait, contrairement à ce que suggérait l'audit initial.
- Tests a11y automatisés (axe-core/pa11y) : chantier d'infra CI séparé, pas traité ici.

## Test plan

- [x] `npm run build --workspace=apps/docs` : build OK, 23 pages générées
- [x] `npm run test --workspace=apps/docs` : 56/56 tests passent
- [x] Vérifié en dev server : un seul landmark `role="status"` (plus de doublon banner), `scope="col"` présent, emojis/SVG décoratifs marqués `aria-hidden`

🤖 Generated with [Claude Code](https://claude.com/claude-code)