### PR TITLE
fix: généralise le scoping des tokens sémantiques (audit #129, volet architecture)

### DIFF
--- a/docs/superpowers/plans/2026-07-24-scoped-tokens-generalization-129.md
+++ b/docs/superpowers/plans/2026-07-24-scoped-tokens-generalization-129.md
@@ -1,0 +1,587 @@
+# Généralisation du scoping des tokens sémantiques (#129, volet architecture) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Scoper les 13 consommations directes de tokens sémantiques globaux (`--ar-color-bg`, `--ar-color-text`, `--ar-color-text-inverse`, `--ar-color-interactive`, `--ar-focus-ring-color`, `--ar-focus-ring-offset`) trouvées dans 6 composants (`alert`, `breadcrumb`, `stepper`, `datepicker`, `tab`, `pagination`), en appliquant la Règle 1 actée le 2026-07-23 (généralisation du scoping systématique — révoque l'exception « point d'extension public » posée dans l'addendum #127 du 2026-07-22 pour ces 6 tokens précis).
+
+**Architecture:** Reprend exactement le pattern d'alias déjà établi par #125/#128 (ADR-005) et généralisé par #127/PR #132 : le composant déclare son propre token `--ar-<composant>-<rôle>`, `default.css` l'aliase par défaut vers le token global concerné, et le `.styles.ts` du composant consomme uniquement son propre token scopé. Aucun changement visuel : chaque nouvel alias pointe par défaut vers exactement la même valeur héritée.
+
+**Tech Stack:** Lit 3 + TypeScript, CSS custom properties (`@layer ariane.theme` dans `packages/core/src/styles/themes/default.css`), `packages/core/scripts/validate-cssprop-defaults.js` (vérifie que chaque token de `default.css` a une entrée `@cssprop` correspondante dans le JSDoc du composant, exécuté via `npm run build:manifest`).
+
+## Global Constraints
+
+- Aucun changement visuel : chaque nouvel alias pointe par défaut vers exactement le token global qu'il remplace, même valeur héritée.
+- Chaque token scopé nouvellement créé remplace l'entrée `@cssprop` existante qui documentait la consommation directe (supprimer l'ancienne entrée « Token sémantique global (non scopé à ar-X) », ajouter la nouvelle avec la mention « cascade vers --ar-<token-global> »).
+- Prettier : 100 caractères, 4 espaces, quotes simples (appliqué automatiquement par `lint-staged` au commit).
+- Conventional Commits — chaque tâche se termine par un commit séparé.
+- Ne jamais committer `packages/core/dist/`.
+- Chaque tâche est indépendante (fichiers disjoints) — peut être exécutée dans n'importe quel ordre.
+- Vérification par tâche : `npx vitest run <nom-composant>` (depuis `packages/core/`) pour la non-régression comportementale, et `npm run build:manifest --workspace=packages/core` (depuis la racine) pour valider la couverture `@cssprop`/`default.css` (échoue si un token de `default.css` n'a pas d'entrée `@cssprop`, ou si le manifest ne se régénère pas proprement).
+
+---
+
+## Task 0: Corrige la dérive de documentation `datepicker.ts` (bug trouvé pendant l'audit)
+
+**Contexte:** PR #134 a changé `datepicker.styles.ts` pour référencer `--ar-panel-bg` au lieu de `--ar-color-bg` dans le cutout de focus de la cellule jour, mais a oublié de mettre à jour le JSDoc `@cssprop` correspondant dans `datepicker.ts`, qui documente encore `--ar-color-bg`. Trouvé pendant l'audit exploratoire du volet architecture — à corriger avant de toucher au reste du fichier dans la Task 4 (évite un conflit d'édition sur la même zone).
+
+**Files:**
+
+- Modify: `packages/core/src/components/datepicker/datepicker.ts:101`
+
+**Interfaces:** aucune — commentaire JSDoc uniquement, aucun changement de comportement ni de token.
+
+- [ ] **Step 1: Corriger l'entrée `@cssprop`**
+
+Dans `packages/core/src/components/datepicker/datepicker.ts`, remplacer la ligne 101 :
+
+```ts
+ * @cssprop --ar-color-bg - Couleur de bordure de la cellule jour focusée dans la grille (contraste avec l'anneau de focus). Token sémantique global (non scopé à ar-datepicker).
+```
+
+par :
+
+```ts
+ * @cssprop --ar-panel-bg - Couleur de bordure de la cellule jour focusée dans la grille (contraste avec l'anneau de focus). Le popover pilote son fond réel via ce token (panelStyles) ; référencer --ar-color-bg directement casserait ce cutout pour un consommateur ne surchargeant que --ar-panel-bg.
+```
+
+- [ ] **Step 2: Vérifier la génération du manifest**
+
+Run (depuis la racine du repo) : `npm run build:manifest --workspace=packages/core`
+Expected: aucune erreur `validate-cssprop-defaults`, sortie se termine par `Created new manifest.`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/src/components/datepicker/datepicker.ts
+git commit -m "docs(datepicker): corrige le token documenté du cutout de focus (--ar-panel-bg)"
+```
+
+---
+
+## Task 1: Scope `--ar-color-text` pour `ar-alert`
+
+**Files:**
+
+- Modify: `packages/core/src/styles/themes/default.css` (section `/* alert */`, ligne 296)
+- Modify: `packages/core/src/components/alert/alert.styles.ts:12`
+- Modify: `packages/core/src/components/alert/alert.ts:53`
+
+**Interfaces:** Produces `--ar-alert-color` (alias de `--ar-color-text`), consommé uniquement par `alert.styles.ts`.
+
+- [ ] **Step 1: Ajouter l'alias dans `default.css`**
+
+Dans la section `/* alert */` (ligne 296), ajouter en première ligne du bloc :
+
+```css
+/* alert */
+--ar-alert-color: var(--ar-color-text);
+--ar-alert-padding: 1rem;
+```
+
+- [ ] **Step 2: Consommer le token scopé dans `alert.styles.ts`**
+
+Remplacer (ligne 12) :
+
+```ts
+        color: var(--ar-color-text);
+```
+
+par :
+
+```ts
+        color: var(--ar-alert-color);
+```
+
+- [ ] **Step 3: Mettre à jour le JSDoc `@cssprop`**
+
+Dans `alert.ts`, remplacer (ligne 53) :
+
+```ts
+ * @cssprop --ar-color-text - Couleur du texte de l'alerte. Token sémantique global (non scopé à ar-alert) : le surcharger affecte aussi tous les autres composants qui le consomment directement.
+```
+
+par (à sa place alphabétique/logique dans le bloc, en tête des `@cssprop` de couleur) :
+
+```ts
+ * @cssprop --ar-alert-color - Couleur du texte de l'alerte (cascade vers --ar-color-text).
+```
+
+- [ ] **Step 4: Lancer les tests du composant**
+
+Run (depuis `packages/core/`) : `npx vitest run alert`
+Expected: tous les tests passent (aucune assertion sur la couleur de texte, changement purement visuel).
+
+- [ ] **Step 5: Vérifier la génération du manifest**
+
+Run (depuis la racine du repo) : `npm run build:manifest --workspace=packages/core`
+Expected: aucune erreur `validate-cssprop-defaults`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/styles/themes/default.css packages/core/src/components/alert/alert.styles.ts packages/core/src/components/alert/alert.ts
+git commit -m "fix(alert): scope --ar-color-text en --ar-alert-color (audit #129)"
+```
+
+---
+
+## Task 2: Scope `--ar-color-bg` et `--ar-color-interactive` pour `ar-breadcrumb`
+
+**Files:**
+
+- Modify: `packages/core/src/styles/themes/default.css` (section `/* breadcrumb */`, lignes 347-364)
+- Modify: `packages/core/src/components/breadcrumb/breadcrumb.styles.ts:101,112`
+- Modify: `packages/core/src/components/breadcrumb/breadcrumb.ts:56-57`
+
+**Interfaces:** Produces `--ar-breadcrumb-bullet-ring-color` (alias de `--ar-color-bg`) et `--ar-breadcrumb-active-bullet-color` (alias de `--ar-color-interactive`), consommés uniquement par `breadcrumb.styles.ts`.
+
+- [ ] **Step 1: Ajouter les alias dans `default.css`**
+
+Dans la section `/* breadcrumb */`, après la ligne `--ar-breadcrumb-mobile-separator-color: var(--ar-color-neutral-90);`, ajouter :
+
+```css
+--ar-breadcrumb-mobile-separator-color: var(--ar-color-neutral-90);
+--ar-breadcrumb-bullet-ring-color: var(--ar-color-bg);
+--ar-breadcrumb-active-bullet-color: var(--ar-color-interactive);
+```
+
+- [ ] **Step 2: Consommer les tokens scopés dans `breadcrumb.styles.ts`**
+
+Remplacer (ligne 101) :
+
+```ts
+        box-shadow: 0 0 0 2px var(--ar-color-bg);
+```
+
+par :
+
+```ts
+        box-shadow: 0 0 0 2px var(--ar-breadcrumb-bullet-ring-color);
+```
+
+Remplacer (ligne 112) :
+
+```ts
+        background-color: var(--ar-color-interactive);
+```
+
+par :
+
+```ts
+        background-color: var(--ar-breadcrumb-active-bullet-color);
+```
+
+- [ ] **Step 3: Mettre à jour le JSDoc `@cssprop`**
+
+Dans `breadcrumb.ts`, remplacer (lignes 56-57) :
+
+```ts
+ * @cssprop --ar-color-bg - Couleur du liseré autour des puces de la liste mobile (`box-shadow`). Token sémantique global (non scopé à ar-breadcrumb).
+ * @cssprop --ar-color-interactive - Couleur de la puce du dernier élément de la liste mobile (élément actif/courant). Token sémantique global (non scopé à ar-breadcrumb).
+```
+
+par :
+
+```ts
+ * @cssprop --ar-breadcrumb-bullet-ring-color - Couleur du liseré autour des puces de la liste mobile (`box-shadow`, cascade vers --ar-color-bg).
+ * @cssprop --ar-breadcrumb-active-bullet-color - Couleur de la puce du dernier élément de la liste mobile (élément actif/courant, cascade vers --ar-color-interactive).
+```
+
+- [ ] **Step 4: Lancer les tests du composant**
+
+Run (depuis `packages/core/`) : `npx vitest run breadcrumb`
+Expected: tous les tests passent.
+
+- [ ] **Step 5: Vérifier la génération du manifest**
+
+Run (depuis la racine du repo) : `npm run build:manifest --workspace=packages/core`
+Expected: aucune erreur `validate-cssprop-defaults`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/styles/themes/default.css packages/core/src/components/breadcrumb/breadcrumb.styles.ts packages/core/src/components/breadcrumb/breadcrumb.ts
+git commit -m "fix(breadcrumb): scope les tokens de puce mobile (audit #129)"
+```
+
+---
+
+## Task 3: Scope les 4 tokens hover/focus pour `ar-stepper`
+
+**Files:**
+
+- Modify: `packages/core/src/styles/themes/default.css` (section `/* stepper */`, lignes 366-388)
+- Modify: `packages/core/src/components/stepper/stepper.styles.ts:110,116,121,128`
+- Modify: `packages/core/src/components/stepper/stepper.ts:82-84`
+
+**Interfaces:** Produces `--ar-stepper-link-hover-bullet-color` (alias `--ar-color-interactive`), `--ar-stepper-link-hover-label-color` (alias `--ar-color-text`), `--ar-stepper-link-hover-bullet-text-color` (alias `--ar-color-text-inverse`), `--ar-stepper-link-focus-outline-color` (alias `--ar-color-interactive`) — consommés uniquement par `stepper.styles.ts`.
+
+- [ ] **Step 1: Ajouter les alias dans `default.css`**
+
+Dans la section `/* stepper */`, après la ligne `--ar-stepper-link-hover-color: var(--ar-color-text-muted);`, ajouter :
+
+```css
+--ar-stepper-link-hover-color: var(--ar-color-text-muted);
+--ar-stepper-link-hover-bullet-color: var(--ar-color-interactive);
+--ar-stepper-link-hover-label-color: var(--ar-color-text);
+--ar-stepper-link-hover-bullet-text-color: var(--ar-color-text-inverse);
+--ar-stepper-link-focus-outline-color: var(--ar-color-interactive);
+```
+
+- [ ] **Step 2: Consommer les tokens scopés dans `stepper.styles.ts`**
+
+Remplacer (ligne 110, bloc `.stepper-item .stepper-link:focus:before, .stepper-item .stepper-link:hover:before`) :
+
+```ts
+        background-color: var(--ar-color-interactive);
+```
+
+par :
+
+```ts
+        background-color: var(--ar-stepper-link-hover-bullet-color);
+```
+
+Remplacer (ligne 116, bloc `.stepper-item-label` au hover/focus) :
+
+```ts
+        color: var(--ar-color-text);
+```
+
+par :
+
+```ts
+        color: var(--ar-stepper-link-hover-label-color);
+```
+
+Remplacer (ligne 121, bloc `.stepper-item-bullet` au hover/focus) :
+
+```ts
+        color: var(--ar-color-text-inverse);
+```
+
+par :
+
+```ts
+        color: var(--ar-stepper-link-hover-bullet-text-color);
+```
+
+Remplacer (ligne 128, bloc `.stepper-link:focus`) :
+
+```ts
+        outline-color: var(--ar-color-interactive);
+```
+
+par :
+
+```ts
+        outline-color: var(--ar-stepper-link-focus-outline-color);
+```
+
+- [ ] **Step 3: Mettre à jour le JSDoc `@cssprop`**
+
+Dans `stepper.ts`, remplacer (lignes 82-84) :
+
+```ts
+ * @cssprop --ar-color-interactive - Couleur de la puce et de l'anneau de focus du lien d'étape au survol/focus. Token sémantique global (non scopé à ar-stepper).
+ * @cssprop --ar-color-text - Couleur du label de l'étape au survol/focus. Token sémantique global (non scopé à ar-stepper).
+ * @cssprop --ar-color-text-inverse - Couleur du numéro affiché dans la puce au survol/focus. Token sémantique global (non scopé à ar-stepper).
+```
+
+par :
+
+```ts
+ * @cssprop --ar-stepper-link-hover-bullet-color - Couleur de la puce du lien d'étape au survol/focus (cascade vers --ar-color-interactive).
+ * @cssprop --ar-stepper-link-hover-label-color - Couleur du label de l'étape au survol/focus (cascade vers --ar-color-text).
+ * @cssprop --ar-stepper-link-hover-bullet-text-color - Couleur du numéro affiché dans la puce au survol/focus (cascade vers --ar-color-text-inverse).
+ * @cssprop --ar-stepper-link-focus-outline-color - Couleur de l'anneau de focus du lien d'étape (cascade vers --ar-color-interactive).
+```
+
+- [ ] **Step 4: Lancer les tests du composant**
+
+Run (depuis `packages/core/`) : `npx vitest run stepper`
+Expected: tous les tests passent.
+
+- [ ] **Step 5: Vérifier la génération du manifest**
+
+Run (depuis la racine du repo) : `npm run build:manifest --workspace=packages/core`
+Expected: aucune erreur `validate-cssprop-defaults`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/styles/themes/default.css packages/core/src/components/stepper/stepper.styles.ts packages/core/src/components/stepper/stepper.ts
+git commit -m "fix(stepper): scope les tokens hover/focus du lien d'étape (audit #129)"
+```
+
+---
+
+## Task 4: Scope les 3 tokens restants pour `ar-datepicker`
+
+**Contexte:** Dépend de la Task 0 (doit être appliquée avant, même fichier `datepicker.ts`). La cellule jour a déjà ses propres tokens scopés pour le focus (`--ar-datepicker-day-focus-ring-color/-width/-offset`) ; l'incohérence porte sur les boutons nav/footer (encore en tokens génériques) et la couleur de base du texte des cellules.
+
+**Files:**
+
+- Modify: `packages/core/src/styles/themes/default.css` (section `/* ar-datepicker */`, lignes 530-617)
+- Modify: `packages/core/src/components/datepicker/datepicker.styles.ts:88-91,116-119,142`
+- Modify: `packages/core/src/components/datepicker/datepicker.ts:98,100` (101 déjà traité en Task 0)
+
+**Interfaces:** Produces `--ar-datepicker-nav-btn-focus-ring-color`/`--ar-datepicker-nav-btn-focus-ring-offset` (alias `--ar-focus-ring-color`/`--ar-focus-ring-offset`), `--ar-datepicker-footer-btn-focus-ring-color`/`--ar-datepicker-footer-btn-focus-ring-offset` (mêmes alias), `--ar-datepicker-day-color` (alias `--ar-color-text`) — consommés uniquement par `datepicker.styles.ts`.
+
+- [ ] **Step 1: Ajouter les alias dans `default.css`**
+
+Après `--ar-datepicker-nav-btn-active-bg: color-mix(...)` (fin du bloc nav-btn, ligne ~567), ajouter :
+
+```css
+--ar-datepicker-nav-btn-focus-ring-color: var(--ar-focus-ring-color);
+--ar-datepicker-nav-btn-focus-ring-offset: var(--ar-focus-ring-offset);
+```
+
+Après `--ar-datepicker-footer-btn-active-bg: color-mix(...)` (fin du bloc footer-btn, ligne ~587), ajouter :
+
+```css
+--ar-datepicker-footer-btn-focus-ring-color: var(--ar-focus-ring-color);
+--ar-datepicker-footer-btn-focus-ring-offset: var(--ar-focus-ring-offset);
+```
+
+Après `--ar-datepicker-day-font-size: 1rem;` (ligne 595), ajouter :
+
+```css
+--ar-datepicker-day-color: var(--ar-color-text);
+```
+
+- [ ] **Step 2: Consommer les tokens scopés dans `datepicker.styles.ts`**
+
+Remplacer (bloc `[part~='nav-btn']:focus-visible`) :
+
+```ts
+    [part~='nav-btn']:focus-visible {
+        outline: 2px solid var(--ar-focus-ring-color, ButtonText);
+        outline-offset: var(--ar-focus-ring-offset);
+    }
+```
+
+par :
+
+```ts
+    [part~='nav-btn']:focus-visible {
+        outline: 2px solid var(--ar-datepicker-nav-btn-focus-ring-color, ButtonText);
+        outline-offset: var(--ar-datepicker-nav-btn-focus-ring-offset);
+    }
+```
+
+Remplacer (bloc `[part~='footer-btn']:focus-visible`) :
+
+```ts
+    [part~='footer-btn']:focus-visible {
+        outline: 2px solid var(--ar-focus-ring-color, ButtonText);
+        outline-offset: var(--ar-focus-ring-offset);
+    }
+```
+
+par :
+
+```ts
+    [part~='footer-btn']:focus-visible {
+        outline: 2px solid var(--ar-datepicker-footer-btn-focus-ring-color, ButtonText);
+        outline-offset: var(--ar-datepicker-footer-btn-focus-ring-offset);
+    }
+```
+
+Remplacer (bloc `[part='day']`) :
+
+```ts
+    [part='day'] {
+        font-size: var(--ar-datepicker-day-font-size);
+        color: var(--ar-color-text);
+```
+
+par :
+
+```ts
+    [part='day'] {
+        font-size: var(--ar-datepicker-day-font-size);
+        color: var(--ar-datepicker-day-color);
+```
+
+- [ ] **Step 3: Mettre à jour le JSDoc `@cssprop`**
+
+Dans `datepicker.ts`, remplacer :
+
+```ts
+ * @cssprop --ar-focus-ring-color - Couleur de l'anneau de focus des boutons de navigation et du footer. Token sémantique global (non scopé à ar-datepicker) — les cellules jour ont leur propre token scopé, --ar-datepicker-day-focus-ring-color. Repli `ButtonText` si aucun thème n'est chargé (WCAG 2.4.7).
+ * @cssprop --ar-focus-ring-offset - Décalage de l'anneau de focus des boutons de navigation et du footer. Token sémantique global (non scopé à ar-datepicker).
+ * @cssprop --ar-color-text - Couleur du texte des cellules jour. Token sémantique global (non scopé à ar-datepicker).
+```
+
+par :
+
+```ts
+ * @cssprop --ar-datepicker-nav-btn-focus-ring-color - Couleur de l'anneau de focus des boutons de navigation (cascade vers --ar-focus-ring-color). Repli `ButtonText` si aucun thème n'est chargé (WCAG 2.4.7).
+ * @cssprop --ar-datepicker-nav-btn-focus-ring-offset - Décalage de l'anneau de focus des boutons de navigation (cascade vers --ar-focus-ring-offset).
+ * @cssprop --ar-datepicker-footer-btn-focus-ring-color - Couleur de l'anneau de focus des boutons du footer (cascade vers --ar-focus-ring-color). Repli `ButtonText` si aucun thème n'est chargé (WCAG 2.4.7).
+ * @cssprop --ar-datepicker-footer-btn-focus-ring-offset - Décalage de l'anneau de focus des boutons du footer (cascade vers --ar-focus-ring-offset).
+ * @cssprop --ar-datepicker-day-color - Couleur du texte des cellules jour (cascade vers --ar-color-text).
+```
+
+- [ ] **Step 4: Lancer les tests du composant**
+
+Run (depuis `packages/core/`) : `npx vitest run datepicker`
+Expected: tous les tests passent (81 tests attendus, cf. PR #134).
+
+- [ ] **Step 5: Vérifier la génération du manifest**
+
+Run (depuis la racine du repo) : `npm run build:manifest --workspace=packages/core`
+Expected: aucune erreur `validate-cssprop-defaults`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/styles/themes/default.css packages/core/src/components/datepicker/datepicker.styles.ts packages/core/src/components/datepicker/datepicker.ts
+git commit -m "fix(datepicker): scope les tokens focus nav/footer-btn et day-color (audit #129)"
+```
+
+---
+
+## Task 5: Scope `--ar-focus-ring-color` pour `ar-tab`
+
+**Files:**
+
+- Modify: `packages/core/src/styles/themes/default.css` (section `/* tab */`, ligne 503-522)
+- Modify: `packages/core/src/components/tab/tab.styles.ts:47`
+- Modify: `packages/core/src/components/tab/tab.ts:31`
+
+**Interfaces:** Produces `--ar-tab-focus-ring-color` (alias de `--ar-focus-ring-color`), consommé uniquement par `tab.styles.ts`. Le composant a déjà `--ar-tab-focus-ring-offset` scopé — ce token complète la paire.
+
+- [ ] **Step 1: Ajouter l'alias dans `default.css`**
+
+Après `--ar-tab-focus-ring-offset: -2px;` (ligne 522), ajouter :
+
+```css
+--ar-tab-focus-ring-offset: -2px;
+--ar-tab-focus-ring-color: var(--ar-focus-ring-color);
+```
+
+- [ ] **Step 2: Consommer le token scopé dans `tab.styles.ts`**
+
+Remplacer (ligne 47) :
+
+```ts
+        outline: 2px solid var(--ar-focus-ring-color, ButtonText);
+```
+
+par :
+
+```ts
+        outline: 2px solid var(--ar-tab-focus-ring-color, ButtonText);
+```
+
+- [ ] **Step 3: Mettre à jour le JSDoc `@cssprop`**
+
+Dans `tab.ts`, remplacer (ligne 31) :
+
+```ts
+ * @cssprop --ar-focus-ring-color - Couleur de la bague de focus de l'onglet. Token sémantique global (non scopé à ar-tab). Repli `ButtonText` si aucun thème n'est chargé (WCAG 2.4.7).
+```
+
+par :
+
+```ts
+ * @cssprop --ar-tab-focus-ring-color - Couleur de la bague de focus de l'onglet (cascade vers --ar-focus-ring-color). Repli `ButtonText` si aucun thème n'est chargé (WCAG 2.4.7).
+```
+
+- [ ] **Step 4: Lancer les tests du composant**
+
+Run (depuis `packages/core/`) : `npx vitest run tab`
+Expected: tous les tests passent (75 tests attendus, cf. PR #135).
+
+- [ ] **Step 5: Vérifier la génération du manifest**
+
+Run (depuis la racine du repo) : `npm run build:manifest --workspace=packages/core`
+Expected: aucune erreur `validate-cssprop-defaults`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/styles/themes/default.css packages/core/src/components/tab/tab.styles.ts packages/core/src/components/tab/tab.ts
+git commit -m "fix(tab): scope --ar-focus-ring-color en --ar-tab-focus-ring-color (audit #129)"
+```
+
+---
+
+## Task 6: Scope `--ar-color-bg` pour `ar-pagination`
+
+**Files:**
+
+- Modify: `packages/core/src/styles/themes/default.css` (section `/* pagination */`, lignes 403-410)
+- Modify: `packages/core/src/components/pagination/pagination.styles.ts:67`
+- Modify: `packages/core/src/components/pagination/pagination.ts:47`
+
+**Interfaces:** Produces `--ar-pagination-active-bg` (alias de `--ar-color-bg`), consommé uniquement par `pagination.styles.ts`. À ne pas confondre avec `--ar-pagination-bg` (fond des boutons non-actifs, déjà scopé).
+
+- [ ] **Step 1: Ajouter l'alias dans `default.css`**
+
+Dans la section `/* pagination */`, ajouter la ligne (après le dernier token existant de la section, avant `/* spinner */`) :
+
+```css
+--ar-pagination-active-bg: var(--ar-color-bg);
+```
+
+- [ ] **Step 2: Consommer le token scopé dans `pagination.styles.ts`**
+
+Remplacer (ligne 67) :
+
+```ts
+        background-color: var(--ar-color-bg);
+```
+
+par :
+
+```ts
+        background-color: var(--ar-pagination-active-bg);
+```
+
+- [ ] **Step 3: Mettre à jour le JSDoc `@cssprop`**
+
+Dans `pagination.ts`, remplacer (ligne 47) :
+
+```ts
+ * @cssprop --ar-color-bg - Couleur du fond du numéro de page actif. Token sémantique global (non scopé à ar-pagination).
+```
+
+par :
+
+```ts
+ * @cssprop --ar-pagination-active-bg - Couleur du fond du numéro de page actif (cascade vers --ar-color-bg).
+```
+
+- [ ] **Step 4: Lancer les tests du composant**
+
+Run (depuis `packages/core/`) : `npx vitest run pagination`
+Expected: tous les tests passent.
+
+- [ ] **Step 5: Vérifier la génération du manifest**
+
+Run (depuis la racine du repo) : `npm run build:manifest --workspace=packages/core`
+Expected: aucune erreur `validate-cssprop-defaults`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/styles/themes/default.css packages/core/src/components/pagination/pagination.styles.ts packages/core/src/components/pagination/pagination.ts
+git commit -m "fix(pagination): scope --ar-color-bg en --ar-pagination-active-bg (audit #129)"
+```
+
+---
+
+## Hors périmètre (confirmé sans action pendant l'audit)
+
+- **`ar-tab-group`** (bordure de séparation `--ar-tab-group-border-color`) — cosmétique, décision déjà actée, cf. PR #135.
+- **`ar-charcounter`** (warning/error indiscernables sans thème) — décision déjà actée en #133, pas d'équivalent couleur système fiable.
+- **`ar-datepicker` `[part='error']` sans fallback `font-weight`** — incohérence mineure trouvée pendant l'audit (parité avec `ar-charcounter`), sous le seuil de gravité retenu, à noter dans #129 mais pas de tâche dans ce plan (cohérent avec le traitement de `ar-charcounter`, pas de demande concrète).
+- **Règles `::part()` de `default.css` ciblant `ar-datepicker`** (`::part(hint)`, `::part(error)`) — vérifiées pendant l'audit : aucun mécanisme essentiel manquant dans le composant nu, uniquement des enrichissements cosmétiques sur des éléments HTML natifs déjà fonctionnels sans thème. Aucune violation de la Règle 2 trouvée sur l'ensemble des 19 composants.
+- **13 autres composants** (`breadcrumb-item`, `charcounter`, `collapse`, `dialog`, `dropdown`, `dropdown-item`, `progressbar`, `spinner`, `stepper-item`, `tab-group`, `tab-panel`, `table-sort`, `tooltip`) — aucune consommation directe de token générique trouvée, `.styles.ts` déjà propre.
+
+## Suite
+
+Une fois les 6 tâches ci-dessus mergées, le volet architecture de #129 sera traité dans son intégralité (audit du style nu + généralisation du scoping). Reste uniquement `ar-charcounter` (warning/error) en veille, sans action requise sauf besoin concret futur — l'issue #129 pourra alors être fermée.

--- a/packages/core/src/components/alert/alert.styles.ts
+++ b/packages/core/src/components/alert/alert.styles.ts
@@ -9,7 +9,7 @@ export default css`
         align-items: center;
         opacity: 1;
         transform: scale(1);
-        color: var(--ar-color-text);
+        color: var(--ar-alert-color);
         padding: var(--ar-alert-padding);
         border-radius: var(--ar-alert-border-radius);
         border-width: var(--ar-alert-border-width);

--- a/packages/core/src/components/alert/alert.ts
+++ b/packages/core/src/components/alert/alert.ts
@@ -50,7 +50,7 @@ export type ArAlertVariant = 'success' | 'warning' | 'error' | 'info';
  * @cssprop --ar-alert-success-border - Bordure de l'alerte "success".
  * @cssprop --ar-alert-success-icon - Couleur de l'icône "success".
  * @cssprop --ar-alert-close-transition-duration - Durée de la transition (opacity/background-color) du bouton de fermeture au survol/focus.
- * @cssprop --ar-color-text - Couleur du texte de l'alerte. Token sémantique global (non scopé à ar-alert) : le surcharger affecte aussi tous les autres composants qui le consomment directement.
+ * @cssprop --ar-alert-color - Couleur du texte de l'alerte (cascade vers --ar-color-text).
 
  *
  * @event {CustomEvent} ar-alert-close - Émis après la fermeture de l'alerte (fin de transition).

--- a/packages/core/src/components/breadcrumb/breadcrumb.styles.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.styles.ts
@@ -98,7 +98,7 @@ export default css`
         background-color: var(--ar-breadcrumb-bullet-color);
         margin: 0 0.75rem;
         flex-shrink: 0;
-        box-shadow: 0 0 0 2px var(--ar-color-bg);
+        box-shadow: 0 0 0 2px var(--ar-breadcrumb-bullet-ring-color);
     }
 
     .breadcrumb-mobile .breadcrumb-item:first-child:before,
@@ -109,7 +109,7 @@ export default css`
     }
 
     .breadcrumb-mobile .breadcrumb-item:last-child:before {
-        background-color: var(--ar-color-interactive);
+        background-color: var(--ar-breadcrumb-active-bullet-color);
     }
 
     .breadcrumb-mobile .breadcrumb-link,

