### PR TITLE
fix(core): corrige le faux-positif du marqueur dark mode dans validate-cssprop-defaults.js

### DIFF
--- a/packages/core/scripts/validate-cssprop-defaults.js
+++ b/packages/core/scripts/validate-cssprop-defaults.js
@@ -18,6 +18,21 @@ const DARK_OVERRIDE_RE =
     /:root\[data-theme=['"]dark['"]\]|@media\s*\(\s*prefers-color-scheme\s*:\s*dark\s*\)/;
 
 /**
+ * Remplace le contenu de chaque commentaire `/* ... *\/` par des espaces de même
+ * longueur, pour que `DARK_OVERRIDE_RE` ne matche jamais une mention purement
+ * documentaire (ex. le header de `default.css` qui cite littéralement
+ * `:root[data-theme='dark']` en prose) tout en préservant les index d'origine —
+ * indispensable puisque `darkStart` sert ensuite à découper la chaîne source non
+ * modifiée via `.slice()`.
+ *
+ * @param {string} css
+ * @returns {string}
+ */
+function blankComments(css) {
+    return css.replace(/\/\*[\s\S]*?\*\//g, (comment) => ' '.repeat(comment.length));
+}
+
+/**
  * Parse un fichier CSS de thème et retourne une map nom de token → valeur nettoyée
  * (commentaire `/* ... *\/` trailing retiré, valeur triée). Ignore le nesting
  * (`@layer`/`:root`) — la regex matche sur le contenu brut du fichier. Ne considère
@@ -30,7 +45,7 @@ const DARK_OVERRIDE_RE =
  * @returns {Map<string, string>}
  */
 export function extractThemeTokens(css) {
-    const darkStart = css.search(DARK_OVERRIDE_RE);
+    const darkStart = blankComments(css).search(DARK_OVERRIDE_RE);
     const baseCss = darkStart === -1 ? css : css.slice(0, darkStart);
 
     const tokens = new Map();

--- a/packages/core/scripts/validate-cssprop-defaults.test.js
+++ b/packages/core/scripts/validate-cssprop-defaults.test.js
@@ -14,6 +14,28 @@ describe('extractThemeTokens', () => {
         expect(tokens.get('--ar-color-primary-05')).toBe('#010105');
     });
 
+    it("ignore une occurrence du marqueur dark mode a l'interieur d'un commentaire (faux-positif du header de default.css)", () => {
+        // Reproduit le header réel de default.css : le commentaire de tête mentionne
+        // littéralement ":root[data-theme='dark']" à titre de documentation, avant le
+        // vrai bloc :root de base. Sans filtrage des commentaires, DARK_OVERRIDE_RE
+        // matche cette occurrence textuelle et tronque baseCss dès le commentaire,
+        // ne laissant plus aucun token "clair" détecté.
+        const css = `
+            /**
+             * Le bloc de base doit précéder toute surcharge (:root[data-theme='dark']).
+             */
+            :root {
+                --ar-color-text: #171717;
+            }
+
+            :root[data-theme='dark'] {
+                --ar-color-text: #e6e7ec;
+            }
+        `;
+        const tokens = extractThemeTokens(css);
+        expect(tokens.get('--ar-color-text')).toBe('#171717');
+    });
+
     it('garde une référence var() non résolue', () => {
         const css = `:root { --ar-pagination-bg: var(--ar-button-tertiary-bg); }`;
         const tokens = extractThemeTokens(css);

--- a/packages/core/src/components/datepicker/datepicker.ts
+++ b/packages/core/src/components/datepicker/datepicker.ts
@@ -42,6 +42,9 @@ import { warn } from '../../utils/warn.js';
  * @csspart today-btn  - Bouton « Aujourd'hui ».
  * @csspart close-btn  - Bouton « Fermer ».
  *
+ * @cssprop --ar-datepicker-gap - Espacement vertical entre le label, le champ et l'indice.
+ * @cssprop --ar-datepicker-label-gap - Marge sous le label (combinée à `--ar-datepicker-gap` via `calc()`).
+ * @cssprop --ar-datepicker-error-color - Couleur du message d'erreur.
  * @cssprop --ar-datepicker-panel-width - Largeur du popover.
  * @cssprop --ar-datepicker-distance - Espacement entre le trigger et le panel.
  * @cssprop --ar-datepicker-offset - Décalage latéral du panel.

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -74,6 +74,8 @@ if (typeof document !== 'undefined') {
  * @cssprop --ar-dialog-spacing - Padding interne (block et inline) de la zone de contenu.
  * @cssprop --ar-dialog-spacing-block - Padding haut/bas. Prend le pas sur `--ar-dialog-spacing` si défini.
  * @cssprop --ar-dialog-spacing-inline - Padding gauche/droite. Prend le pas sur `--ar-dialog-spacing` si défini.
+ * @cssprop --ar-dialog-shadow - Ombre portée du dialog.
+ * @cssprop --ar-dialog-backdrop - Couleur de fond du voile derrière le dialog (mode modal).
  * @cssprop --ar-dialog-close-bg - Fond du bouton de fermeture.
  * @cssprop --ar-dialog-close-bg-hover - Fond du bouton de fermeture au survol.
  * @cssprop --ar-dialog-close-bg-pressed - Fond du bouton de fermeture pressé.

--- a/packages/core/src/components/stepper/stepper.ts
+++ b/packages/core/src/components/stepper/stepper.ts
@@ -63,6 +63,7 @@ export interface ArStepperStepChangeDetail {
  * @cssprop --ar-stepper-bullet-color - Couleur du numéro dans les puces visitables.
  * @cssprop --ar-stepper-bullet-border-color - Bordure des puces des étapes suivantes.
  * @cssprop --ar-stepper-bullet-hover-bg - Fond de la puce au survol.
+ * @cssprop --ar-stepper-link-color - Couleur du texte du lien.
  * @cssprop --ar-stepper-link-hover-color - Couleur du texte du lien au survol.
  * @cssprop --ar-stepper-bullet-radius - Border-radius de la puce.
  * @cssprop --ar-stepper-link-focus-radius - Border-radius de l'anneau de focus du lien.


### PR DESCRIPTION
## Résumé

Le garde-fou CI `validateCssPropertyCoverage` (censé faire échouer `npm run build:manifest` quand un token de `default.css` n'a pas d'entrée `@cssprop`) était silencieusement désactivé depuis son introduction (PR #114).

**Cause** : le commentaire d'en-tête de `default.css` mentionne littéralement la chaîne `:root[data-theme='dark']` à titre documentaire. `DARK_OVERRIDE_RE.search()` matche cette occurrence dès la ligne 4 du fichier, bien avant le vrai bloc dark mode (ligne 595). Conséquence vérifiée : `extractThemeTokens` retournait **0 token "clair"** sur le vrai `default.css` (les 420 tokens du fichier étaient tous mal classés "dark").

**Découverte** : en manipulant la nouvelle page de personnalisation de thème (#120, branche séparée), plusieurs tokens sans effet visible ou visiblement "génériques non documentés" ont été signalés — la vérification a mené à ce bug racine.

## Correctif

`extractThemeTokens` neutralise désormais le contenu des commentaires (remplacés par des espaces de même longueur, pour préserver les index) avant de chercher le marqueur dark mode.

Une fois le garde-fou réactivé, `npm run build:manifest` a révélé 6 tokens réellement non documentés :
- `ArStepper` : `--ar-stepper-link-color`
- `ArDialog` : `--ar-dialog-shadow`, `--ar-dialog-backdrop`
- `ArDatepicker` : `--ar-datepicker-gap`, `--ar-datepicker-label-gap`, `--ar-datepicker-error-color`

`@cssprop` ajoutés pour chacun.

## Test plan

- [x] Test unitaire reproduisant le faux-positif (commentaire contenant le marqueur avant le vrai `:root`)
- [x] `npm run test` : 749/749 tests core passent
- [x] `npm run build:manifest` : passe (les 6 trous réels ont été comblés)
- [x] `npm run build --workspace=@ariane-ui/core` : build complet vert

🤖 Generated with [Claude Code](https://claude.com/claude-code)