### PR TITLE
refactor(datepicker): réduit la prolifération de tokens via ::part() (audit #129)

### DIFF
--- a/docs/decisions/ADR-005-tokens-pilotes-par-attribut.md
+++ b/docs/decisions/ADR-005-tokens-pilotes-par-attribut.md
@@ -122,17 +122,31 @@ Un token consommé **uniquement** par la propre règle `::part()` de `default.cs
 le composant) n'est pas une vraie surface d'API — repli direct sur une valeur littérale dans
 la règle, pas de token `:root`.
 
-**Deux contraintes techniques** limitent la branche 4 : `::part()` ne peut cibler que des
+**Trois contraintes techniques** limitent la branche 4 : `::part()` ne peut cibler que des
 éléments portant un `part` (jamais `:host`) — une propriété sur `:host` reste nécessairement
 un token quel que soit son usage. Une **valeur dark-mode calibrée indépendamment de son alias
 clair** (pas une simple variance héritée) prime aussi sur le critère « usage unique » — un tel
 token reste en place plutôt que d'être aplati en valeur littérale dans une règle `::part()`,
-ce qui perdrait sa calibration sans dupliquer la règle sous un bloc dark.
+ce qui perdrait sa calibration sans dupliquer la règle sous un bloc dark. Enfin, **une
+propriété qu'une règle interne au shadow DOM du composant doit pouvoir surcharger selon un
+état** (classe posée par le composant — `.today`, `.selected`, `:hover`…) doit rester un
+token consommé à l'intérieur du composant, jamais migrée dans une règle `::part()` du thème :
+vérifié empiriquement (Chromium réel, via Playwright) qu'une règle `::part()` déclarée dans la
+feuille de style _externe_ (le thème) l'emporte sur une règle interne au shadow DOM ciblant la
+même propriété, **même quand la règle interne a une spécificité CSS plus élevée**. Concrètement
+sur `ar-datepicker` : `color`/`background-color` de `[part='day']` ont dû rester des tokens
+(`--ar-datepicker-day-color`, `--ar-datepicker-day-bg`) car les règles d'état internes
+(`.today`, `.selected`, `:hover`, `.other-month`) les surchargent — les migrer dans
+`::part(day)` aurait rendu les jours sélectionné/actif/survolé indiscernables des autres
+(régression WCAG), trouvé et corrigé en revue finale de la PR de migration. `font-size`,
+`border-radius` et `border-width` de `[part='day']` n'ont pas ce problème (aucune règle
+interne ne les surcharge) et sont bien restés dans `::part(day)`.
 
-**Application** : `ar-datepicker` (cas d'étude), 35 tokens sur 58 migrés vers 8 nouvelles
+**Application** : `ar-datepicker` (cas d'étude), 33 tokens sur 58 migrés vers 8 nouvelles
 règles `::part()` groupées (`nav-btn`, `footer-btn`, `header`, `footer`, `weekday` — nouveau
-part créé pour l'occasion —, `day`, `panel`, `label` amendée). 23 tokens conservés. Détail
-complet : `docs/superpowers/specs/2026-07-24-token-vs-part-datepicker-design.md`. Les 5
+part créé pour l'occasion —, `day`, `panel`, `label` amendée). 25 tokens conservés (23 issus
+du critère initial + 2 réintroduits pour la contrainte de cascade `::part()` ci-dessus).
+Détail complet : `docs/superpowers/specs/2026-07-24-token-vs-part-datepicker-design.md`. Les 5
 autres composants scopés par PR #136 n'ont pas été réaudités sous cet angle — périmètre
 volontairement limité au cas d'étude, à généraliser dans un chantier séparé si le critère
 fait ses preuves.

--- a/docs/decisions/ADR-005-tokens-pilotes-par-attribut.md
+++ b/docs/decisions/ADR-005-tokens-pilotes-par-attribut.md
@@ -97,3 +97,42 @@ et les états de la grille `ar-datepicker`.
 
 Détail complet du raisonnement, du périmètre et des tokens concernés :
 `docs/superpowers/specs/2026-07-22-css-fallback-accessibilite-design.md`.
+
+## Amendement (2026-07-24) : critère token scopé vs `::part()`
+
+La généralisation du scoping systématique (issue #129, PR #136) a produit un volume de
+tokens à usage unique difficile à justifier — `ar-datepicker` déclarait 58 tokens `:root`
+dont 65% consommés à un seul endroit. Une variable n'est vraiment utile que si elle est
+réutilisable ; `::part()` offre déjà un point de surcharge gratuit pour toute propriété d'un
+élément interne, sans nécessiter de token dédié.
+
+**Critère retenu**, à appliquer dans l'ordre pour toute propriété CSS consommée via un token
+scopé :
+
+1. Mécanisme WCAG/fonctionnel critique sans thème (fallback déjà requis par l'amendement du
+   2026-07-22) → reste un token, avec son fallback.
+2. Lu en JavaScript (`getComputedStyle`, ex. `AnchoredController`) → reste un token `:root`,
+   `::part()` n'est pas lisible en JS.
+3. Réutilisé ≥ 2 fois dans le `.styles.ts` du composant (vraie valeur DRY) → reste un token.
+4. Sinon (usage unique, propriété d'un élément interne portant un `part`, pas de fallback
+   critique) → la propriété n'est pas déclarée dans le composant ; `default.css` la stylise
+   directement via une règle `::part()`, sans token scopé intermédiaire ni `@cssprop` dédié.
+
+Un token consommé **uniquement** par la propre règle `::part()` de `default.css` (jamais par
+le composant) n'est pas une vraie surface d'API — repli direct sur une valeur littérale dans
+la règle, pas de token `:root`.
+
+**Deux contraintes techniques** limitent la branche 4 : `::part()` ne peut cibler que des
+éléments portant un `part` (jamais `:host`) — une propriété sur `:host` reste nécessairement
+un token quel que soit son usage. Une **valeur dark-mode calibrée indépendamment de son alias
+clair** (pas une simple variance héritée) prime aussi sur le critère « usage unique » — un tel
+token reste en place plutôt que d'être aplati en valeur littérale dans une règle `::part()`,
+ce qui perdrait sa calibration sans dupliquer la règle sous un bloc dark.
+
+**Application** : `ar-datepicker` (cas d'étude), 35 tokens sur 58 migrés vers 8 nouvelles
+règles `::part()` groupées (`nav-btn`, `footer-btn`, `header`, `footer`, `weekday` — nouveau
+part créé pour l'occasion —, `day`, `panel`, `label` amendée). 23 tokens conservés. Détail
+complet : `docs/superpowers/specs/2026-07-24-token-vs-part-datepicker-design.md`. Les 5
+autres composants scopés par PR #136 n'ont pas été réaudités sous cet angle — périmètre
+volontairement limité au cas d'étude, à généraliser dans un chantier séparé si le critère
+fait ses preuves.

--- a/docs/superpowers/specs/2026-07-24-token-vs-part-datepicker-design.md
+++ b/docs/superpowers/specs/2026-07-24-token-vs-part-datepicker-design.md
@@ -104,6 +104,23 @@ Classification complète des 58 tokens actuels, par branche :
 **Total : 23 tokens conservés** (15+2+1+1+4) sur 58, soit une réduction d'environ **60%** de
 la surface de tokens `:root` d'`ar-datepicker`.
 
+> **Correction post-implémentation (revue finale de la PR de migration) :** cette
+> classification initiale n'anticipait pas une contrainte technique supplémentaire, trouvée et
+> vérifiée empiriquement (Chromium réel, via Playwright) en revue finale : **une règle
+> `::part()` déclarée dans le thème (feuille de style externe) l'emporte sur une règle interne
+> au shadow DOM du composant ciblant la même propriété, même quand la règle interne a une
+> spécificité CSS plus élevée.** `--ar-datepicker-day-color` et `--ar-datepicker-day-bg`
+> avaient été classés candidats branche 4 (cf. `::part(day)` ci-dessous) — à tort, car les
+> règles d'état internes du composant (`.today`, `.selected`, `:hover`, `.other-month`)
+> surchargent ces deux propriétés par classe CSS, un mécanisme que `::part()` ne peut pas
+> reproduire depuis l'extérieur (pas de chaînage de classe après `::part()`). Les migrer aurait
+> rendu les jours sélectionné/actif/survolé indiscernables des autres — régression WCAG.
+> **Ces deux tokens ont été réintroduits** : le total réel est donc **25 tokens conservés**
+> (33 migrés, pas 35). Détail : `ADR-005`, amendement du 2026-07-24 (section mise à jour).
+> Nouvelle contrainte ajoutée au critère : une propriété surchargée par une règle d'état
+> interne au composant (classe) doit rester un token consommé dans le composant, jamais migrée
+> en `::part()` du thème.
+
 ### Nouvelles règles `::part()` à créer dans `default.css`
 
 Regroupement des 34 tokens confirmés par part, dans le même style que le bloc
@@ -122,10 +139,13 @@ Regroupement des 34 tokens confirmés par part, dans le même style que le bloc
   aujourd'hui **aucun** attribut `part` ; un sélecteur de thème ne peut pas traverser la
   frontière du shadow DOM sans `::part()`, donc un `part="weekday"` doit être ajouté sur le
   `<th>` dans `datepicker.ts`)_ : `color`, `font-size`.
-- **`ar-datepicker::part(day)`** : `background`, `font-size`, `color`, `border-radius`.
-  `border-width`/`border-color` restent pilotés par les tokens conservés (branche 1, cutout
-  de focus). Les propriétés spécifiques à l'état « aujourd'hui »
-  (`day-today-bg`/`day-today-color`) restent des tokens, cf. contrainte dark-mode ci-dessus.
+- **`ar-datepicker::part(day)`** : `font-size`, `border-radius`. `border-width`/`border-color`
+  restent pilotés par les tokens conservés (branche 1, cutout de focus). `color` et
+  `background-color` restent **également** des tokens (`--ar-datepicker-day-color`/`-day-bg`)
+  — cf. correction post-implémentation ci-dessus, ces propriétés sont surchargées par les
+  règles d'état internes du composant. Les propriétés spécifiques à l'état « aujourd'hui »
+  (`day-today-bg`/`day-today-color`) restent aussi des tokens, cf. contrainte dark-mode
+  ci-dessus.
 - **`ar-datepicker::part(panel)`** : `width`, `padding`. `max-width` reste piloté par le
   token conservé (branche 1, fallback WCAG 25rem).
 - **`ar-datepicker::part(label)`** _(règle existante, amendée)_ : `margin-bottom` calculé
@@ -137,8 +157,9 @@ restent inchangés.
 
 ### JSDoc / `@cssprop`
 
-`datepicker.ts` perd les entrées `@cssprop` des 34 tokens retirés (+ `label-gap`, 35 au
-total). Les 23 tokens conservés gardent leur entrée. Aucune régression de couverture
+`datepicker.ts` perd les entrées `@cssprop` des 32 tokens retirés (+ `label-gap`, 33 au
+total — `day-color`/`day-bg` réintroduits en revue finale, cf. correction post-implémentation
+plus haut). Les 25 tokens conservés gardent leur entrée. Aucune régression de couverture
 attendue : `validate-cssprop-defaults.js` ne vérifie qu'une seule direction (tout token
 présent dans `default.css` doit avoir une entrée `@cssprop`) — retirer les deux en même temps
 est sans risque pour `npm run build:manifest`.
@@ -155,7 +176,7 @@ dépendant des tokens candidats à la suppression (`grep` sur `datepicker.*.test
 
 ## Breaking change (assumé, alpha)
 
-Même précédent que PR #136 : un consommateur qui surchargeait un des 35 tokens retirés
+Même précédent que PR #136 : un consommateur qui surchargeait un des 33 tokens retirés
 (ex. `--ar-datepicker-nav-btn-radius`) doit migrer vers une règle `::part()` directe
 (`ar-datepicker::part(nav-btn) { border-radius: ... }`) — mécanisme déjà disponible
 aujourd'hui même pour les composants qui exposent un token (`::part()` n'a jamais été

--- a/packages/core/src/components/datepicker/datepicker.styles.ts
+++ b/packages/core/src/components/datepicker/datepicker.styles.ts
@@ -50,11 +50,6 @@ export default css`
         align-items: center;
         justify-content: space-between;
         gap: 0.25rem;
-        font-size: var(--ar-datepicker-header-font-size);
-        margin: var(--ar-datepicker-header-margin);
-        padding: var(--ar-datepicker-header-padding);
-        background: var(--ar-datepicker-header-bg);
-        border-radius: var(--ar-datepicker-header-radius);
     }
 
     [part='header'] span[aria-live] {
@@ -201,8 +196,5 @@ export default css`
         display: flex;
         justify-content: space-between;
         gap: 0.5rem;
-        margin: var(--ar-datepicker-footer-margin);
-        padding: var(--ar-datepicker-footer-padding);
-        background: var(--ar-datepicker-footer-bg);
     }
 `;

--- a/packages/core/src/components/datepicker/datepicker.styles.ts
+++ b/packages/core/src/components/datepicker/datepicker.styles.ts
@@ -66,30 +66,16 @@ export default css`
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        width: var(--ar-datepicker-nav-btn-size);
         aspect-ratio: 1 / 1;
         cursor: pointer;
         font: inherit;