--- a/packages/core/src/components/breadcrumb/breadcrumb.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.ts
@@ -53,8 +53,8 @@ import { AnchoredController } from '../../controllers/anchored.controller.js';
  * @cssprop --ar-breadcrumb-toggle-bg-hover - Fond du bouton retour/trigger mobile au survol.
  * @cssprop --ar-breadcrumb-toggle-bg-pressed - Fond du bouton retour/trigger mobile pressé.
  * @cssprop --ar-breadcrumb-toggle-bg-focus - Fond du bouton retour/trigger mobile au focus.
- * @cssprop --ar-color-bg - Couleur du liseré autour des puces de la liste mobile (`box-shadow`). Token sémantique global (non scopé à ar-breadcrumb).
- * @cssprop --ar-color-interactive - Couleur de la puce du dernier élément de la liste mobile (élément actif/courant). Token sémantique global (non scopé à ar-breadcrumb).
+ * @cssprop --ar-breadcrumb-bullet-ring-color - Couleur du liseré autour des puces de la liste mobile (`box-shadow`, cascade vers --ar-color-bg).
+ * @cssprop --ar-breadcrumb-active-bullet-color - Couleur de la puce du dernier élément de la liste mobile (élément actif/courant, cascade vers --ar-color-interactive).
  *
  * @event {CustomEvent} ar-breadcrumb-show           - Émis avant l'ouverture du dropdown mobile. @cancelable
  * @event {CustomEvent} ar-breadcrumb-show-prevented - Émis si ar-breadcrumb-show est annulé.

