### PR TITLE
test(docs): ajoute des tests a11y automatisés (axe-core + Playwright)

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -52,9 +52,6 @@ jobs:
       - name: Check build output
         run: npm run test:build --workspace=apps/docs
 
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
-
       - name: Test docs (a11y)
         run: npm run test:a11y --workspace=apps/docs
 

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -51,3 +51,17 @@ jobs:
 
       - name: Check build output
         run: npm run test:build --workspace=apps/docs
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Test docs (a11y)
+        run: npm run test:a11y --workspace=apps/docs
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: apps/docs/playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ node-compile-cache/
 
 # ── Tests ─────────────────────────────────────────────────────
 coverage/
+test-results/
+playwright-report/
 
 # ── Logs ──────────────────────────────────────────────────────
 *.log

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -9,7 +9,8 @@
     "lint": "astro check",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:build": "node scripts/check-build.js"
+    "test:build": "node scripts/check-build.js",
+    "test:a11y": "playwright test"
   },
   "dependencies": {
     "@ariane-ui/core": "*",
@@ -19,6 +20,8 @@
     "typescript": "^6.0.2"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
+    "@playwright/test": "^1.61.1",
     "vitest": "^4.1.8"
   }
 }

--- a/apps/docs/playwright.config.ts
+++ b/apps/docs/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from '@playwright/test';
+
+/**
+ * Config Playwright dédiée aux tests d'accessibilité (axe-core) — teste le
+ * build statique (`dist/`) servi par `astro preview`, pas le dev server
+ * (build de prod = CSS/JS final, pas de HMR qui pourrait fausser un scan).
+ *
+ * `npm run build` doit avoir tourné avant `npm run test:a11y`.
+ */
+export default defineConfig({
+    testDir: './tests/a11y',
+    fullyParallel: true,
+    forbidOnly: !!process.env.CI,
+    retries: process.env.CI ? 1 : 0,
+    reporter: process.env.CI ? [['list'], ['github'], ['html', { open: 'never' }]] : 'list',
+    use: {
+        baseURL: 'http://localhost:4322',
+    },
+    webServer: {
+        command: 'npx astro preview --port 4322',
+        url: 'http://localhost:4322',
+        reuseExistingServer: !process.env.CI,
+        timeout: 30_000,
+    },
+    projects: [{ name: 'chromium', use: { browserName: 'chromium' } }],
+});

--- a/apps/docs/playwright.config.ts
+++ b/apps/docs/playwright.config.ts
@@ -22,5 +22,19 @@ export default defineConfig({
         reuseExistingServer: !process.env.CI,
         timeout: 30_000,
     },
-    projects: [{ name: 'chromium', use: { browserName: 'chromium' } }],
+    projects: [
+        {
+            name: 'chromium',
+            use: {
+                browserName: 'chromium',
+                // En CI : utilise google-chrome-stable préinstallé sur le runner
+                // (évite `playwright install --with-deps`, ~10 min d'apt-get sur
+                // ubuntu-latest) — même convention que web-test-runner.config.js
+                // côté packages/core.
+                launchOptions: {
+                    executablePath: process.env.CI ? '/usr/bin/google-chrome-stable' : undefined,
+                },
+            },
+        },
+    ],
 });

