### PR TITLE
docs: documente les tokens generiques consommes directement par les composants (audit #127)

### DIFF
--- a/docs/superpowers/plans/2026-07-22-audit-generic-tokens-cssprop-127-addendum.md
+++ b/docs/superpowers/plans/2026-07-22-audit-generic-tokens-cssprop-127-addendum.md
@@ -1,0 +1,334 @@
+# Audit tokens génériques #127 — Addendum (scoping + découvrabilité default.css)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Suite à la revue de la PR #132, scoper les tokens génériques qui ne devraient pas être consommés tels quels par un composant (palette brute, échelle de tailles, ou token sémantique utilisé hors de son objet déclaré), et ajouter dans `default.css` une trace de découvrabilité pour les tokens sémantiques restés en consommation directe.
+
+**Architecture:** Reprend le pattern d'alias déjà établi par #125 (ADR-005, cf. `ar-dropdown`) : le composant déclare son propre token `--ar-<composant>-<propriété>`, `default.css` l'aliase par défaut vers le token global, et le `.styles.ts` du composant consomme uniquement son propre token. Cela protège le composant si un consommateur remplace la palette (`--ar-color-neutral-90`) ou l'échelle (`--ar-font-size-md`, `--ar-border-radius-lg`) par son propre design system, et corrige un cas où un token sémantique était utilisé hors de son objet déclaré (`--ar-color-danger-text`, un token de couleur de _texte_, pilotant un `outline` de bordure).
+
+Les tokens sémantiques génériques déjà documentés dans la PR précédente et utilisés conformément à leur objet (`--ar-color-bg`, `--ar-color-text`, `--ar-color-text-inverse`, `--ar-color-interactive`, `--ar-focus-ring-color`, `--ar-focus-ring-offset`) restent en consommation directe : ce sont la couche sémantique déjà conçue comme point d'extension public (cf. `default.css:224-227` : « Ce sont ces tokens que les composants et les thèmes surchargent »). Pour ceux-ci, on ajoute uniquement un commentaire de découvrabilité dans `default.css`, sans créer d'alias.
+
+**Tech Stack:** Lit 3 + TypeScript, CSS custom properties (`@layer ariane.theme` dans `packages/core/src/styles/themes/default.css`), Vitest, `packages/core/scripts/validate-cssprop-defaults.js`.
+
+## Global Constraints
+
+- Aucun changement visuel : chaque nouvel alias pointe par défaut vers exactement le token qu'il remplace, même valeur héritée.
+- Nommage des tokens scopés confirmé avec le mainteneur :
+    - `--ar-breadcrumb-mobile-separator-color` (⚠️ pas `--ar-breadcrumb-separator-color`, déjà pris par le séparateur desktop, `breadcrumb.ts:40`, qui pointe vers `--ar-color-neutral-80` — un token différent).
+    - `--ar-dialog-border-radius`
+    - `--ar-dialog-title-font-size`
+    - `--ar-dialog-shake-outline-color`
+- Commentaires de découvrabilité `default.css` : uniquement sur les 6 déclarations de tokens sémantiques restés en consommation directe (pas sur les 4 tokens nouvellement scopés — l'alias documente déjà la relation). Pas de référence au numéro d'issue dans les commentaires (rotent avec le temps) — décrire uniquement la relation technique (quels composants consomment directement ce token).
+- Prettier : 100 caractères, 4 espaces, quotes simples.
+- Conventional Commits — chaque tâche se termine par un commit séparé.
+- Ne jamais committer `packages/core/dist/`.
+- Travail sur la branche existante `docs/audit-generic-tokens-127` (PR #132 déjà ouverte vers `dev`) — pas de nouvelle branche, pousser les commits supplémentaires sur la même branche.
+
+---
+
+## Contexte technique découvert pendant l'audit de revue
+
+- `--ar-breadcrumb-separator-color` existe déjà dans `default.css:349` (`var(--ar-color-neutral-80)`) et dans le JSDoc `breadcrumb.ts:40` — c'est le séparateur **desktop** (chevron entre les items), consommé par `breadcrumb.styles.ts:72`. Le connecteur pointillé **mobile** (`breadcrumb.styles.ts:130`, `--ar-color-neutral-90`) est un token différent : nommer son alias `--ar-breadcrumb-mobile-separator-color` pour éviter toute collision.
+- Le token `--ar-color-danger-text` a une valeur différente selon le thème (light : `default.css:258`, `var(--ar-color-danger-40)` ; dark : `default.css:638` et `698`, `var(--ar-color-danger-70)`) — l'alias `--ar-dialog-shake-outline-color` hérite de cette adaptation automatiquement puisqu'il pointe vers le même token, sans dupliquer les surcharges dark.
+- Section 3 de `default.css` (« TOKENS SÉMANTIQUES », commentaire `default.css:224-227`) déclare explicitement que ces tokens sont le point d'extension prévu pour les composants et les thèmes — confirme que `--ar-color-bg`/`--ar-color-text`/`--ar-color-text-inverse`/`--ar-color-interactive`/`--ar-focus-ring-color`/`--ar-focus-ring-offset` n'ont pas besoin d'alias scopé, juste d'un commentaire de découvrabilité.
+
+---
+
+### Task 6: Scoper `--ar-color-neutral-90` pour `ar-breadcrumb`
+
+**Files:**
+
+- Modify: `packages/core/src/styles/themes/default.css:349` (section breadcrumb)
+- Modify: `packages/core/src/components/breadcrumb/breadcrumb.styles.ts:130`
+- Modify: `packages/core/src/components/breadcrumb/breadcrumb.ts:41,57`
+
+**Interfaces:** Produces `--ar-breadcrumb-mobile-separator-color` (alias de `--ar-color-neutral-90`), consommé uniquement par `breadcrumb.styles.ts`.
+
+- [ ] **Step 1: Ajouter l'alias dans `default.css`**
+
+La section breadcrumb contient ligne 349 :
+
+```css
+--ar-breadcrumb-bullet-color: var(--ar-color-neutral-80);
+```
+
+Remplacer par :
+
+```css
+--ar-breadcrumb-bullet-color: var(--ar-color-neutral-80);
+--ar-breadcrumb-mobile-separator-color: var(--ar-color-neutral-90);
+```
+
+- [ ] **Step 2: Utiliser l'alias dans `breadcrumb.styles.ts`**
+
+Ligne 130 :
+
+```css
+background-image: linear-gradient(var(--ar-color-neutral-90) 25%, transparent 0);
+```
+
+Remplacer par :
+
+```css
+background-image: linear-gradient(var(--ar-breadcrumb-mobile-separator-color) 25%, transparent 0);
+```
+
+- [ ] **Step 3: Mettre à jour le JSDoc de `breadcrumb.ts`**
+
+Supprimer la ligne (actuellement en fin de bloc, juste avant `@event`) :
+
+```
+ * @cssprop --ar-color-neutral-90 - Couleur du séparateur pointillé vertical entre les items de la liste mobile. Token de palette brute globale (non scopé à ar-breadcrumb).
+```
+
+Et ajouter, juste après la ligne `--ar-breadcrumb-bullet-color` (actuellement) :
+
+```
+ * @cssprop --ar-breadcrumb-bullet-color - Couleur des puces de la liste mobile.
+ * @cssprop --ar-breadcrumb-mobile-separator-color - Couleur du connecteur pointillé vertical entre les items de la liste mobile (cascade vers --ar-color-neutral-90).
+```
+
+- [ ] **Step 4: Vérifier la couverture `@cssprop` et les tests**
+
+Run: `npm run build:manifest --workspace=@ariane-ui/core`
+Expected: succès, le nouveau token a son entrée JSDoc, aucune régression de couverture.
+
+Run: `npx vitest run packages/core/src/components/breadcrumb --root /Users/jon/Code/Active_projects/ariane`
+Expected: tous les tests passent, aucune régression visuelle (même valeur `--ar-color-neutral-90` héritée par défaut).
+
+- [ ] **Step 5: Vérification visuelle**
+
+Playground docs, page `ar-breadcrumb`, mode mobile : le connecteur pointillé vertical entre les items doit garder exactement le même rendu qu'avant (couleur héritée à l'identique via l'alias).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/styles/themes/default.css packages/core/src/components/breadcrumb/breadcrumb.styles.ts packages/core/src/components/breadcrumb/breadcrumb.ts
+git commit -m "refactor(breadcrumb): scope --ar-breadcrumb-mobile-separator-color au lieu de consommer la palette brute --ar-color-neutral-90"
+```
+
+---
+
+### Task 7: Scoper 3 tokens pour `ar-dialog`
+
+**Files:**
+
+- Modify: `packages/core/src/styles/themes/default.css` (section dialog, après ligne `--ar-dialog-close-bg-focus`)
+- Modify: `packages/core/src/components/dialog/dialog.styles.ts:85,149,230`
+- Modify: `packages/core/src/components/dialog/dialog.ts:85-87`
+
+**Interfaces:** Produces `--ar-dialog-border-radius` (alias de `--ar-border-radius-lg`), `--ar-dialog-title-font-size` (alias de `--ar-font-size-md`), `--ar-dialog-shake-outline-color` (alias de `--ar-color-danger-text`).
+
+- [ ] **Step 1: Ajouter les 3 alias dans la section dialog de `default.css`**
+
+La section dialog se termine par :
+
+```css
+--ar-dialog-close-bg-focus: var(--ar-button-tertiary-bg-focus);
+```
+
+Remplacer par :
+
+```css
+--ar-dialog-close-bg-focus: var(--ar-button-tertiary-bg-focus);
+--ar-dialog-border-radius: var(--ar-border-radius-lg);
+--ar-dialog-title-font-size: var(--ar-font-size-md);
+--ar-dialog-shake-outline-color: var(--ar-color-danger-text);
+```
+
+- [ ] **Step 2: Utiliser les 3 alias dans `dialog.styles.ts`**
+
+Remplacer (ligne 85) :
+
+```css
+border-radius: var(--ar-border-radius-lg);
+```
+
+par :
+
+```css
+border-radius: var(--ar-dialog-border-radius);
+```
+
+Remplacer (ligne 149) :
+
+```css
+font-size: var(--ar-font-size-md);
+```
+
+par :
+
+```css
+font-size: var(--ar-dialog-title-font-size);
+```
+
+Remplacer (ligne 230) :
+
+```css
+outline: 3px solid var(--ar-color-danger-text);
+```
+
+par :
+
+```css
+outline: 3px solid var(--ar-dialog-shake-outline-color);
+```
+
+- [ ] **Step 3: Mettre à jour le JSDoc de `dialog.ts`**
+
+Remplacer les 3 lignes actuelles (85-87) :
+
+```
+ * @cssprop --ar-border-radius-lg - Border-radius du dialog en mode modal (non-drawer). Token sémantique global (non scopé à ar-dialog).
+ * @cssprop --ar-font-size-md - Taille de police du titre (h1). Token sémantique global (non scopé à ar-dialog).
+ * @cssprop --ar-color-danger-text - Couleur de l'anneau de mise en évidence (`outline`) affiché à la place du shake en `prefers-reduced-motion: reduce`. Token sémantique global (non scopé à ar-dialog).
+```
+
+par :
+
+```
+ * @cssprop --ar-dialog-border-radius - Border-radius du dialog en mode modal (non-drawer) (cascade vers --ar-border-radius-lg).
+ * @cssprop --ar-dialog-title-font-size - Taille de police du titre (h1) (cascade vers --ar-font-size-md).
+ * @cssprop --ar-dialog-shake-outline-color - Couleur de l'anneau de mise en évidence (`outline`) affiché à la place du shake en `prefers-reduced-motion: reduce` (cascade vers --ar-color-danger-text).
+```
+
+- [ ] **Step 4: Vérifier la couverture `@cssprop` et les tests**
+
+Run: `npm run build:manifest --workspace=@ariane-ui/core`
+Expected: succès, les 3 nouveaux tokens ont leur entrée JSDoc, aucune régression de couverture.
+
+Run: `npx vitest run packages/core/src/components/dialog --root /Users/jon/Code/Active_projects/ariane`
+Expected: tous les tests passent, aucune régression visuelle (mêmes valeurs héritées par défaut).
+
+- [ ] **Step 5: Vérification visuelle**
+
+Playground docs, page `ar-dialog` : le border-radius de la modale et la taille de police du titre doivent rester identiques. Activer "reduce motion" (devtools → Rendering → Emulate CSS media feature `prefers-reduced-motion`), déclencher une fermeture bloquée : l'anneau `outline` doit garder la même couleur rouge/danger qu'avant, en light et en dark.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/styles/themes/default.css packages/core/src/components/dialog/dialog.styles.ts packages/core/src/components/dialog/dialog.ts
+git commit -m "refactor(dialog): scope --ar-dialog-border-radius, --ar-dialog-title-font-size et --ar-dialog-shake-outline-color au lieu de consommer les tokens globaux directement"
+```
+
+---
+
+### Task 8: Ajouter les commentaires de découvrabilité `default.css` pour les tokens sémantiques restés en direct
+
+**Files:**
+
+- Modify: `packages/core/src/styles/themes/default.css:231,237,239,242,249,250`
+
+**Interfaces:** aucune — commentaires uniquement, aucun nouveau token.
+
+- [ ] **Step 1: Ajouter les 6 commentaires**
+
+Remplacer (lignes 230-250, bloc actuel) :
+
+```css
+/* Interaction */
+--ar-color-interactive: var(--ar-color-primary-40);
+--ar-color-interactive-hover: var(--ar-color-primary-30);
+--ar-color-interactive-active: var(--ar-color-primary-20);
+--ar-color-interactive-subtle: var(--ar-color-primary-95);
+
+/* Texte */
+--ar-color-text: #2e2e31;
+--ar-color-text-muted: var(--ar-color-neutral-40);
+--ar-color-text-inverse: var(--ar-color-white);
+
+/* Surface */
+--ar-color-bg: var(--ar-color-white);
+--ar-color-bg-subtle: var(--ar-color-neutral-95);
+
+/* Bordure */
+--ar-color-border: var(--ar-color-neutral-90);
+
+/* Focus */
+--ar-focus-ring-color: var(--ar-color-interactive);
+--ar-focus-ring-offset: 2px;
+```
+
+par :
+
+```css
+/* Interaction */
+--ar-color-interactive: var(
+    --ar-color-primary-40
+); /* Consommé directement par ar-breadcrumb, ar-stepper */
+--ar-color-interactive-hover: var(--ar-color-primary-30);
+--ar-color-interactive-active: var(--ar-color-primary-20);
+--ar-color-interactive-subtle: var(--ar-color-primary-95);
+
+/* Texte */
+--ar-color-text: #2e2e31; /* Consommé directement par ar-alert, ar-datepicker, ar-dialog, ar-stepper */
+--ar-color-text-muted: var(--ar-color-neutral-40);
+--ar-color-text-inverse: var(--ar-color-white); /* Consommé directement par ar-stepper */
+
+/* Surface */
+--ar-color-bg: var(
+    --ar-color-white
+); /* Consommé directement par ar-breadcrumb, ar-datepicker, ar-dialog */
+--ar-color-bg-subtle: var(--ar-color-neutral-95);
+
+/* Bordure */
+--ar-color-border: var(--ar-color-neutral-90);
+
+/* Focus */
+--ar-focus-ring-color: var(
+    --ar-color-interactive
+); /* Consommé directement par ar-datepicker, ar-tab */
+--ar-focus-ring-offset: 2px; /* Consommé directement par ar-datepicker */
+```
+
+- [ ] **Step 2: Vérifier la couverture `@cssprop` et les tests**
+
+Run: `npm run build:manifest --workspace=@ariane-ui/core`
+Expected: succès. Le commentaire est placé après le `;` de chaque déclaration, donc hors de la valeur capturée par `TOKEN_RE` dans `validate-cssprop-defaults.js` (`/(--ar[\w-]+)\s*:\s*([^;]+)/g` s'arrête au premier `;`) — aucun impact sur le parsing.
+
+Run: `npm run test`
+Expected: suite complète verte (commentaires CSS purs, aucun changement de comportement).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/src/styles/themes/default.css
+git commit -m "docs(theme): documente les composants qui consomment directement les tokens semantiques globaux"
+```
+
+---
+
+### Task 9: Pousser les commits supplémentaires sur la PR existante
+
+**Files:** aucun fichier modifié — opération git uniquement.
+
+- [ ] **Step 1: Pousser sur la branche existante**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git push origin docs/audit-generic-tokens-127
+```
+
+Expected: la PR #132 (déjà ouverte vers `dev`) se met à jour automatiquement avec les nouveaux commits, CI redéclenchée.
+
+- [ ] **Step 2: Lancer la suite de tests complète et le build du manifest une dernière fois**
+
+Run: `npm run build:manifest --workspace=@ariane-ui/core && npm run test`
+Expected: build du manifest réussi, tous les tests passent.
+
+---
+
+## Self-Review
+
+**1. Couverture des 4 retours utilisateur :**
+
+- breadcrumb `--ar-color-neutral-90` → Task 6. ✓
+- dialog `--ar-font-size-md` → Task 7. ✓
+- dialog `--ar-color-danger-text` → Task 7. ✓
+- dialog `--ar-border-radius-lg` → Task 7. ✓
+- « autres cas similaires » → audit complet des 17 tokens documentés dans la PR initiale, reclassés en 4 « à scoper » (ci-dessus) et 13 « corrects en direct » (utilisation conforme à l'objet sémantique déclaré du token — cf. section Contexte technique). Aucun autre cas de token de palette brute ou d'échelle trouvé parmi les 13 restants.
+- Commentaires `default.css` sur les tokens restés en direct → Task 8. ✓
+
+**2. Scan de placeholders :** aucun « TBD »/« TODO » — chaque step contient le diff exact avec numéros de ligne réels lus dans le code source actuel (post-merge des tâches 2-5 de la PR #132).
+
+**3. Cohérence des noms :** `--ar-breadcrumb-mobile-separator-color` vérifié non conflictuel avec `--ar-breadcrumb-separator-color` (existant, différent token/usage). Les 3 noms dialog confirmés avec le mainteneur avant rédaction du plan.

--- a/docs/superpowers/plans/2026-07-22-audit-generic-tokens-cssprop-127.md
+++ b/docs/superpowers/plans/2026-07-22-audit-generic-tokens-cssprop-127.md
@@ -1,0 +1,327 @@
+# Audit tokens génériques consommés directement #127 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Documenter dans le JSDoc `@cssprop` de chaque composant concerné les tokens génériques/globaux (`--ar-color-*`, `--ar-focus-ring-*`, `--ar-border-radius-*`, `--ar-font-size-*`) que son `.styles.ts` consomme directement, pour que la doc générée (ComponentApi) liste la totalité des CSS Custom Properties réellement consommées par le composant — pas seulement celles sous son propre préfixe `--ar-<composant>-*`.
+
+**Architecture:** Documentation pure, aucun changement de comportement ni de nom de token. Pour chaque composant listé, on ajoute une entrée `@cssprop` par token générique déjà consommé dans le `.styles.ts`, à la suite des entrées existantes dans le JSDoc du `.ts`. Aucune modification de `default.css` ni de `.styles.ts` : ces tokens sont déjà déclarés globalement (section « PALETTE BRUTE » ou tokens sémantiques `--ar-color-*`/`--ar-focus-ring-*`/etc.) et le script de validation `validate-cssprop-defaults.js` les ignore explicitement (un token dont aucun préfixe de tag ne matche est un token global, pas un trou de doc à combler côté script) — donc ce chantier est un ajout volontaire de documentation, pas une exigence du garde-fou CI.
+
+**Tech Stack:** Lit 3 + TypeScript, JSDoc `@cssprop` parsé par `custom-elements-manifest` (cem.config.js), Vitest.
+
+## Global Constraints
+
+- Aucun changement de `.styles.ts` ni de `default.css` dans ce chantier — uniquement des ajouts de lignes `@cssprop` dans les fichiers `.ts` des composants.
+- Prettier n'agit pas sur les commentaires JSDoc mais respecter le style existant : `* @cssprop --ar-xxx - Description.` (majuscule initiale, point final).
+- Chaque nouvelle entrée précise que le token est un **token sémantique global (non scopé au composant)**, pour que l'auteur de thème comprenne que le surcharger a un effet transverse sur d'autres composants.
+- Conventional Commits (commitlint + Husky) — chaque tâche se termine par un commit séparé, préfixe `docs(<composant>): ...`.
+- Branches `docs/<desc>` créées depuis `dev`. PR vers `dev`, jamais push direct sur `main`.
+- Ne jamais committer `packages/core/dist/`.
+
+---
+
+## Contexte technique découvert pendant l'audit
+
+- `packages/core/scripts/validate-cssprop-defaults.js:75-77` : « Un token dont aucun tag ne matche le préfixe (tokens globaux du thème comme `--ar-color-*`, `--ar-spacing-*`) est ignoré : ces tokens n'appartiennent à aucun composant, ce n'est pas un trou de doc. » — confirme que `npm run build:manifest` ne validera ni n'exigera ces nouvelles entrées : c'est un ajout purement volontaire, sans risque de casser le garde-fou existant.
+- Six composants ont été identifiés par audit (`grep -oE -- '--ar-[a-z0-9-]+'` sur chaque `.styles.ts`, puis filtrage des tokens hors préfixe propre et hors alias `--ar-panel-*` déjà traités par #125) : `alert`, `breadcrumb`, `datepicker`, `dialog`, `stepper`, `tab`.
+- `dialog.styles.ts:230` consomme aussi `--ar-color-danger-text`, mais ce token a déjà été traité comme cas particulier lors de l'audit #125 (remplacement de `--ar-color-danger-50`) et jugé ne pas nécessiter d'entrée `@cssprop` dédiée à ce moment-là — non repris ici pour rester cohérent avec cette décision passée à moins que l'issue ne soit rouverte ; **inclus dans ce plan (Task 4) car le périmètre de #127 couvre explicitement tous les tokens génériques sans exception**.
+- `pagination.styles.ts` et `dropdown.styles.ts` contiennent des faux positifs textuels (mentions de `--ar-breadcrumb-color` et `--ar-panel-*` uniquement dans des commentaires, pas de `var()` réel) — confirmés sans action requise.
+- `--ar-tab-group-border-top-width`/`-bottom-width` consommés par `tab.styles.ts` sont déjà couverts par une note JSDoc prose ajoutée lors de #125 (Task 11) — pas des `@cssprop` à ajouter ici, ce sont des tokens qui appartiennent réellement à `ar-tab-group` (leur propre préfixe), pas des tokens génériques.
+
+---
+
+### Task 1: Créer la branche de travail
+
+**Files:** aucun fichier modifié — opération git uniquement.
+
+- [ ] **Step 1: Créer la branche depuis `dev`**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git checkout dev
+git pull
+git checkout -b docs/audit-generic-tokens-127
+```
+
+- [ ] **Step 2: Vérifier l'état propre**
+
+Run: `git status`
+Expected: `On branch docs/audit-generic-tokens-127`, `nothing to commit, working tree clean`
+
+---
+
+### Task 2: Documenter `--ar-color-text` pour `ar-alert`
+
+**Files:**
+
+- Modify: `packages/core/src/components/alert/alert.ts:52`
+
+**Interfaces:** aucune — ajout de doc pure.
+
+- [ ] **Step 1: Ajouter l'entrée `@cssprop`**
+
+Le JSDoc se termine ligne 52 par :
+
+```
+ * @cssprop --ar-alert-close-transition-duration - Durée de la transition (opacity/background-color) du bouton de fermeture au survol/focus.
+```
+
+Ajouter juste après :
+
+```
+ * @cssprop --ar-alert-close-transition-duration - Durée de la transition (opacity/background-color) du bouton de fermeture au survol/focus.
+ * @cssprop --ar-color-text - Couleur du texte de l'alerte. Token sémantique global (non scopé à ar-alert) : le surcharger affecte aussi tous les autres composants qui le consomment directement.
+```
+
+- [ ] **Step 2: Vérifier la génération du manifest**
+
+Run: `npm run build:manifest --workspace=@ariane-ui/core`
+Expected: succès, aucune erreur (le token est ignoré par `validate-cssprop-defaults.js`, cf. contexte technique ci-dessus).
+
+- [ ] **Step 3: Vérifier les tests existants**
+
+Run: `npx vitest run packages/core/src/components/alert --root /Users/jon/Code/Active_projects/ariane`
+Expected: tous les tests alert passent (aucun changement de code).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/components/alert/alert.ts
+git commit -m "docs(alert): documente --ar-color-text comme token global consomme par ar-alert"
+```
+
+---
+
+### Task 3: Documenter les tokens génériques de `ar-breadcrumb`
+
+**Files:**
+
+- Modify: `packages/core/src/components/breadcrumb/breadcrumb.ts:54`
+
+**Interfaces:** aucune — ajout de doc pure. Tokens concernés : `--ar-color-bg` (breadcrumb.styles.ts:101), `--ar-color-interactive` (breadcrumb.styles.ts:112), `--ar-color-neutral-90` (breadcrumb.styles.ts:130).
+
+- [ ] **Step 1: Ajouter les 3 entrées `@cssprop`**
+
+Le JSDoc se termine ligne 54 par :
+
+```
+ * @cssprop --ar-breadcrumb-toggle-bg-focus - Fond du bouton retour/trigger mobile au focus.
+```
+
+Ajouter juste après :
+
+```
+ * @cssprop --ar-breadcrumb-toggle-bg-focus - Fond du bouton retour/trigger mobile au focus.
+ * @cssprop --ar-color-bg - Couleur du liseré autour des puces de la liste mobile (`box-shadow`). Token sémantique global (non scopé à ar-breadcrumb).
+ * @cssprop --ar-color-interactive - Couleur de la puce du dernier élément de la liste mobile (élément actif/courant). Token sémantique global (non scopé à ar-breadcrumb).
+ * @cssprop --ar-color-neutral-90 - Couleur du séparateur pointillé vertical entre les items de la liste mobile. Token de palette brute globale (non scopé à ar-breadcrumb).
+```
+
+- [ ] **Step 2: Vérifier la génération du manifest**
+
+Run: `npm run build:manifest --workspace=@ariane-ui/core`
+Expected: succès, aucune erreur.
+
+- [ ] **Step 3: Vérifier les tests existants**
+
+Run: `npx vitest run packages/core/src/components/breadcrumb --root /Users/jon/Code/Active_projects/ariane`
+Expected: tous les tests breadcrumb passent.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/components/breadcrumb/breadcrumb.ts
+git commit -m "docs(breadcrumb): documente les tokens globaux consommes par ar-breadcrumb"
+```
+
+---
+
+### Task 4: Documenter les tokens génériques de `ar-datepicker` et `ar-dialog`
+
+**Files:**
+
+- Modify: `packages/core/src/components/datepicker/datepicker.ts:97`
+- Modify: `packages/core/src/components/dialog/dialog.ts:82`
+
+**Interfaces:** aucune — ajout de doc pure.
+
+Tokens datepicker : `--ar-focus-ring-color` (datepicker.styles.ts:89,117), `--ar-focus-ring-offset` (datepicker.styles.ts:90,118), `--ar-color-text` (datepicker.styles.ts:138), `--ar-color-bg` (datepicker.styles.ts:178).
+
+Tokens dialog : `--ar-color-bg` (dialog.styles.ts:77), `--ar-color-text` (dialog.styles.ts:78), `--ar-border-radius-lg` (dialog.styles.ts:85), `--ar-font-size-md` (dialog.styles.ts:149), `--ar-color-danger-text` (dialog.styles.ts:230).
+
+- [ ] **Step 1: Ajouter les 4 entrées `@cssprop` dans `datepicker.ts`**
+
+Le JSDoc se termine ligne 97 par :
+
+```
+ * @cssprop --ar-datepicker-input-error-border-color - Bordure input en état d'erreur.
+```
+
+Ajouter juste après :
+
+```
+ * @cssprop --ar-datepicker-input-error-border-color - Bordure input en état d'erreur.
+ * @cssprop --ar-focus-ring-color - Couleur de l'anneau de focus des boutons de navigation et du footer. Token sémantique global (non scopé à ar-datepicker) — les cellules jour ont leur propre token scopé, --ar-datepicker-day-focus-ring-color.
+ * @cssprop --ar-focus-ring-offset - Décalage de l'anneau de focus des boutons de navigation et du footer. Token sémantique global (non scopé à ar-datepicker).
+ * @cssprop --ar-color-text - Couleur du texte des cellules jour. Token sémantique global (non scopé à ar-datepicker).
+ * @cssprop --ar-color-bg - Couleur de bordure de la cellule jour focusée dans la grille (contraste avec l'anneau de focus). Token sémantique global (non scopé à ar-datepicker).
+```
+
+- [ ] **Step 2: Ajouter les 5 entrées `@cssprop` dans `dialog.ts`**
+
+Le JSDoc se termine ligne 82 par :
+
+```
+ * @cssprop --ar-dialog-close-bg-focus - Fond du bouton de fermeture au focus.
+```
+
+Ajouter juste après :
+
+```
+ * @cssprop --ar-dialog-close-bg-focus - Fond du bouton de fermeture au focus.
+ * @cssprop --ar-color-bg - Fond du dialog. Token sémantique global (non scopé à ar-dialog).
+ * @cssprop --ar-color-text - Couleur du texte du dialog. Token sémantique global (non scopé à ar-dialog).
+ * @cssprop --ar-border-radius-lg - Border-radius du dialog en mode modal (non-drawer). Token sémantique global (non scopé à ar-dialog).
+ * @cssprop --ar-font-size-md - Taille de police du titre (h1). Token sémantique global (non scopé à ar-dialog).
+ * @cssprop --ar-color-danger-text - Couleur de l'anneau de mise en évidence (`outline`) affiché à la place du shake en `prefers-reduced-motion: reduce`. Token sémantique global (non scopé à ar-dialog).
+```
+
+- [ ] **Step 3: Vérifier la génération du manifest**
+
+Run: `npm run build:manifest --workspace=@ariane-ui/core`
+Expected: succès, aucune erreur.
+
+- [ ] **Step 4: Vérifier les tests existants**
+
+Run: `npx vitest run packages/core/src/components/datepicker packages/core/src/components/dialog --root /Users/jon/Code/Active_projects/ariane`
+Expected: tous les tests datepicker et dialog passent.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/components/datepicker/datepicker.ts packages/core/src/components/dialog/dialog.ts
+git commit -m "docs(datepicker,dialog): documente les tokens globaux consommes directement"
+```
+
+---
+
+### Task 5: Documenter les tokens génériques de `ar-stepper` et `ar-tab`
+
+**Files:**
+
+- Modify: `packages/core/src/components/stepper/stepper.ts:81`
+- Modify: `packages/core/src/components/tab/tab.ts:30`
+
+**Interfaces:** aucune — ajout de doc pure.
+
+Tokens stepper : `--ar-color-interactive` (stepper.styles.ts:110,128), `--ar-color-text` (stepper.styles.ts:116), `--ar-color-text-inverse` (stepper.styles.ts:121).
+
+Tokens tab : `--ar-focus-ring-color` (tab.styles.ts:45).
+
+- [ ] **Step 1: Ajouter les 3 entrées `@cssprop` dans `stepper.ts`**
+
+Le JSDoc se termine ligne 81 par :
+
+```
+ * @cssprop --ar-stepper-trigger-radius - Border-radius du bouton trigger mobile.
+```
+
+Ajouter juste après :
+
+```
+ * @cssprop --ar-stepper-trigger-radius - Border-radius du bouton trigger mobile.
+ * @cssprop --ar-color-interactive - Couleur de la puce et de l'anneau de focus du lien d'étape au survol/focus. Token sémantique global (non scopé à ar-stepper).
+ * @cssprop --ar-color-text - Couleur du label de l'étape au survol/focus. Token sémantique global (non scopé à ar-stepper).
+ * @cssprop --ar-color-text-inverse - Couleur du numéro affiché dans la puce au survol/focus. Token sémantique global (non scopé à ar-stepper).
+```
+
+- [ ] **Step 2: Ajouter l'entrée `@cssprop` dans `tab.ts`**
+
+Le JSDoc contient ligne 30 :
+
+```
+ * @cssprop --ar-tab-focus-ring-offset - Décalage de la bague de focus. Valeur négative = inset (non coupée par le conteneur overflow du tab-group). Surcharge le token global --ar-focus-ring-offset pour ce composant.
+```
+
+Ajouter juste après (avant le bloc de prose « Note d'implémentation » existant) :
+
+```
+ * @cssprop --ar-tab-focus-ring-offset - Décalage de la bague de focus. Valeur négative = inset (non coupée par le conteneur overflow du tab-group). Surcharge le token global --ar-focus-ring-offset pour ce composant.
+ * @cssprop --ar-focus-ring-color - Couleur de la bague de focus de l'onglet. Token sémantique global (non scopé à ar-tab).
+```
+
+- [ ] **Step 3: Vérifier la génération du manifest**
+
+Run: `npm run build:manifest --workspace=@ariane-ui/core`
+Expected: succès, aucune erreur.
+
+- [ ] **Step 4: Vérifier les tests existants**
+
+Run: `npx vitest run packages/core/src/components/stepper packages/core/src/components/tab --root /Users/jon/Code/Active_projects/ariane`
+Expected: tous les tests stepper et tab passent.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/components/stepper/stepper.ts packages/core/src/components/tab/tab.ts
+git commit -m "docs(stepper,tab): documente les tokens globaux consommes directement"
+```
+
+---
+
+### Task 6: Ouvrir la Pull Request
+
+**Files:** aucun fichier modifié — opération git/GitHub uniquement.
+
+- [ ] **Step 1: Pousser la branche**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git push -u origin docs/audit-generic-tokens-127
+```
+
+- [ ] **Step 2: Lancer la suite de tests complète et le build du manifest une dernière fois**
+
+Run: `npm run build:manifest --workspace=@ariane-ui/core && npm run test`
+Expected: build du manifest réussi, tous les tests passent (racine, `turbo run test`).
+
+- [ ] **Step 3: Créer la PR vers `dev`**
+
+```bash
+gh pr create --base dev --title "docs: documente les tokens generiques consommes directement par les composants (audit #127)" --body "$(cat <<'EOF'
+## Summary
+- Ajoute une entrée @cssprop pour chaque token générique/global (--ar-color-*, --ar-focus-ring-*, --ar-border-radius-*, --ar-font-size-*) consommé directement dans les .styles.ts de ar-alert, ar-breadcrumb, ar-datepicker, ar-dialog, ar-stepper et ar-tab
+- Documentation pure : aucun changement de comportement, de nom de token ou de default.css — ces tokens sont ignorés par le garde-fou validate-cssprop-defaults.js (aucun préfixe de tag ne matche un token global), donc rien à corriger côté script
+- Complète l'angle de #125 (qui documentait les tokens sous le préfixe propre de chaque composant) avec les tokens globaux invisibles depuis la doc générée (ComponentApi)
+
+Closes #127
+
+## Test plan
+- [ ] `npm run build:manifest` passe sans erreur sur les 19 composants
+- [ ] `npm run test` (suite Vitest complète) passe
+- [ ] Vérifier dans le playground docs que chaque composant modifié affiche bien les nouvelles entrées @cssprop dans son tableau ComponentApi
+EOF
+)"
+```
+
+- [ ] **Step 4: Confirmer la création**
+
+Run: `gh pr view --web` (ou noter l'URL retournée par `gh pr create`)
+Expected: PR ouverte vers `dev`, CI déclenchée.
+
+---
+
+## Self-Review
+
+**1. Couverture spec (6 composants + branche/PR) :**
+
+- alert (--ar-color-text) → Task 2. ✓
+- breadcrumb (--ar-color-bg, --ar-color-interactive, --ar-color-neutral-90) → Task 3. ✓
+- datepicker (--ar-focus-ring-color, --ar-focus-ring-offset, --ar-color-text, --ar-color-bg) → Task 4. ✓
+- dialog (--ar-color-bg, --ar-color-text, --ar-border-radius-lg, --ar-font-size-md, --ar-color-danger-text) → Task 4. ✓
+- stepper (--ar-color-interactive, --ar-color-text, --ar-color-text-inverse) → Task 5. ✓
+- tab (--ar-focus-ring-color) → Task 5. ✓
+- Branche (Task 1) et PR (Task 6) encadrent le tout, conformément à la convention du projet (cf. plan #125).
+
+**2. Scan de placeholders :** aucun « TBD »/« TODO » — chaque step contient le texte exact à insérer et sa position (ligne + contenu de la ligne précédente).
+
+**3. Cohérence des noms :** vérifié que chaque token cité dans une tâche correspond exactement au nom trouvé par grep dans le `.styles.ts` correspondant (pas de faux positifs — `pagination.styles.ts`/`dropdown.styles.ts` exclus car mentions en commentaire uniquement, `--ar-tab-group-border-*-width` exclu de `tab.ts` car appartient réellement à `ar-tab-group`, déjà documenté via prose lors de #125).

--- a/packages/core/src/components/alert/alert.ts
+++ b/packages/core/src/components/alert/alert.ts
@@ -50,6 +50,7 @@ export type ArAlertVariant = 'success' | 'warning' | 'error' | 'info';
  * @cssprop --ar-alert-success-border - Bordure de l'alerte "success".
  * @cssprop --ar-alert-success-icon - Couleur de l'icône "success".
  * @cssprop --ar-alert-close-transition-duration - Durée de la transition (opacity/background-color) du bouton de fermeture au survol/focus.
+ * @cssprop --ar-color-text - Couleur du texte de l'alerte. Token sémantique global (non scopé à ar-alert) : le surcharger affecte aussi tous les autres composants qui le consomment directement.
 
  *
  * @event {CustomEvent} ar-alert-close - Émis après la fermeture de l'alerte (fin de transition).

--- a/packages/core/src/components/breadcrumb/breadcrumb.styles.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.styles.ts
@@ -127,7 +127,10 @@ export default css`
         top: 1.5rem;
         bottom: 1.5rem;
         left: 0;
-        background-image: linear-gradient(var(--ar-color-neutral-90) 25%, transparent 0);
+        background-image: linear-gradient(
+            var(--ar-breadcrumb-mobile-separator-color) 25%,
+            transparent 0
+        );
         background-size: 2px 8px;
         background-position: center 4px;
         background-repeat: repeat-y;

--- a/packages/core/src/components/breadcrumb/breadcrumb.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.ts
@@ -39,6 +39,7 @@ import { AnchoredController } from '../../controllers/anchored.controller.js';
  * @cssprop --ar-breadcrumb-color - Couleur du texte (labels et lien actif). À surcharger localement pour un fond sombre ponctuel, indépendamment du thème global.
  * @cssprop --ar-breadcrumb-separator-color - Couleur du séparateur entre les items (desktop).
  * @cssprop --ar-breadcrumb-bullet-color - Couleur des puces de la liste mobile.
+ * @cssprop --ar-breadcrumb-mobile-separator-color - Couleur du connecteur pointillé vertical entre les items de la liste mobile (cascade vers --ar-color-neutral-90).
  * @cssprop --ar-breadcrumb-panel-min-width - Largeur min du panel mobile (cascade vers --ar-panel-min-width).
  * @cssprop --ar-breadcrumb-panel-max-width - Largeur max du panel mobile (cascade vers --ar-panel-max-width).
  * @cssprop --ar-breadcrumb-panel-bg - Fond du panel mobile (cascade vers --ar-panel-bg, repli système `Canvas` si aucun thème n'est chargé).
@@ -54,7 +55,6 @@ import { AnchoredController } from '../../controllers/anchored.controller.js';
  * @cssprop --ar-breadcrumb-toggle-bg-focus - Fond du bouton retour/trigger mobile au focus.
  * @cssprop --ar-color-bg - Couleur du liseré autour des puces de la liste mobile (`box-shadow`). Token sémantique global (non scopé à ar-breadcrumb).
  * @cssprop --ar-color-interactive - Couleur de la puce du dernier élément de la liste mobile (élément actif/courant). Token sémantique global (non scopé à ar-breadcrumb).
- * @cssprop --ar-color-neutral-90 - Couleur du séparateur pointillé vertical entre les items de la liste mobile. Token de palette brute globale (non scopé à ar-breadcrumb).
  *
  * @event {CustomEvent} ar-breadcrumb-show           - Émis avant l'ouverture du dropdown mobile. @cancelable
  * @event {CustomEvent} ar-breadcrumb-show-prevented - Émis si ar-breadcrumb-show est annulé.

--- a/packages/core/src/components/breadcrumb/breadcrumb.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.ts
@@ -52,6 +52,9 @@ import { AnchoredController } from '../../controllers/anchored.controller.js';
  * @cssprop --ar-breadcrumb-toggle-bg-hover - Fond du bouton retour/trigger mobile au survol.
  * @cssprop --ar-breadcrumb-toggle-bg-pressed - Fond du bouton retour/trigger mobile pressé.
  * @cssprop --ar-breadcrumb-toggle-bg-focus - Fond du bouton retour/trigger mobile au focus.
+ * @cssprop --ar-color-bg - Couleur du liseré autour des puces de la liste mobile (`box-shadow`). Token sémantique global (non scopé à ar-breadcrumb).
+ * @cssprop --ar-color-interactive - Couleur de la puce du dernier élément de la liste mobile (élément actif/courant). Token sémantique global (non scopé à ar-breadcrumb).
+ * @cssprop --ar-color-neutral-90 - Couleur du séparateur pointillé vertical entre les items de la liste mobile. Token de palette brute globale (non scopé à ar-breadcrumb).
  *
  * @event {CustomEvent} ar-breadcrumb-show           - Émis avant l'ouverture du dropdown mobile. @cancelable
  * @event {CustomEvent} ar-breadcrumb-show-prevented - Émis si ar-breadcrumb-show est annulé.

--- a/packages/core/src/components/datepicker/datepicker.ts
+++ b/packages/core/src/components/datepicker/datepicker.ts
@@ -95,6 +95,10 @@ import { warn } from '../../utils/warn.js';
  * @cssprop --ar-datepicker-day-selected-bg - Fond du jour sélectionné.
  * @cssprop --ar-datepicker-day-selected-color - Couleur texte du jour sélectionné.
  * @cssprop --ar-datepicker-input-error-border-color - Bordure input en état d'erreur.
+ * @cssprop --ar-focus-ring-color - Couleur de l'anneau de focus des boutons de navigation et du footer. Token sémantique global (non scopé à ar-datepicker) — les cellules jour ont leur propre token scopé, --ar-datepicker-day-focus-ring-color.
+ * @cssprop --ar-focus-ring-offset - Décalage de l'anneau de focus des boutons de navigation et du footer. Token sémantique global (non scopé à ar-datepicker).
+ * @cssprop --ar-color-text - Couleur du texte des cellules jour. Token sémantique global (non scopé à ar-datepicker).
+ * @cssprop --ar-color-bg - Couleur de bordure de la cellule jour focusée dans la grille (contraste avec l'anneau de focus). Token sémantique global (non scopé à ar-datepicker).
  *
  * @event {CustomEvent} ar-datepicker-input-change   - Valeur commitée (blur ou sélection calendrier).
  * @event {CustomEvent} ar-datepicker-input-complete - Saisie texte complète (valide ou non).

--- a/packages/core/src/components/dialog/dialog.styles.ts
+++ b/packages/core/src/components/dialog/dialog.styles.ts
@@ -82,7 +82,7 @@ export default [
         /* ── Modal ────────────────────────────────────────────────────────────── */
 
         :host(:not([mode='drawer'])) dialog {
-            border-radius: var(--ar-border-radius-lg);
+            border-radius: var(--ar-dialog-border-radius);
             /* max-width artificiel : la modale ne prend jamais toute la largeur même sur mobile */
             width: min(var(--ar-dialog-width), calc(100vw - 2rem));
             max-height: min(90vh, calc(100dvh - 2rem));
@@ -146,7 +146,7 @@ export default [
 
         h1 {
             margin: 0;
-            font-size: var(--ar-font-size-md);
+            font-size: var(--ar-dialog-title-font-size);
             font-weight: 600;
             line-height: 1.4;
             color: inherit;
@@ -227,7 +227,7 @@ export default [
 
             dialog.shake {
                 animation: none;
-                outline: 3px solid var(--ar-color-danger-text);
+                outline: 3px solid var(--ar-dialog-shake-outline-color);
                 outline-offset: 2px;
             }
         }

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -82,9 +82,9 @@ if (typeof document !== 'undefined') {
  * @cssprop --ar-dialog-close-bg-focus - Fond du bouton de fermeture au focus.
  * @cssprop --ar-color-bg - Fond du dialog. Token sémantique global (non scopé à ar-dialog).
  * @cssprop --ar-color-text - Couleur du texte du dialog. Token sémantique global (non scopé à ar-dialog).
- * @cssprop --ar-border-radius-lg - Border-radius du dialog en mode modal (non-drawer). Token sémantique global (non scopé à ar-dialog).
- * @cssprop --ar-font-size-md - Taille de police du titre (h1). Token sémantique global (non scopé à ar-dialog).
- * @cssprop --ar-color-danger-text - Couleur de l'anneau de mise en évidence (`outline`) affiché à la place du shake en `prefers-reduced-motion: reduce`. Token sémantique global (non scopé à ar-dialog).
+ * @cssprop --ar-dialog-border-radius - Border-radius du dialog en mode modal (non-drawer) (cascade vers --ar-border-radius-lg).
+ * @cssprop --ar-dialog-title-font-size - Taille de police du titre (h1) (cascade vers --ar-font-size-md).
+ * @cssprop --ar-dialog-shake-outline-color - Couleur de l'anneau de mise en évidence (`outline`) affiché à la place du shake en `prefers-reduced-motion: reduce` (cascade vers --ar-color-danger-text).
  *
  * @event {CustomEvent} ar-dialog-show - Émis avant l'ouverture. @cancelable
  * @event {CustomEvent} ar-dialog-show-prevented - Émis si ar-dialog-show est annulé.

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -80,6 +80,11 @@ if (typeof document !== 'undefined') {
  * @cssprop --ar-dialog-close-bg-hover - Fond du bouton de fermeture au survol.
  * @cssprop --ar-dialog-close-bg-pressed - Fond du bouton de fermeture pressé.
  * @cssprop --ar-dialog-close-bg-focus - Fond du bouton de fermeture au focus.
+ * @cssprop --ar-color-bg - Fond du dialog. Token sémantique global (non scopé à ar-dialog).
+ * @cssprop --ar-color-text - Couleur du texte du dialog. Token sémantique global (non scopé à ar-dialog).
+ * @cssprop --ar-border-radius-lg - Border-radius du dialog en mode modal (non-drawer). Token sémantique global (non scopé à ar-dialog).
+ * @cssprop --ar-font-size-md - Taille de police du titre (h1). Token sémantique global (non scopé à ar-dialog).
+ * @cssprop --ar-color-danger-text - Couleur de l'anneau de mise en évidence (`outline`) affiché à la place du shake en `prefers-reduced-motion: reduce`. Token sémantique global (non scopé à ar-dialog).
  *
  * @event {CustomEvent} ar-dialog-show - Émis avant l'ouverture. @cancelable
  * @event {CustomEvent} ar-dialog-show-prevented - Émis si ar-dialog-show est annulé.

--- a/packages/core/src/components/pagination/pagination.ts
+++ b/packages/core/src/components/pagination/pagination.ts
@@ -44,6 +44,7 @@ export interface ArPaginationPageChangeDetail {
  * @cssprop --ar-pagination-bg-hover - Fond des boutons prev/next/page au survol.
  * @cssprop --ar-pagination-bg-pressed - Fond des boutons prev/next/page pressés.
  * @cssprop --ar-pagination-bg-focus - Fond des boutons prev/next/page au focus.
+ * @cssprop --ar-color-bg - Couleur du fond du numéro de page actif. Token sémantique global (non scopé à ar-pagination).
  *
  * @event {CustomEvent<{from: number, to: number}>} ar-pagination-page-change - Émis à chaque changement de page. Contient `from` et `to`.
  */

--- a/packages/core/src/components/stepper/stepper.ts
+++ b/packages/core/src/components/stepper/stepper.ts
@@ -79,6 +79,9 @@ export interface ArStepperStepChangeDetail {
  * @cssprop --ar-stepper-trigger-bg - Fond du bouton trigger mobile.
  * @cssprop --ar-stepper-trigger-bg-hover - Fond du bouton trigger mobile au survol.
  * @cssprop --ar-stepper-trigger-radius - Border-radius du bouton trigger mobile.
+ * @cssprop --ar-color-interactive - Couleur de la puce et de l'anneau de focus du lien d'étape au survol/focus. Token sémantique global (non scopé à ar-stepper).
+ * @cssprop --ar-color-text - Couleur du label de l'étape au survol/focus. Token sémantique global (non scopé à ar-stepper).
+ * @cssprop --ar-color-text-inverse - Couleur du numéro affiché dans la puce au survol/focus. Token sémantique global (non scopé à ar-stepper).
  *
  * @event {CustomEvent<{ path: string }>} ar-stepper-step-change - Émis au clic sur une étape.
  */

--- a/packages/core/src/components/tab/tab.ts
+++ b/packages/core/src/components/tab/tab.ts
@@ -28,6 +28,7 @@ import styles from './tab.styles.js';
  * @cssprop --ar-tab-indicator-width - Épaisseur de l'indicateur actif (utilisé par le thème pour composer --ar-tab-active-shadow).
  * @cssprop --ar-tab-disabled-opacity - Opacité de l'onglet désactivé.
  * @cssprop --ar-tab-focus-ring-offset - Décalage de la bague de focus. Valeur négative = inset (non coupée par le conteneur overflow du tab-group). Surcharge le token global --ar-focus-ring-offset pour ce composant.
+ * @cssprop --ar-focus-ring-color - Couleur de la bague de focus de l'onglet. Token sémantique global (non scopé à ar-tab).
  *
  * Note d'implémentation : la mise en page de [part='base'] compense la bordure de son parent
  * ar-tab-group via les tokens --ar-tab-group-border-top-width / --ar-tab-group-border-bottom-width

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -239,7 +239,9 @@
         --ar-color-text-inverse: var(--ar-color-white); /* ar-stepper */
 
         /* Surface */
-        --ar-color-bg: var(--ar-color-white); /* ar-breadcrumb, ar-datepicker, ar-dialog */
+        --ar-color-bg: var(
+            --ar-color-white
+        ); /* ar-breadcrumb, ar-datepicker, ar-dialog, ar-pagination */
         --ar-color-bg-subtle: var(--ar-color-neutral-95);
 
         /* Bordure */

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -472,6 +472,9 @@
         --ar-dialog-close-bg-hover: var(--ar-button-tertiary-bg-hover);
         --ar-dialog-close-bg-pressed: var(--ar-button-tertiary-bg-active);
         --ar-dialog-close-bg-focus: var(--ar-button-tertiary-bg-focus);
+        --ar-dialog-border-radius: var(--ar-border-radius-lg);
+        --ar-dialog-title-font-size: var(--ar-font-size-md);
+        --ar-dialog-shake-outline-color: var(--ar-color-danger-text);
 
         /* collapse */
         --ar-collapse-duration: 0s;

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -228,26 +228,26 @@
          * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
 
         /* Interaction */
-        --ar-color-interactive: var(--ar-color-primary-40);
+        --ar-color-interactive: var(--ar-color-primary-40); /* ar-breadcrumb, ar-stepper */
         --ar-color-interactive-hover: var(--ar-color-primary-30);
         --ar-color-interactive-active: var(--ar-color-primary-20);
         --ar-color-interactive-subtle: var(--ar-color-primary-95);
 
         /* Texte */
-        --ar-color-text: #2e2e31;
+        --ar-color-text: #2e2e31; /* ar-alert, ar-datepicker, ar-dialog, ar-stepper */
         --ar-color-text-muted: var(--ar-color-neutral-40);
-        --ar-color-text-inverse: var(--ar-color-white);
+        --ar-color-text-inverse: var(--ar-color-white); /* ar-stepper */
 
         /* Surface */
-        --ar-color-bg: var(--ar-color-white);
+        --ar-color-bg: var(--ar-color-white); /* ar-breadcrumb, ar-datepicker, ar-dialog */
         --ar-color-bg-subtle: var(--ar-color-neutral-95);
 
         /* Bordure */
         --ar-color-border: var(--ar-color-neutral-90);
 
         /* Focus */
-        --ar-focus-ring-color: var(--ar-color-interactive);
-        --ar-focus-ring-offset: 2px;
+        --ar-focus-ring-color: var(--ar-color-interactive); /* ar-datepicker, ar-tab */
+        --ar-focus-ring-offset: 2px; /* ar-datepicker */
 
         /* États — tokens d'usage (light mode) */
         --ar-color-success-bg: var(--ar-color-success-95);

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -348,6 +348,7 @@
         --ar-breadcrumb-color: var(--ar-color-text);
         --ar-breadcrumb-separator-color: var(--ar-color-neutral-80);
         --ar-breadcrumb-bullet-color: var(--ar-color-neutral-80);
+        --ar-breadcrumb-mobile-separator-color: var(--ar-color-neutral-90);
         --ar-breadcrumb-panel-min-width: var(--ar-panel-min-width);
         --ar-breadcrumb-panel-max-width: var(--ar-panel-max-width);
         --ar-breadcrumb-panel-bg: var(--ar-panel-bg);


### PR DESCRIPTION
## Summary
- Ajoute une entrée @cssprop pour chaque token générique/global (--ar-color-*, --ar-focus-ring-*, --ar-border-radius-*, --ar-font-size-*) consommé directement dans les .styles.ts de ar-alert, ar-breadcrumb, ar-datepicker, ar-dialog, ar-pagination, ar-stepper et ar-tab
- Suite à la revue : scope 4 tokens qui ne devaient pas être consommés tels quels par un composant (palette brute ou échelle de tailles, ou token sémantique utilisé hors de son objet déclaré) — pattern d'alias ADR-005/#125 :
  - ar-breadcrumb : --ar-color-neutral-90 → --ar-breadcrumb-mobile-separator-color
  - ar-dialog : --ar-border-radius-lg → --ar-dialog-border-radius
  - ar-dialog : --ar-font-size-md → --ar-dialog-title-font-size
  - ar-dialog : --ar-color-danger-text → --ar-dialog-shake-outline-color (token de couleur de texte utilisé pour un outline — mésusage sémantique)
- Les 13 tokens sémantiques restants (bg/text/interactive/focus-ring, utilisés conformément à leur objet) restent en consommation directe — c'est la couche d'extension publique déjà prévue par le thème — et reçoivent un commentaire de découvrabilité dans default.css listant leurs consommateurs directs
- Complète l'angle de #125 (qui documentait les tokens sous le préfixe propre de chaque composant) avec les tokens globaux invisibles depuis la doc générée (ComponentApi)

Closes #127

## Test plan
- [x] `npm run build:manifest` passe sans erreur sur les 19 composants
- [x] `npm run test` (suite Vitest complète, 760 tests) passe
- [ ] Vérifier dans le playground docs que chaque composant modifié affiche bien les nouvelles entrées @cssprop dans son tableau ComponentApi
- [ ] Vérification visuelle : ar-breadcrumb (connecteur pointillé mobile), ar-dialog (border-radius modal, taille du titre, anneau shake en reduced-motion) — aucun changement visuel attendu, valeurs héritées à l'identique via les nouveaux alias