--- a/packages/core/src/components/datepicker/datepicker.styles.ts
+++ b/packages/core/src/components/datepicker/datepicker.styles.ts
@@ -88,8 +88,8 @@ export default css`
     }
 
     [part~='nav-btn']:focus-visible {
-        outline: 2px solid var(--ar-focus-ring-color, ButtonText);
-        outline-offset: var(--ar-focus-ring-offset);
+        outline: 2px solid var(--ar-datepicker-nav-btn-focus-ring-color, ButtonText);
+        outline-offset: var(--ar-datepicker-nav-btn-focus-ring-offset);
     }
 
     [part~='footer-btn'] {
@@ -118,8 +118,8 @@ export default css`
     }
 
     [part~='footer-btn']:focus-visible {
-        outline: 2px solid var(--ar-focus-ring-color, ButtonText);
-        outline-offset: var(--ar-focus-ring-offset);
+        outline: 2px solid var(--ar-datepicker-footer-btn-focus-ring-color, ButtonText);
+        outline-offset: var(--ar-datepicker-footer-btn-focus-ring-offset);
     }
 
     [part='grid'] {
@@ -139,7 +139,7 @@ export default css`
 
     [part='day'] {
         font-size: var(--ar-datepicker-day-font-size);
-        color: var(--ar-color-text);
+        color: var(--ar-datepicker-day-color);
         /* a11y-fallback: WCAG 2.5.8 (Target Size Minimum) — [part='grid'] a border-collapse: collapse, qui supprime l'espacement natif du <table> ; sans thème la cellule se dimensionnerait à son seul contenu textuel */
         width: var(--ar-datepicker-day-size, 2.5rem);
         /* a11y-fallback: WCAG 2.5.8 (Target Size Minimum) — [part='grid'] a border-collapse: collapse, qui supprime l'espacement natif du <table> ; sans thème la cellule se dimensionnerait à son seul contenu textuel */

--- a/packages/core/src/components/datepicker/datepicker.ts
+++ b/packages/core/src/components/datepicker/datepicker.ts
@@ -95,9 +95,11 @@ import { warn } from '../../utils/warn.js';
  * @cssprop --ar-datepicker-day-selected-bg - Fond du jour sélectionné. Repli `Highlight` si aucun thème n'est chargé (sinon indiscernable des jours non sélectionnés).
  * @cssprop --ar-datepicker-day-selected-color - Couleur texte du jour sélectionné. Repli `HighlightText` si aucun thème n'est chargé.
  * @cssprop --ar-datepicker-input-error-border-color - Bordure input en état d'erreur.
- * @cssprop --ar-focus-ring-color - Couleur de l'anneau de focus des boutons de navigation et du footer. Token sémantique global (non scopé à ar-datepicker) — les cellules jour ont leur propre token scopé, --ar-datepicker-day-focus-ring-color. Repli `ButtonText` si aucun thème n'est chargé (WCAG 2.4.7).
- * @cssprop --ar-focus-ring-offset - Décalage de l'anneau de focus des boutons de navigation et du footer. Token sémantique global (non scopé à ar-datepicker).
- * @cssprop --ar-color-text - Couleur du texte des cellules jour. Token sémantique global (non scopé à ar-datepicker).
+ * @cssprop --ar-datepicker-nav-btn-focus-ring-color - Couleur de l'anneau de focus des boutons de navigation (cascade vers --ar-focus-ring-color). Repli `ButtonText` si aucun thème n'est chargé (WCAG 2.4.7).
+ * @cssprop --ar-datepicker-nav-btn-focus-ring-offset - Décalage de l'anneau de focus des boutons de navigation (cascade vers --ar-focus-ring-offset).
+ * @cssprop --ar-datepicker-footer-btn-focus-ring-color - Couleur de l'anneau de focus des boutons du footer (cascade vers --ar-focus-ring-color). Repli `ButtonText` si aucun thème n'est chargé (WCAG 2.4.7).
+ * @cssprop --ar-datepicker-footer-btn-focus-ring-offset - Décalage de l'anneau de focus des boutons du footer (cascade vers --ar-focus-ring-offset).
+ * @cssprop --ar-datepicker-day-color - Couleur du texte des cellules jour (cascade vers --ar-color-text).
  * @cssprop --ar-panel-bg - Couleur de bordure de la cellule jour focusée dans la grille (contraste avec l'anneau de focus). Le popover pilote son fond réel via ce token (panelStyles) ; référencer --ar-color-bg directement casserait ce cutout pour un consommateur ne surchargeant que --ar-panel-bg.
  *
  * @event {CustomEvent} ar-datepicker-input-change   - Valeur commitée (blur ou sélection calendrier).

--- a/packages/core/src/components/datepicker/datepicker.ts
+++ b/packages/core/src/components/datepicker/datepicker.ts
@@ -98,7 +98,7 @@ import { warn } from '../../utils/warn.js';
  * @cssprop --ar-focus-ring-color - Couleur de l'anneau de focus des boutons de navigation et du footer. Token sémantique global (non scopé à ar-datepicker) — les cellules jour ont leur propre token scopé, --ar-datepicker-day-focus-ring-color. Repli `ButtonText` si aucun thème n'est chargé (WCAG 2.4.7).
  * @cssprop --ar-focus-ring-offset - Décalage de l'anneau de focus des boutons de navigation et du footer. Token sémantique global (non scopé à ar-datepicker).
  * @cssprop --ar-color-text - Couleur du texte des cellules jour. Token sémantique global (non scopé à ar-datepicker).
- * @cssprop --ar-color-bg - Couleur de bordure de la cellule jour focusée dans la grille (contraste avec l'anneau de focus). Token sémantique global (non scopé à ar-datepicker).
+ * @cssprop --ar-panel-bg - Couleur de bordure de la cellule jour focusée dans la grille (contraste avec l'anneau de focus). Le popover pilote son fond réel via ce token (panelStyles) ; référencer --ar-color-bg directement casserait ce cutout pour un consommateur ne surchargeant que --ar-panel-bg.
  *
  * @event {CustomEvent} ar-datepicker-input-change   - Valeur commitée (blur ou sélection calendrier).
  * @event {CustomEvent} ar-datepicker-input-complete - Saisie texte complète (valide ou non).

--- a/packages/core/src/components/pagination/pagination.styles.ts
+++ b/packages/core/src/components/pagination/pagination.styles.ts
@@ -64,7 +64,7 @@ export default css`
     .pagination-item.active .btn-tertiary {
         z-index: 3;
         color: var(--ar-pagination-active-color);
-        background-color: var(--ar-color-bg);
+        background-color: var(--ar-pagination-active-bg);
         border: 1px solid var(--ar-pagination-active-color);
         font-weight: 700;
     }

--- a/packages/core/src/components/pagination/pagination.ts
+++ b/packages/core/src/components/pagination/pagination.ts
@@ -44,7 +44,7 @@ export interface ArPaginationPageChangeDetail {
  * @cssprop --ar-pagination-bg-hover - Fond des boutons prev/next/page au survol.
  * @cssprop --ar-pagination-bg-pressed - Fond des boutons prev/next/page pressés.
  * @cssprop --ar-pagination-bg-focus - Fond des boutons prev/next/page au focus.
- * @cssprop --ar-color-bg - Couleur du fond du numéro de page actif. Token sémantique global (non scopé à ar-pagination).
+ * @cssprop --ar-pagination-active-bg - Couleur du fond du numéro de page actif (cascade vers --ar-color-bg).
  *
  * @event {CustomEvent<{from: number, to: number}>} ar-pagination-page-change - Émis à chaque changement de page. Contient `from` et `to`.
  */

--- a/packages/core/src/components/stepper/stepper.styles.ts
+++ b/packages/core/src/components/stepper/stepper.styles.ts
@@ -107,25 +107,25 @@ export default css`
 
     .stepper-item .stepper-link:focus:before,
     .stepper-item .stepper-link:hover:before {
-        background-color: var(--ar-color-interactive);
+        background-color: var(--ar-stepper-link-hover-bullet-color);
     }
 
     .stepper-item .stepper-link:focus .stepper-item-label,
     .stepper-item .stepper-link:hover .stepper-item-label {
         text-decoration: none;
-        color: var(--ar-color-text);
+        color: var(--ar-stepper-link-hover-label-color);
     }
 
     .stepper-item .stepper-link:focus .stepper-item-bullet,
     .stepper-item .stepper-link:hover .stepper-item-bullet {
-        color: var(--ar-color-text-inverse);
+        color: var(--ar-stepper-link-hover-bullet-text-color);
         background-color: var(--ar-stepper-bullet-hover-bg);
         box-shadow: none;
     }
 
     .stepper-item .stepper-link:focus {
         outline-offset: 4px;
-        outline-color: var(--ar-color-interactive);
+        outline-color: var(--ar-stepper-link-focus-outline-color);
         border-radius: var(--ar-stepper-link-focus-radius);
     }
 

--- a/packages/core/src/components/stepper/stepper.ts
+++ b/packages/core/src/components/stepper/stepper.ts
@@ -79,9 +79,10 @@ export interface ArStepperStepChangeDetail {
  * @cssprop --ar-stepper-trigger-bg - Fond du bouton trigger mobile.
  * @cssprop --ar-stepper-trigger-bg-hover - Fond du bouton trigger mobile au survol.
  * @cssprop --ar-stepper-trigger-radius - Border-radius du bouton trigger mobile.
- * @cssprop --ar-color-interactive - Couleur de la puce et de l'anneau de focus du lien d'étape au survol/focus. Token sémantique global (non scopé à ar-stepper).
- * @cssprop --ar-color-text - Couleur du label de l'étape au survol/focus. Token sémantique global (non scopé à ar-stepper).
- * @cssprop --ar-color-text-inverse - Couleur du numéro affiché dans la puce au survol/focus. Token sémantique global (non scopé à ar-stepper).
+ * @cssprop --ar-stepper-link-hover-bullet-color - Couleur de la puce du lien d'étape au survol/focus (cascade vers --ar-color-interactive).
+ * @cssprop --ar-stepper-link-hover-label-color - Couleur du label de l'étape au survol/focus (cascade vers --ar-color-text).
+ * @cssprop --ar-stepper-link-hover-bullet-text-color - Couleur du numéro affiché dans la puce au survol/focus (cascade vers --ar-color-text-inverse).
+ * @cssprop --ar-stepper-link-focus-outline-color - Couleur de l'anneau de focus du lien d'étape (cascade vers --ar-color-interactive).
  *
  * @event {CustomEvent<{ path: string }>} ar-stepper-step-change - Émis au clic sur une étape.
  */

--- a/packages/core/src/components/tab/tab.styles.ts
+++ b/packages/core/src/components/tab/tab.styles.ts
@@ -44,7 +44,7 @@ export default css`
     }
 
     :host(:focus-visible) {
-        outline: 2px solid var(--ar-focus-ring-color, ButtonText);
+        outline: 2px solid var(--ar-tab-focus-ring-color, ButtonText);
         outline-offset: var(--ar-tab-focus-ring-offset);
     }
 `;

--- a/packages/core/src/components/tab/tab.ts
+++ b/packages/core/src/components/tab/tab.ts
@@ -28,7 +28,7 @@ import styles from './tab.styles.js';
  * @cssprop --ar-tab-indicator-width - Épaisseur de l'indicateur actif (utilisé par le thème pour composer --ar-tab-active-shadow).
  * @cssprop --ar-tab-disabled-opacity - Opacité de l'onglet désactivé.
  * @cssprop --ar-tab-focus-ring-offset - Décalage de la bague de focus. Valeur négative = inset (non coupée par le conteneur overflow du tab-group). Surcharge le token global --ar-focus-ring-offset pour ce composant.
- * @cssprop --ar-focus-ring-color - Couleur de la bague de focus de l'onglet. Token sémantique global (non scopé à ar-tab). Repli `ButtonText` si aucun thème n'est chargé (WCAG 2.4.7).
+ * @cssprop --ar-tab-focus-ring-color - Couleur de la bague de focus de l'onglet (cascade vers --ar-focus-ring-color). Repli `ButtonText` si aucun thème n'est chargé (WCAG 2.4.7).
  *
  * Note d'implémentation : la mise en page de [part='base'] compense la bordure de son parent
  * ar-tab-group via les tokens --ar-tab-group-border-top-width / --ar-tab-group-border-bottom-width

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -352,6 +352,8 @@
         --ar-breadcrumb-separator-color: var(--ar-color-neutral-80);
         --ar-breadcrumb-bullet-color: var(--ar-color-neutral-80);
         --ar-breadcrumb-mobile-separator-color: var(--ar-color-neutral-90);
+        --ar-breadcrumb-bullet-ring-color: var(--ar-color-bg);
+        --ar-breadcrumb-active-bullet-color: var(--ar-color-interactive);
         --ar-breadcrumb-panel-min-width: var(--ar-panel-min-width);
         --ar-breadcrumb-panel-max-width: var(--ar-panel-max-width);
         --ar-breadcrumb-panel-bg: var(--ar-panel-bg);

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -414,6 +414,7 @@
         --ar-pagination-bg-hover: var(--ar-button-tertiary-bg-hover);
         --ar-pagination-bg-pressed: var(--ar-button-tertiary-bg-active);
         --ar-pagination-bg-focus: var(--ar-button-tertiary-bg-focus);
+        --ar-pagination-active-bg: var(--ar-color-bg);
 
         /* spinner */
         --ar-spinner-stroke-color: currentColor;

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -571,6 +571,8 @@
             var(--ar-color-text) 14%,
             transparent
         );
+        --ar-datepicker-nav-btn-focus-ring-color: var(--ar-focus-ring-color);
+        --ar-datepicker-nav-btn-focus-ring-offset: var(--ar-focus-ring-offset);
 
         --ar-datepicker-footer-margin: 0;
         --ar-datepicker-footer-padding: 0.75rem 0 0;
@@ -593,6 +595,8 @@
             var(--ar-color-interactive) 18%,
             transparent
         );
+        --ar-datepicker-footer-btn-focus-ring-color: var(--ar-focus-ring-color);
+        --ar-datepicker-footer-btn-focus-ring-offset: var(--ar-focus-ring-offset);
 
         /* neutral-60 (~2.6:1 sur blanc) — distinction visuelle prioritaire sur AA strict */
         --ar-datepicker-weekday-color: var(--ar-color-neutral-50);
@@ -600,6 +604,7 @@
         --ar-datepicker-day-other-month-color: var(--ar-color-neutral-50);
 
         --ar-datepicker-day-font-size: 1rem;
+        --ar-datepicker-day-color: var(--ar-color-text);
         --ar-datepicker-day-size: 2.5rem;
         --ar-datepicker-day-radius: 0.5rem;
         --ar-datepicker-day-bg: transparent;

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -527,6 +527,7 @@
 
         --ar-tab-disabled-opacity: 0.5;
         --ar-tab-focus-ring-offset: -2px;
+        --ar-tab-focus-ring-color: var(--ar-focus-ring-color);
 
         --ar-tab-group-gap: 0;
         --ar-tab-group-border-color: var(--ar-color-border);

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -379,6 +379,10 @@
         --ar-stepper-bullet-hover-bg: var(--ar-color-text-muted);
         --ar-stepper-link-color: var(--ar-color-interactive);
         --ar-stepper-link-hover-color: var(--ar-color-text-muted);
+        --ar-stepper-link-hover-bullet-color: var(--ar-color-interactive);
+        --ar-stepper-link-hover-label-color: var(--ar-color-text);
+        --ar-stepper-link-hover-bullet-text-color: var(--ar-color-text-inverse);
+        --ar-stepper-link-focus-outline-color: var(--ar-color-interactive);
         --ar-stepper-active-label-color: var(--ar-color-interactive);
         --ar-stepper-active-bullet-color: var(--ar-color-text-inverse);
         --ar-stepper-active-bullet-bg: var(--ar-color-interactive);

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -294,6 +294,7 @@
          * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
 
         /* alert */
+        --ar-alert-color: var(--ar-color-text);
         --ar-alert-padding: 1rem;
         --ar-alert-border-radius: 0.75rem;
         --ar-alert-border-width: 1px;


### PR DESCRIPTION
Traite le gros du volet architecture de #129 : audit du style « nu » des 19 composants (aucune violation de la Règle 2 trouvée — pas de mécanisme `::part()` manquant nulle part), puis application de la Règle 1 (généralisation du scoping systématique décidée le 2026-07-23, révoquant l'exception « point d'extension public » posée un jour plus tôt par l'addendum #127).

14 tokens scopés créés sur 6 composants (`alert`, `breadcrumb`, `stepper`, `datepicker`, `tab`, `pagination`) — chaque nouveau token est un alias 1:1 pur vers le token global qu'il remplace, aucun changement visuel. Un bug de documentation trouvé pendant l'audit (JSDoc `datepicker.ts` pas mis à jour après le fix `--ar-panel-bg` de PR #134) est corrigé en Task 0.

Plan exécuté en subagent-driven-development : 7 tâches, chacune revue individuellement (spec + qualité, toutes approuvées), puis revue finale de branche (opus) — verdict **prêt à merger**, aucun defect de code trouvé.

**Note breaking change (acceptable en alpha, cf. CLAUDE.md)** : un consommateur qui surchargeait `--ar-color-bg`/`--ar-color-text`/`--ar-color-text-inverse`/`--ar-color-interactive`/`--ar-focus-ring-color`/`--ar-focus-ring-offset` spécifiquement pour recolorer un seul de ces 6 composants doit migrer vers le nouveau token scopé correspondant — sa surcharge globale ne les affectera plus silencieusement. Fenêtre d'exposition très courte (l'exception de #127 n'a duré qu'un jour, du 2026-07-22 au 2026-07-23).

Hors périmètre confirmé pendant l'audit (pas d'action) : `ar-tab-group` (bordure cosmétique), `ar-charcounter` (warning/error), règles `::part()` de `default.css` sur `ar-datepicker` (cosmétiques, aucun mécanisme essentiel manquant).

Part of #129.

## Test plan
- [x] `npx vitest run <alert|breadcrumb|stepper|datepicker|tab|pagination>` (depuis `packages/core`) — tous verts (35/45/58/81/75/40 tests)
- [x] `npm run build:manifest --workspace=packages/core` — aucune erreur `validate-cssprop-defaults` après chaque tâche