-        border-radius: var(--ar-datepicker-nav-btn-radius);
-        background: var(--ar-datepicker-nav-btn-bg);
         border-style: solid;
-        border-width: var(--ar-datepicker-nav-btn-border-width);
         /* a11y-fallback: border: raccourci scindé en longhands — un var() défaillant dans un raccourci invalide border-style, ce qui ferait disparaître la bordure entièrement sans thème */
         border-color: var(--ar-datepicker-nav-btn-border-color, transparent);
-        color: var(--ar-datepicker-nav-btn-color);
-    }
-
-    [part~='nav-btn']:hover {
-        background: var(--ar-datepicker-nav-btn-hover-bg);
-    }
-
-    [part~='nav-btn']:active {
-        background: var(--ar-datepicker-nav-btn-active-bg);
     }
 
     [part~='nav-btn']:focus-visible {
         outline: 2px solid var(--ar-datepicker-nav-btn-focus-ring-color, ButtonText);
-        outline-offset: var(--ar-datepicker-nav-btn-focus-ring-offset);
     }
 
     [part~='footer-btn'] {

--- a/packages/core/src/components/datepicker/datepicker.styles.ts
+++ b/packages/core/src/components/datepicker/datepicker.styles.ts
@@ -96,11 +96,9 @@ export default css`
 
     [part='grid'] th {
         text-align: center;
-        font-size: var(--ar-datepicker-weekday-font-size);
         font-weight: normal;
         padding-block: 0.5rem;
         text-transform: uppercase;
-        color: var(--ar-datepicker-weekday-color);
     }
 
     [part='day'] {

--- a/packages/core/src/components/datepicker/datepicker.styles.ts
+++ b/packages/core/src/components/datepicker/datepicker.styles.ts
@@ -39,10 +39,8 @@ export default css`
     }
 
     [part='panel'] {
-        width: var(--ar-datepicker-panel-width);
         /* a11y-fallback: évite que la grille de ~35 jours s'étale sur toute la largeur de la page sans thème chargé */
         max-width: var(--ar-datepicker-panel-max-width, 25rem);
-        padding: var(--ar-datepicker-panel-padding);
     }
 
     [part='header'] {

--- a/packages/core/src/components/datepicker/datepicker.styles.ts
+++ b/packages/core/src/components/datepicker/datepicker.styles.ts
@@ -109,6 +109,8 @@ export default css`
         justify-content: center;
         margin: auto;
         cursor: pointer;
+        color: var(--ar-datepicker-day-color);
+        background-color: var(--ar-datepicker-day-bg);
         border-style: solid;
         /* a11y-fallback: border: raccourci scindé en longhands — un var() défaillant dans un raccourci invalide border-style, ce qui casse la surcharge border-color de .today ci-dessous */
         border-color: var(--ar-datepicker-day-border-color, transparent);

--- a/packages/core/src/components/datepicker/datepicker.styles.ts
+++ b/packages/core/src/components/datepicker/datepicker.styles.ts
@@ -84,28 +84,13 @@ export default css`
         justify-content: center;
         cursor: pointer;
         font: inherit;
-        padding: var(--ar-datepicker-footer-btn-padding);
-        border-radius: var(--ar-datepicker-footer-btn-radius);
-        background: var(--ar-datepicker-footer-btn-bg);
         border-style: solid;
-        border-width: var(--ar-datepicker-footer-btn-border-width);
         /* a11y-fallback: border: raccourci scindé en longhands — un var() défaillant dans un raccourci invalide border-style, ce qui ferait disparaître la bordure entièrement sans thème */
         border-color: var(--ar-datepicker-footer-btn-border-color, transparent);
-        color: var(--ar-datepicker-footer-btn-color);
-    }
-
-    [part~='footer-btn']:hover {
-        background: var(--ar-datepicker-footer-btn-hover-bg);
-        border-color: var(--ar-datepicker-footer-btn-hover-border-color);
-    }
-
-    [part~='footer-btn']:active {
-        background: var(--ar-datepicker-footer-btn-active-bg);
     }
 
     [part~='footer-btn']:focus-visible {
         outline: 2px solid var(--ar-datepicker-footer-btn-focus-ring-color, ButtonText);
-        outline-offset: var(--ar-datepicker-footer-btn-focus-ring-offset);
     }
 
     [part='grid'] {

--- a/packages/core/src/components/datepicker/datepicker.styles.ts
+++ b/packages/core/src/components/datepicker/datepicker.styles.ts
@@ -102,8 +102,6 @@ export default css`
     }
 
     [part='day'] {
-        font-size: var(--ar-datepicker-day-font-size);
-        color: var(--ar-datepicker-day-color);
         /* a11y-fallback: WCAG 2.5.8 (Target Size Minimum) — [part='grid'] a border-collapse: collapse, qui supprime l'espacement natif du <table> ; sans thème la cellule se dimensionnerait à son seul contenu textuel */
         width: var(--ar-datepicker-day-size, 2.5rem);
         /* a11y-fallback: WCAG 2.5.8 (Target Size Minimum) — [part='grid'] a border-collapse: collapse, qui supprime l'espacement natif du <table> ; sans thème la cellule se dimensionnerait à son seul contenu textuel */
@@ -113,10 +111,7 @@ export default css`
         justify-content: center;
         margin: auto;
         cursor: pointer;
-        border-radius: var(--ar-datepicker-day-radius);
-        background-color: var(--ar-datepicker-day-bg);
         border-style: solid;
-        border-width: var(--ar-datepicker-day-border-width);
         /* a11y-fallback: border: raccourci scindé en longhands — un var() défaillant dans un raccourci invalide border-style, ce qui casse la surcharge border-color de .today ci-dessous */
         border-color: var(--ar-datepicker-day-border-color, transparent);
     }

