### PR TITLE
refactor(alert): migre token vs ::part() (lot 3a, #129)

### DIFF
--- a/docs/decisions/ADR-005-tokens-pilotes-par-attribut.md
+++ b/docs/decisions/ADR-005-tokens-pilotes-par-attribut.md
@@ -129,7 +129,8 @@ propriété sur `:host` de la branche 4, au motif que « `::part()` ne peut cibl
 éléments portant un `part`, jamais `:host` ». C'est vrai mais insuffisant — vérifié
 empiriquement (Chromium réel, Playwright) qu'une règle de thème ciblant le tag directement
 (`ar-alert { border-radius: 2rem; }`, sans `::part()`) l'emporte elle aussi sur la règle
-`:host { border-radius: var(--ar-alert-border-radius); }` interne au composant, **même si le
+`:host { border-radius: var(--ar-alert-border-radius); }` (depuis migré — cf. « Application —
+`ar-alert` » ci-dessous) interne au composant, **même si le
 composant continue de déclarer une valeur sur `:host`** — le même mécanisme « la feuille de
 style externe l'emporte sur la règle interne » s'applique, que la cible soit un `[part]` via
 `::part()` ou l'hôte lui-même via son nom de tag (l'hôte reste un élément du light DOM,
@@ -181,6 +182,15 @@ seules les contraintes suivantes restent des exclusions réelles.
    même quand l'ancêtre est survolé. Concrètement : `--ar-stepper-bullet-hover-bg`,
    `--ar-stepper-link-hover-bullet-color`, `--ar-stepper-link-hover-bullet-text-color` et
    `--ar-stepper-link-hover-label-color` restent des tokens pour cette raison.
+6. **Propriété annulée par une garde interne sous `@media` (ex. `prefers-reduced-motion:
+reduce`)** → doit rester un token consommé à l'intérieur du composant, même raisonnement
+   que la contrainte 2 mais pour une règle interne conditionnée par un media query plutôt
+   qu'un état posé par le composant. Vérifié empiriquement (Chromium réel, Playwright) sur
+   `ar-alert` : une règle externe `::part(close) { transition: ... }` déclarée dans le thème
+   l'emporte sur la garde interne `@media (prefers-reduced-motion: reduce) { [part='close']
+{ transition: none; } }`, même quand le media query correspond — la transition externe
+   reste active, ce qui casserait l'accessibilité motion. `--ar-alert-close-transition-duration`
+   reste un token pour cette raison (en plus d'être réutilisé 2× dans le composant, critère 3).
 
 **`:host` n'est plus une exclusion en soi** (correction du 2026-07-25 ci-dessus) — une
 propriété sur `:host` suit le même critère que les autres, migrée vers une règle externe
@@ -335,3 +345,17 @@ quel `var(--ar-*)` consommé dans une règle `::part()`. Le couplage reste garan
 techniquement (pas qu'un commentaire), sans figurer dans l'API publique du composant ni dans sa
 documentation `@cssprop` — et sert au passage d'exemple concret pour un thème qui voudrait
 reproduire la même technique avec sa propre variable.
+
+**Application — `ar-alert` (2026-07-28)**, troisième composant traité (lot 3a, `ar-dialog`
+reste à traiter séparément). 5 tokens migrés : `--ar-alert-padding`, `--ar-alert-border-radius`,
+`--ar-alert-border-width`, `--ar-alert-border-style` (propriétés `:host`, migrées vers une
+règle `ar-alert { }` ciblant directement le tag) et `--ar-alert-close-radius` (migré vers
+`ar-alert::part(close)`). `--ar-alert-close-size` reste un token (réutilisé 2× dans le
+composant pour `width`/`height`, critère 3) mais gagne un fallback WCAG 2.5.8 manquant
+(`var(--ar-alert-close-size, 2rem)`), sur le modèle de `--ar-datepicker-day-size`.
+`--ar-alert-close-transition-duration` reste un token — nouvelle contrainte 6 découverte à
+cette occasion (garde `prefers-reduced-motion` défaite par une règle externe, cf.
+ci-dessus). Les 12 tokens sémantiques (fond/bordure/icône des 4 variants) restent tokens,
+hors périmètre de cette migration (fallback WCAG de contraste + calibration dark-mode
+indépendante sur les bordures). Détail complet :
+`docs/superpowers/plans/2026-07-28-alert-token-vs-part-129.md`.

--- a/docs/decisions/ADR-005-tokens-pilotes-par-attribut.md
+++ b/docs/decisions/ADR-005-tokens-pilotes-par-attribut.md
@@ -359,3 +359,45 @@ ci-dessus). Les 12 tokens sémantiques (fond/bordure/icône des 4 variants) rest
 hors périmètre de cette migration (fallback WCAG de contraste + calibration dark-mode
 indépendante sur les bordures). Détail complet :
 `docs/superpowers/plans/2026-07-28-alert-token-vs-part-129.md`.
+
+**Deuxième passe (même jour)** : audit élargi aux valeurs jamais tokenisées et à une
+recatégorisation. `column-gap` du `:host` (jamais tokenisé) migré en littéral dans
+`ar-alert { }`. `--ar-alert-close-bg`/`--ar-alert-close-hover-bg` — laissés tokens par erreur
+de catégorisation lors de la première passe (supposés sémantiques comme les couleurs de
+variant, sans revérifier les critères) — migrés en littéral dans `ar-alert::part(close)`/
+`::part(close):hover`, même pattern que `nav-btn`/`footer-btn` de `ar-datepicker`. `opacity`/
+`position`/`top`/`right` de `[part='close']` migrés de la même façon ; `:focus-visible`
+(`outline: currentColor`) reste interne (contraste du focus ring contre les 4 fonds de
+variant, probable exigence WCAG 2.4.7). `font-size` de `[part='icon']` migré vers
+`::part(icon)`. La durée d'animation de sortie (`0.33s`, jamais tokenisée) devient
+`--ar-alert-hide-transition-duration`, consommée en interne uniquement (bloquée en externe
+par la contrainte 6 — même garde `prefers-reduced-motion` que `close-transition-duration`).
+Les valeurs finales de l'état `[hiding]` (`opacity: 0`/`transform: scale(0.75)`) migrées vers
+`ar-alert[hiding] { }` — **nouveau cas vérifié empiriquement** : un sélecteur d'attribut
+externe sur le tag suit le cascade CSS normal face à une règle `:host` interne
+inconditionnelle (contrairement à `::part()`/tag non conditionné, qui l'emporte toujours),
+et n'interfère pas avec la garde reduced-motion tant que la propriété `transition`
+elle-même reste interne. `position: relative` mort sur `:host` retiré (aucun descendant n'en
+dépendait). Trou de documentation préexistant comblé : `@csspart icon-svg` (SVG de l'icône de
+variant, jamais documenté depuis l'origine du composant).
+
+**Clarification de la contrainte 2 (même jour)** : la vérification de cette deuxième passe a
+mis au jour une régression réelle sur le bouton de fermeture d'`ar-alert`. La tâche 3 avait
+migré la valeur au repos `opacity: 0.75` vers une règle externe (`ar-alert::part(close)`),
+mais laissé inchangées en interne les règles `&:hover { opacity: 1; }` et
+`&:focus-visible { opacity: 1; ... }` — cassant le hover/focus (opacity bloquée à 0.75),
+confirmé par Playwright. Corrigé en externalisant aussi la gestion hover/focus de l'opacité
+(`&::part(close):hover`/`&::part(close):focus-visible` dans le thème), ne laissant en interne
+que `outline`/`outline-offset` (critique pour l'accessibilité). Le texte de la contrainte 2
+dit que les pseudo-classes natives (`:hover`, `:focus-visible`, etc.) « composent normalement »
+avec une règle externe `::part()`/tag, ce qui peut se lire à tort comme « toujours sûr de
+laisser une règle de pseudo-classe native en interne ». Ce cas prouve cette lecture fausse :
+ce n'est sûr que lorsque la règle de la pseudo-classe elle-même, pour cette même propriété,
+est **aussi** externe. Si le base d'une propriété est migré en externe mais qu'une surcharge
+de pseudo-classe native pour cette même propriété reste interne, le base externe défait quand
+même la surcharge interne (même mécanisme « l'externe l'emporte toujours » que le cas de l'état
+posé par le composant dans la contrainte 2 d'origine) — l'exemption des pseudo-classes natives
+s'applique à la façon dont elles composent avec un base externe (par exemple
+`ar-x:hover { color: red }` se combine sans problème avec une règle de base externe séparée),
+pas au fait de laisser une surcharge d'état seule en interne une fois que son base a quitté le
+composant.

--- a/docs/decisions/ADR-005-tokens-pilotes-par-attribut.md
+++ b/docs/decisions/ADR-005-tokens-pilotes-par-attribut.md
@@ -390,6 +390,19 @@ doit se prémunir contre une durée calculée nulle (absence de thème chargé),
 `ar-collapse` via `_shouldAnimate()`. `ar-alert` a été corrigé dans le même esprit après cette
 migration (garde JS `_shouldAnimate()` avant `_hide()`, cf. issue #129).
 
+**Correctif du correctif (même jour)** : la garde `_shouldAnimate()` ci-dessus lisait
+`getComputedStyle(this).transitionDuration` juste après avoir posé `this.hiding = true`, de
+façon synchrone. Or Lit ne reflète une propriété `@property({ reflect: true })` vers son
+attribut qu'au tour de microtâche suivant (dans `update()`), pas au moment du setter — donc
+l'attribut `hiding` n'existait pas encore dans le DOM au moment de la lecture, `:host([hiding])`
+ne matchait jamais, et la transition restait mesurée à `0s` **même thème chargé** : l'animation
+de sortie ne se déclenchait plus du tout en pratique (mesuré à ~3ms au lieu de ~330ms). Contrairement à
+`ar-collapse`, dont la transition est inconditionnelle sur `:host`, celle d'`ar-alert` est
+conditionnée par l'attribut que la garde vient elle-même de poser — la garde doit donc attendre
+que la réflexion ait eu lieu (`await this.updateComplete`) avant de lire `getComputedStyle`,
+sans quoi une transition pilotée par attribut n'a jamais la chance de matcher avant d'être
+évaluée.
+
 **Clarification de la contrainte 2 (même jour)** : la vérification de cette deuxième passe a
 mis au jour une régression réelle sur le bouton de fermeture d'`ar-alert`. La tâche 3 avait
 migré la valeur au repos `opacity: 0.75` vers une règle externe (`ar-alert::part(close)`),

--- a/docs/decisions/ADR-005-tokens-pilotes-par-attribut.md
+++ b/docs/decisions/ADR-005-tokens-pilotes-par-attribut.md
@@ -401,7 +401,11 @@ de sortie ne se déclenchait plus du tout en pratique (mesuré à ~3ms au lieu d
 conditionnée par l'attribut que la garde vient elle-même de poser — la garde doit donc attendre
 que la réflexion ait eu lieu (`await this.updateComplete`) avant de lire `getComputedStyle`,
 sans quoi une transition pilotée par attribut n'a jamais la chance de matcher avant d'être
-évaluée.
+évaluée. Cette réparation ayant rendu le chemin animé de nouveau atteignable en usage réel, une
+revue a également relevé et corrigé un bug d'idempotence préexistant dans `_finishHide` : le
+thème animant `opacity` et `transform` simultanément, `transitionend` se déclenche deux fois (une
+par propriété) — sans reset de `hiding` dans `_finishHide`, le second appel repassait la garde et
+ré-émettait `ar-alert-close` / redonnait le focus une seconde fois.
 
 **Clarification de la contrainte 2 (même jour)** : la vérification de cette deuxième passe a
 mis au jour une régression réelle sur le bouton de fermeture d'`ar-alert`. La tâche 3 avait

--- a/docs/decisions/ADR-005-tokens-pilotes-par-attribut.md
+++ b/docs/decisions/ADR-005-tokens-pilotes-par-attribut.md
@@ -374,12 +374,21 @@ variant, probable exigence WCAG 2.4.7). `font-size` de `[part='icon']` migré ve
 par la contrainte 6 — même garde `prefers-reduced-motion` que `close-transition-duration`).
 Les valeurs finales de l'état `[hiding]` (`opacity: 0`/`transform: scale(0.75)`) migrées vers
 `ar-alert[hiding] { }` — **nouveau cas vérifié empiriquement** : un sélecteur d'attribut
-externe sur le tag suit le cascade CSS normal face à une règle `:host` interne
-inconditionnelle (contrairement à `::part()`/tag non conditionné, qui l'emporte toujours),
-et n'interfère pas avec la garde reduced-motion tant que la propriété `transition`
-elle-même reste interne. `position: relative` mort sur `:host` retiré (aucun descendant n'en
-dépendait). Trou de documentation préexistant comblé : `@csspart icon-svg` (SVG de l'icône de
-variant, jamais documenté depuis l'origine du composant).
+externe conditionné sur le même attribut qu'une règle `:host` interne l'emporte
+purement et simplement sur cette dernière, exactement le même mécanisme « l'externe
+l'emporte toujours » que `::part()` ou une règle de tag non conditionnée — ce n'est pas le
+cascade CSS normal (spécificité/ordre) qui joue ici. Cette migration reste sûre non pas parce
+que le cascade se comporte normalement, mais parce que la règle externe ne matche que
+conditionnellement (absente quand l'attribut est absent) et parce que la propriété
+`transition` elle-même reste interne, ce qui préserve la garde reduced-motion. `position:
+relative` mort sur `:host` retiré (aucun descendant n'en dépendait). Trou de documentation
+préexistant comblé : `@csspart icon-svg` (SVG de l'icône de variant, jamais documenté depuis
+l'origine du composant). **Leçon généralisable** : externaliser les valeurs d'état final
+animées d'un élément implique que la logique de complétion propre au composant (tout ce qui
+dépend de `transitionend`) ne peut plus supposer qu'une transition aura toujours lieu — elle
+doit se prémunir contre une durée calculée nulle (absence de thème chargé), comme le fait déjà
+`ar-collapse` via `_shouldAnimate()`. `ar-alert` a été corrigé dans le même esprit après cette
+migration (garde JS `_shouldAnimate()` avant `_hide()`, cf. issue #129).
 
 **Clarification de la contrainte 2 (même jour)** : la vérification de cette deuxième passe a
 mis au jour une régression réelle sur le bouton de fermeture d'`ar-alert`. La tâche 3 avait

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -159,13 +159,13 @@ this.dispatchEvent(
 
 ### Nommage — cohérence stricte
 
-| Élément          | Convention                | Exemple              |
-| ---------------- | ------------------------- | -------------------- |
-| Tag HTML         | `ar-<name>`               | `ar-alert`           |
-| Classe           | `Ar<Name>`                | `ArAlert`            |
-| Événements       | `ar-<event>`              | `ar-alert-close`     |
-| CSS custom props | `--ar-<composant>-<prop>` | `--ar-alert-padding` |
-| CSS parts        | `part="base"`             | `part="label"`       |
+| Élément          | Convention                | Exemple                 |
+| ---------------- | ------------------------- | ----------------------- |
+| Tag HTML         | `ar-<name>`               | `ar-alert`              |
+| Classe           | `Ar<Name>`                | `ArAlert`               |
+| Événements       | `ar-<event>`              | `ar-alert-close`        |
+| CSS custom props | `--ar-<composant>-<prop>` | `--ar-alert-close-size` |
+| CSS parts        | `part="base"`             | `part="label"`          |
 
 ### Thémabilité
 
@@ -173,8 +173,8 @@ Les aspects visuels sont exposés via CSS custom properties. Les utilisateurs pe
 
 ```css
 ar-alert {
-    --ar-alert-border-radius: 0.5rem;
-    --ar-alert-padding: 0.75rem;
+    --ar-alert-close-size: 2.5rem;
+    --ar-alert-info-bg: #e0f2fe;
 }
 ```
 

--- a/docs/superpowers/plans/2026-07-28-alert-token-vs-part-129-pass2.md
+++ b/docs/superpowers/plans/2026-07-28-alert-token-vs-part-129-pass2.md
@@ -1,0 +1,716 @@
+# Migration token vs ::part() — ar-alert, 2ᵉ passe (issue #129, lot 3a bis) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Compléter la migration token-vs-`::part()` d'`ar-alert` (déjà partiellement faite sur la branche `fix/alert-token-vs-part-129`, PR #142) avec les valeurs de design jamais tokenisées trouvées lors d'un second audit : `column-gap` du `:host`, l'intégralité du design de `[part='close']` (fond/survol/opacité/position), `font-size` de `[part='icon']`, la durée d'animation de sortie (`:host([hiding])`), et un nettoyage de code mort + un trou de documentation JSDoc.
+
+**Architecture:** Continue sur la même branche `fix/alert-token-vs-part-129` (déjà poussée, PR #142 ouverte, pas mergée). Ajoute de nouveaux commits par-dessus. `alert.styles.ts` perd encore plusieurs propriétés qui deviennent des règles externes littérales dans le bloc `ar-alert { }` de `default.css` déjà créé au premier passage : `column-gap` (propriété `:host`), tout le design de `[part='close']` (`background-color`/`:hover`/`:focus-visible` opacity/`position`+`top`+`right`, sous `&::part(close)` + `&::part(close):hover` + `&::part(close):focus-visible`), `font-size` de `[part='icon']` (`&::part(icon)`), et les valeurs finales de l'état `[hiding]` (`opacity: 0`/`transform: scale(0.75)`, via une nouvelle règle `ar-alert[hiding] { }` — vérifié empiriquement, cf. Global Constraints). La durée de transition de sortie (`0.33s`, codée en dur aujourd'hui) devient un token interne `--ar-alert-hide-transition-duration` (comme `--ar-alert-close-transition-duration`, bloquée en interne par la contrainte 6 d'ADR-005 — reduced-motion). `position: relative` mort sur `:host` est retiré. `@csspart icon-svg` manquant est ajouté au JSDoc.
+
+**Tech Stack:** Lit 3, TypeScript, CSS natif avec nesting (`&::part()`, sélecteurs d'attribut), Vitest, `@web/test-runner`, garde-fous CEM.
+
+## Global Constraints
+
+- Prettier : 100 caractères, 4 espaces, quotes simples.
+- Aucune valeur de design en dur dans `*.styles.ts` sauf token consommé via `var()` — `validate-no-hardcoded-tokens.js` (`npm run build:manifest`) ne détecte que les assignations `--ar-*: littéral;`, pas les propriétés CSS ordinaires : cette passe est un audit manuel, pas automatisé.
+- Tout token `:root` de `default.css` appartenant à un composant doit avoir une entrée `@cssprop` (`validate-cssprop-defaults.js`).
+- **Vérifié empiriquement (Chromium/Playwright, avant ce plan)** : une règle externe conditionnée par un sélecteur d'attribut sur le tag (`ar-alert[hiding] { ... }`) suit le cascade CSS normal face à une règle `:host` interne inconditionnelle — contrairement au mécanisme `::part()`/tag non conditionné, elle ne l'emporte PAS automatiquement, elle se comporte comme n'importe quelle règle CSS standard. Testé avec la garde `@media (prefers-reduced-motion: reduce)` active sur la propriété `transition` (restée interne) : la garde reste effective (`transitionDuration: 0s` sous reduced-motion), et les valeurs finales externes s'appliquent correctement dans les deux cas. C'est ce qui rend cette migration sûre.
+- Ne jamais merger sur `dev` sans confirmation explicite de l'utilisateur — la PR #142 reste ouverte, pas de merge dans ce plan.
+
+---
+
+### Task 1 : Vérifier l'état de la branche existante
+
+**Files:** aucun fichier modifié.
+
+- [ ] **Step 1 : Confirmer qu'on est sur la bonne branche, à jour**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git status
+git branch --show-current
+```
+
+Expected : branche `fix/alert-token-vs-part-129`, aucun fichier modifié non commité.
+
+- [ ] **Step 2 : Baseline de tests avant modification**
+
+```bash
+npm run test --workspace=packages/core
+```
+
+Expected : tous les tests passent (774/774 attendus, éventuellement plus si des tests ont été ajoutés depuis).
+
+---
+
+### Task 2 : Migrer `column-gap` et retirer `position: relative` mort du `:host`
+
+**Files:**
+
+- Modify: `packages/core/src/components/alert/alert.styles.ts` (bloc `:host`)
+- Modify: `packages/core/src/styles/themes/default.css` (bloc `ar-alert { }`, actuellement lignes 917-926)
+
+**Interfaces:**
+
+- Consumes: bloc `ar-alert { }` existant (créé au premier passage de ce lot).
+- Produces: bloc `ar-alert { }` enrichi de `column-gap`, réutilisé tel quel par les tâches suivantes qui y ajoutent d'autres propriétés/règles imbriquées.
+
+- [ ] **Step 1 : Vérifier qu'aucun descendant n'utilise `position: absolute`, pour confirmer que `position: relative` du `:host` est bien mort**
+
+```bash
+grep -n "position: absolute" packages/core/src/components/alert/alert.styles.ts
+```
+
+Expected : aucune occurrence (confirme que rien ne dépend d'un contexte de positionnement posé par `:host`).
+
+- [ ] **Step 2 : Modifier le bloc `:host` de `alert.styles.ts`**
+
+Bloc actuel :
+
+```css
+:host {
+    display: flex;
+    box-sizing: border-box;
+    column-gap: 0.75rem;
+    position: relative;
+    align-items: center;
+    opacity: 1;
+    transform: scale(1);
+    color: var(--ar-alert-color);
+}
+```
+
+Remplacer par (retire `column-gap` et `position: relative` — la propriété `column-gap` n'est plus déclarée par le composant du tout, `position: relative` est retiré car mort, aucun descendant n'en dépend) :
+
+```css
+:host {
+    display: flex;
+    box-sizing: border-box;
+    align-items: center;
+    opacity: 1;
+    transform: scale(1);
+    color: var(--ar-alert-color);
+}
+```
+
+- [ ] **Step 3 : Ajouter `column-gap` au bloc `ar-alert { }` de `default.css`**
+
+Bloc actuel (`default.css:917-926`) :
+
+```css
+ar-alert {
+    padding: 1rem;
+    border-radius: 0.75rem;
+    border-width: 1px;
+    border-style: solid;
+
+    &::part(close) {
+        border-radius: 7px;
+    }
+}
+```
+
+Remplacer par :
+
+```css
+ar-alert {
+    padding: 1rem;
+    border-radius: 0.75rem;
+    border-width: 1px;
+    border-style: solid;
+    column-gap: 0.75rem;
+
+    &::part(close) {
+        border-radius: 7px;
+    }
+}
+```
+
+- [ ] **Step 4 : Régénérer le manifest**
+
+```bash
+npm run build:manifest --workspace=packages/core
+```
+
+Expected : succès, aucune erreur de garde-fou (aucun token n'est touché ici, juste une propriété CSS ordinaire déplacée).
+
+- [ ] **Step 5 : Tests**
+
+```bash
+npm run test --workspace=packages/core
+```
+
+Expected : tous les tests passent, aucune régression (aucun test n'asserte sur `column-gap` ou `position`).
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git add packages/core/src/components/alert/alert.styles.ts packages/core/src/styles/themes/default.css
+git commit -m "refactor(alert): migre column-gap, retire position:relative mort (#129)"
+```
+
+---
+
+### Task 3 : Migrer le design de `[part='close']` (fond, survol, opacité, position)
+
+**Files:**
+
+- Modify: `packages/core/src/components/alert/alert.styles.ts` (bloc `[part='close']`)
+- Modify: `packages/core/src/components/alert/alert.ts` (retrait des entrées `@cssprop --ar-alert-close-bg` et `--ar-alert-close-hover-bg`)
+- Modify: `packages/core/src/styles/themes/default.css` (retrait des 2 tokens `:root`, ajout de règles imbriquées dans `ar-alert { }`)
+
+**Interfaces:**
+
+- Consumes: bloc `ar-alert { }` de la Task 2 (avec `&::part(close) { border-radius: 7px; }` déjà présent).
+- Produces: bloc `ar-alert { }` avec `&::part(close)` enrichi de `background-color`/`opacity`/`position`/`top`/`right`, plus deux nouvelles règles imbriquées `&::part(close):hover` et `&::part(close):focus-visible`.
+
+Contexte : `--ar-alert-close-bg`/`--ar-alert-close-hover-bg` avaient été laissés tokens au premier passage par erreur de catégorisation (supposés « sémantiques » comme les couleurs de variant). Vérifié : aucune calibration dark-mode, aucune réutilisation, aucune lecture JS — ils suivent exactement le même critère que `padding`/`border-radius`/etc, et le même pattern déjà utilisé pour `nav-btn`/`footer-btn` de `ar-datepicker` (design entièrement externalisé, sans token). `:focus-visible` (outline `currentColor`) reste interne — probable exigence de contraste du focus ring contre les 4 fonds de variant (WCAG 2.4.7), pas un choix esthétique arbitraire, donc hors périmètre de cette migration.
+
+- [ ] **Step 1 : Modifier le bloc `[part='close']` de `alert.styles.ts`**
+
+Bloc actuel :
+
+```css
+[part='close'] {
+    order: 1;
+    align-self: flex-start;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    /* a11y-fallback: WCAG 2.5.8 (Target Size Minimum) — sans thème chargé, le bouton perdrait sa taille de cible tactile */
+    width: var(--ar-alert-close-size, 2rem);
+    /* a11y-fallback: WCAG 2.5.8 (Target Size Minimum) — sans thème chargé, le bouton perdrait sa taille de cible tactile */
+    height: var(--ar-alert-close-size, 2rem);
+    padding: 0;
+    border: none;
+    background-color: var(--ar-alert-close-bg);
+    color: currentColor;
+    cursor: pointer;
+    opacity: 0.75;
+    transition:
+        opacity var(--ar-alert-close-transition-duration),
+        background-color var(--ar-alert-close-transition-duration);
+    position: relative;
+    top: -0.2rem;
+    right: -0.2rem;
+
+    &:hover {
+        opacity: 1;
+        background-color: var(--ar-alert-close-hover-bg);
+    }
+
+    &:focus-visible {
+        opacity: 1;
+        outline: 2px solid currentColor;
+        outline-offset: 2px;
+    }
+}
+```
+
+Remplacer par (retire `background-color`, `opacity` de base, `position`/`top`/`right`, et le `background-color` de `&:hover` — ces propriétés ne sont plus déclarées par le composant du tout ; `&:hover`/`&:focus-visible` gardent uniquement `opacity: 1` car cette valeur reste correcte par défaut sans thème (bouton pleinement visible au survol/focus, un bon défaut structurel, alors que l'opacité 0.75 au repos est un choix esthétique) :
+
+```css
+[part='close'] {
+    order: 1;
+    align-self: flex-start;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    /* a11y-fallback: WCAG 2.5.8 (Target Size Minimum) — sans thème chargé, le bouton perdrait sa taille de cible tactile */
+    width: var(--ar-alert-close-size, 2rem);
+    /* a11y-fallback: WCAG 2.5.8 (Target Size Minimum) — sans thème chargé, le bouton perdrait sa taille de cible tactile */
+    height: var(--ar-alert-close-size, 2rem);
+    padding: 0;
+    border: none;
+    color: currentColor;
+    cursor: pointer;
+    transition:
+        opacity var(--ar-alert-close-transition-duration),
+        background-color var(--ar-alert-close-transition-duration);
+
+    &:hover {
+        opacity: 1;
+    }
+
+    &:focus-visible {
+        opacity: 1;
+        outline: 2px solid currentColor;
+        outline-offset: 2px;
+    }
+}
+```
+
+- [ ] **Step 2 : Retirer les 2 tokens de `default.css` (`:root`)**
+
+Dans le bloc `/* alert */` de `:root` (`default.css:294-311` actuelles), supprimer ces 2 lignes :
+
+```css
+--ar-alert-close-bg: color-mix(in srgb, currentColor 8%, transparent);
+--ar-alert-close-hover-bg: color-mix(in srgb, currentColor 20%, transparent);
+```
+
+- [ ] **Step 3 : Ajouter le design externalisé dans le bloc `ar-alert { }`**
+
+Le bloc `&::part(close)` (créé Task 2, contenant déjà `border-radius: 7px;`) devient, avec deux nouvelles règles imbriquées juste après :
+
+```css
+&::part(close) {
+    border-radius: 7px;
+    background-color: color-mix(in srgb, currentColor 8%, transparent);
+    opacity: 0.75;
+    position: relative;
+    top: -0.2rem;
+    right: -0.2rem;
+}
+
+&::part(close):hover {
+    background-color: color-mix(in srgb, currentColor 20%, transparent);
+}
+```
+
+(Placer ces deux règles au même niveau que `&::part(close)` dans `ar-alert { }`, juste après elle.)
+
+- [ ] **Step 4 : Retirer les 2 entrées `@cssprop` du JSDoc de `alert.ts`**
+
+Supprimer :
+
+```
+ * @cssprop --ar-alert-close-bg - Fond du bouton de fermeture au repos.
+ * @cssprop --ar-alert-close-hover-bg - Fond du bouton de fermeture au survol.
+```
+
+- [ ] **Step 5 : Régénérer le manifest**
+
+```bash
+npm run build:manifest --workspace=packages/core
+```
+
+Expected : succès.
+
+- [ ] **Step 6 : Tests**
+
+```bash
+npm run test --workspace=packages/core
+```
+
+Expected : tous les tests passent.
+
+- [ ] **Step 7 : Commit**
+
+```bash
+git add packages/core/src/components/alert/alert.styles.ts \
+        packages/core/src/components/alert/alert.ts \
+        packages/core/src/styles/themes/default.css
+git commit -m "refactor(alert): migre le design de close (fond/opacite/position) vers le theme (#129)"
+```
+
+---
+
+### Task 4 : Migrer `font-size` de `[part='icon']`
+
+**Files:**
+
+- Modify: `packages/core/src/components/alert/alert.styles.ts` (bloc `[part='icon']`)
+- Modify: `packages/core/src/styles/themes/default.css` (ajout de `&::part(icon)` dans `ar-alert { }`)
+
+**Interfaces:**
+
+- Consumes: bloc `ar-alert { }` de la Task 3.
+- Produces: nouvelle règle imbriquée `&::part(icon)` dans `ar-alert { }`.
+
+- [ ] **Step 1 : Retirer `font-size: 1.5em` du bloc `[part='icon']` de `alert.styles.ts`**
+
+Bloc actuel :
+
+```css
+[part='icon'] {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    font-size: 1.5em;
+}
+```
+
+Remplacer par :
+
+```css
+[part='icon'] {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+}
+```
+
+- [ ] **Step 2 : Ajouter `&::part(icon)` au bloc `ar-alert { }` de `default.css`**
+
+Ajouter, au même niveau que `&::part(close)` (par exemple juste après le bloc `&::part(close):hover` ajouté en Task 3) :
+
+```css
+&::part(icon) {
+    font-size: 1.5em;
+}
+```
+
+- [ ] **Step 3 : Régénérer le manifest**
+
+```bash
+npm run build:manifest --workspace=packages/core
+```
+
+Expected : succès.
+
+- [ ] **Step 4 : Tests**
+
+```bash
+npm run test --workspace=packages/core
+```
+
+Expected : tous les tests passent.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add packages/core/src/components/alert/alert.styles.ts packages/core/src/styles/themes/default.css
+git commit -m "refactor(alert): migre font-size de icon vers ::part(icon) (#129)"
+```
+
+---
+
+### Task 5 : Tokeniser la durée de transition de sortie (`:host([hiding])`)
+
+**Files:**
+
+- Modify: `packages/core/src/components/alert/alert.styles.ts` (bloc `:host([hiding])`)
+- Modify: `packages/core/src/components/alert/alert.ts` (ajout d'une entrée `@cssprop --ar-alert-hide-transition-duration`)
+- Modify: `packages/core/src/styles/themes/default.css` (ajout du token `:root`)
+
+**Interfaces:**
+
+- Consumes: rien des tâches précédentes.
+- Produces: token `--ar-alert-hide-transition-duration`, consommé uniquement en interne (jamais externalisé — cf. contrainte 6 ADR-005, la garde `@media (prefers-reduced-motion: reduce)` porte sur cette transition).
+
+Contexte : la durée `0.33s` est codée en dur deux fois dans `:host([hiding])` (`opacity`/`transform`), jamais tokenisée — violation du principe de base d'ADR-005 (toute valeur de design vient de `default.css`). Contrairement à `--ar-alert-close-transition-duration`, elle n'a même pas de token aujourd'hui. Elle doit en devenir un, mais rester consommée en interne : la garde reduced-motion (`alert.styles.ts:59-64`) porte sur cette même transition, et l'externaliser la neutraliserait (même mécanisme que `close-transition-duration`, déjà vérifié empiriquement dans le premier passage de ce lot).
+
+- [ ] **Step 1 : Ajouter le token dans `default.css`**
+
+Dans le bloc `/* alert */` de `:root`, ajouter une ligne (par exemple juste après `--ar-alert-close-transition-duration`) :
+
+```css
+--ar-alert-hide-transition-duration: 0.33s;
+```
+
+- [ ] **Step 2 : Consommer le token dans `alert.styles.ts`**
+
+Bloc actuel :
+
+```css
+:host([hiding]) {
+    opacity: 0;
+    transform: scale(0.75);
+    transition:
+        opacity 0.33s,
+        transform 0.33s;
+}
+```
+
+Remplacer par :
+
+```css
+:host([hiding]) {
+    opacity: 0;
+    transform: scale(0.75);
+    transition:
+        opacity var(--ar-alert-hide-transition-duration),
+        transform var(--ar-alert-hide-transition-duration);
+}
+```
+
+(Les valeurs `opacity: 0`/`transform: scale(0.75)` restent ici pour l'instant — elles seront retirées dans la Task 6, qui les externalise séparément. Ne pas les toucher dans cette tâche.)
+
+- [ ] **Step 3 : Ajouter l'entrée `@cssprop` dans le JSDoc de `alert.ts`**
+
+Ajouter, dans la liste `@cssprop` existante (par exemple juste après `--ar-alert-close-transition-duration`) :
+
+```
+ * @cssprop --ar-alert-hide-transition-duration - Durée de la transition de sortie (opacity/transform) à la fermeture.
+```
+
+- [ ] **Step 4 : Régénérer le manifest**
+
+```bash
+npm run build:manifest --workspace=packages/core
+```
+
+Expected : succès (nouveau token avec son entrée `@cssprop` correspondante).
+
+- [ ] **Step 5 : Tests**
+
+```bash
+npm run test --workspace=packages/core
+```
+
+Expected : tous les tests passent (aucun test n'asserte sur la valeur exacte de la durée de transition).
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git add packages/core/src/components/alert/alert.styles.ts \
+        packages/core/src/components/alert/alert.ts \
+        packages/core/src/styles/themes/default.css
+git commit -m "refactor(alert): tokenise la duree de transition de sortie (#129)"
+```
+
+---
+
+### Task 6 : Externaliser les valeurs finales de l'état `[hiding]`
+
+**Files:**
+
+- Modify: `packages/core/src/components/alert/alert.styles.ts` (bloc `:host([hiding])`)
+- Modify: `packages/core/src/styles/themes/default.css` (nouvelle règle `ar-alert[hiding] { }`)
+
+**Interfaces:**
+
+- Consumes: bloc `:host([hiding])` de la Task 5 (avec la transition déjà tokenisée).
+- Produces: nouvelle règle top-level `ar-alert[hiding] { }` dans `default.css`, indépendante du bloc `ar-alert { }` existant (elle ne peut pas être nichée dedans — `ar-alert[hiding]` est un sélecteur distinct de `ar-alert`, pas une règle imbriquée valide avec `&`).
+
+Contexte : vérifié empiriquement (Chromium/Playwright, cf. Global Constraints du plan) qu'une règle externe conditionnée par attribut suit le cascade normal et ne casse pas la garde reduced-motion (qui porte sur la `transition`, restée interne depuis la Task 5, pas sur ces valeurs finales).
+
+- [ ] **Step 1 : Retirer `opacity: 0`/`transform: scale(0.75)` du bloc `:host([hiding])`**
+
+Bloc actuel (après Task 5) :
+
+```css
+:host([hiding]) {
+    opacity: 0;
+    transform: scale(0.75);
+    transition:
+        opacity var(--ar-alert-hide-transition-duration),
+        transform var(--ar-alert-hide-transition-duration);
+}
+```
+
+Remplacer par :
+
+```css
+:host([hiding]) {
+    transition:
+        opacity var(--ar-alert-hide-transition-duration),
+        transform var(--ar-alert-hide-transition-duration);
+}
+```
+
+- [ ] **Step 2 : Ajouter la règle externe dans `default.css`**
+
+Ajouter une nouvelle règle top-level, au même niveau que le bloc `ar-alert { }` existant (donc à l'intérieur de `@layer ariane.theme { }`, comme sibling du bloc `ar-alert { }`, pas imbriquée dedans) :
+
+```css
+ar-alert[hiding] {
+    opacity: 0;
+    transform: scale(0.75);
+}
+```
+
+- [ ] **Step 3 : Régénérer le manifest**
+
+```bash
+npm run build:manifest --workspace=packages/core
+```
+
+Expected : succès.
+
+- [ ] **Step 4 : Tests**
+
+```bash
+npm run test --workspace=packages/core
+```
+
+Expected : tous les tests passent — en particulier les tests qui vérifient le cycle de fermeture d'`ar-alert` (`alert.test.ts`, recherche de `hiding`/`ar-alert-close`) doivent continuer de passer, car le comportement (attribut posé, event émis, focus reporté) n'est pas affecté par où vivent les valeurs CSS.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add packages/core/src/components/alert/alert.styles.ts packages/core/src/styles/themes/default.css
+git commit -m "refactor(alert): externalise les valeurs finales de l'etat hiding (#129)"
+```
+
+---
+
+### Task 7 : Documenter `@csspart icon-svg`
+
+**Files:**
+
+- Modify: `packages/core/src/components/alert/alert.ts` (ajout d'une entrée `@csspart`)
+
+**Interfaces:**
+
+- Consumes: rien.
+- Produces: rien consommé par une tâche suivante.
+
+Contexte : `_defaultIcon()` (dans `alert.ts`) rend un `<svg part="icon-svg" ...>` — ce `part` existe dans le code depuis l'origine du composant mais n'a jamais été documenté dans le JSDoc (trou préexistant, indépendant de ce lot). Décision : documenter seulement, ne pas ajouter de `part` symétrique sur le SVG de `_defaultCloseIcon()` (resté un détail d'implémentation non exposé, correct ainsi).
+
+- [ ] **Step 1 : Ajouter l'entrée `@csspart` manquante**
+
+Dans le JSDoc de `alert.ts`, la liste `@csspart` actuelle est :
+
+```
+ * @csspart icon      - Le conteneur de l'icône de variant.
+ * @csspart body      - Le conteneur du titre et du contenu.
+ * @csspart close     - Le bouton de fermeture (présent uniquement si `next-focus` est défini).
+```
+
+Remplacer par :
+
+```
+ * @csspart icon      - Le conteneur de l'icône de variant.
+ * @csspart icon-svg  - Le SVG de l'icône de variant par défaut (absent si le slot `icon` est utilisé).
+ * @csspart body      - Le conteneur du titre et du contenu.
+ * @csspart close     - Le bouton de fermeture (présent uniquement si `next-focus` est défini).
+```
+
+- [ ] **Step 2 : Régénérer le manifest**
+
+```bash
+npm run build:manifest --workspace=packages/core
+```
+
+Expected : succès.
+
+- [ ] **Step 3 : Commit**
+
+```bash
+git add packages/core/src/components/alert/alert.ts
+git commit -m "docs(alert): documente le csspart icon-svg manquant (#129)"
+```
+
+---
+
+### Task 8 : Vérification visuelle et suite de tests complète
+
+**Files:** aucun fichier de code modifié — vérification uniquement.
+
+**Interfaces:**
+
+- Consumes: l'ensemble des changements des Tasks 2-7.
+
+- [ ] **Step 1 : Rebuild explicite du JS de `packages/core`**
+
+```bash
+npm run build:dev --workspace=packages/core
+```
+
+Expected : build réussi. (Rappel : `npm run dev --workspace=apps/docs` seul ne reconstruit pas ce JS.)
+
+- [ ] **Step 2 : Vérification des valeurs calculées sur le site de doc**
+
+```bash
+npm run dev --workspace=apps/docs
+```
+
+Sur `http://localhost:4321/components/ar-alert` (ou le port affiché), vérifier via DevTools (`getComputedStyle`) sur les 3 variants :
+
+- Hôte `ar-alert` : `columnGap` résout à `12px` (0.75rem).
+- `[part='close']` (variant dismissible) : `backgroundColor` résout à `color-mix(in srgb, currentColor 8%, transparent)` évalué (une couleur teintée, pas transparent pur) au repos, plus foncé au survol ; `opacity` résout à `0.75` au repos, `1` au survol/focus ; `position: relative`, `top: -3.2px` (-0.2rem), `right: -3.2px`.
+- `[part='icon']` : `fontSize` résout à ~`24px` (1.5em, dépend du `font-size` hérité).
+- Déclencher la fermeture (bouton close sur le variant dismissible) : l'alerte doit toujours s'animer en fondu/réduction puis disparaître du DOM et reporter le focus, comme avant.
+
+Expected : aucune régression visuelle ni comportementale.
+
+- [ ] **Step 3 : Suite de tests complète**
+
+```bash
+npm run test --workspace=packages/core
+npm run test:all
+```
+
+Expected : tous les tests passent (Vitest + WTR navigateur).
+
+- [ ] **Step 4 : Vérifier qu'aucune référence morte ne subsiste**
+
+```bash
+grep -rn -- "--ar-alert-close-bg\|--ar-alert-close-hover-bg" packages/core/src apps/docs/src packages/core/README.md docs/onboarding.md
+```
+
+Expected : aucune occurrence (élargi cette fois à `README.md`/`onboarding.md`, la revue finale du premier passage ayant montré que le grep initial les manquait).
+
+---
+
+### Task 9 : Mise à jour d'ADR-005 et push sur la PR existante
+
+**Files:**
+
+- Modify: `docs/decisions/ADR-005-tokens-pilotes-par-attribut.md` (complète la section "Application — `ar-alert`" ajoutée au premier passage)
+
+**Interfaces:**
+
+- Consumes: la section "**Application — `ar-alert` (2026-07-28)**" existante (ajoutée lors de la revue finale du premier passage de ce lot).
+
+- [ ] **Step 1 : Compléter la section existante**
+
+Chercher la section `**Application — `ar-alert` (2026-07-28)**` dans `docs/decisions/ADR-005-tokens-pilotes-par-attribut.md` (fin de fichier) et ajouter un paragraphe à la suite, sur le modèle des autres sections "Application" :
+
+```
+
+**Deuxième passe (même jour)** : audit élargi aux valeurs jamais tokenisées et à une
+recatégorisation. `column-gap` du `:host` (jamais tokenisé) migré en littéral dans
+`ar-alert { }`. `--ar-alert-close-bg`/`--ar-alert-close-hover-bg` — laissés tokens par erreur
+de catégorisation lors de la première passe (supposés sémantiques comme les couleurs de
+variant, sans revérifier les critères) — migrés en littéral dans `ar-alert::part(close)`/
+`::part(close):hover`, même pattern que `nav-btn`/`footer-btn` de `ar-datepicker`. `opacity`/
+`position`/`top`/`right` de `[part='close']` migrés de la même façon ; `:focus-visible`
+(`outline: currentColor`) reste interne (contraste du focus ring contre les 4 fonds de
+variant, probable exigence WCAG 2.4.7). `font-size` de `[part='icon']` migré vers
+`::part(icon)`. La durée d'animation de sortie (`0.33s`, jamais tokenisée) devient
+`--ar-alert-hide-transition-duration`, consommée en interne uniquement (bloquée en externe
+par la contrainte 6 — même garde `prefers-reduced-motion` que `close-transition-duration`).
+Les valeurs finales de l'état `[hiding]` (`opacity: 0`/`transform: scale(0.75)`) migrées vers
+`ar-alert[hiding] { }` — **nouveau cas vérifié empiriquement** : un sélecteur d'attribut
+externe sur le tag suit le cascade CSS normal face à une règle `:host` interne
+inconditionnelle (contrairement à `::part()`/tag non conditionné, qui l'emporte toujours),
+et n'interfère pas avec la garde reduced-motion tant que la propriété `transition`
+elle-même reste interne. `position: relative` mort sur `:host` retiré (aucun descendant n'en
+dépendait). Trou de documentation préexistant comblé : `@csspart icon-svg` (SVG de l'icône de
+variant, jamais documenté depuis l'origine du composant).
+```
+
+- [ ] **Step 2 : Tests**
+
+```bash
+npm run test --workspace=packages/core
+```
+
+Expected : tous les tests passent (changement doc-only).
+
+- [ ] **Step 3 : Commit et push sur la branche existante**
+
+```bash
+git add docs/decisions/ADR-005-tokens-pilotes-par-attribut.md
+git commit -m "docs(adr): complete la section ar-alert avec la 2e passe (#129)"
+git push
+```
+
+Expected : push réussi sur `fix/alert-token-vs-part-129`, la PR #142 se met à jour automatiquement avec les nouveaux commits.
+
+- [ ] **Step 4 : Attendre la confirmation explicite de l'utilisateur avant tout merge**
+
+Ne pas merger sur `dev` sans confirmation explicite — règle permanente depuis l'incident PR #137.
+
+---
+
+## Self-Review
+
+**Spec coverage** :
+
+- `column-gap` + `position:relative` mort → Task 2. ✅
+- Design de `[part='close']` (bg/hover-bg/opacity/position) → Task 3. ✅
+- `font-size` de `[part='icon']` → Task 4. ✅
+- Durée de transition `hiding` tokenisée → Task 5. ✅
+- Valeurs finales `hiding` externalisées → Task 6. ✅
+- `@csspart icon-svg` → Task 7. ✅
+- Vérification élargie (README/onboarding inclus) → Task 8. ✅
+- Doc ADR-005 + push (pas de merge) → Task 9. ✅
+
+**Placeholder scan** : aucun "TBD" — chaque step contient le code exact avant/après.
+
+**Type consistency** : les noms de tokens (`--ar-alert-hide-transition-duration`) et de règles (`ar-alert[hiding]`, `&::part(close)`, `&::part(close):hover`, `&::part(icon)`) sont utilisés de façon cohérente entre les tâches qui les créent et celles qui les consomment (Task 5 crée le token consommé par Task 6's contexte ; Task 2/3/4 enrichissent successivement le même bloc `ar-alert { }`).

--- a/docs/superpowers/plans/2026-07-28-alert-token-vs-part-129.md
+++ b/docs/superpowers/plans/2026-07-28-alert-token-vs-part-129.md
@@ -1,0 +1,389 @@
+# Migration token vs ::part() — ar-alert (issue #129, lot 3a) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Appliquer à `ar-alert` le même critère token-vs-`::part()` déjà appliqué à `ar-stepper` (PR #138) et `ar-datepicker` (PR #141) — migrer les tokens structurels non réutilisés vers des règles externes de `default.css`, ajouter un fallback WCAG 2.5.8 manquant sur `--ar-alert-close-size`, et nettoyer la documentation JSDoc en conséquence.
+
+**Architecture:** `alert.styles.ts` perd 5 déclarations `var(--ar-alert-*)` qui deviennent des valeurs littérales dans deux nouvelles règles de `packages/core/src/styles/themes/default.css` : `ar-alert { padding; border-radius; border-width; border-style; }` (propriétés sur `:host`, ciblage direct du tag) et `ar-alert::part(close) { border-radius; }`. Les 5 tokens `:root` correspondants sont supprimés de `default.css`, ainsi que leurs entrées `@cssprop` dans `alert.ts`. `--ar-alert-close-size` reste un token (réutilisé 2× dans `alert.styles.ts` pour `width`/`height` — critère 3 ADR-005) mais gagne un fallback `var(--ar-alert-close-size, 2rem)` avec commentaire `a11y-fallback` (WCAG 2.5.8), sur le modèle de `--ar-datepicker-day-size`. `--ar-alert-close-transition-duration` reste inchangé — vérifié empiriquement (Playwright/Chromium) qu'une règle externe `::part(close)` portant la transition annulerait la garde interne `prefers-reduced-motion: reduce`, ce qui casserait l'accessibilité motion.
+
+**Tech Stack:** Lit 3, TypeScript, CSS natif avec nesting (`&::part()`), Vitest, `@web/test-runner` (navigateur réel), garde-fous CEM (`packages/core/scripts/validate-cssprop-defaults.js`, `validate-no-hardcoded-tokens.js`).
+
+## Global Constraints
+
+- Prettier : 100 caractères, 4 espaces, quotes simples (CLAUDE.md).
+- Aucune valeur de design en dur dans `*.styles.ts` (`validate-no-hardcoded-tokens.js` fait échouer `npm run build:manifest` sinon) — les 5 tokens migrés doivent disparaître entièrement de `alert.styles.ts`, pas juste être renommés.
+- Tout token `:root` de `default.css` appartenant à un composant doit avoir une entrée `@cssprop` dans son JSDoc (`validate-cssprop-defaults.js`) — supprimer les 5 entrées correspondantes dans `alert.ts` en même temps que les tokens.
+- `npm run test` (Vitest, racine) et `npm run test:all` (Vitest + WTR navigateur) doivent passer avant toute revue finale.
+- Ne jamais merger sur `dev` sans confirmation explicite de l'utilisateur.
+
+---
+
+### Task 1 : Créer la branche et vérifier l'état de départ
+
+**Files:** aucun fichier modifié dans cette tâche.
+
+- [ ] **Step 1: Vérifier que `dev` est à jour et propre**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git status
+git checkout dev
+git pull origin dev
+```
+
+Expected: `git status` ne montre aucun fichier modifié avant le checkout ; `dev` à jour après le pull.
+
+- [ ] **Step 2: Créer la branche de travail**
+
+```bash
+git checkout -b fix/alert-token-vs-part-129
+```
+
+Expected: bascule sur la nouvelle branche, confirmé par `git branch --show-current`.
+
+- [ ] **Step 3: Faire tourner la suite de tests existante comme référence avant modification**
+
+```bash
+npm run test --workspace=packages/core
+```
+
+Expected: tous les tests passent (baseline verte avant toute modification).
+
+---
+
+### Task 2 : Migrer les 4 tokens `:host` (padding, border-radius, border-width, border-style)
+
+**Files:**
+
+- Modify: `packages/core/src/components/alert/alert.styles.ts:4-17`
+- Modify: `packages/core/src/components/alert/alert.ts:32-35` (retrait des 4 entrées `@cssprop`)
+- Modify: `packages/core/src/styles/themes/default.css:294-299` (retrait des 4 tokens `:root`)
+- Modify: `packages/core/src/styles/themes/default.css:921` (ajout du nouveau bloc `ar-alert { }` en fin de fichier)
+
+**Interfaces:**
+
+- Consumes: rien d'une tâche précédente.
+- Produces: bloc `ar-alert { padding: 1rem; border-radius: 0.75rem; border-width: 1px; border-style: solid; }` dans `default.css`, réutilisé par la Task 3 qui y ajoute `&::part(close) { ... }` dans le même bloc.
+
+- [ ] **Step 1 : Retirer les 4 `var()` de `alert.styles.ts` et les remplacer par rien (propriété retirée du composant)**
+
+Dans `packages/core/src/components/alert/alert.styles.ts`, le bloc `:host` actuel (lignes 4-17) est :
+
+```css
+:host {
+    display: flex;
+    box-sizing: border-box;
+    column-gap: 0.75rem;
+    position: relative;
+    align-items: center;
+    opacity: 1;
+    transform: scale(1);
+    color: var(--ar-alert-color);
+    padding: var(--ar-alert-padding);
+    border-radius: var(--ar-alert-border-radius);
+    border-width: var(--ar-alert-border-width);
+    border-style: var(--ar-alert-border-style);
+}
+```
+
+Remplacer par (retire `padding`, `border-radius`, `border-width`, `border-style` — ces propriétés ne sont plus déclarées par le composant du tout, elles viendront de la règle externe `ar-alert { }` de `default.css`) :
+
+```css
+:host {
+    display: flex;
+    box-sizing: border-box;
+    column-gap: 0.75rem;
+    position: relative;
+    align-items: center;
+    opacity: 1;
+    transform: scale(1);
+    color: var(--ar-alert-color);
+}
+```
+
+- [ ] **Step 2 : Retirer les 4 tokens de `default.css` (`:root`)**
+
+Dans `packages/core/src/styles/themes/default.css`, supprimer ces 4 lignes du bloc `/* alert */` (lignes 296-299 actuelles) :
+
+```css
+--ar-alert-padding: 1rem;
+--ar-alert-border-radius: 0.75rem;
+--ar-alert-border-width: 1px;
+--ar-alert-border-style: solid;
+```
+
+Le bloc `/* alert */` restant commence directement par `--ar-alert-color` puis enchaîne sur `--ar-alert-close-size`.
+
+- [ ] **Step 3 : Ajouter le nouveau bloc `ar-alert { }` en fin de `default.css`**
+
+Le fichier se termine actuellement par le bloc `ar-stepper { ... }` puis les deux accolades fermantes du `@layer ariane.theme { :root { ... } ... }`. Insérer un nouveau bloc `ar-alert { }` juste après la fermeture du bloc `ar-stepper` (avant la dernière accolade fermante du `@layer`) :
+
+```css
+    ar-alert {
+        padding: 1rem;
+        border-radius: 0.75rem;
+        border-width: 1px;
+        border-style: solid;
+    }
+}
+```
+
+(la dernière accolade `}` ci-dessus est celle, déjà existante, qui ferme `@layer ariane.theme`).
+
+- [ ] **Step 4 : Retirer les 4 entrées `@cssprop` correspondantes du JSDoc de `alert.ts`**
+
+Dans `packages/core/src/components/alert/alert.ts`, dans le bloc JSDoc de la classe (lignes 32-35 actuelles), supprimer :
+
+```
+ * @cssprop --ar-alert-border-radius - Arrondi des alertes.
+ * @cssprop --ar-alert-padding - Marge interne des alertes.
+ * @cssprop --ar-alert-border-width - Epaisseur des bordures.
+ * @cssprop --ar-alert-border-style - Style des bordures.
+```
+
+- [ ] **Step 5 : Régénérer le manifest et vérifier les garde-fous CEM**
+
+```bash
+npm run build:manifest --workspace=packages/core
+```
+
+Expected: la commande réussit sans erreur `validate-cssprop-defaults`/`validate-no-hardcoded-tokens` (ces 4 tokens ne sont plus dans `default.css` ni référencés dans `alert.styles.ts`, donc plus aucune incohérence à détecter pour eux).
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git add packages/core/src/components/alert/alert.styles.ts \
+        packages/core/src/components/alert/alert.ts \
+        packages/core/src/styles/themes/default.css \
+        packages/core/dist/custom-elements.json
+git commit -m "refactor(alert): migre padding/border-radius/border-width/border-style vers règle externe ar-alert (#129)"
+```
+
+---
+
+### Task 3 : Migrer `--ar-alert-close-radius` vers `::part(close)`
+
+**Files:**
+
+- Modify: `packages/core/src/components/alert/alert.styles.ts:70-103` (bloc `[part='close']`)
+- Modify: `packages/core/src/components/alert/alert.ts` (retrait de l'entrée `@cssprop --ar-alert-close-radius`)
+- Modify: `packages/core/src/styles/themes/default.css` (retrait du token `:root`, ajout de `&::part(close) { border-radius: 7px; }` dans le bloc `ar-alert { }` créé en Task 2)
+
+**Interfaces:**
+
+- Consumes: bloc `ar-alert { }` créé en Task 2 (Step 3).
+- Produces: aucune interface consommée par une tâche suivante — cette migration est indépendante des Tasks 4/5.
+
+- [ ] **Step 1 : Retirer `border-radius: var(--ar-alert-close-radius)` du bloc `[part='close']` de `alert.styles.ts`**
+
+Ligne actuelle (dans le bloc `[part='close']`, `packages/core/src/components/alert/alert.styles.ts:81`) :
+
+```css
+border-radius: var(--ar-alert-close-radius);
+```
+
+Supprimer cette ligne entièrement (le reste du bloc `[part='close']` — `order`, `align-self`, `flex-shrink`, `display`, `align-items`, `justify-content`, `width`, `height`, `padding`, `border`, `background-color`, `color`, `cursor`, `opacity`, `transition`, `position`, `top`, `right`, et les sous-règles `&:hover`/`&:focus-visible` — reste inchangé).
+
+- [ ] **Step 2 : Retirer le token de `default.css`**
+
+Supprimer la ligne `--ar-alert-close-radius: 7px;` du bloc `/* alert */` de `:root`.
+
+- [ ] **Step 3 : Ajouter la règle `::part(close)` dans le bloc `ar-alert { }`**
+
+Le bloc créé en Task 2 devient :
+
+```css
+    ar-alert {
+        padding: 1rem;
+        border-radius: 0.75rem;
+        border-width: 1px;
+        border-style: solid;
+
+        &::part(close) {
+            border-radius: 7px;
+        }
+    }
+}
+```
+
+- [ ] **Step 4 : Retirer l'entrée `@cssprop --ar-alert-close-radius` du JSDoc de `alert.ts`**
+
+Supprimer la ligne :
+
+```
+ * @cssprop --ar-alert-close-radius - Arrondi du bouton de fermeture.
+```
+
+- [ ] **Step 5 : Régénérer le manifest**
+
+```bash
+npm run build:manifest --workspace=packages/core
+```
+
+Expected: succès, aucune erreur de garde-fou CEM.
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git add packages/core/src/components/alert/alert.styles.ts \
+        packages/core/src/components/alert/alert.ts \
+        packages/core/src/styles/themes/default.css \
+        packages/core/dist/custom-elements.json
+git commit -m "refactor(alert): migre close-radius vers ::part(close) (#129)"
+```
+
+---
+
+### Task 4 : Ajouter le fallback WCAG 2.5.8 manquant sur `--ar-alert-close-size`
+
+**Files:**
+
+- Modify: `packages/core/src/components/alert/alert.styles.ts:77-78`
+
+**Interfaces:**
+
+- Consumes: rien des tâches précédentes.
+- Produces: rien consommé par une tâche suivante.
+
+Contexte : `--ar-alert-close-size` reste un token (réutilisé 2× dans le fichier pour `width`/`height`), mais contrairement à `--ar-datepicker-day-size` (qui a un fallback `var(--ar-datepicker-day-size, 2.5rem)` avec commentaire `a11y-fallback` documentant WCAG 2.5.8), `--ar-alert-close-size` n'a aujourd'hui aucun fallback — sans thème chargé, le bouton de fermeture perdrait sa taille de cible tactile.
+
+- [ ] **Step 1 : Ajouter le fallback et le commentaire, sur le modèle de `datepicker.styles.ts:94-97`**
+
+Lignes actuelles (`alert.styles.ts:77-78`) :
+
+```css
+width: var(--ar-alert-close-size);
+height: var(--ar-alert-close-size);
+```
+
+Remplacer par :
+
+```css
+/* a11y-fallback: WCAG 2.5.8 (Target Size Minimum) — sans thème chargé, le bouton perdrait sa taille de cible tactile */
+width: var(--ar-alert-close-size, 2rem);
+/* a11y-fallback: WCAG 2.5.8 (Target Size Minimum) — sans thème chargé, le bouton perdrait sa taille de cible tactile */
+height: var(--ar-alert-close-size, 2rem);
+```
+
+- [ ] **Step 2 : Régénérer le manifest et vérifier le garde-fou `validate-no-hardcoded-tokens` (justification de fallback)**
+
+```bash
+npm run build:manifest --workspace=packages/core
+```
+
+Expected: succès — le commentaire `a11y-fallback` précédant chaque ligne est détecté par `findUnjustifiedFallbacks` (cf. `validate-no-hardcoded-tokens.js`), pas d'échec de garde-fou.
+
+- [ ] **Step 3 : Commit**
+
+```bash
+git add packages/core/src/components/alert/alert.styles.ts packages/core/dist/custom-elements.json
+git commit -m "fix(alert): ajoute le fallback WCAG 2.5.8 manquant sur close-size (#129)"
+```
+
+---
+
+### Task 5 : Vérification visuelle Playwright et suite de tests complète
+
+**Files:** aucun fichier de code modifié — vérification uniquement.
+
+**Interfaces:**
+
+- Consumes: l'ensemble des changements des Tasks 2-4.
+
+- [ ] **Step 1 : Rebuild explicite du JS de `packages/core` avant toute vérification navigateur**
+
+```bash
+npm run build:dev --workspace=packages/core
+```
+
+Expected: build réussi. (Rappel : `npm run dev --workspace=apps/docs` seul ne reconstruit pas ce JS — rebuild explicite obligatoire avant toute vérification Playwright d'un changement de renderer/thème.)
+
+- [ ] **Step 2 : Lancer le site de doc et vérifier visuellement les 3 variants d'`ar-alert` (default, success, dismissible)**
+
+```bash
+npm run dev --workspace=apps/docs
+```
+
+Ouvrir `http://localhost:4321/components/ar-alert` (ou le port affiché) et vérifier à l'œil :
+
+- Les 4 variants (`info`/`warning`/`error`/`success`) gardent leur padding, arrondi et bordure identiques à avant (aucun changement visuel attendu, seulement un changement de source de la valeur).
+- Le bouton de fermeture (variant "dismissible") garde son arrondi (7px) et sa taille (2rem).
+- Vérifier dans les DevTools (`getComputedStyle` sur l'hôte `ar-alert` et sur le bouton `[part='close']`) que `padding`, `border-radius`, `border-width`, `border-style` résolvent bien aux mêmes valeurs qu'avant (1rem / 0.75rem / 1px / solid), et que `[part='close']` résout `border-radius: 7px`.
+
+Expected: aucune régression visuelle.
+
+- [ ] **Step 3 : Faire tourner la suite de tests complète**
+
+```bash
+npm run test --workspace=packages/core
+npm run test:all
+```
+
+Expected: tous les tests passent (Vitest + WTR navigateur), y compris `alert.test.ts` et `alert.a11y.test.ts` sans modification requise (aucune assertion existante ne porte sur ces tokens).
+
+- [ ] **Step 4 : Vérifier qu'aucune référence morte aux 5 tokens migrés ne subsiste**
+
+```bash
+grep -rn -- "--ar-alert-padding\|--ar-alert-border-radius\|--ar-alert-border-width\|--ar-alert-border-style\|--ar-alert-close-radius" packages/core/src apps/docs/src
+```
+
+Expected: aucune occurrence (les 5 tokens ont été entièrement retirés du composant, du thème et du JSDoc).
+
+---
+
+### Task 6 : Revue finale de branche et ouverture de la PR
+
+**Files:** aucun nouveau fichier — revue + PR.
+
+- [ ] **Step 1 : Diff complet de la branche pour auto-revue**
+
+```bash
+git diff dev...fix/alert-token-vs-part-129
+```
+
+Vérifier : les 5 tokens supprimés du `:root` de `default.css` correspondent exactement aux 5 entrées `@cssprop` supprimées de `alert.ts` ; le nouveau bloc `ar-alert { }` reproduit exactement les valeurs d'origine (`1rem`/`0.75rem`/`1px`/`solid`/`7px`) ; `--ar-alert-close-size` et `--ar-alert-close-transition-duration` sont inchangés à l'exception du fallback ajouté sur le premier.
+
+- [ ] **Step 2 : Pousser la branche et ouvrir la PR vers `dev`**
+
+```bash
+git push -u origin fix/alert-token-vs-part-129
+gh pr create --base dev --title "refactor(alert): migre token vs ::part() (lot 3a, #129)" --body "$(cat <<'EOF'
+## Résumé
+
+- Migre 5 tokens structurels d'`ar-alert` vers des règles externes de `default.css` (critère ADR-005) : `padding`/`border-radius`/`border-width`/`border-style` (règle `ar-alert { }` sur l'hôte) et `close-radius` (`ar-alert::part(close)`).
+- Ajoute le fallback WCAG 2.5.8 manquant sur `--ar-alert-close-size` (sur le modèle de `--ar-datepicker-day-size`), qui reste un token (réutilisé 2× dans le composant).
+- `--ar-alert-close-transition-duration` reste inchangé : vérifié empiriquement (Chromium/Playwright) qu'externaliser la transition casserait la garde `prefers-reduced-motion: reduce`.
+- Les 12 tokens sémantiques (bg/border/icon des 4 variants) restent tokens (fallback WCAG + calibration dark-mode sur les bordures) — hors périmètre de cette migration.
+
+## Test plan
+
+- [ ] `npm run test --workspace=packages/core` vert
+- [ ] `npm run test:all` vert
+- [ ] `npm run build:manifest --workspace=packages/core` sans erreur de garde-fou
+- [ ] Vérification visuelle des 4 variants + bouton fermer sur le site de doc (aucune régression)
+EOF
+)"
+```
+
+Expected: PR créée, lien affiché.
+
+- [ ] **Step 3 : Attendre la confirmation explicite de l'utilisateur avant tout merge**
+
+Ne pas merger sur `dev` sans confirmation explicite — règle permanente depuis l'incident PR #137.
+
+---
+
+## Self-Review
+
+**Spec coverage** :
+
+- Migration des 4 tokens `:host` → Task 2. ✅
+- Migration de `close-radius` → Task 3. ✅
+- Fallback WCAG manquant sur `close-size` → Task 4. ✅
+- `close-transition-duration` explicitement laissé inchangé (justifié) → mentionné dans le header du plan et le corps de PR (Task 6), aucune tâche de code nécessaire. ✅
+- Vérification visuelle + tests → Task 5. ✅
+- Branche en Task 1, PR en dernière tâche → conforme à la convention du projet. ✅
+
+**Placeholder scan** : aucun "TBD"/"implement later" — chaque step contient le code exact à écrire/retirer.
+
+**Type consistency** : les noms de tokens (`--ar-alert-padding`, `--ar-alert-border-radius`, `--ar-alert-border-width`, `--ar-alert-border-style`, `--ar-alert-close-radius`, `--ar-alert-close-size`) sont utilisés de façon cohérente entre toutes les tâches ; le bloc `ar-alert { }` de `default.css` est introduit en Task 2 et complété en Task 3 sans redéfinition contradictoire.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -75,8 +75,8 @@ Chaque composant expose des **CSS Custom Properties** pour la personnalisation s
 ```css
 /* Exemple : personnaliser ar-alert */
 ar-alert {
-    --ar-alert-border-radius: 0.5rem;
-    --ar-alert-padding: 0.75rem;
+    --ar-alert-close-size: 2.5rem;
+    --ar-alert-info-bg: #e0f2fe;
 }
 ```
 

--- a/packages/core/src/components/alert/alert.styles.ts
+++ b/packages/core/src/components/alert/alert.styles.ts
@@ -72,6 +72,11 @@ export default css`
         height: var(--ar-alert-close-size, 2rem);
         padding: 0;
         border: none;
+        /* Reset structurel : sans cette déclaration, en l'absence de thème, aucune règle
+         * ne pilote plus background-color depuis la migration vers ::part(close) — le
+         * bouton hérite alors du chrome natif du navigateur (souvent gris clair opaque),
+         * qui peut entrer en conflit avec la couleur héritée de l'icône (currentColor). */
+        background-color: transparent;
         color: currentColor;
         cursor: pointer;
         transition:

--- a/packages/core/src/components/alert/alert.styles.ts
+++ b/packages/core/src/components/alert/alert.styles.ts
@@ -72,12 +72,6 @@ export default css`
         height: var(--ar-alert-close-size, 2rem);
         padding: 0;
         border: none;
-        /* Reset structurel : sans cette déclaration, en l'absence de thème, aucune règle
-         * ne pilote plus background-color depuis la migration vers ::part(close) — le
-         * bouton hérite alors du chrome natif du navigateur (souvent gris clair opaque),
-         * qui peut entrer en conflit avec la couleur héritée de l'icône (currentColor). */
-        background-color: transparent;
-        color: currentColor;
         cursor: pointer;
         transition:
             opacity var(--ar-alert-close-transition-duration),

--- a/packages/core/src/components/alert/alert.styles.ts
+++ b/packages/core/src/components/alert/alert.styles.ts
@@ -78,12 +78,7 @@ export default css`
             opacity var(--ar-alert-close-transition-duration),
             background-color var(--ar-alert-close-transition-duration);
 
-        &:hover {
-            opacity: 1;
-        }
-
         &:focus-visible {
-            opacity: 1;
             outline: 2px solid currentColor;
             outline-offset: 2px;
         }

--- a/packages/core/src/components/alert/alert.styles.ts
+++ b/packages/core/src/components/alert/alert.styles.ts
@@ -50,8 +50,8 @@ export default css`
         opacity: 0;
         transform: scale(0.75);
         transition:
-            opacity 0.33s,
-            transform 0.33s;
+            opacity var(--ar-alert-hide-transition-duration),
+            transform var(--ar-alert-hide-transition-duration);
     }
 
     @media (prefers-reduced-motion: reduce) {

--- a/packages/core/src/components/alert/alert.styles.ts
+++ b/packages/core/src/components/alert/alert.styles.ts
@@ -10,10 +10,6 @@ export default css`
         opacity: 1;
         transform: scale(1);
         color: var(--ar-alert-color);
-        padding: var(--ar-alert-padding);
-        border-radius: var(--ar-alert-border-radius);
-        border-width: var(--ar-alert-border-width);
-        border-style: var(--ar-alert-border-style);
     }
 
     :host([variant='info']) {

--- a/packages/core/src/components/alert/alert.styles.ts
+++ b/packages/core/src/components/alert/alert.styles.ts
@@ -74,7 +74,6 @@ export default css`
         height: var(--ar-alert-close-size);
         padding: 0;
         border: none;
-        border-radius: var(--ar-alert-close-radius);
         background-color: var(--ar-alert-close-bg);
         color: currentColor;
         cursor: pointer;

--- a/packages/core/src/components/alert/alert.styles.ts
+++ b/packages/core/src/components/alert/alert.styles.ts
@@ -74,20 +74,14 @@ export default css`
         height: var(--ar-alert-close-size, 2rem);
         padding: 0;
         border: none;
-        background-color: var(--ar-alert-close-bg);
         color: currentColor;
         cursor: pointer;
-        opacity: 0.75;
         transition:
             opacity var(--ar-alert-close-transition-duration),
             background-color var(--ar-alert-close-transition-duration);
-        position: relative;
-        top: -0.2rem;
-        right: -0.2rem;
 
         &:hover {
             opacity: 1;
-            background-color: var(--ar-alert-close-hover-bg);
         }
 
         &:focus-visible {

--- a/packages/core/src/components/alert/alert.styles.ts
+++ b/packages/core/src/components/alert/alert.styles.ts
@@ -47,8 +47,6 @@ export default css`
     }
 
     :host([hiding]) {
-        opacity: 0;
-        transform: scale(0.75);
         transition:
             opacity var(--ar-alert-hide-transition-duration),
             transform var(--ar-alert-hide-transition-duration);

--- a/packages/core/src/components/alert/alert.styles.ts
+++ b/packages/core/src/components/alert/alert.styles.ts
@@ -101,6 +101,5 @@ export default css`
         flex: 0 0 auto;
         display: flex;
         align-items: center;
-        font-size: 1.5em;
     }
 `;

--- a/packages/core/src/components/alert/alert.styles.ts
+++ b/packages/core/src/components/alert/alert.styles.ts
@@ -70,8 +70,10 @@ export default css`
         display: flex;
         align-items: center;
         justify-content: center;
-        width: var(--ar-alert-close-size);
-        height: var(--ar-alert-close-size);
+        /* a11y-fallback: WCAG 2.5.8 (Target Size Minimum) — sans thème chargé, le bouton perdrait sa taille de cible tactile */
+        width: var(--ar-alert-close-size, 2rem);
+        /* a11y-fallback: WCAG 2.5.8 (Target Size Minimum) — sans thème chargé, le bouton perdrait sa taille de cible tactile */
+        height: var(--ar-alert-close-size, 2rem);
         padding: 0;
         border: none;
         background-color: var(--ar-alert-close-bg);

--- a/packages/core/src/components/alert/alert.styles.ts
+++ b/packages/core/src/components/alert/alert.styles.ts
@@ -4,8 +4,6 @@ export default css`
     :host {
         display: flex;
         box-sizing: border-box;
-        column-gap: 0.75rem;
-        position: relative;
         align-items: center;
         opacity: 1;
         transform: scale(1);

--- a/packages/core/src/components/alert/alert.test.ts
+++ b/packages/core/src/components/alert/alert.test.ts
@@ -218,8 +218,12 @@ describe('ArAlert', () => {
             expect(el.hasAttribute('hiding')).toBe(true);
         });
 
-        it('émet ar-alert-close après transitionend quand hiding=true', async () => {
+        it('émet ar-alert-close après transitionend quand hiding=true (thème avec transition réelle)', async () => {
             el = await fixture('<ar-alert next-focus="btn-retour"></ar-alert>');
+            // Force une durée de transition non nulle (simule un thème chargé) pour exercer
+            // le chemin asynchrone : sans ça, _shouldAnimate() renverrait false en happy-dom
+            // (aucune feuille de style chargée) et la fermeture serait synchrone.
+            el.style.transitionDuration = '0.3s';
             const handler = vi.fn();
             el.addEventListener('ar-alert-close', handler);
 
@@ -227,10 +231,38 @@ describe('ArAlert', () => {
             (requirePart(el, 'close') as HTMLButtonElement).click();
             await waitForUpdate(el);
 
+            // La fermeture attend bien la transition : rien n'est émis avant transitionend.
+            expect(handler).not.toHaveBeenCalled();
+
             // Simule la fin de la transition CSS (transitionend)
             el.dispatchEvent(new Event('transitionend'));
 
             expect(handler).toHaveBeenCalledOnce();
+        });
+
+        it("ferme instantanément (sans transitionend) quand aucun thème n'est chargé (durée de transition à 0)", async () => {
+            // Régression #129 : si default.css n'est pas chargé, la transition CSS externalisée
+            // (opacity/transform) ne s'applique jamais et la durée calculée reste à 0 — sans
+            // garde JS, transitionend ne se déclencherait jamais et l'alerte resterait bloquée.
+            const target = document.createElement('button');
+            target.id = 'btn-retour-sans-theme';
+            document.body.appendChild(target);
+
+            el = await fixture('<ar-alert next-focus="btn-retour-sans-theme"></ar-alert>');
+            const handler = vi.fn();
+            el.addEventListener('ar-alert-close', handler);
+
+            // Aucun style inline, aucune feuille de thème chargée en environnement de test :
+            // getComputedStyle(el).transitionDuration vaut '' (→ 0) en happy-dom par défaut.
+            (requirePart(el, 'close') as HTMLButtonElement).click();
+            await waitForUpdate(el);
+
+            // La fermeture doit être synchrone : pas de transitionend nécessaire.
+            expect(handler).toHaveBeenCalledOnce();
+            expect(el.isConnected).toBe(false);
+            expect(document.activeElement).toBe(target);
+
+            target.remove();
         });
 
         it("n'émet pas ar-alert-close si hiding=false au transitionend", async () => {
@@ -266,9 +298,10 @@ describe('ArAlert', () => {
             const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
             el = await fixture('<ar-alert next-focus="id-inexistant"></ar-alert>');
 
+            // Sans thème chargé (durée de transition à 0 en happy-dom), la fermeture se termine
+            // synchroniquement au clic — pas besoin de simuler transitionend.
             (requirePart(el, 'close') as HTMLButtonElement).click();
             await waitForUpdate(el);
-            el.dispatchEvent(new Event('transitionend'));
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy.mock.calls[0][0]).toContain('id-inexistant');
@@ -283,9 +316,10 @@ describe('ArAlert', () => {
 
             el = await fixture('<ar-alert next-focus="btn-retour-focus"></ar-alert>');
 
+            // Sans thème chargé (durée de transition à 0 en happy-dom), la fermeture se termine
+            // synchroniquement au clic — pas besoin de simuler transitionend.
             (requirePart(el, 'close') as HTMLButtonElement).click();
             await waitForUpdate(el);
-            el.dispatchEvent(new Event('transitionend'));
 
             expect(document.activeElement).toBe(target);
 

--- a/packages/core/src/components/alert/alert.test.ts
+++ b/packages/core/src/components/alert/alert.test.ts
@@ -205,6 +205,10 @@ describe('ArAlert', () => {
     describe('fermeture', () => {
         it('un clic sur close passe hiding à true', async () => {
             el = await fixture('<ar-alert next-focus="btn-retour"></ar-alert>');
+            // Force une durée de transition non nulle (simule un thème chargé) : sans thème,
+            // _shouldAnimate() renvoie false et _finishHide() s'exécute de façon synchrone,
+            // ce qui repasserait hiding à false avant même l'assertion ci-dessous.
+            el.style.transitionDuration = '0.3s';
             (requirePart(el, 'close') as HTMLButtonElement).click();
             await waitForUpdate(el);
             // hiding est un protected property — on y accède via cast
@@ -213,6 +217,9 @@ describe('ArAlert', () => {
 
         it('hiding=true applique l\'attribut "hiding" sur le host', async () => {
             el = await fixture('<ar-alert next-focus="btn-retour"></ar-alert>');
+            // Cf. commentaire ci-dessus : durée de transition non nulle requise pour que
+            // hiding reste true (chemin asynchrone) au moment de l'assertion.
+            el.style.transitionDuration = '0.3s';
             (requirePart(el, 'close') as HTMLButtonElement).click();
             await waitForUpdate(el);
             expect(el.hasAttribute('hiding')).toBe(true);
@@ -235,6 +242,27 @@ describe('ArAlert', () => {
             expect(handler).not.toHaveBeenCalled();
 
             // Simule la fin de la transition CSS (transitionend)
+            el.dispatchEvent(new Event('transitionend'));
+
+            expect(handler).toHaveBeenCalledOnce();
+        });
+
+        it('ignore un second transitionend dans la même tâche (thème anime opacity ET transform)', async () => {
+            // Régression #129 : le thème déclenche la transition sur deux propriétés
+            // simultanément (opacity + transform). Par spec, `transitionend` se déclenche
+            // une fois PAR PROPRIÉTÉ transitionnée — donc deux fois de suite ici. Sans reset
+            // de `hiding` dans `_finishHide`, le second appel repasserait la garde et
+            // ré-émettrait ar-alert-close / redonnerait le focus une seconde fois.
+            el = await fixture('<ar-alert next-focus="btn-retour"></ar-alert>');
+            el.style.transitionDuration = '0.3s';
+            const handler = vi.fn();
+            el.addEventListener('ar-alert-close', handler);
+
+            (requirePart(el, 'close') as HTMLButtonElement).click();
+            await waitForUpdate(el);
+
+            // Simule les deux transitionend (opacity, puis transform) dans la même tâche.
+            el.dispatchEvent(new Event('transitionend'));
             el.dispatchEvent(new Event('transitionend'));
 
             expect(handler).toHaveBeenCalledOnce();

--- a/packages/core/src/components/alert/alert.ts
+++ b/packages/core/src/components/alert/alert.ts
@@ -174,9 +174,13 @@ export class ArAlert extends LitElement {
     private _hide = (): void => {
         if (!this.canBeHidden) return;
         this.hiding = true;
-        if (!this._shouldAnimate()) {
-            this._finishHide();
-        }
+        // La reflection de l'attribut `hiding` par Lit n'est pas synchrone : on attend
+        // updateComplete pour que `:host([hiding])` ait pu matcher avant de mesurer la durée.
+        void this.updateComplete.then(() => {
+            if (!this._shouldAnimate()) {
+                this._finishHide();
+            }
+        });
     };
 
     /** Supprime l'alerte du DOM et reporte le focus après la fin de la transition CSS */

--- a/packages/core/src/components/alert/alert.ts
+++ b/packages/core/src/components/alert/alert.ts
@@ -186,6 +186,9 @@ export class ArAlert extends LitElement {
     /** Supprime l'alerte du DOM et reporte le focus après la fin de la transition CSS */
     private _finishHide = (): void => {
         if (!this.canBeHidden || !this.hiding) return;
+        // Idempotent : le thème anime opacity ET transform, donc `transitionend` se déclenche
+        // deux fois (une par propriété) — sans ce reset, le second appel repasserait la garde.
+        this.hiding = false;
 
         this.dispatchEvent(new CustomEvent('ar-alert-close', { bubbles: true, composed: true }));
         this.remove();

--- a/packages/core/src/components/alert/alert.ts
+++ b/packages/core/src/components/alert/alert.ts
@@ -43,6 +43,7 @@ export type ArAlertVariant = 'success' | 'warning' | 'error' | 'info';
  * @cssprop --ar-alert-success-border - Bordure de l'alerte "success".
  * @cssprop --ar-alert-success-icon - Couleur de l'icône "success".
  * @cssprop --ar-alert-close-transition-duration - Durée de la transition (opacity/background-color) du bouton de fermeture au survol/focus.
+ * @cssprop --ar-alert-hide-transition-duration - Durée de la transition de sortie (opacity/transform) à la fermeture.
  * @cssprop --ar-alert-color - Couleur du texte de l'alerte (cascade vers --ar-color-text).
 
  *

--- a/packages/core/src/components/alert/alert.ts
+++ b/packages/core/src/components/alert/alert.ts
@@ -26,6 +26,7 @@ export type ArAlertVariant = 'success' | 'warning' | 'error' | 'info';
  * @slot close-icon   - Icône du bouton de fermeture. Remplace le SVG "×" par défaut.
  *
  * @csspart icon      - Le conteneur de l'icône de variant.
+ * @csspart icon-svg  - Le SVG de l'icône de variant par défaut (absent si le slot `icon` est utilisé).
  * @csspart body      - Le conteneur du titre et du contenu.
  * @csspart close     - Le bouton de fermeture (présent uniquement si `next-focus` est défini).
  *

--- a/packages/core/src/components/alert/alert.ts
+++ b/packages/core/src/components/alert/alert.ts
@@ -30,7 +30,6 @@ export type ArAlertVariant = 'success' | 'warning' | 'error' | 'info';
  * @csspart close     - Le bouton de fermeture (présent uniquement si `next-focus` est défini).
  *
  * @cssprop --ar-alert-close-size - Taille (width/height) du bouton de fermeture.
- * @cssprop --ar-alert-close-radius - Arrondi du bouton de fermeture.
  * @cssprop --ar-alert-close-bg - Fond du bouton de fermeture au repos.
  * @cssprop --ar-alert-close-hover-bg - Fond du bouton de fermeture au survol.
  * @cssprop --ar-alert-info-bg - Fond de l'alerte "info".

--- a/packages/core/src/components/alert/alert.ts
+++ b/packages/core/src/components/alert/alert.ts
@@ -30,8 +30,6 @@ export type ArAlertVariant = 'success' | 'warning' | 'error' | 'info';
  * @csspart close     - Le bouton de fermeture (présent uniquement si `next-focus` est défini).
  *
  * @cssprop --ar-alert-close-size - Taille (width/height) du bouton de fermeture.
- * @cssprop --ar-alert-close-bg - Fond du bouton de fermeture au repos.
- * @cssprop --ar-alert-close-hover-bg - Fond du bouton de fermeture au survol.
  * @cssprop --ar-alert-info-bg - Fond de l'alerte "info".
  * @cssprop --ar-alert-info-border - Bordure de l'alerte "info".
  * @cssprop --ar-alert-info-icon - Couleur de l'icône "info".

--- a/packages/core/src/components/alert/alert.ts
+++ b/packages/core/src/components/alert/alert.ts
@@ -164,10 +164,17 @@ export class ArAlert extends LitElement {
         return this.nextFocus !== undefined && this.nextFocus?.replaceAll(' ', '') !== '';
     }
 
+    private _shouldAnimate(): boolean {
+        // transitionend ne se déclenche pas si duration=0s (défaut headless sans thème).
+        // On vérifie la durée calculée pour éviter que la fermeture reste bloquée indéfiniment.
+        const d = parseFloat(getComputedStyle(this).transitionDuration) || 0;
+        return !prefersReducedMotion() && d > 0;
+    }
+
     private _hide = (): void => {
         if (!this.canBeHidden) return;
         this.hiding = true;
-        if (prefersReducedMotion()) {
+        if (!this._shouldAnimate()) {
             this._finishHide();
         }
     };

--- a/packages/core/src/components/alert/alert.ts
+++ b/packages/core/src/components/alert/alert.ts
@@ -29,10 +29,6 @@ export type ArAlertVariant = 'success' | 'warning' | 'error' | 'info';
  * @csspart body      - Le conteneur du titre et du contenu.
  * @csspart close     - Le bouton de fermeture (présent uniquement si `next-focus` est défini).
  *
- * @cssprop --ar-alert-border-radius - Arrondi des alertes.
- * @cssprop --ar-alert-padding - Marge interne des alertes.
- * @cssprop --ar-alert-border-width - Epaisseur des bordures.
- * @cssprop --ar-alert-border-style - Style des bordures.
  * @cssprop --ar-alert-close-size - Taille (width/height) du bouton de fermeture.
  * @cssprop --ar-alert-close-radius - Arrondi du bouton de fermeture.
  * @cssprop --ar-alert-close-bg - Fond du bouton de fermeture au repos.

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -307,6 +307,7 @@
         --ar-alert-success-border: var(--ar-color-success-bg);
         --ar-alert-success-icon: var(--ar-color-success-text);
         --ar-alert-close-transition-duration: var(--ar-button-transition-duration);
+        --ar-alert-hide-transition-duration: 0.33s;
 
         /* button */
         --ar-button-bg: var(--ar-color-interactive);

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -294,7 +294,6 @@
         /* alert */
         --ar-alert-color: var(--ar-color-text);
         --ar-alert-close-size: 2rem;
-        --ar-alert-close-radius: 7px;
         --ar-alert-close-bg: color-mix(in srgb, currentColor 8%, transparent);
         --ar-alert-close-hover-bg: color-mix(in srgb, currentColor 20%, transparent);
         --ar-alert-info-bg: var(--ar-color-info-bg);
@@ -920,5 +919,9 @@
         border-radius: 0.75rem;
         border-width: 1px;
         border-style: solid;
+
+        &::part(close) {
+            border-radius: 7px;
+        }
     }
 }

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -922,6 +922,7 @@
 
         &::part(close) {
             border-radius: 7px;
+            color: currentColor;
             background-color: color-mix(in srgb, currentColor 8%, transparent);
             opacity: 0.75;
             position: relative;

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -919,6 +919,7 @@
         border-radius: 0.75rem;
         border-width: 1px;
         border-style: solid;
+        column-gap: 0.75rem;
 
         &::part(close) {
             border-radius: 7px;

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -931,5 +931,9 @@
         &::part(close):hover {
             background-color: color-mix(in srgb, currentColor 20%, transparent);
         }
+
+        &::part(icon) {
+            font-size: 1.5em;
+        }
     }
 }

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -931,6 +931,11 @@
 
         &::part(close):hover {
             background-color: color-mix(in srgb, currentColor 20%, transparent);
+            opacity: 1;
+        }
+
+        &::part(close):focus-visible {
+            opacity: 1;
         }
 
         &::part(icon) {

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -937,4 +937,9 @@
             font-size: 1.5em;
         }
     }
+
+    ar-alert[hiding] {
+        opacity: 0;
+        transform: scale(0.75);
+    }
 }

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -294,8 +294,6 @@
         /* alert */
         --ar-alert-color: var(--ar-color-text);
         --ar-alert-close-size: 2rem;
-        --ar-alert-close-bg: color-mix(in srgb, currentColor 8%, transparent);
-        --ar-alert-close-hover-bg: color-mix(in srgb, currentColor 20%, transparent);
         --ar-alert-info-bg: var(--ar-color-info-bg);
         --ar-alert-info-border: var(--ar-color-info-bg);
         --ar-alert-info-icon: var(--ar-color-info-text);
@@ -923,6 +921,15 @@
 
         &::part(close) {
             border-radius: 7px;
+            background-color: color-mix(in srgb, currentColor 8%, transparent);
+            opacity: 0.75;
+            position: relative;
+            top: -0.2rem;
+            right: -0.2rem;
+        }
+
+        &::part(close):hover {
+            background-color: color-mix(in srgb, currentColor 20%, transparent);
         }
     }
 }

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -293,10 +293,6 @@
 
         /* alert */
         --ar-alert-color: var(--ar-color-text);
-        --ar-alert-padding: 1rem;
-        --ar-alert-border-radius: 0.75rem;
-        --ar-alert-border-width: 1px;
-        --ar-alert-border-style: solid;
         --ar-alert-close-size: 2rem;
         --ar-alert-close-radius: 7px;
         --ar-alert-close-bg: color-mix(in srgb, currentColor 8%, transparent);
@@ -917,5 +913,12 @@
             color: var(--ar-color-text-inverse);
             box-shadow: none;
         }
+    }
+
+    ar-alert {
+        padding: 1rem;
+        border-radius: 0.75rem;
+        border-width: 1px;
+        border-style: solid;
     }
 }


### PR DESCRIPTION
## Résumé

- Migre 5 tokens structurels d'`ar-alert` vers des règles externes de `default.css` (critère ADR-005) : `padding`/`border-radius`/`border-width`/`border-style` (règle `ar-alert { }` sur l'hôte) et `close-radius` (`ar-alert::part(close)`).
- Ajoute le fallback WCAG 2.5.8 manquant sur `--ar-alert-close-size` (sur le modèle de `--ar-datepicker-day-size`), qui reste un token (réutilisé 2× dans le composant).
- `--ar-alert-close-transition-duration` reste inchangé : vérifié empiriquement (Chromium/Playwright) qu'externaliser la transition casserait la garde `prefers-reduced-motion: reduce` — nouvelle contrainte 6 documentée dans ADR-005.
- Les 12 tokens sémantiques (bg/border/icon des 4 variants) restent tokens (fallback WCAG + calibration dark-mode sur les bordures) — hors périmètre de cette migration.
- Corrige au passage deux exemples de documentation (`packages/core/README.md`, `docs/onboarding.md`) qui citaient des tokens désormais supprimés, et documente le lot dans ADR-005 (section "Application — ar-alert").

## Test plan

- [x] `npm run test --workspace=packages/core` vert (774/774)
- [x] `npm run test:all` vert (WTR Chromium 227/227)
- [x] `npm run build:manifest --workspace=packages/core` sans erreur de garde-fou
- [x] Vérification des valeurs calculées (padding/border-radius/border-width/border-style/close-radius/close-size) sur les 3 variants du site de doc — aucune régression

🤖 Généré avec [Claude Code](https://claude.com/claude-code)