### PR TITLE
fix(tab): ajoute un fallback padding sur ar-tab

### DIFF
--- a/packages/core/src/components/tab/tab.styles.ts
+++ b/packages/core/src/components/tab/tab.styles.ts
@@ -15,7 +15,8 @@ export default css`
         align-items: center;
         color: var(--ar-tab-color);
         background: var(--ar-tab-bg);
-        padding: var(--ar-tab-padding-y) var(--ar-tab-padding-x);
+        /* a11y-fallback: sans thème, --ar-tab-bg reste transparent même par défaut — le padding est le seul mécanisme séparant visuellement des onglets adjacents ; sans lui les libellés se collent les uns aux autres */
+        padding: var(--ar-tab-padding-y, 1rem) var(--ar-tab-padding-x, 1.5rem);
         border-radius: inherit;
         margin-block-start: calc(-1 * var(--ar-tab-group-border-top-width, 0px));
         margin-block-end: calc(-1 * var(--ar-tab-group-border-bottom-width, 0px));


### PR DESCRIPTION
## Summary
Nouveau cas trouvé pendant la relecture des items déférés de #129 (`ar-tab-group`) : `--ar-tab-bg` reste `transparent` même thémé (`default.css`), donc le `padding` de chaque `ar-tab` est le seul mécanisme séparant visuellement des onglets adjacents. Sans fallback, il retombe à `0` et les libellés se collent sans limite perceptible pour un utilisateur voyant sans lecteur d'écran.

À distinguer de `--ar-tab-group-border-color` (bordure externe décorative du bandeau, explicitement exclue du périmètre de #129) : ce token-ci conditionne la distinction entre onglets individuels, pas une simple décoration.

Related to #129.

## Test plan
- [x] `npx vitest run tab` (depuis `packages/core`) — 75/75 tests passent