--- a/packages/core/src/components/datepicker/datepicker.test.ts
+++ b/packages/core/src/components/datepicker/datepicker.test.ts
@@ -472,7 +472,7 @@ describe('ArDatepicker', () => {
     });
 
     describe('fonds par défaut du calendrier (thème)', () => {
-        it('default.css définit --ar-datepicker-header-bg, -day-bg et -footer-bg', async () => {
+        it('default.css définit -day-bg et les ::part(header)/::part(footer)', async () => {
             // Lecture directe du fichier source : le thème n'est pas chargé dans
             // l'environnement de test (happy-dom), voir vitest.config.ts.
             // `new URL(relative, import.meta.url)` est évité car happy-dom remplace le
@@ -486,9 +486,13 @@ describe('ArDatepicker', () => {
                 '../../styles/themes/default.css',
             );
             const themeCss = readFileSync(themePath, 'utf-8');
-            expect(themeCss).toMatch(/--ar-datepicker-header-bg:/);
             expect(themeCss).toMatch(/--ar-datepicker-day-bg:/);
-            expect(themeCss).toMatch(/--ar-datepicker-footer-bg:/);
+            expect(themeCss).toMatch(
+                /ar-datepicker::part\(header\)\s*{[^}]*background: transparent;/,
+            );
+            expect(themeCss).toMatch(
+                /ar-datepicker::part\(footer\)\s*{[^}]*background: transparent;/,
+            );
         });
     });
 });

--- a/packages/core/src/components/datepicker/datepicker.test.ts
+++ b/packages/core/src/components/datepicker/datepicker.test.ts
@@ -472,7 +472,7 @@ describe('ArDatepicker', () => {
     });
 
     describe('fonds par défaut du calendrier (thème)', () => {
-        it('default.css définit -day-bg et les ::part(header)/::part(footer)', async () => {
+        it('default.css définit -day-bg et un background pour ::part(header)/::part(footer)', async () => {
             // Lecture directe du fichier source : le thème n'est pas chargé dans
             // l'environnement de test (happy-dom), voir vitest.config.ts.
             // `new URL(relative, import.meta.url)` est évité car happy-dom remplace le
@@ -487,12 +487,13 @@ describe('ArDatepicker', () => {
             );
             const themeCss = readFileSync(themePath, 'utf-8');
             expect(themeCss).toMatch(/--ar-datepicker-day-bg:/);
-            expect(themeCss).toMatch(
-                /ar-datepicker::part\(header\)\s*{[^}]*background: transparent;/,
-            );
-            expect(themeCss).toMatch(
-                /ar-datepicker::part\(footer\)\s*{[^}]*background: transparent;/,
-            );
+            // Regex agnostiques du préfixe de sélecteur (flat `ar-datepicker::part(...)`
+            // ou nesting CSS `&::part(...)`) et de la valeur exacte — seule la présence
+            // de la déclaration `background:` est vérifiée.
+            // TODO: ajouter une assertion ::part(day) background-color une fois cette
+            // migration effectuée (tâche ultérieure du même plan).
+            expect(themeCss).toMatch(/::part\(header\)\s*{[^}]*background:/);
+            expect(themeCss).toMatch(/::part\(footer\)\s*{[^}]*background:/);
         });
     });
 });

--- a/packages/core/src/components/datepicker/datepicker.test.ts
+++ b/packages/core/src/components/datepicker/datepicker.test.ts
@@ -472,7 +472,7 @@ describe('ArDatepicker', () => {
     });
 
     describe('fonds par défaut du calendrier (thème)', () => {
-        it('default.css définit -day-bg et un background pour ::part(header)/::part(footer)', async () => {
+        it('default.css définit ::part(day) et un background pour ::part(header)/::part(footer)', async () => {
             // Lecture directe du fichier source : le thème n'est pas chargé dans
             // l'environnement de test (happy-dom), voir vitest.config.ts.
             // `new URL(relative, import.meta.url)` est évité car happy-dom remplace le
@@ -486,12 +486,10 @@ describe('ArDatepicker', () => {
                 '../../styles/themes/default.css',
             );
             const themeCss = readFileSync(themePath, 'utf-8');
-            expect(themeCss).toMatch(/--ar-datepicker-day-bg:/);
             // Regex agnostiques du préfixe de sélecteur (flat `ar-datepicker::part(...)`
             // ou nesting CSS `&::part(...)`) et de la valeur exacte — seule la présence
-            // de la déclaration `background:` est vérifiée.
-            // TODO: ajouter une assertion ::part(day) background-color une fois cette
-            // migration effectuée (tâche ultérieure du même plan).
+            // de la déclaration `background:`/`background-color:` est vérifiée.
+            expect(themeCss).toMatch(/::part\(day\)\s*{[^}]*background-color:/);
             expect(themeCss).toMatch(/::part\(header\)\s*{[^}]*background:/);
             expect(themeCss).toMatch(/::part\(footer\)\s*{[^}]*background:/);
         });

--- a/packages/core/src/components/datepicker/datepicker.test.ts
+++ b/packages/core/src/components/datepicker/datepicker.test.ts
@@ -472,7 +472,7 @@ describe('ArDatepicker', () => {
     });
 
     describe('fonds par défaut du calendrier (thème)', () => {
-        it('default.css définit ::part(day) et un background pour ::part(header)/::part(footer)', async () => {
+        it("default.css définit un background pour ::part(header)/::part(footer), et les tokens color/background-color de la cellule jour (pas ::part(day) : un ::part() de l'outer stylesheet du thème l'emporterait sur les surcharges d'état .today/.selected/:hover du composant, cf #129)", async () => {
             // Lecture directe du fichier source : le thème n'est pas chargé dans
             // l'environnement de test (happy-dom), voir vitest.config.ts.
             // `new URL(relative, import.meta.url)` est évité car happy-dom remplace le
@@ -489,9 +489,15 @@ describe('ArDatepicker', () => {
             // Regex agnostiques du préfixe de sélecteur (flat `ar-datepicker::part(...)`
             // ou nesting CSS `&::part(...)`) et de la valeur exacte — seule la présence
             // de la déclaration `background:`/`background-color:` est vérifiée.
-            expect(themeCss).toMatch(/::part\(day\)\s*{[^}]*background-color:/);
             expect(themeCss).toMatch(/::part\(header\)\s*{[^}]*background:/);
             expect(themeCss).toMatch(/::part\(footer\)\s*{[^}]*background:/);
+            // color/background-color de la cellule jour ne doivent PAS être dans
+            // ::part(day) (voir explication ci-dessus) : ils sont pilotés par des
+            // tokens que le composant consomme lui-même, dans son propre shadow tree.
+            expect(themeCss).not.toMatch(/::part\(day\)\s*{[^}]*background-color:/);
+            expect(themeCss).not.toMatch(/::part\(day\)\s*{[^}]*\bcolor:/);
+            expect(themeCss).toMatch(/--ar-datepicker-day-color:/);
+            expect(themeCss).toMatch(/--ar-datepicker-day-bg:/);
         });
     });
 });

--- a/packages/core/src/components/datepicker/datepicker.ts
+++ b/packages/core/src/components/datepicker/datepicker.ts
@@ -54,10 +54,6 @@ import { warn } from '../../utils/warn.js';
  * @cssprop --ar-datepicker-nav-btn-border-color - Couleur de bordure des boutons nav.
  * @cssprop --ar-datepicker-footer-btn-border-color - Couleur de bordure des boutons footer.
  * @cssprop --ar-datepicker-day-size - Taille des cellules jour (repli `2.5rem` si aucun thème n'est chargé — cible tactile WCAG 2.5.8 Target Size Minimum, la grille utilisant border-collapse: collapse qui supprime l'espacement natif du <table>).
- * @cssprop --ar-datepicker-day-font-size - Taille de police des jours.
- * @cssprop --ar-datepicker-day-radius - Border-radius des cellules jour.
- * @cssprop --ar-datepicker-day-bg - Fond des cellules jour.
- * @cssprop --ar-datepicker-day-border-width - Épaisseur de bordure des cellules jour.
  * @cssprop --ar-datepicker-day-border-color - Couleur de bordure par défaut des cellules jour. Repli `transparent` si aucun thème n'est chargé (préserve l'absence de bordure voulue par défaut ; sans ce repli, une propriété longhand `border-color` isolée dégraderait vers `currentcolor`, une bordure non désirée sur chaque cellule).
  * @cssprop --ar-datepicker-day-other-month-color - Couleur des jours hors du mois affiché. Repli `GrayText` si aucun thème n'est chargé.
  * @cssprop --ar-datepicker-day-today-bg - Fond du jour actuel.
@@ -73,7 +69,6 @@ import { warn } from '../../utils/warn.js';
  * @cssprop --ar-datepicker-input-error-border-color - Bordure input en état d'erreur.
  * @cssprop --ar-datepicker-nav-btn-focus-ring-color - Couleur de l'anneau de focus des boutons de navigation (cascade vers --ar-focus-ring-color). Repli `ButtonText` si aucun thème n'est chargé (WCAG 2.4.7).
  * @cssprop --ar-datepicker-footer-btn-focus-ring-color - Couleur de l'anneau de focus des boutons du footer (cascade vers --ar-focus-ring-color). Repli `ButtonText` si aucun thème n'est chargé (WCAG 2.4.7).
- * @cssprop --ar-datepicker-day-color - Couleur du texte des cellules jour (cascade vers --ar-color-text).
  * @cssprop --ar-panel-bg - Couleur de bordure de la cellule jour focusée dans la grille (contraste avec l'anneau de focus). Le popover pilote son fond réel via ce token (panelStyles) ; référencer --ar-color-bg directement casserait ce cutout pour un consommateur ne surchargeant que --ar-panel-bg.
  *
  * @event {CustomEvent} ar-datepicker-input-change   - Valeur commitée (blur ou sélection calendrier).

--- a/packages/core/src/components/datepicker/datepicker.ts
+++ b/packages/core/src/components/datepicker/datepicker.ts
@@ -52,6 +52,8 @@ import { warn } from '../../utils/warn.js';
  * @cssprop --ar-datepicker-footer-btn-border-color - Couleur de bordure des boutons footer.
  * @cssprop --ar-datepicker-day-size - Taille des cellules jour (repli `2.5rem` si aucun thème n'est chargé — cible tactile WCAG 2.5.8 Target Size Minimum, la grille utilisant border-collapse: collapse qui supprime l'espacement natif du <table>).
  * @cssprop --ar-datepicker-day-border-color - Couleur de bordure par défaut des cellules jour. Repli `transparent` si aucun thème n'est chargé (préserve l'absence de bordure voulue par défaut ; sans ce repli, une propriété longhand `border-color` isolée dégraderait vers `currentcolor`, une bordure non désirée sur chaque cellule).
+ * @cssprop --ar-datepicker-day-color - Couleur du texte des cellules jour (cascade vers --ar-color-text).
+ * @cssprop --ar-datepicker-day-bg - Fond des cellules jour.
  * @cssprop --ar-datepicker-day-other-month-color - Couleur des jours hors du mois affiché. Repli `GrayText` si aucun thème n'est chargé.
  * @cssprop --ar-datepicker-day-today-bg - Fond du jour actuel.
  * @cssprop --ar-datepicker-day-today-color - Couleur texte du jour actuel.

--- a/packages/core/src/components/datepicker/datepicker.ts
+++ b/packages/core/src/components/datepicker/datepicker.ts
@@ -59,15 +59,7 @@ import { warn } from '../../utils/warn.js';
  * @cssprop --ar-datepicker-footer-padding - Padding du footer.
  * @cssprop --ar-datepicker-footer-bg - Fond du footer.
  * @cssprop --ar-datepicker-footer-margin - Margin du footer.
- * @cssprop --ar-datepicker-footer-btn-bg - Fond des boutons du footer.
- * @cssprop --ar-datepicker-footer-btn-border-width - Épaisseur de bordure des boutons footer.
  * @cssprop --ar-datepicker-footer-btn-border-color - Couleur de bordure des boutons footer.
- * @cssprop --ar-datepicker-footer-btn-color - Couleur texte des boutons footer.
- * @cssprop --ar-datepicker-footer-btn-radius - Border-radius des boutons footer.
- * @cssprop --ar-datepicker-footer-btn-padding - Padding des boutons footer.
- * @cssprop --ar-datepicker-footer-btn-hover-bg - Fond au survol des boutons footer.
- * @cssprop --ar-datepicker-footer-btn-hover-border-color - Couleur de bordure au survol des boutons footer.
- * @cssprop --ar-datepicker-footer-btn-active-bg - Fond à l'état actif des boutons footer.
  * @cssprop --ar-datepicker-weekday-color - Couleur des abréviations de jours.
  * @cssprop --ar-datepicker-weekday-font-size - Taille de police des abréviations de jours.
  * @cssprop --ar-datepicker-day-size - Taille des cellules jour (repli `2.5rem` si aucun thème n'est chargé — cible tactile WCAG 2.5.8 Target Size Minimum, la grille utilisant border-collapse: collapse qui supprime l'espacement natif du <table>).
@@ -90,7 +82,6 @@ import { warn } from '../../utils/warn.js';
  * @cssprop --ar-datepicker-input-error-border-color - Bordure input en état d'erreur.
  * @cssprop --ar-datepicker-nav-btn-focus-ring-color - Couleur de l'anneau de focus des boutons de navigation (cascade vers --ar-focus-ring-color). Repli `ButtonText` si aucun thème n'est chargé (WCAG 2.4.7).
  * @cssprop --ar-datepicker-footer-btn-focus-ring-color - Couleur de l'anneau de focus des boutons du footer (cascade vers --ar-focus-ring-color). Repli `ButtonText` si aucun thème n'est chargé (WCAG 2.4.7).
- * @cssprop --ar-datepicker-footer-btn-focus-ring-offset - Décalage de l'anneau de focus des boutons du footer (cascade vers --ar-focus-ring-offset).
  * @cssprop --ar-datepicker-day-color - Couleur du texte des cellules jour (cascade vers --ar-color-text).
  * @cssprop --ar-panel-bg - Couleur de bordure de la cellule jour focusée dans la grille (contraste avec l'anneau de focus). Le popover pilote son fond réel via ce token (panelStyles) ; référencer --ar-color-bg directement casserait ce cutout pour un consommateur ne surchargeant que --ar-panel-bg.
  *

--- a/packages/core/src/components/datepicker/datepicker.ts
+++ b/packages/core/src/components/datepicker/datepicker.ts
@@ -50,15 +50,7 @@ import { warn } from '../../utils/warn.js';
  * @cssprop --ar-datepicker-panel-padding - Padding interne du popover (valeur propre, non cascadée depuis --ar-panel-padding).
  * @cssprop --ar-datepicker-distance - Espacement entre le trigger et le panel.
  * @cssprop --ar-datepicker-offset - Décalage latéral du panel.
- * @cssprop --ar-datepicker-header-font-size - Taille de police de l'en-tête.
- * @cssprop --ar-datepicker-header-padding - Padding de l'en-tête.
- * @cssprop --ar-datepicker-header-margin - Margin de l'en-tête.
- * @cssprop --ar-datepicker-header-radius - Border-radius de l'en-tête.
- * @cssprop --ar-datepicker-header-bg - Fond de l'en-tête.
  * @cssprop --ar-datepicker-nav-btn-border-color - Couleur de bordure des boutons nav.
- * @cssprop --ar-datepicker-footer-padding - Padding du footer.
- * @cssprop --ar-datepicker-footer-bg - Fond du footer.
- * @cssprop --ar-datepicker-footer-margin - Margin du footer.
  * @cssprop --ar-datepicker-footer-btn-border-color - Couleur de bordure des boutons footer.
  * @cssprop --ar-datepicker-weekday-color - Couleur des abréviations de jours.
  * @cssprop --ar-datepicker-weekday-font-size - Taille de police des abréviations de jours.

--- a/packages/core/src/components/datepicker/datepicker.ts
+++ b/packages/core/src/components/datepicker/datepicker.ts
@@ -55,14 +55,7 @@ import { warn } from '../../utils/warn.js';
  * @cssprop --ar-datepicker-header-margin - Margin de l'en-tête.
  * @cssprop --ar-datepicker-header-radius - Border-radius de l'en-tête.
  * @cssprop --ar-datepicker-header-bg - Fond de l'en-tête.
- * @cssprop --ar-datepicker-nav-btn-size - Taille (width = height) des boutons nav.
- * @cssprop --ar-datepicker-nav-btn-bg - Fond des boutons de navigation.
- * @cssprop --ar-datepicker-nav-btn-border-width - Épaisseur de bordure des boutons nav.
  * @cssprop --ar-datepicker-nav-btn-border-color - Couleur de bordure des boutons nav.
- * @cssprop --ar-datepicker-nav-btn-color - Couleur texte des boutons nav.
- * @cssprop --ar-datepicker-nav-btn-radius - Border-radius des boutons nav.
- * @cssprop --ar-datepicker-nav-btn-hover-bg - Fond au survol des boutons nav.
- * @cssprop --ar-datepicker-nav-btn-active-bg - Fond à l'état actif des boutons nav.
  * @cssprop --ar-datepicker-footer-padding - Padding du footer.
  * @cssprop --ar-datepicker-footer-bg - Fond du footer.
  * @cssprop --ar-datepicker-footer-margin - Margin du footer.
@@ -96,7 +89,6 @@ import { warn } from '../../utils/warn.js';
  * @cssprop --ar-datepicker-day-selected-color - Couleur texte du jour sélectionné. Repli `HighlightText` si aucun thème n'est chargé.
  * @cssprop --ar-datepicker-input-error-border-color - Bordure input en état d'erreur.
  * @cssprop --ar-datepicker-nav-btn-focus-ring-color - Couleur de l'anneau de focus des boutons de navigation (cascade vers --ar-focus-ring-color). Repli `ButtonText` si aucun thème n'est chargé (WCAG 2.4.7).
- * @cssprop --ar-datepicker-nav-btn-focus-ring-offset - Décalage de l'anneau de focus des boutons de navigation (cascade vers --ar-focus-ring-offset).
  * @cssprop --ar-datepicker-footer-btn-focus-ring-color - Couleur de l'anneau de focus des boutons du footer (cascade vers --ar-focus-ring-color). Repli `ButtonText` si aucun thème n'est chargé (WCAG 2.4.7).
  * @cssprop --ar-datepicker-footer-btn-focus-ring-offset - Décalage de l'anneau de focus des boutons du footer (cascade vers --ar-focus-ring-offset).
  * @cssprop --ar-datepicker-day-color - Couleur du texte des cellules jour (cascade vers --ar-color-text).

--- a/packages/core/src/components/datepicker/datepicker.ts
+++ b/packages/core/src/components/datepicker/datepicker.ts
@@ -44,7 +44,6 @@ import { warn } from '../../utils/warn.js';
  * @csspart close-btn  - Bouton « Fermer ».
  *
  * @cssprop --ar-datepicker-gap - Espacement vertical entre le label, le champ et l'indice.
- * @cssprop --ar-datepicker-label-gap - Marge sous le label (combinée à `--ar-datepicker-gap` via `calc()`).
  * @cssprop --ar-datepicker-error-color - Couleur du message d'erreur.
  * @cssprop --ar-datepicker-panel-max-width - Largeur maximale du popover (valeur propre, non cascadée depuis --ar-panel-max-width ; repli `25rem` si aucun thème n'est chargé, évite que la grille de ~35 jours s'étale sur toute la largeur de la page).
  * @cssprop --ar-datepicker-distance - Espacement entre le trigger et le panel.

--- a/packages/core/src/components/datepicker/datepicker.ts
+++ b/packages/core/src/components/datepicker/datepicker.ts
@@ -33,6 +33,7 @@ import { warn } from '../../utils/warn.js';
  * @csspart next-month - Bouton mois suivant.
  * @csspart next-year  - Bouton année suivante.
  * @csspart grid       - La grille calendrier.
+ * @csspart weekday    - Les cellules d'en-tête de colonne (abréviations de jours).
  * @csspart label      - L'élément label.
  * @csspart hint       - Le texte d'aide sous l'input.
  * @csspart error      - Le message d'erreur sous l'input.
@@ -52,8 +53,6 @@ import { warn } from '../../utils/warn.js';
  * @cssprop --ar-datepicker-offset - Décalage latéral du panel.
  * @cssprop --ar-datepicker-nav-btn-border-color - Couleur de bordure des boutons nav.
  * @cssprop --ar-datepicker-footer-btn-border-color - Couleur de bordure des boutons footer.
- * @cssprop --ar-datepicker-weekday-color - Couleur des abréviations de jours.
- * @cssprop --ar-datepicker-weekday-font-size - Taille de police des abréviations de jours.
  * @cssprop --ar-datepicker-day-size - Taille des cellules jour (repli `2.5rem` si aucun thème n'est chargé — cible tactile WCAG 2.5.8 Target Size Minimum, la grille utilisant border-collapse: collapse qui supprime l'espacement natif du <table>).
  * @cssprop --ar-datepicker-day-font-size - Taille de police des jours.
  * @cssprop --ar-datepicker-day-radius - Border-radius des cellules jour.
@@ -352,7 +351,9 @@ export class ArDatepicker extends LitElement {
                     <tr>
                         ${dayNames.map(
                             ({ abbr, full }) =>
-                                html`<th aria-label=${full} scope="col">${abbr}</th>`,
+                                html`<th part="weekday" aria-label=${full} scope="col">
+                                    ${abbr}
+                                </th>`,
                         )}
                     </tr>
                 </thead>

--- a/packages/core/src/components/datepicker/datepicker.ts
+++ b/packages/core/src/components/datepicker/datepicker.ts
@@ -46,9 +46,7 @@ import { warn } from '../../utils/warn.js';
  * @cssprop --ar-datepicker-gap - Espacement vertical entre le label, le champ et l'indice.
  * @cssprop --ar-datepicker-label-gap - Marge sous le label (combinée à `--ar-datepicker-gap` via `calc()`).
  * @cssprop --ar-datepicker-error-color - Couleur du message d'erreur.
- * @cssprop --ar-datepicker-panel-width - Largeur du popover.
  * @cssprop --ar-datepicker-panel-max-width - Largeur maximale du popover (valeur propre, non cascadée depuis --ar-panel-max-width ; repli `25rem` si aucun thème n'est chargé, évite que la grille de ~35 jours s'étale sur toute la largeur de la page).
- * @cssprop --ar-datepicker-panel-padding - Padding interne du popover (valeur propre, non cascadée depuis --ar-panel-padding).
  * @cssprop --ar-datepicker-distance - Espacement entre le trigger et le panel.
  * @cssprop --ar-datepicker-offset - Décalage latéral du panel.
  * @cssprop --ar-datepicker-nav-btn-border-color - Couleur de bordure des boutons nav.

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -540,7 +540,6 @@
         --ar-datepicker-distance: var(--ar-anchor-distance);
         --ar-datepicker-offset: var(--ar-anchor-offset);
         --ar-datepicker-gap: 0.35rem;
-        --ar-datepicker-label-gap: 0.5rem;
         /* --ar-color-danger-text (pas red-50 directement) : même convention que
            ar-alert/ar-charcounter, calibré pour le contraste AA sur texte (axe-core) */
         --ar-datepicker-error-color: var(--ar-color-danger-text);
@@ -770,7 +769,7 @@
         font-size: var(--ar-font-size-sm);
         font-weight: var(--ar-font-weight-medium);
         color: var(--ar-color-text);
-        margin-bottom: calc(var(--ar-datepicker-label-gap) - var(--ar-datepicker-gap));
+        margin-bottom: calc(0.5rem - var(--ar-datepicker-gap));
     }
 
     ar-datepicker::part(hint) {

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -559,9 +559,6 @@
         --ar-datepicker-footer-btn-border-color: var(--ar-color-border);
         --ar-datepicker-footer-btn-focus-ring-color: var(--ar-focus-ring-color);
 
-        /* neutral-60 (~2.6:1 sur blanc) — distinction visuelle prioritaire sur AA strict */
-        --ar-datepicker-weekday-color: var(--ar-color-neutral-50);
-        --ar-datepicker-weekday-font-size: 0.75rem;
         --ar-datepicker-day-other-month-color: var(--ar-color-neutral-50);
 
         --ar-datepicker-day-font-size: 1rem;
@@ -851,5 +848,11 @@
     ar-datepicker::part(trigger):disabled {
         opacity: 0.5;
         cursor: not-allowed;
+    }
+
+    /* neutral-60 (~2.6:1 sur blanc) — distinction visuelle prioritaire sur AA strict */
+    ar-datepicker::part(weekday) {
+        color: var(--ar-color-neutral-50);
+        font-size: 0.75rem;
     }
 }

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -561,11 +561,7 @@
 
         --ar-datepicker-day-other-month-color: var(--ar-color-neutral-50);
 
-        --ar-datepicker-day-font-size: 1rem;
-        --ar-datepicker-day-color: var(--ar-color-text);
         --ar-datepicker-day-size: 2.5rem;
-        --ar-datepicker-day-radius: 0.5rem;
-        --ar-datepicker-day-bg: transparent;
 
         --ar-datepicker-day-today-color: var(--ar-color-primary-40);
         --ar-datepicker-day-today-border: var(--ar-color-primary-50);
@@ -577,7 +573,6 @@
         --ar-datepicker-day-focus-ring-color: var(--ar-focus-ring-color);
         --ar-datepicker-day-focus-ring-width: 2px;
         --ar-datepicker-day-focus-ring-offset: 0;
-        --ar-datepicker-day-border-width: 2px;
         --ar-datepicker-day-border-color: transparent;
 
         --ar-datepicker-day-selected-bg: var(--ar-color-primary-40);
@@ -854,5 +849,13 @@
     ar-datepicker::part(weekday) {
         color: var(--ar-color-neutral-50);
         font-size: 0.75rem;
+    }
+
+    ar-datepicker::part(day) {
+        font-size: 1rem;
+        color: var(--ar-color-text);
+        border-radius: 0.5rem;
+        background-color: transparent;
+        border-width: 2px;
     }
 }

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -545,13 +545,11 @@
            ar-alert/ar-charcounter, calibré pour le contraste AA sur texte (axe-core) */
         --ar-datepicker-error-color: var(--ar-color-danger-text);
 
-        --ar-datepicker-panel-width: 20rem;
-        /* Valeurs propres, volontairement non cascadées depuis --ar-panel-max-width/--ar-panel-padding
-           (bloc partagé dropdown/breadcrumb/stepper) : le panel calendrier datepicker a toujours
-           nécessité une taille plus généreuse (25rem/1rem) que la valeur par défaut partagée
-           (18rem/0.25rem) — même précédent que --ar-dropdown-min-width. */
+        /* Valeur propre, volontairement non cascadée depuis --ar-panel-max-width (bloc partagé
+           dropdown/breadcrumb/stepper) : le panel calendrier datepicker a toujours nécessité une
+           taille plus généreuse (25rem) que la valeur par défaut partagée (18rem) — même
+           précédent que --ar-dropdown-min-width. */
         --ar-datepicker-panel-max-width: 25rem;
-        --ar-datepicker-panel-padding: 1rem;
 
         --ar-datepicker-nav-btn-border-color: transparent;
         --ar-datepicker-nav-btn-focus-ring-color: var(--ar-focus-ring-color);
@@ -705,6 +703,11 @@
 
             --ar-datepicker-input-error-border-color: var(--ar-color-red-40);
         }
+    }
+
+    ar-datepicker::part(panel) {
+        width: 20rem;
+        padding: 1rem;
     }
 
     ar-datepicker::part(nav-btn) {

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -571,6 +571,8 @@
         --ar-datepicker-day-focus-ring-width: 2px;
         --ar-datepicker-day-focus-ring-offset: 0;
         --ar-datepicker-day-border-color: transparent;
+        --ar-datepicker-day-color: var(--ar-color-text);
+        --ar-datepicker-day-bg: transparent;
 
         --ar-datepicker-day-selected-bg: var(--ar-color-primary-40);
         --ar-datepicker-day-selected-color: var(--ar-color-white);
@@ -856,9 +858,7 @@
 
         &::part(day) {
             font-size: 1rem;
-            color: var(--ar-color-text);
             border-radius: 0.5rem;
-            background-color: transparent;
             border-width: 2px;
         }
     }

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -566,25 +566,8 @@
         --ar-datepicker-footer-padding: 0.75rem 0 0;
         --ar-datepicker-footer-bg: transparent;
 
-        --ar-datepicker-footer-btn-bg: transparent;
-        --ar-datepicker-footer-btn-border-width: 1px;
         --ar-datepicker-footer-btn-border-color: var(--ar-color-border);
-        --ar-datepicker-footer-btn-color: var(--ar-color-interactive);
-        --ar-datepicker-footer-btn-radius: var(--ar-border-radius-md);
-        --ar-datepicker-footer-btn-padding: 0.375rem 0.75rem;
-        --ar-datepicker-footer-btn-hover-bg: color-mix(
-            in srgb,
-            var(--ar-color-interactive) 10%,
-            transparent
-        );
-        --ar-datepicker-footer-btn-hover-border-color: var(--ar-color-interactive);
-        --ar-datepicker-footer-btn-active-bg: color-mix(
-            in srgb,
-            var(--ar-color-interactive) 18%,
-            transparent
-        );
         --ar-datepicker-footer-btn-focus-ring-color: var(--ar-focus-ring-color);
-        --ar-datepicker-footer-btn-focus-ring-offset: var(--ar-focus-ring-offset);
 
         /* neutral-60 (~2.6:1 sur blanc) — distinction visuelle prioritaire sur AA strict */
         --ar-datepicker-weekday-color: var(--ar-color-neutral-50);
@@ -760,6 +743,27 @@
     }
 
     ar-datepicker::part(nav-btn):focus-visible {
+        outline-offset: var(--ar-focus-ring-offset);
+    }
+
+    ar-datepicker::part(footer-btn) {
+        background: transparent;
+        border-width: 1px;
+        color: var(--ar-color-interactive);
+        border-radius: var(--ar-border-radius-md);
+        padding: 0.375rem 0.75rem;
+    }
+
+    ar-datepicker::part(footer-btn):hover {
+        background: color-mix(in srgb, var(--ar-color-interactive) 10%, transparent);
+        border-color: var(--ar-color-interactive);
+    }
+
+    ar-datepicker::part(footer-btn):active {
+        background: color-mix(in srgb, var(--ar-color-interactive) 18%, transparent);
+    }
+
+    ar-datepicker::part(footer-btn):focus-visible {
         outline-offset: var(--ar-focus-ring-offset);
     }
 

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -559,20 +559,8 @@
         --ar-datepicker-header-radius: 0;
         --ar-datepicker-header-bg: transparent;
 
-        --ar-datepicker-nav-btn-size: 2rem;
-        --ar-datepicker-nav-btn-bg: transparent;
-        --ar-datepicker-nav-btn-border-width: 0px;
         --ar-datepicker-nav-btn-border-color: transparent;
-        --ar-datepicker-nav-btn-color: var(--ar-color-text);
-        --ar-datepicker-nav-btn-radius: var(--ar-border-radius-sm);
-        --ar-datepicker-nav-btn-hover-bg: color-mix(in srgb, var(--ar-color-text) 8%, transparent);
-        --ar-datepicker-nav-btn-active-bg: color-mix(
-            in srgb,
-            var(--ar-color-text) 14%,
-            transparent
-        );
         --ar-datepicker-nav-btn-focus-ring-color: var(--ar-focus-ring-color);
-        --ar-datepicker-nav-btn-focus-ring-offset: var(--ar-focus-ring-offset);
 
         --ar-datepicker-footer-margin: 0;
         --ar-datepicker-footer-padding: 0.75rem 0 0;
@@ -752,6 +740,27 @@
 
             --ar-datepicker-input-error-border-color: var(--ar-color-red-40);
         }
+    }
+
+    ar-datepicker::part(nav-btn) {
+        width: 2rem;
+        height: 2rem;
+        background: transparent;
+        border-width: 0px;
+        color: var(--ar-color-text);
+        border-radius: var(--ar-border-radius-sm);
+    }
+
+    ar-datepicker::part(nav-btn):hover {
+        background: color-mix(in srgb, var(--ar-color-text) 8%, transparent);
+    }
+
+    ar-datepicker::part(nav-btn):active {
+        background: color-mix(in srgb, var(--ar-color-text) 14%, transparent);
+    }
+
+    ar-datepicker::part(nav-btn):focus-visible {
+        outline-offset: var(--ar-focus-ring-offset);
     }
 
     ar-datepicker::part(label) {

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -704,160 +704,162 @@
         }
     }
 
-    ar-datepicker::part(panel) {
-        width: 20rem;
-        padding: 1rem;
-    }
+    ar-datepicker {
+        &::part(panel) {
+            width: 20rem;
+            padding: 1rem;
+        }
 
-    ar-datepicker::part(nav-btn) {
-        width: 2rem;
-        height: 2rem;
-        background: transparent;
-        border-width: 0px;
-        color: var(--ar-color-text);
-        border-radius: var(--ar-border-radius-sm);
-    }
+        &::part(nav-btn) {
+            width: 2rem;
+            height: 2rem;
+            background: transparent;
+            border-width: 0px;
+            color: var(--ar-color-text);
+            border-radius: var(--ar-border-radius-sm);
+        }
 
-    ar-datepicker::part(nav-btn):hover {
-        background: color-mix(in srgb, var(--ar-color-text) 8%, transparent);
-    }
+        &::part(nav-btn):hover {
+            background: color-mix(in srgb, var(--ar-color-text) 8%, transparent);
+        }
 
-    ar-datepicker::part(nav-btn):active {
-        background: color-mix(in srgb, var(--ar-color-text) 14%, transparent);
-    }
+        &::part(nav-btn):active {
+            background: color-mix(in srgb, var(--ar-color-text) 14%, transparent);
+        }
 
-    ar-datepicker::part(nav-btn):focus-visible {
-        outline-offset: var(--ar-focus-ring-offset);
-    }
+        &::part(nav-btn):focus-visible {
+            outline-offset: var(--ar-focus-ring-offset);
+        }
 
-    ar-datepicker::part(footer-btn) {
-        background: transparent;
-        border-width: 1px;
-        color: var(--ar-color-interactive);
-        border-radius: var(--ar-border-radius-md);
-        padding: 0.375rem 0.75rem;
-    }
+        &::part(footer-btn) {
+            background: transparent;
+            border-width: 1px;
+            color: var(--ar-color-interactive);
+            border-radius: var(--ar-border-radius-md);
+            padding: 0.375rem 0.75rem;
+        }
 
-    ar-datepicker::part(footer-btn):hover {
-        background: color-mix(in srgb, var(--ar-color-interactive) 10%, transparent);
-        border-color: var(--ar-color-interactive);
-    }
+        &::part(footer-btn):hover {
+            background: color-mix(in srgb, var(--ar-color-interactive) 10%, transparent);
+            border-color: var(--ar-color-interactive);
+        }
 
-    ar-datepicker::part(footer-btn):active {
-        background: color-mix(in srgb, var(--ar-color-interactive) 18%, transparent);
-    }
+        &::part(footer-btn):active {
+            background: color-mix(in srgb, var(--ar-color-interactive) 18%, transparent);
+        }
 
-    ar-datepicker::part(footer-btn):focus-visible {
-        outline-offset: var(--ar-focus-ring-offset);
-    }
+        &::part(footer-btn):focus-visible {
+            outline-offset: var(--ar-focus-ring-offset);
+        }
 
-    ar-datepicker::part(header) {
-        font-size: 1rem;
-        margin: 0;
-        padding: 0 0 0.75rem;
-        border-radius: 0;
-        background: transparent;
-    }
+        &::part(header) {
+            font-size: 1rem;
+            margin: 0;
+            padding: 0 0 0.75rem;
+            border-radius: 0;
+            background: transparent;
+        }
 
-    ar-datepicker::part(footer) {
-        margin: 0;
-        padding: 0.75rem 0 0;
-        background: transparent;
-    }
+        &::part(footer) {
+            margin: 0;
+            padding: 0.75rem 0 0;
+            background: transparent;
+        }
 
-    ar-datepicker::part(label) {
-        font-size: var(--ar-font-size-sm);
-        font-weight: var(--ar-font-weight-medium);
-        color: var(--ar-color-text);
-        margin-bottom: calc(0.5rem - var(--ar-datepicker-gap));
-    }
+        &::part(label) {
+            font-size: var(--ar-font-size-sm);
+            font-weight: var(--ar-font-weight-medium);
+            color: var(--ar-color-text);
+            margin-bottom: calc(0.5rem - var(--ar-datepicker-gap));
+        }
 
-    ar-datepicker::part(hint) {
-        font-size: var(--ar-font-size-sm);
-        color: var(--ar-color-text-muted);
-    }
+        &::part(hint) {
+            font-size: var(--ar-font-size-sm);
+            color: var(--ar-color-text-muted);
+        }
 
-    ar-datepicker::part(error) {
-        font-size: var(--ar-font-size-sm);
-        color: var(--ar-datepicker-error-color);
-    }
+        &::part(error) {
+            font-size: var(--ar-font-size-sm);
+            color: var(--ar-datepicker-error-color);
+        }
 
-    ar-datepicker::part(input) {
-        height: var(--ar-button-height);
-        box-sizing: border-box;
-        padding: 0 0.75rem;
-        border: 1px solid var(--ar-color-border);
-        border-right: none;
-        border-radius: var(--ar-border-radius-md) 0 0 var(--ar-border-radius-md);
-        background: var(--ar-color-bg);
-        color: var(--ar-color-text);
-        font-size: var(--ar-font-size-md);
-        font-family: inherit;
-        outline: none;
-        transition: border-color 0.15s ease;
-    }
+        &::part(input) {
+            height: var(--ar-button-height);
+            box-sizing: border-box;
+            padding: 0 0.75rem;
+            border: 1px solid var(--ar-color-border);
+            border-right: none;
+            border-radius: var(--ar-border-radius-md) 0 0 var(--ar-border-radius-md);
+            background: var(--ar-color-bg);
+            color: var(--ar-color-text);
+            font-size: var(--ar-font-size-md);
+            font-family: inherit;
+            outline: none;
+            transition: border-color 0.15s ease;
+        }
 
-    ar-datepicker::part(input):focus-visible {
-        outline: 2px solid var(--ar-focus-ring-color);
-        outline-offset: var(--ar-focus-ring-offset);
-        border-color: var(--ar-color-interactive);
-    }
+        &::part(input):focus-visible {
+            outline: 2px solid var(--ar-focus-ring-color);
+            outline-offset: var(--ar-focus-ring-offset);
+            border-color: var(--ar-color-interactive);
+        }
 
-    ar-datepicker::part(input):read-only {
-        background: var(--ar-color-bg-subtle);
-        cursor: default;
-    }
+        &::part(input):read-only {
+            background: var(--ar-color-bg-subtle);
+            cursor: default;
+        }
 
-    ar-datepicker::part(input):disabled {
-        opacity: 0.5;
-        cursor: not-allowed;
-        background: var(--ar-color-bg-subtle);
-    }
+        &::part(input):disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+            background: var(--ar-color-bg-subtle);
+        }
 
-    ar-datepicker::part(trigger) {
-        width: var(--ar-button-height);
-        height: var(--ar-button-height);
-        background: var(--ar-color-interactive);
-        color: var(--ar-color-text-inverse);
-        border: 1px solid var(--ar-color-interactive);
-        border-radius: 0 var(--ar-border-radius-md) var(--ar-border-radius-md) 0;
-        cursor: pointer;
-        transition:
-            background 0.15s ease,
-            border-color 0.15s ease;
-    }
+        &::part(trigger) {
+            width: var(--ar-button-height);
+            height: var(--ar-button-height);
+            background: var(--ar-color-interactive);
+            color: var(--ar-color-text-inverse);
+            border: 1px solid var(--ar-color-interactive);
+            border-radius: 0 var(--ar-border-radius-md) var(--ar-border-radius-md) 0;
+            cursor: pointer;
+            transition:
+                background 0.15s ease,
+                border-color 0.15s ease;
+        }
 
-    ar-datepicker::part(trigger):hover:not(:disabled) {
-        background: var(--ar-color-interactive-hover);
-        border-color: var(--ar-color-interactive-hover);
-    }
+        &::part(trigger):hover:not(:disabled) {
+            background: var(--ar-color-interactive-hover);
+            border-color: var(--ar-color-interactive-hover);
+        }
 
-    ar-datepicker::part(trigger):active:not(:disabled) {
-        background: var(--ar-color-interactive-active);
-        border-color: var(--ar-color-interactive-active);
-    }
+        &::part(trigger):active:not(:disabled) {
+            background: var(--ar-color-interactive-active);
+            border-color: var(--ar-color-interactive-active);
+        }
 
-    ar-datepicker::part(trigger):focus-visible {
-        outline: 2px solid var(--ar-focus-ring-color);
-        outline-offset: var(--ar-focus-ring-offset);
-    }
+        &::part(trigger):focus-visible {
+            outline: 2px solid var(--ar-focus-ring-color);
+            outline-offset: var(--ar-focus-ring-offset);
+        }
 
-    ar-datepicker::part(trigger):disabled {
-        opacity: 0.5;
-        cursor: not-allowed;
-    }
+        &::part(trigger):disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
 
-    /* neutral-60 (~2.6:1 sur blanc) — distinction visuelle prioritaire sur AA strict */
-    ar-datepicker::part(weekday) {
-        color: var(--ar-color-neutral-50);
-        font-size: 0.75rem;
-    }
+        /* neutral-60 (~2.6:1 sur blanc) — distinction visuelle prioritaire sur AA strict */
+        &::part(weekday) {
+            color: var(--ar-color-neutral-50);
+            font-size: 0.75rem;
+        }
 
-    ar-datepicker::part(day) {
-        font-size: 1rem;
-        color: var(--ar-color-text);
-        border-radius: 0.5rem;
-        background-color: transparent;
-        border-width: 2px;
+        &::part(day) {
+            font-size: 1rem;
+            color: var(--ar-color-text);
+            border-radius: 0.5rem;
+            background-color: transparent;
+            border-width: 2px;
+        }
     }
 }

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -553,18 +553,8 @@
         --ar-datepicker-panel-max-width: 25rem;
         --ar-datepicker-panel-padding: 1rem;
 
-        --ar-datepicker-header-font-size: 1rem;
-        --ar-datepicker-header-margin: 0;
-        --ar-datepicker-header-padding: 0 0 0.75rem;
-        --ar-datepicker-header-radius: 0;
-        --ar-datepicker-header-bg: transparent;
-
         --ar-datepicker-nav-btn-border-color: transparent;
         --ar-datepicker-nav-btn-focus-ring-color: var(--ar-focus-ring-color);
-
-        --ar-datepicker-footer-margin: 0;
-        --ar-datepicker-footer-padding: 0.75rem 0 0;
-        --ar-datepicker-footer-bg: transparent;
 
         --ar-datepicker-footer-btn-border-color: var(--ar-color-border);
         --ar-datepicker-footer-btn-focus-ring-color: var(--ar-focus-ring-color);
@@ -765,6 +755,20 @@
 
     ar-datepicker::part(footer-btn):focus-visible {
         outline-offset: var(--ar-focus-ring-offset);
+    }
+
+    ar-datepicker::part(header) {
+        font-size: 1rem;
+        margin: 0;
+        padding: 0 0 0.75rem;
+        border-radius: 0;
+        background: transparent;
+    }
+
+    ar-datepicker::part(footer) {
+        margin: 0;
+        padding: 0.75rem 0 0;
+        background: transparent;
     }
 
     ar-datepicker::part(label) {


### PR DESCRIPTION
## Summary
Traite la réflexion token vs `::part()` (suite à PR #136), avec `ar-datepicker` comme cas d'étude explicitement demandé : sur 58 tokens `:root`, 65% n'étaient consommés qu'à un seul endroit — pure valeur d'override sans réutilisation DRY, alors que `::part()` offre déjà ce point de surcharge gratuitement.

**Critère à 4 branches** appliqué (détail : `docs/superpowers/specs/2026-07-24-token-vs-part-datepicker-design.md`, amendement ADR-005) : fallback WCAG/fonctionnel, lu en JS, réutilisé ≥2×, sinon → migré vers `::part()`. **33 tokens migrés vers 8 nouvelles règles `::part()`** groupées (`nav-btn`, `footer-btn`, `header`, `footer`, `weekday` — nouveau part créé —, `day`, `panel`, `label` amendée), puis regroupées sous nesting CSS natif (`ar-datepicker { &::part(...) { ... } }`) pour la lisibilité. **25 tokens conservés** sur 58 (-57%).

**Bug critique trouvé et corrigé en revue finale** : une règle `::part()` externe (thème) l'emporte sur une règle interne au shadow DOM ciblant la même propriété, **même à spécificité CSS inférieure** — vérifié empiriquement (Chromium réel via Playwright). `color`/`background-color` de `[part='day']` avaient été migrées vers `::part(day)`, ce qui aurait rendu les jours sélectionné/actif/survolé indiscernables des autres (régression WCAG) puisque les règles d'état internes du composant (`.today`, `.selected`, `:hover`) ne peuvent plus les surcharger. Ces deux propriétés sont restées des tokens (`--ar-datepicker-day-color`/`-day-bg`), nouvelle contrainte documentée dans l'amendement ADR-005.

Exécuté en subagent-driven-development : 10 tâches, chacune revue individuellement (spec + qualité), deux tâches ont anticipé un test cassé par leurs propres changements (corrigé au fil de l'eau avec une regex tolérante au nesting à venir). Revue finale de branche (opus) : un Critical trouvé (le bug de cascade ci-dessus) et corrigé, puis re-revue → prêt à merger.

Part of #129.

## Test plan
- [x] `npx vitest run datepicker` (depuis `packages/core`) — 81/81 verts
- [x] `npm run build:manifest --workspace=packages/core` — aucune erreur `validate-cssprop-defaults`
- [x] Vérification empirique du bug de cascade `::part()` et de son correctif via Playwright (harnais temporaire, non committé)