--- a/apps/docs/public/js/playground.js
+++ b/apps/docs/public/js/playground.js
@@ -1,10 +1,11 @@
 /**
  * playground.js
  *
- * Gère trois responsabilités :
+ * Gère quatre responsabilités :
  * 1. Coloration syntaxique — highlight.js colore tous les blocs au chargement
  * 2. Boutons "Copier" — copie le contenu du bloc code adjacent
  * 3. Playground interactif — les contrôles modifient les attributs du composant en live
+ * 4. Accessibilité clavier des blocs de code qui débordent horizontalement
  */
 
 document.addEventListener('DOMContentLoaded', function () {
@@ -13,6 +14,20 @@ document.addEventListener('DOMContentLoaded', function () {
     if (window.hljs) {
         window.hljs.highlightAll();
     }
+
+    // ── Accessibilité clavier des <pre> scrollables (WCAG 2.1.1) ────────────────
+    // Tous les blocs de code ont overflow-x:auto (doc-prose.css/Playground.astro) —
+    // rendus focusables inconditionnellement plutôt que de tester scrollWidth vs
+    // clientWidth, qui peut être en course avec le layout/la coloration syntaxique.
+    // axe-core (règle scrollable-region-focusable) cible le <code> lui-même —
+    // plus large que son <pre> parent une fois coloré par highlight.js — pas
+    // seulement le <pre> : un ancêtre focusable ne suffit pas pour cette règle.
+
+    document.querySelectorAll('pre').forEach(function (pre) {
+        pre.setAttribute('tabindex', '0');
+        var code = pre.querySelector('code');
+        if (code) code.setAttribute('tabindex', '0');
+    });
 
     // ── Boutons Copier (blocs variantes) ────────────────────────────────────────
 

--- a/apps/docs/src/components/ComponentApi.astro
+++ b/apps/docs/src/components/ComponentApi.astro
@@ -211,7 +211,7 @@ const publicMethods = (component.members ?? []).filter(
 
     .hint {
         font-size:     0.875rem;
-        color:         var(--doc-text-muted, #6b7280);
+        color:         var(--doc-text-muted);
         margin-bottom: 0.75rem;
     }
 </style>

--- a/apps/docs/src/components/PaletteGrid.astro
+++ b/apps/docs/src/components/PaletteGrid.astro
@@ -79,7 +79,7 @@ function needsBorder(value: string): boolean {
 
     .stop-header {
         font-size: 0.65rem;
-        color: var(--doc-text-muted, #6b7280);
+        color: var(--doc-text-muted);
         font-weight: 400;
         text-align: center;
         padding: 0 2px 0.4rem;
@@ -88,7 +88,7 @@ function needsBorder(value: string): boolean {
     .hue-label {
         font-size: .75rem;
         font-family: monospace;
-        color: var(--doc-text-muted, #6b7280);
+        color: var(--doc-text-muted);
         padding-right: 0.5rem;
         padding-bottom: 2.5rem;
         vertical-align: middle;
@@ -117,7 +117,7 @@ function needsBorder(value: string): boolean {
     }
 
     .swatch-bordered {
-        border: 1px solid var(--doc-border, #e5e7eb);
+        border: 1px solid var(--doc-border);
     }
 
     .swatch-empty {
@@ -128,7 +128,7 @@ function needsBorder(value: string): boolean {
     .stop-value {
         font-size: 0.65rem;
         font-family: monospace;
-        color: var(--doc-text-muted, #6b7280);
+        color: var(--doc-text-muted);
         text-align: center;
         width: 100%;
         overflow: hidden;

--- a/apps/docs/src/components/Playground.astro
+++ b/apps/docs/src/components/Playground.astro
@@ -204,7 +204,7 @@ const showPlayground = displayMode === 'demo';
         font-weight:    600;
         letter-spacing: 0.1em;
         text-transform: uppercase;
-        color:          var(--doc-accent, #7c3aed);
+        color:          var(--doc-accent);
         margin-bottom:  0.5rem;
         display:        flex;
         align-items:    center;
@@ -218,7 +218,7 @@ const showPlayground = displayMode === 'demo';
     h5 {
         font-size:   1rem;
         font-weight: 600;
-        color:       var(--doc-text, #374151);
+        color:       var(--doc-text);
         margin:      0;
     }
 
@@ -243,17 +243,17 @@ const showPlayground = displayMode === 'demo';
         justify-content: center;
         width:           1.75rem;
         height:          1.75rem;
-        background:      color-mix(in srgb, var(--doc-bg, #ffffff) 75%, transparent);
+        background:      color-mix(in srgb, var(--doc-bg) 75%, transparent);
         backdrop-filter: blur(4px);
-        border:          1px solid var(--doc-border, #e5e7eb);
+        border:          1px solid var(--doc-border);
         border-radius:   0.375rem;
         cursor:          pointer;
-        color:           var(--doc-text-muted, #6b7280);
+        color:           var(--doc-text-muted);
         transition:      background 0.15s;
     }
 
     .preview-theme-toggle:hover {
-        background: var(--doc-bg, #ffffff);
+        background: var(--doc-bg);
     }
 
     .preview {
@@ -262,7 +262,7 @@ const showPlayground = displayMode === 'demo';
         gap:           0.75rem;
         align-items:   center;
         padding:       2rem;
-        border:        1px solid var(--doc-border, #e5e7eb);
+        border:        1px solid var(--doc-border);
         border-bottom: 0;
         border-radius: 0.5rem 0.5rem 0 0;
         background: var(--doc-bg);
@@ -273,7 +273,7 @@ const showPlayground = displayMode === 'demo';
     .code-block,
     .playground-code-block {
         position:   relative;
-        border:     1px solid var(--doc-border, #e5e7eb);
+        border:     1px solid var(--doc-border);
         border-top: none;
         overflow:   hidden;
     }
@@ -308,7 +308,7 @@ const showPlayground = displayMode === 'demo';
         font-family: 'Fira Code', 'Cascadia Code', monospace;
         font-size:   0.8rem;
         line-height: 1.6;
-        background:  var(--doc-code-block-bg, #1e1e2e);
+        background:  var(--doc-code-block-bg);
     }
 
     :global(.code-block pre code),
@@ -333,14 +333,14 @@ const showPlayground = displayMode === 'demo';
     .playground-section .preview-wrap { margin-bottom: 0; }
     .playground-section .preview {
         border:        none;
-        border-bottom: 1px solid var(--doc-border, #e8e6e0);
+        border-bottom: 1px solid var(--doc-border);
         border-bottom: 0;
         border-radius: 0;
     }
 
     .playground-section .playground-code-block {
         border:        none;
-        border-bottom: 1px solid var(--doc-border, #e8e6e0);
+        border-bottom: 1px solid var(--doc-border);
         border-bottom: 0;
     }
 
@@ -350,11 +350,11 @@ const showPlayground = displayMode === 'demo';
     }
 
     .controls-panel {
-        border:        1px solid var(--doc-border, #e5e7eb);
+        border:        1px solid var(--doc-border);
         border-top:    none;
         border-radius: 0 0 0.5rem 0.5rem;
         padding:       1rem 1.5rem;
-        background:    var(--doc-nav-bg, #f9fafb);
+        background:    var(--doc-nav-bg);
         display:       flex;
         flex-wrap:     wrap;
         gap:           1rem 2rem;
@@ -371,7 +371,7 @@ const showPlayground = displayMode === 'demo';
     .control-label {
         font-size:   0.75rem;
         font-weight: 600;
-        color:       var(--doc-text-muted, #6b7280);
+        color:       var(--doc-text-muted);
         font-family: 'Fira Code', 'Cascadia Code', monospace;
     }
 
@@ -379,11 +379,11 @@ const showPlayground = displayMode === 'demo';
     .control-row input[type="text"],
     .control-row input[type="number"] {
         padding:       0.3rem 0.5rem;
-        border:        1px solid var(--doc-accent-border, #e0d0ff);
+        border:        1px solid var(--doc-accent-border);
         border-radius: 0.25rem;
         font-size:     0.875rem;
-        background:    var(--doc-bg, #fff);
-        color:         var(--doc-text, #111827);
+        background:    var(--doc-bg);
+        color:         var(--doc-text);
         width:         100%;
     }
 
@@ -405,7 +405,7 @@ const showPlayground = displayMode === 'demo';
         border:        1px solid color-mix(in srgb, var(--ar-color-interactive, #2563eb) 20%, transparent);
         border-radius: 0.5rem;
         font-size:     0.875rem;
-        color:         var(--doc-text, #374151);
+        color:         var(--doc-text);
         margin:        1rem 0;
     }
 

--- a/apps/docs/src/components/SiteNav.astro
+++ b/apps/docs/src/components/SiteNav.astro
@@ -149,18 +149,18 @@ const componentItems: NavItem[] = allComponents
         justify-content: space-between;
         flex-grow:       1;
         padding:         4rem 0.75rem 1.25rem;
-        border-right:    1px solid var(--doc-nav-border, #e2e4e9);
-        background:      var(--doc-nav-bg, #f8f9fb);
+        border-right:    1px solid var(--doc-nav-border);
+        background:      var(--doc-nav-bg);
         position:        sticky;
         top:             0;
         height:          100%;
         overflow-y:      auto;
         scrollbar-width: thin;
-        scrollbar-color: var(--doc-border, #d1d5db) transparent;
+        scrollbar-color: var(--doc-border) transparent;
     }
 
     nav::-webkit-scrollbar       { width: 4px; }
-    nav::-webkit-scrollbar-thumb { background: var(--doc-border, #d1d5db); border-radius: 4px; }
+    nav::-webkit-scrollbar-thumb { background: var(--doc-border); border-radius: 4px; }
 
     /* ── Marque (masquée sur desktop, le header a déjà le logo) ── */
 
@@ -168,7 +168,7 @@ const componentItems: NavItem[] = allComponents
         font-weight:     500;
         font-size:       .8rem;
         letter-spacing:  -0.02em;
-        color:           var(--doc-text, #1a1d26);
+        color:           var(--doc-text);
         text-decoration: none;
         margin: 0;
         flex-shrink:     0;
@@ -195,7 +195,7 @@ const componentItems: NavItem[] = allComponents
         font-weight:    600;
         text-transform: uppercase;
         letter-spacing: 0.08em;
-        color:          var(--doc-text-muted, #6b7280);
+        color:          var(--doc-text-muted);
         padding:        0 0.75rem;
         margin:         0 0 0.4rem;
     }
@@ -212,7 +212,7 @@ const componentItems: NavItem[] = allComponents
     .nav-list a {
         display:         block;
         padding:         0.4rem 0.75rem;
-        color:           var(--doc-text-subtle, #4b5563);
+        color:           var(--doc-text-subtle);
         text-decoration: none;
         border-radius:   0.375rem;
         font-size:       0.85rem;
@@ -222,16 +222,16 @@ const componentItems: NavItem[] = allComponents
     }
 
     .nav-list a:hover {
-        background: var(--doc-nav-bg-hover, #f3efff);
+        background: var(--doc-nav-bg-hover);
         color:      var(--doc-text);
     }
 
     .nav-list a[aria-current="page"] {
-        background:                var(--doc-accent-bg, #f3efff);
-        color:                     var(--doc-accent, #7c3aed);
+        background:                var(--doc-accent-bg);
+        color:                     var(--doc-accent);
         border-top-left-radius:    0;
         border-bottom-left-radius: 0;
-        border-left-color:         var(--doc-accent, #7c3aed);
+        border-left-color:         var(--doc-accent);
     }
 
     /* ── Enfants (sous-composants) ───────────────────────────── */
@@ -239,13 +239,13 @@ const componentItems: NavItem[] = allComponents
     .nav-children {
         margin:       0.15rem 0 0.25rem 1.2rem;
         padding-left: 0;
-        border-left:  1.5px solid var(--doc-border, #dfe1e7);
+        border-left:  1.5px solid var(--doc-border);
     }
 
     .nav-children a {
         font-size: 0.78rem;
         padding:   0.3rem 0.6rem;
-        color:     var(--doc-text-subtle, #4b5563);
+        color:     var(--doc-text-subtle);
     }
 
     /* ── Footer nav (theme toggle dans le drawer mobile uniquement) ── */
@@ -257,7 +257,7 @@ const componentItems: NavItem[] = allComponents
         flex-direction: column;
         row-gap: .5rem;
         padding:     1rem 0.75rem 0;
-        border-top:  1px solid var(--doc-border, #e5e7eb);
+        border-top:  1px solid var(--doc-border);
         flex-shrink: 0;
     }
 
@@ -274,18 +274,18 @@ const componentItems: NavItem[] = allComponents
         display:         flex;
         align-items:     center;
         gap:             0.3rem;
-        color:           var(--doc-text-muted, #6b7280);
+        color:           var(--doc-text-muted);
         text-decoration: none;
         font-size:       0.8rem;
         transition:      color 0.12s;
     }
 
-    .nav-footer-link:hover { color: var(--doc-text, #111827); }
+    .nav-footer-link:hover { color: var(--doc-text); }
 
     .nav-footer-version {
         font-size:   0.7rem;
         margin: 0;
         font-family: 'Fira Code', 'Cascadia Code', monospace;
-        color:       var(--doc-text-muted, #9ca3af);
+        color:       var(--doc-text-muted);
     } */
 </style>

--- a/apps/docs/src/components/TableOfContents.astro
+++ b/apps/docs/src/components/TableOfContents.astro
@@ -106,7 +106,7 @@ const { entries, mobileOnly = false } = Astro.props;
         font-weight:    600;
         text-transform: uppercase;
         letter-spacing: 0.08em;
-        color:          var(--doc-text-muted, #6b7280);
+        color:          var(--doc-text-muted);
         margin:         0 0 0.5rem;
     }
 
@@ -124,7 +124,7 @@ const { entries, mobileOnly = false } = Astro.props;
         display:         block;
         padding:         0.25rem 0;
         padding-left:    0.75rem;
-        color:           var(--doc-text-subtle, #4b5563);
+        color:           var(--doc-text-subtle);
         text-decoration: none;
         border-left:     2px solid transparent;
         line-height:     1.4;
@@ -134,13 +134,13 @@ const { entries, mobileOnly = false } = Astro.props;
 
     .toc-link:hover,
     .toc-link-m:hover {
-        color:        var(--doc-text, #111827);
-        border-color: var(--doc-border, #e5e7eb);
+        color:        var(--doc-text);
+        border-color: var(--doc-border);
     }
 
     .toc-link.active {
-        color:        var(--doc-accent, #7c3aed);
-        border-color: var(--doc-accent, #7c3aed);
+        color:        var(--doc-accent);
+        border-color: var(--doc-accent);
     }
 
     /* ── Mobile ─────────────────────────────────────────────── */
@@ -150,9 +150,9 @@ const { entries, mobileOnly = false } = Astro.props;
         .toc-mobile  {
             display:       block;
             margin:        0 0 1.5rem;
-            border:        1px solid var(--doc-border, #e5e7eb);
+            border:        1px solid var(--doc-border);
             border-radius: 0.5rem;
-            background:    var(--doc-nav-bg, #f8f9fb);
+            background:    var(--doc-nav-bg);
             font-size:     0.875rem;
         }
 
@@ -162,7 +162,7 @@ const { entries, mobileOnly = false } = Astro.props;
             font-size:       0.8rem;
             text-transform:  uppercase;
             letter-spacing:  0.06em;
-            color:           var(--doc-text-muted, #6b7280);
+            color:           var(--doc-text-muted);
             cursor:          pointer;
             list-style:      none;
             display:         flex;
@@ -182,7 +182,7 @@ const { entries, mobileOnly = false } = Astro.props;
 
         .toc-mobile ul {
             padding:       0 0.5rem 0.5rem;
-            border-top:    1px solid var(--doc-border, #e5e7eb);
+            border-top:    1px solid var(--doc-border);
         }
     }
 </style>

--- a/apps/docs/src/layouts/Layout.astro
+++ b/apps/docs/src/layouts/Layout.astro
@@ -62,7 +62,7 @@ const {
             input:focus-visible,
             select:focus-visible,
             summary:focus-visible {
-                outline: 2px solid var(--doc-accent, #7c3aed);
+                outline: 2px solid var(--doc-accent);
                 outline-offset: 2px;
                 border-radius: 2px;
             }
@@ -130,6 +130,7 @@ const {
                 --doc-accent-hover:   #6d28d9;
                 --doc-accent-bg:      #f3efff;
                 --doc-accent-border:  #e0d0ff;
+                --doc-link-visited:   #6d28d9;
                 --doc-code-bg:        #f3f4f6;
                 --doc-code-block-bg:  #0d1219;
                 --doc-header-bg:      rgba(250,250,248,0.92);
@@ -152,6 +153,9 @@ const {
                 --doc-accent-hover:   #8b5cf6;
                 --doc-accent-bg:      #2d2040;
                 --doc-accent-border:  #4c3280;
+                /* #8b5cf6 (--doc-accent-hover) échoue l'AA sur ce fond (4.09:1) —
+                   teinte plus claire dédiée aux liens visités (9.37:1) */
+                --doc-link-visited:   #c4b5fd;
                 --doc-cta-bg:         #2d2040;
                 --doc-cta-border:     #30215a;
                 --doc-code-bg:        #1e1e2e;
@@ -298,7 +302,7 @@ const {
             .brand-dot {
                 display:        inline-block;
                 font-size:      0.55rem;
-                color:          var(--doc-accent, #7c3aed);
+                color:          var(--doc-accent);
                 margin-left:    3px;
                 vertical-align: middle;
                 position:       relative;
@@ -311,9 +315,9 @@ const {
                 /* var(--doc-text-muted) échoue le contraste AA (4.28:1) sur ce fond en
                    thème clair — même paire que .badge (var(--doc-accent)/-bg), conforme
                    dans les deux thèmes (5.05:1 clair, 5.54:1 sombre). */
-                color:         var(--doc-accent, #7c3aed);
-                background:    var(--doc-accent-bg, #f3efff);
-                border:        1px solid var(--doc-accent-border, #e0d0ff);
+                color:         var(--doc-accent);
+                background:    var(--doc-accent-bg);
+                border:        1px solid var(--doc-accent-border);
                 padding:       1px 8px;
                 border-radius: 20px;
             }

--- a/apps/docs/src/layouts/Layout.astro
+++ b/apps/docs/src/layouts/Layout.astro
@@ -81,8 +81,6 @@ const {
 
             .narrative a {
                 color: var(--doc-accent);
-                text-decoration: underline;
-                text-underline-offset: 2px;
             }
 
             .narrative a:visited {

--- a/apps/docs/src/pages/components/[slug].astro
+++ b/apps/docs/src/pages/components/[slug].astro
@@ -164,10 +164,10 @@ const tocEntries = [
     .narrative :global(h3) {
         font-size: 1.25rem;
         font-weight: 600;
-        border-bottom: 2px solid var(--doc-border, #e5e7eb);
+        border-bottom: 2px solid var(--doc-border);
         padding-bottom: 1rem;
         margin: 2rem 0 1rem;
-        color: var(--doc-text, #111827);
+        color: var(--doc-text);
     }
 
     .narrative :global(h3:first-child) { margin-top: 0; }
@@ -175,21 +175,21 @@ const tocEntries = [
     .narrative :global(h4) {
         font-size: 1.05rem;
         font-weight: 600;
-        color: var(--doc-text-subtle, #374151);
+        color: var(--doc-text-subtle);
         margin: 1.25rem 0 0.5rem;
     }
 
     .narrative :global(p) {
         font-size: 0.9rem;
         line-height: 1.75;
-        color: var(--doc-text, #374151);
+        color: var(--doc-text);
         margin: 0;
     }
 
     .narrative :global(.narrative-list) {
         font-size: 0.9rem;
         line-height: 1.75;
-        color: var(--doc-text, #374151);
+        color: var(--doc-text);
         margin: 0;
         padding-left: 1.25rem;
     }
@@ -205,25 +205,25 @@ const tocEntries = [
     .narrative :global(th) {
         text-align: left;
         padding: 0.5rem 0.75rem;
-        background: var(--doc-nav-bg, #f9fafb);
-        color: var(--doc-text, #111827);
+        background: var(--doc-nav-bg);
+        color: var(--doc-text);
         font-weight: 600;
-        border-bottom: 1px solid var(--doc-border, #e5e7eb);
+        border-bottom: 1px solid var(--doc-border);
     }
 
     .narrative :global(td) {
         padding: 0.5rem 0.75rem;
-        border-bottom: 1px solid var(--doc-border, #f3f4f6);
+        border-bottom: 1px solid var(--doc-border);
         vertical-align: top;
-        color: var(--doc-text, #111827);
+        color: var(--doc-text);
     }
 
     .narrative :global(td code),
     .narrative :global(th code) {
         font-family: 'Fira Code', 'Cascadia Code', monospace;
         font-size: 0.8rem;
-        background: var(--doc-accent-bg, #f3efff);
-        color: var(--doc-accent, #7c3aed);
+        background: var(--doc-accent-bg);
+        color: var(--doc-accent);
         padding: 0.1em 0.35em;
         border-radius: 0.25em;
     }
@@ -231,12 +231,12 @@ const tocEntries = [
     .narrative :global(kbd) {
         font-family: 'Fira Code', 'Cascadia Code', monospace;
         font-size: 0.75rem;
-        background: var(--doc-nav-bg, #f9fafb);
-        color: var(--doc-text, #111827);
-        border: 1px solid var(--doc-border, #d1d5db);
+        background: var(--doc-nav-bg);
+        color: var(--doc-text);
+        border: 1px solid var(--doc-border);
         border-radius: 0.25rem;
         padding: 0.15em 0.45em;
-        box-shadow: 0 1px 0 var(--doc-border, #d1d5db);
+        box-shadow: 0 1px 0 var(--doc-border);
         white-space: nowrap;
     }
 </style>

--- a/apps/docs/src/pages/foundations/tokens.astro
+++ b/apps/docs/src/pages/foundations/tokens.astro
@@ -116,12 +116,12 @@ const tocEntries = [
 
     .section-desc {
         font-size: 0.875rem;
-        color: var(--doc-text-muted, #6b7280);
+        color: var(--doc-text-muted);
         margin: -0.5rem 0 1rem;
     }
 
     .value {
         /* var(--doc-text-muted) échoue le contraste AA sur le fond de <code> (axe-core) */
-        color: var(--doc-text, #111827);
+        color: var(--doc-text);
     }
 </style>

--- a/apps/docs/src/pages/foundations/tokens.astro
+++ b/apps/docs/src/pages/foundations/tokens.astro
@@ -121,6 +121,7 @@ const tocEntries = [
     }
 
     .value {
-        color: var(--doc-text-muted, #6b7280);
+        /* var(--doc-text-muted) échoue le contraste AA sur le fond de <code> (axe-core) */
+        color: var(--doc-text, #111827);
     }
 </style>

--- a/apps/docs/src/pages/index.astro
+++ b/apps/docs/src/pages/index.astro
@@ -114,9 +114,9 @@ const firstComponentHref = rootComponents[0]?.tagName
         gap:            0.4rem;
         font-size:      0.75rem;
         font-weight:    600;
-        color:          var(--doc-accent, #7c3aed);
-        background:     var(--doc-accent-bg, #f3efff);
-        border:         1px solid var(--doc-accent-border, #e0d0ff);
+        color:          var(--doc-accent);
+        background:     var(--doc-accent-bg);
+        border:         1px solid var(--doc-accent-border);
         padding:        0.25rem 0.85rem;
         border-radius:  20px;
         margin-bottom:  1.75rem;
@@ -127,7 +127,7 @@ const firstComponentHref = rootComponents[0]?.tagName
         content:       '';
         width:         6px;
         height:        6px;
-        background:    var(--doc-accent, #7c3aed);
+        background:    var(--doc-accent);
         border-radius: 50%;
         display:       inline-block;
     }
@@ -137,7 +137,7 @@ const firstComponentHref = rootComponents[0]?.tagName
         font-weight:    800;
         letter-spacing: -0.04em;
         line-height:    1.1;
-        color:          var(--doc-text, #0f0f0f);
+        color:          var(--doc-text);
         margin-bottom:  1.25rem;
     }
 
@@ -151,7 +151,7 @@ const firstComponentHref = rootComponents[0]?.tagName
 
     .hero-pitch {
         font-size:    1.05rem;
-        color:        var(--doc-text-subtle, #4b5563);
+        color:        var(--doc-text-subtle);
         line-height:  1.75;
         max-width:    560px;
         margin:       0 auto 2rem;
@@ -171,9 +171,9 @@ const firstComponentHref = rootComponents[0]?.tagName
         gap:           0.35rem;
         font-size:     0.72rem;
         font-weight:   500;
-        color:         var(--doc-text-muted, #6b7280);
-        background:    var(--doc-bg, #fff);
-        border:        1px solid var(--doc-border, #e8e6e0);
+        color:         var(--doc-text-muted);
+        background:    var(--doc-bg);
+        border:        1px solid var(--doc-border);
         padding:       0.25rem 0.75rem;
         border-radius: 20px;
     }
@@ -182,7 +182,7 @@ const firstComponentHref = rootComponents[0]?.tagName
         width:         6px;
         height:        6px;
         border-radius: 50%;
-        background:    var(--doc-accent, #7c3aed);
+        background:    var(--doc-accent);
         flex-shrink:   0;
     }
 
@@ -223,28 +223,28 @@ const firstComponentHref = rootComponents[0]?.tagName
         align-items:     center;
         gap:             0.4rem;
         background:      transparent;
-        color:           var(--doc-text, #374151);
+        color:           var(--doc-text);
         font-family:     inherit;
         font-size:       0.9rem;
         font-weight:     600;
         padding:         0.65rem 1.5rem;
         border-radius:   8px;
         text-decoration: none;
-        border:          1.5px solid var(--doc-border, #e8e6e0);
+        border:          1.5px solid var(--doc-border);
         cursor:          pointer;
         transition:      border-color 0.15s, color 0.15s;
     }
 
     .btn-secondary:hover {
-        border-color: var(--doc-accent, #7c3aed);
-        color:        var(--doc-accent, #7c3aed);
+        border-color: var(--doc-accent);
+        color:        var(--doc-accent);
     }
 
     /* ── Séparateur ────────────────────────────────────────── */
 
     .divider {
         border:     none;
-        border-top: 1px solid var(--doc-border, #e8e6e0);
+        border-top: 1px solid var(--doc-border);
         margin:     0;
     }
 
@@ -265,13 +265,13 @@ const firstComponentHref = rootComponents[0]?.tagName
         font-size:      1.85rem;
         font-weight:    700;
         letter-spacing: -0.03em;
-        color:          var(--doc-text, #0f0f0f);
+        color:          var(--doc-text);
         margin-bottom:  0.6rem;
     }
 
     .selling-header p {
         font-size:  0.95rem;
-        color:      var(--doc-text-muted, #6b7280);
+        color:      var(--doc-text-muted);
         max-width:  480px;
         margin:     0 auto;
     }
@@ -284,8 +284,8 @@ const firstComponentHref = rootComponents[0]?.tagName
     }
 
     .selling-card {
-        background:    var(--doc-bg, #fff);
-        border:        1px solid var(--doc-border, #e8e6e0);
+        background:    var(--doc-bg);
+        border:        1px solid var(--doc-border);
         border-radius: 12px;
         padding:       1.75rem;
         transition:    border-color 0.15s, box-shadow 0.15s;
@@ -299,7 +299,7 @@ const firstComponentHref = rootComponents[0]?.tagName
     .selling-icon {
         width:           40px;
         height:          40px;
-        background:      var(--doc-accent-bg, #f3efff);
+        background:      var(--doc-accent-bg);
         border-radius:   10px;
         display:         flex;
         align-items:     center;
@@ -311,14 +311,14 @@ const firstComponentHref = rootComponents[0]?.tagName
     .selling-card h3 {
         font-size:      0.95rem;
         font-weight:    700;
-        color:          var(--doc-text, #111);
+        color:          var(--doc-text);
         letter-spacing: -0.01em;
         margin-bottom:  0.4rem;
     }
 
     .selling-card p {
         font-size:   0.82rem;
-        color:       var(--doc-text-muted, #6b7280);
+        color:       var(--doc-text-muted);
         line-height: 1.7;
         margin:      0;
     }
@@ -326,30 +326,30 @@ const firstComponentHref = rootComponents[0]?.tagName
     /* ── Placeholder différentiation ────────────────────── */
 
     .placeholder-section {
-        border:        2px dashed var(--doc-accent-border, #e0d0ff);
+        border:        2px dashed var(--doc-accent-border);
         border-radius: 12px;
         padding:       2rem;
         text-align:    center;
-        background:    color-mix(in srgb, var(--doc-accent-bg, #f3efff) 30%, transparent);
+        background:    color-mix(in srgb, var(--doc-accent-bg) 30%, transparent);
         margin-bottom: 0;
     }
 
     .placeholder-section p {
         font-size:   0.82rem;
-        color:       var(--doc-text-muted, #9d8fc2);
+        color:       var(--doc-text-muted);
         margin:      0 0 0.25rem;
     }
 
     .placeholder-section strong {
-        color: var(--doc-accent, #7c3aed);
+        color: var(--doc-accent);
     }
 
     /* ── CTA bas de page ────────────────────────────────── */
 
     .cta-bottom {
-        background:    var(--doc-cta-bg, var(--doc-accent-bg, #f3efff));
-        border-top:    1px solid var(--doc-cta-border, var(--doc-accent-border, #e0d0ff));
-        border-bottom: 1px solid var(--doc-cta-border, var(--doc-accent-border, #e0d0ff));
+        background:    var(--doc-cta-bg);
+        border-top:    1px solid var(--doc-cta-border);
+        border-bottom: 1px solid var(--doc-cta-border);
         text-align:    center;
         padding:       4rem 2rem;
     }
@@ -358,14 +358,14 @@ const firstComponentHref = rootComponents[0]?.tagName
         font-size:      1.6rem;
         font-weight:    700;
         letter-spacing: -0.03em;
-        color:          var(--doc-text, #0f0f0f);
+        color:          var(--doc-text);
         margin-bottom:  0.5rem;
     }
 
     .cta-bottom p {
         font-size:     0.9rem;
         /* var(--doc-text-muted) échoue le contraste AA sur ce fond (axe-core) */
-        color:         var(--doc-text, #1a1a1a);
+        color:         var(--doc-text);
         margin-bottom: 1.75rem;
     }
 
@@ -380,7 +380,7 @@ const firstComponentHref = rootComponents[0]?.tagName
 
     .landing-footer {
         padding:         2rem 2.5rem;
-        border-top:      1px solid var(--doc-border, #e8e6e0);
+        border-top:      1px solid var(--doc-border);
         display:         flex;
         justify-content: space-between;
         align-items:     center;
@@ -390,12 +390,12 @@ const firstComponentHref = rootComponents[0]?.tagName
 
     .landing-footer p {
         font-size: 0.78rem;
-        color:     var(--doc-text-muted, #6b7280);
+        color:     var(--doc-text-muted);
         margin:    0;
     }
 
     .landing-footer a {
-        color:           var(--doc-accent, #7c3aed);
+        color:           var(--doc-accent);
         text-decoration: underline;
         text-underline-offset: 2px;
     }

--- a/apps/docs/src/pages/index.astro
+++ b/apps/docs/src/pages/index.astro
@@ -364,7 +364,8 @@ const firstComponentHref = rootComponents[0]?.tagName
 
     .cta-bottom p {
         font-size:     0.9rem;
-        color:         var(--doc-text-muted, #6b7280);
+        /* var(--doc-text-muted) échoue le contraste AA sur ce fond (axe-core) */
+        color:         var(--doc-text, #1a1a1a);
         margin-bottom: 1.75rem;
     }
 
@@ -395,10 +396,9 @@ const firstComponentHref = rootComponents[0]?.tagName
 
     .landing-footer a {
         color:           var(--doc-accent, #7c3aed);
-        text-decoration: none;
+        text-decoration: underline;
+        text-underline-offset: 2px;
     }
-
-    .landing-footer a:hover { text-decoration: underline; }
 
     /* ── Responsive ─────────────────────────────────────── */
 

--- a/apps/docs/src/styles/doc-prose.css
+++ b/apps/docs/src/styles/doc-prose.css
@@ -25,7 +25,7 @@
 }
 
 .page-title {
-    color: var(--doc-text, #111827);
+    color: var(--doc-text);
     font-size: 2rem;
     margin: 0;
 }
@@ -55,10 +55,10 @@
 .section-title {
     font-size: 1.25rem;
     font-weight: 600;
-    border-bottom: 2px solid var(--doc-border, #e5e7eb);
+    border-bottom: 2px solid var(--doc-border);
     padding-bottom: 1rem;
     margin: 0 0 2rem;
-    color: var(--doc-text, #111827);
+    color: var(--doc-text);
     display: flex;
     align-items: center;
     gap: 0.5rem;
@@ -67,7 +67,7 @@
 .subsection-title {
     font-size: 1.05rem;
     font-weight: 600;
-    color: var(--doc-text-subtle, #374151);
+    color: var(--doc-text-subtle);
     margin: 0;
     display: flex;
     align-items: center;
@@ -76,25 +76,25 @@
 
 .summary {
     font-size: 1.05rem;
-    color: var(--doc-text-muted, #4b5563);
+    color: var(--doc-text-muted);
     margin: 0;
 }
 
 /* p {
-    color: var(--doc-text, #374151);
+    color: var(--doc-text);
     margin-bottom: 0.75rem;
     line-height: 1.65;
 } */
 
 ul {
     font-size: 0.95rem;
-    color: var(--doc-text, #374151);
+    color: var(--doc-text);
     padding-left: 1.25rem;
     line-height: 1.8;
 }
 
 a {
-    color: var(--doc-accent, #7c3aed);
+    color: var(--doc-accent);
     /* Un lien dans du texte courant ne doit pas être distingué par la seule
        couleur (WCAG 1.4.1) — soulignement permanent, pas seulement au survol. */
     text-decoration: underline;
@@ -102,15 +102,15 @@ a {
 }
 
 a:visited {
-    color: var(--doc-link-visited, #6d28d9);
+    color: var(--doc-link-visited);
 }
 
 a:active {
-    color: var(--doc-accent, #7c3aed);
+    color: var(--doc-accent);
 }
 
 pre {
-    background: var(--doc-code-block-bg, #1e1e2e);
+    background: var(--doc-code-block-bg);
     border-radius: 0.5rem;
     padding: 1rem 1.25rem;
     overflow-x: auto;
@@ -131,16 +131,16 @@ pre code {
     font-weight: 600;
     padding: 0.15em 0.5em;
     border-radius: 0.25rem;
-    background: var(--doc-accent-bg, #f3efff);
-    color: var(--doc-accent, #7c3aed);
-    border: 1px solid var(--doc-accent-border, #e0d0ff);
+    background: var(--doc-accent-bg);
+    color: var(--doc-accent);
+    border: 1px solid var(--doc-accent-border);
     letter-spacing: 0.02em;
 }
 
 .callout {
     padding: 1rem 1.25rem;
-    background: var(--doc-accent-bg, rgba(243, 239, 255, 0.5));
-    border: 1px solid var(--doc-accent-border, #e0d0ff);
+    background: var(--doc-accent-bg);
+    border: 1px solid var(--doc-accent-border);
     border-radius: 0.5rem;
 }
 
@@ -149,7 +149,7 @@ pre code {
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.06em;
-    color: var(--doc-accent, #7c3aed);
+    color: var(--doc-accent);
     margin: 0 0 0.6rem;
 }
 
@@ -158,7 +158,7 @@ pre code {
     padding-left: 1.25rem;
     font-size: 0.875rem;
     line-height: 1.7;
-    color: var(--doc-text, #374151);
+    color: var(--doc-text);
 }
 
 .badge-subtle {
@@ -166,8 +166,8 @@ pre code {
     font-weight: 600;
     padding: 0.15em 0.5em;
     border-radius: 0.25rem;
-    background: color-mix(in srgb, var(--doc-border, #e5e7eb) 80%, transparent);
+    background: color-mix(in srgb, var(--doc-border) 80%, transparent);
     /* var(--doc-text-muted) échoue le contraste AA sur ce fond clair (axe-core) */
-    color: var(--doc-text, #111827);
+    color: var(--doc-text);
     letter-spacing: 0.02em;
 }

--- a/apps/docs/src/styles/doc-prose.css
+++ b/apps/docs/src/styles/doc-prose.css
@@ -95,7 +95,10 @@ ul {
 
 a {
     color: var(--doc-accent, #7c3aed);
-    text-decoration: none;
+    /* Un lien dans du texte courant ne doit pas être distingué par la seule
+       couleur (WCAG 1.4.1) — soulignement permanent, pas seulement au survol. */
+    text-decoration: underline;
+    text-underline-offset: 2px;
 }
 
 a:visited {
@@ -104,10 +107,6 @@ a:visited {
 
 a:active {
     color: var(--doc-accent, #7c3aed);
-}
-
-a:hover {
-    text-decoration: underline;
 }
 
 pre {
@@ -168,6 +167,7 @@ pre code {
     padding: 0.15em 0.5em;
     border-radius: 0.25rem;
     background: color-mix(in srgb, var(--doc-border, #e5e7eb) 80%, transparent);
-    color: var(--doc-text-muted, #6b7280);
+    /* var(--doc-text-muted) échoue le contraste AA sur ce fond clair (axe-core) */
+    color: var(--doc-text, #111827);
     letter-spacing: 0.02em;
 }

--- a/apps/docs/src/styles/doc-table.css
+++ b/apps/docs/src/styles/doc-table.css
@@ -22,17 +22,17 @@ table {
 th {
     text-align: left;
     padding: 0.5rem 0.75rem;
-    background: var(--doc-nav-bg, #f9fafb);
-    color: var(--doc-text, #111827);
+    background: var(--doc-nav-bg);
+    color: var(--doc-text);
     font-weight: 600;
-    border-bottom: 1px solid var(--doc-border, #e5e7eb);
+    border-bottom: 1px solid var(--doc-border);
 }
 
 td {
     padding: 0.5rem 0.75rem;
-    border-bottom: 1px solid var(--doc-border, #f3f4f6);
+    border-bottom: 1px solid var(--doc-border);
     vertical-align: top;
-    color: var(--doc-text, #111827);
+    color: var(--doc-text);
 }
 
 /* La première colonne (Nom) se cale sur son contenu (nom de token/attribut,
@@ -48,8 +48,8 @@ td:first-child {
 code {
     font-family: 'Fira Code', 'Cascadia Code', monospace;
     font-size: 0.8rem;
-    background: var(--doc-accent-bg, #f3efff);
-    color: var(--doc-accent, #7c3aed);
+    background: var(--doc-accent-bg);
+    color: var(--doc-accent);
     padding: 0.1em 0.35em;
     border-radius: 0.25em;
 }
@@ -59,7 +59,7 @@ code {
     width: 2rem;
     height: 2rem;
     border-radius: 4px;
-    outline: var(--doc-swatch-outline, 1px solid rgba(0, 0, 0, 0.25));
+    outline: var(--doc-swatch-outline);
     outline-offset: 1px;
     vertical-align: middle;
     margin-right: 0.5rem;

--- a/apps/docs/tests/a11y/discover-pages.mjs
+++ b/apps/docs/tests/a11y/discover-pages.mjs
@@ -1,0 +1,34 @@
+import { readdirSync, statSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const DIST = join(__dirname, '..', '..', 'dist');
+
+/**
+ * Parcourt `dist/` (build Astro) et retourne les routes de toutes les pages
+ * statiques générées (une entrée `index.html` → une route), sans liste à
+ * maintenir à la main — contrairement à `scripts/check-build.js` qui ne
+ * vérifie qu'un sous-ensemble de pages statiques connues.
+ *
+ * @returns {string[]} routes, ex. ['/', '/components/alert/', ...]
+ */
+export function discoverPages() {
+    const routes = [];
+
+    function walk(dir) {
+        for (const entry of readdirSync(dir)) {
+            const fullPath = join(dir, entry);
+            if (statSync(fullPath).isDirectory()) {
+                walk(fullPath);
+                continue;
+            }
+            if (entry !== 'index.html') continue;
+            const rel = relative(DIST, fullPath).split(sep).slice(0, -1).join('/');
+            routes.push(rel ? `/${rel}/` : '/');
+        }
+    }
+
+    walk(DIST);
+    return routes.sort();
+}

--- a/apps/docs/tests/a11y/pages.spec.ts
+++ b/apps/docs/tests/a11y/pages.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+import { discoverPages } from './discover-pages.mjs';
+
+const routes = discoverPages();
+
+test.describe('a11y — pages du site de doc (axe-core)', () => {
+    for (const route of routes) {
+        test(`${route} ne remonte aucune violation`, async ({ page }) => {
+            await page.goto(route);
+            await page.waitForLoadState('networkidle');
+
+            const results = await new AxeBuilder({ page })
+                .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+                .analyze();
+
+            const summary = results.violations.map(
+                (v) =>
+                    `[${v.impact}] ${v.id} (${v.nodes.length} élément(s)) — ${v.help}\n` +
+                    v.nodes.map((n) => `    ${n.target.join(' ')}`).join('\n'),
+            );
+
+            expect(summary, summary.join('\n\n')).toEqual([]);
+        });
+    }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,8 @@
         "typescript": "^6.0.2"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.12.1",
+        "@playwright/test": "^1.61.1",
         "vitest": "^4.1.8"
       }
     },
@@ -235,6 +237,19 @@
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.8.3"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2498,6 +2513,54 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@prettier/sync": {
       "version": "0.5.5",
@@ -5026,9 +5089,9 @@
       "license": "MIT"
     },
     "node_modules/axe-core": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
-      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -14730,7 +14793,7 @@
     },
     "packages/core": {
       "name": "@ariane-ui/core",
-      "version": "0.1.0-alpha.7",
+      "version": "0.1.0-alpha.8",
       "dependencies": {
         "@floating-ui/dom": "^1.6.0",
         "@lit/context": "^1.1.6",

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -510,7 +510,9 @@
         --ar-datepicker-offset: var(--ar-anchor-offset);
         --ar-datepicker-gap: 0.35rem;
         --ar-datepicker-label-gap: 0.5rem;
-        --ar-datepicker-error-color: var(--ar-color-red-50);
+        /* --ar-color-danger-text (pas red-50 directement) : même convention que
+           ar-alert/ar-charcounter, calibré pour le contraste AA sur texte (axe-core) */
+        --ar-datepicker-error-color: var(--ar-color-danger-text);
 
         --ar-datepicker-panel-width: 20rem;
 


### PR DESCRIPTION
## Contexte

Dernier point ouvert de #109 sur l'axe Accessibilité : aucun test a11y automatisé côté doc, seulement des vérifications manuelles ponctuelles (dont l'audit de la PR #122).

## Choix techniques

- **axe-core** via **`@axe-core/playwright`** — combinaison standard pour scanner des pages HTML complètes (contrairement à pa11y, moins maintenu).
- **Playwright Test** comme runner dédié (`apps/docs/playwright.config.ts`), pas Vitest ni le WTR de `packages/core` — ces deux-là sont conçus pour tester des fixtures/composants, pas naviguer de vraies pages. Playwright est déjà présent dans l'écosystème du repo via `@web/test-runner-playwright` (core), donc pas de nouveau navigateur à gérer.
- Scan du **build statique** (`dist/`, servi par `astro preview`) plutôt que le dev server — CSS/JS final, pas de HMR qui pourrait fausser un résultat.
- **Découverte automatique des routes** (`tests/a11y/discover-pages.mjs` parcourt `dist/**/index.html`) — pas de liste à maintenir à la main, contrairement à `scripts/check-build.js`.

## Violations trouvées et corrigées en construisant les tests

**Contraste (AA)** — même paire fautive répétée 4 fois (`var(--doc-text-muted)` sur un fond qui échoue l'AA) :
- `.header-version` (déjà vu et corrigé différemment en PR #122 — ici c'est `.badge-subtle`, `.cta-bottom p` et `.value` de la page Design Tokens qui restaient)
- Toutes remplacées par `var(--doc-text)`.

**Liens dans le texte courant (WCAG 1.4.1)** — `text-decoration` appliqué seulement au survol, jamais au repos → `doc-prose.css` (`a` global) et le footer de la landing page passent en soulignement permanent.

**Blocs de code scrollables non atteignables au clavier** — `tabindex="0"` posé par `playground.js` après `highlight.js`. axe cible spécifiquement le `<code>` interne (plus large que son `<pre>` après coloration syntaxique), pas seulement l'ancêtre `<pre>` — un ancêtre focusable ne suffit pas pour cette règle (bug Safari ciblé par axe-core).

**Vrai bug composant, pas seulement doc** (`packages/core/src/styles/themes/default.css`) : `--ar-datepicker-error-color` utilisait `--ar-color-red-50` (4.38:1, sous AA) au lieu du token dédié `--ar-color-danger-text` déjà utilisé par `ar-alert`/`ar-charcounter` pour ce même usage — le thème sombre avait déjà la bonne valeur, seul le clair était affecté. Trouvé parce que la démo `ar-datepicker` du site l'expose dans son slot `error`.

## CI

`ci-docs.yml` : nouvelle étape après le build (`npx playwright install --with-deps chromium` puis `npm run test:a11y --workspace=apps/docs`), rapport HTML publié en artefact si échec.

## Suite (même PR) — retrait des fallbacks `var(--doc-*, ...)`

Discussion post-review : les `--doc-*` sont toujours déclarées dans `Layout.astro` (clair + sombre), contrairement aux tokens `--ar-*` de `packages/core` qui doivent rester headless pour des consommateurs tiers. Les fallbacks littéraux (`var(--doc-text, #111827)`) n'avaient donc aucun consommateur réel — retirés partout (134 occurrences, 11 fichiers).

Détecté au passage : `--doc-link-visited` était utilisée avec fallback mais **jamais déclarée** — les liens visités restaient figés sur `#6d28d9` même en dark mode. Déclarée dans les deux thèmes (`#6d28d9` clair, `#c4b5fd` sombre — la valeur de `--doc-accent-hover` en dark, `#8b5cf6`, aurait échoué l'AA à 4.09:1).

## Test plan

- [x] `npm run test:a11y --workspace=apps/docs` : 23/23 pages passent
- [x] `npm run build --workspace=packages/core` + `npm run test --workspace=packages/core` : 748/748
- [x] `npm run build --workspace=apps/docs` + `npm run test --workspace=apps/docs` : 56/56
- [x] `npm run lint` (core + docs) : clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)