### PR TITLE
refactor(alert): découple variant et role, généricise les tokens CSS

### DIFF
--- a/apps/docs/src/content/components/ar-alert.mdx
+++ b/apps/docs/src/content/components/ar-alert.mdx
@@ -51,6 +51,10 @@ import WcagRef from '../../components/WcagRef.astro';
   présence (`<ar-alert urgent>`, pas besoin de `="true"`) force `role="alert"`. Elle
   n'est jamais forcée par son absence — sans elle, le rôle retombe sur la déduction
   ci-dessus.
+- `role` est entièrement calculé par le composant. Toute tentative de le poser manuellement
+  en markup (`<ar-alert role="banner">`) sera écrasée : le composant émet un avertissement
+  en dev et applique sa propre logique. Pour contrôler le rôle ARIA, utilisez `urgent` ou
+  laissez le composant déduire de `variant`.
 - L'icône est masquée aux lecteurs d'écran (`aria-hidden`). L'information de sévérité
   est portée par le `role`, pas par l'icône.
 - Une icône par défaut est fournie pour les 4 variants connus (`error`, `warning`,

--- a/apps/docs/src/content/components/ar-alert.mdx
+++ b/apps/docs/src/content/components/ar-alert.mdx
@@ -41,17 +41,24 @@ import WcagRef from '../../components/WcagRef.astro';
 ### Pris en charge automatiquement
 
 - `role="alert"` (interruption immédiate) ou `role="status"` (annonce polie) posé sur
-  l'hôte selon le variant — `info` → `status`, tous les autres → `alert` — conforme
+  l'hôte selon `variant` — `error`/`warning` → `alert`, `success`/`info` → `status`, tout
+  variant custom non reconnu → `status` (défaut sûr) — conforme
     <WcagRef
         criterion="4.1.3"
         summary="Status Messages : les messages de statut doivent être annoncés aux technologies d'assistance sans déplacer le focus."
     />
+- La prop `urgent` permet de forcer ce niveau indépendamment de `variant` : sa seule
+  présence (`<ar-alert urgent>`, pas besoin de `="true"`) force `role="alert"`. Elle
+  n'est jamais forcée par son absence — sans elle, le rôle retombe sur la déduction
+  ci-dessus.
 - L'icône est masquée aux lecteurs d'écran (`aria-hidden`). L'information de sévérité
   est portée par le `role`, pas par l'icône.
-- Une icône par défaut est fournie pour chaque variant. Elle peut être remplacée via le
-  slot `icon`, mais il est déconseillé de la supprimer : elle constitue un repère visuel
-  non colorimétrique, important pour les utilisateurs daltoniens ou en environnement à
-  faible contraste.
+- Une icône par défaut est fournie pour les 4 variants connus (`error`, `warning`,
+  `success`, `info`). Elle peut être remplacée via le slot `icon`, mais il est
+  déconseillé de la supprimer : elle constitue un repère visuel non colorimétrique,
+  important pour les utilisateurs daltoniens ou en environnement à faible contraste. Un
+  `variant` custom non reconnu par le composant n'affiche aucune icône par défaut (un
+  avertissement en console le rappelle en dev) — fournissez `slot="icon"` dans ce cas.
 - Le focus est reporté sur l'élément cible (`next-focus`) à la fermeture — l'utilisateur
   clavier ne se retrouve pas désorienté.
 
@@ -63,6 +70,11 @@ import WcagRef from '../../components/WcagRef.astro';
 - **Niveau de sévérité cohérent.** `error` pour les erreurs bloquantes, `warning` pour
   les situations qui méritent attention sans bloquer, `success` pour les confirmations,
   `info` pour les informations neutres.
+- **Styliser un `variant` custom.** Au-delà des 4 presets fournis par `default.css`
+  (`error`/`warning`/`success`/`info`), tout autre `variant` doit définir lui-même
+  `--ar-alert-bg`, `--ar-alert-border` et `--ar-alert-icon` (ex.
+  `ar-alert[variant='promo'] { --ar-alert-bg: ...; }`) et fournir une icône via
+  `slot="icon"`.
 - **`next-focus` obligatoire sur les alertes dismissibles.** Un bouton de fermeture sans
   destination de focus laisse l'utilisateur clavier sans repère.
 

--- a/apps/docs/src/pages/getting-started/utilisation.astro
+++ b/apps/docs/src/pages/getting-started/utilisation.astro
@@ -32,8 +32,8 @@ await Promise.all(tags.map(tag => customElements.whenDefined(tag)));
 // Tous les composants ar-* sont prêts`;
 
 const codeCustomProps = `.alerte-succes-perso {
-    --ar-alert-info-bg:   #f5f0ff;
-    --ar-alert-info-icon: #7c3aed;
+    --ar-alert-bg:   #f5f0ff;
+    --ar-alert-icon: #7c3aed;
 }`;
 
 const codeTokens = `:root {

--- a/apps/docs/src/utils/cem-types.test.ts
+++ b/apps/docs/src/utils/cem-types.test.ts
@@ -157,4 +157,22 @@ describe('buildControls', () => {
         const members = [makeField({ kind: 'method' })];
         expect(buildControls(members)).toHaveLength(0);
     });
+
+    it('convertit la chaîne "undefined" en valeur undefined', () => {
+        const members = [makeField({ default: 'undefined' })];
+        const controls = buildControls(members);
+        expect(controls[0].default).toBeUndefined();
+    });
+
+    it('préserve les valeurs par défaut quoted', () => {
+        const members = [makeField({ default: "'right'" })];
+        const controls = buildControls(members);
+        expect(controls[0].default).toBe('right');
+    });
+
+    it('préserve les valeurs par défaut quoted avec guillemets doubles', () => {
+        const members = [makeField({ default: '"center"' })];
+        const controls = buildControls(members);
+        expect(controls[0].default).toBe('center');
+    });
 });

--- a/apps/docs/src/utils/cem-types.ts
+++ b/apps/docs/src/utils/cem-types.ts
@@ -131,6 +131,7 @@ export function hasUndefined(typeText: string): boolean {
 /** Supprime les guillemets encadrant les string literals TypeScript (`'foo'` → `foo`). */
 function stripQuotes(val: string | undefined): string | undefined {
     if (!val) return val;
+    if (val === 'undefined') return undefined;
     return val.replace(/^(['"`])(.*)\1$/, '$2');
 }
 

--- a/apps/docs/src/utils/cem-types.ts
+++ b/apps/docs/src/utils/cem-types.ts
@@ -157,7 +157,7 @@ export function buildControls(members: CemMember[]): CemControl[] {
                 default: stripQuotes(m.default),
                 controlType: stringUnion
                     ? ('select' as const)
-                    : typeText === 'boolean'
+                    : typeText === 'boolean' || typeText === 'boolean | undefined'
                       ? ('checkbox' as const)
                       : typeText === 'number' || typeText === 'number | undefined'
                         ? ('number' as const)

--- a/docs/superpowers/plans/2026-07-28-alert-variant-role-decoupling.md
+++ b/docs/superpowers/plans/2026-07-28-alert-variant-role-decoupling.md
@@ -1,0 +1,856 @@
+# ar-alert — découplage variant/role Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remplacer le mapping binaire `variant === 'info' ? 'status' : 'alert'` par une table de
+correspondance à 4 entrées + un override explicite (`urgent`), et remplacer les 12 tokens CSS
+nommés par variant par 3 tokens génériques + presets dans le thème.
+
+**Architecture:** `alert.ts` gagne une table `ROLE_BY_VARIANT` (private static) et une nouvelle
+prop `urgent?: boolean` consultée en priorité dans la logique de rôle déjà présente dans
+`updated()`. `variant` est retypé en union ouverte (`ArAlertVariant | (string & {})`) sans
+changer son nom ni son comportement par défaut. `alert.styles.ts` n'a plus qu'un seul bloc de
+règles CSS consommant 3 tokens génériques ; `default.css` porte la logique de sélection par
+variant via des sélecteurs d'attribut (`ar-alert[variant='...']`).
+
+**Tech Stack:** Lit 3, TypeScript, Vitest (tests unitaires jsdom/happy-dom), Web Test Runner
+(tests navigateur/a11y), `warn()` (infra `__DEV__` existante).
+
+## Global Constraints
+
+- Prettier : 100 caractères, 4 espaces, quotes simples.
+- Toujours `import type` pour les imports de types.
+- Conventional Commits (commitlint + Husky) — préfixe `refactor(alert):` pour ce chantier.
+- Aucun fallback cosmétique dans les composants (`var(--token)` sans valeur par défaut) —
+  `packages/core` reste headless, les valeurs vont dans `themes/default.css`.
+- `exactOptionalPropertyTypes: true` — toute prop optionnelle réassignable à `undefined` se
+  déclare `?: T` sans valeur par défaut sur le champ de classe (pas de fallback implicite `T
+| undefined`).
+- Tout nouveau token `--ar-*` doit avoir son entrée `@cssprop` dans le JSDoc du composant.
+- Breaking change assumé sans `warnDeprecated` (alpha, aucun consommateur réel).
+- Spec source : `docs/superpowers/specs/2026-07-28-alert-variant-role-decoupling-design.md`.
+
+---
+
+## Fichiers concernés
+
+- Modifier : `packages/core/src/components/alert/alert.ts` — typage `variant`, table
+  `ROLE_BY_VARIANT`, prop `urgent`, logique de rôle, fallback icône + warn.
+- Modifier : `packages/core/src/components/alert/alert.styles.ts` — 3 tokens génériques au lieu
+  des 4 blocs `:host([variant='...'])`.
+- Modifier : `packages/core/src/styles/themes/default.css` — presets par attribut de variant
+  (light + dark).
+- Modifier : `packages/core/src/components/alert/alert.test.ts` — tests existants à corriger
+  (mapping success/warning) + nouveaux tests (table, `urgent`, warn icône).
+- Modifier : `apps/docs/src/content/components/ar-alert.mdx` — doc `variant`/`role`/`urgent`.
+
+---
+
+### Task 1: Créer la branche de travail
+
+**Files:** aucun.
+
+- [ ] **Step 1: Créer et basculer sur la branche depuis `dev`**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git checkout dev
+git pull
+git checkout -b refactor/alert-variant-role-decoupling
+```
+
+Expected: la branche `refactor/alert-variant-role-decoupling` est active
+(`git branch --show-current` → `refactor/alert-variant-role-decoupling`).
+
+---
+
+### Task 2: Élargir le typage de `variant` et introduire `ROLE_BY_VARIANT`
+
+**Files:**
+
+- Modify: `packages/core/src/components/alert/alert.ts:18` (type `ArAlertVariant`), `:82-83`
+  (prop `variant`)
+- Test: `packages/core/src/components/alert/alert.test.ts`
+
+**Interfaces:**
+
+- Produces: `ArAlertVariant` (union `'success'|'warning'|'error'|'info'`, inchangée en tant que
+  type nommé), prop `variant: ArAlertVariant | (string & {})` (comportement par défaut
+  inchangé : `'error'`), constante privée statique
+  `ArAlert._ROLE_BY_VARIANT: Record<string, 'alert' | 'status'>`.
+
+Ce task ne change pas encore le calcul du `role` dans `updated()` (fait au Task 3) — il prépare
+juste le typage et la table, avec un test qui vérifie que la table est correctement consultable
+en interne via son effet observable (le futur calcul de rôle). Comme la table seule n'a pas
+d'effet observable sans être branchée, ce task et le Task 3 sont fusionnés en pratique : écrire
+le test du Task 3 d'abord (rouge), introduire la table + le branchement en une fois.
+
+- [ ] **Step 1: Écrire les tests rouges pour le nouveau mapping role/variant**
+
+Dans `packages/core/src/components/alert/alert.test.ts`, remplacer le bloc
+`describe('accessibilité ARIA', ...)` (lignes 68-94 actuelles) par :
+
+```ts
+describe('accessibilité ARIA', () => {
+    it('variant="error" donne role="alert" au host', async () => {
+        el = await fixture('<ar-alert variant="error"></ar-alert>');
+        expect(el.getAttribute('role')).toBe('alert');
+    });
+
+    it('variant="warning" donne role="alert" au host', async () => {
+        el = await fixture('<ar-alert variant="warning"></ar-alert>');
+        expect(el.getAttribute('role')).toBe('alert');
+    });
+
+    it('variant="success" donne role="status" au host', async () => {
+        el = await fixture('<ar-alert variant="success"></ar-alert>');
+        expect(el.getAttribute('role')).toBe('status');
+    });
+
+    it('variant="info" donne role="status" au host', async () => {
+        el = await fixture('<ar-alert variant="info"></ar-alert>');
+        expect(el.getAttribute('role')).toBe('status');
+    });
+
+    it('un variant custom inconnu donne role="status" (défaut sûr)', async () => {
+        el = await fixture('<ar-alert variant="promo"></ar-alert>');
+        expect(el.getAttribute('role')).toBe('status');
+    });
+
+    it('without-notification supprime le role du host', async () => {
+        el = await fixture('<ar-alert without-notification></ar-alert>');
+        expect(el.hasAttribute('role')).toBe(false);
+    });
+});
+```
+
+- [ ] **Step 2: Lancer les tests pour vérifier l'échec sur success/promo**
+
+Run: `cd /Users/jon/Code/Active_projects/ariane && npm run test --workspace=packages/core -- alert.test.ts`
+Expected: FAIL sur `variant="success" donne role="status"` et `variant custom inconnu` (le code
+actuel donne encore `role="alert"` pour ces deux cas).
+
+- [ ] **Step 3: Élargir le typage de `variant` et brancher la table de correspondance**
+
+Dans `packages/core/src/components/alert/alert.ts`, le type nommé `ArAlertVariant` (ligne 18)
+reste inchangé — il continue de documenter les 4 presets connus pour l'autocomplétion :
+
+```ts
+export type ArAlertVariant = 'success' | 'warning' | 'error' | 'info';
+```
+
+Remplacer les lignes 82-83 :
+
+```ts
+    @property({ reflect: true, type: String })
+    variant: 'success' | 'warning' | 'error' | 'info' = 'error';
+```
+
+par :
+
+```ts
+    @property({ reflect: true, type: String })
+    variant: ArAlertVariant | (string & {}) = 'error';
+```
+
+Ajouter, juste avant `_ICON_PATHS` (ligne 109 actuelle), la table de correspondance :
+
+```ts
+    private static readonly _ROLE_BY_VARIANT: Record<string, 'alert' | 'status'> = {
+        error: 'alert',
+        warning: 'alert',
+        success: 'status',
+        info: 'status',
+    };
+```
+
+Remplacer le bloc `updated()` (lignes 99-107 actuelles) :
+
+```ts
+    override updated(changed: Map<string, unknown>) {
+        if (changed.has('variant') || changed.has('withoutNotification')) {
+            if (this.withoutNotification) {
+                this.removeAttribute('role');
+                return;
+            }
+            this.role = this.variant === 'info' ? 'status' : 'alert';
+        }
+    }
+```
+
+par :
+
+```ts
+    override updated(changed: Map<string, unknown>) {
+        if (changed.has('variant') || changed.has('withoutNotification')) {
+            this._updateRole();
+        }
+    }
+
+    private _updateRole(): void {
+        if (this.withoutNotification) {
+            this.removeAttribute('role');
+            return;
+        }
+        this.role = ArAlert._ROLE_BY_VARIANT[this.variant] ?? 'status';
+    }
+```
+
+(la gestion de `urgent` est ajoutée au Task 3 — ce step isole le passage de la table).
+
+- [ ] **Step 4: Relancer les tests pour vérifier qu'ils passent**
+
+Run: `cd /Users/jon/Code/Active_projects/ariane && npm run test --workspace=packages/core -- alert.test.ts`
+Expected: PASS sur les 6 tests du bloc `accessibilité ARIA`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/components/alert/alert.ts packages/core/src/components/alert/alert.test.ts
+git commit -m "refactor(alert): remplace le mapping binaire variant/role par une table de correspondance"
+```
+
+---
+
+### Task 3: Ajouter la prop `urgent` (override explicite du rôle)
+
+**Files:**
+
+- Modify: `packages/core/src/components/alert/alert.ts`
+- Test: `packages/core/src/components/alert/alert.test.ts`
+
+**Interfaces:**
+
+- Consumes: `ArAlert._ROLE_BY_VARIANT`, `_updateRole()` (Task 2).
+- Produces: prop `urgent?: boolean` (pas de valeur par défaut sur le champ de classe — reste
+  `undefined` tant que l'attribut n'est jamais posé).
+
+- [ ] **Step 1: Écrire les tests rouges pour `urgent`**
+
+Dans `packages/core/src/components/alert/alert.test.ts`, ajouter un nouveau bloc `describe`
+après `describe('accessibilité ARIA', ...)` :
+
+```ts
+// ── Prop urgent (override du rôle) ──────────────────────────────────────
+
+describe('prop urgent', () => {
+    it('urgent est undefined par défaut', async () => {
+        el = await fixture('<ar-alert></ar-alert>');
+        expect(el.urgent).toBeUndefined();
+    });
+
+    it('la seule présence de l\'attribut urgent force role="alert"', async () => {
+        el = await fixture('<ar-alert variant="success" urgent></ar-alert>');
+        expect(el.getAttribute('role')).toBe('alert');
+    });
+
+    it('urgent en absence ne force pas role="status" (retombe sur la table)', async () => {
+        el = await fixture('<ar-alert variant="error"></ar-alert>');
+        expect(el.getAttribute('role')).toBe('alert');
+    });
+
+    it('urgent=false (JS) force role="status" même sur un variant "error"', async () => {
+        el = await fixture('<ar-alert variant="error"></ar-alert>');
+        el.urgent = false;
+        await waitForUpdate(el);
+        expect(el.getAttribute('role')).toBe('status');
+    });
+
+    it("urgent est prioritaire sur withoutNotification=false mais pas l'inverse", async () => {
+        el = await fixture('<ar-alert variant="success" urgent without-notification></ar-alert>');
+        expect(el.hasAttribute('role')).toBe(false);
+    });
+});
+```
+
+- [ ] **Step 2: Lancer les tests pour vérifier l'échec**
+
+Run: `cd /Users/jon/Code/Active_projects/ariane && npm run test --workspace=packages/core -- alert.test.ts`
+Expected: FAIL — `el.urgent` n'existe pas encore (erreur TypeScript à la compilation du test, ou
+`undefined` non typé selon le runner ; en tout cas les assertions sur `role="alert"`/`role="status"`
+forcés échouent puisque la prop n'existe pas).
+
+- [ ] **Step 3: Ajouter la prop `urgent` et la brancher dans `_updateRole()`**
+
+Dans `packages/core/src/components/alert/alert.ts`, ajouter après la prop `withoutNotification`
+(après la ligne 76 actuelle) :
+
+```ts
+    /**
+     * Force le niveau d'urgence ARIA indépendamment de `variant` : `role="alert"` si présent,
+     * sinon déduit de `variant` via une table de correspondance interne (`error`/`warning` →
+     * `alert`, `success`/`info` → `status`, tout autre variant → `status`).
+     * @attr urgent
+     * @default undefined
+     */
+    @property({ type: Boolean })
+    urgent?: boolean;
+```
+
+Modifier `_updateRole()` (ajoutée au Task 2) :
+
+```ts
+    private _updateRole(): void {
+        if (this.withoutNotification) {
+            this.removeAttribute('role');
+            return;
+        }
+        if (this.urgent !== undefined) {
+            this.role = this.urgent ? 'alert' : 'status';
+            return;
+        }
+        this.role = ArAlert._ROLE_BY_VARIANT[this.variant] ?? 'status';
+    }
+```
+
+Et étendre la condition dans `updated()` pour réagir aux changements de `urgent` :
+
+```ts
+    override updated(changed: Map<string, unknown>) {
+        if (changed.has('variant') || changed.has('withoutNotification') || changed.has('urgent')) {
+            this._updateRole();
+        }
+    }
+```
+
+- [ ] **Step 4: Relancer les tests**
+
+Run: `cd /Users/jon/Code/Active_projects/ariane && npm run test --workspace=packages/core -- alert.test.ts`
+Expected: PASS sur tout `alert.test.ts`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/components/alert/alert.ts packages/core/src/components/alert/alert.test.ts
+git commit -m "feat(alert): ajoute la prop urgent pour surcharger le role indépendamment de variant"
+```
+
+---
+
+### Task 4: Icône par défaut absente + warning dev pour variant custom
+
+**Files:**
+
+- Modify: `packages/core/src/components/alert/alert.ts`
+- Test: `packages/core/src/components/alert/alert.test.ts`
+
+**Interfaces:**
+
+- Consumes: `warn` depuis `../../utils/warn.js` (déjà importé), `_ICON_PATHS`.
+- Produces: `_defaultIcon()` retourne `TemplateResult | typeof nothing`.
+
+- [ ] **Step 1: Écrire les tests rouges**
+
+Dans `packages/core/src/components/alert/alert.test.ts`, dans le bloc `describe('icône', ...)`,
+ajouter :
+
+```ts
+it("n'affiche pas d'icône par défaut pour un variant custom inconnu", async () => {
+    el = await fixture('<ar-alert variant="promo"></ar-alert>');
+    expect(requireShadow(el).querySelector('slot[name="icon"] svg')).toBeNull();
+});
+
+it('logue un avertissement pour un variant custom inconnu', async () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    el = await fixture('<ar-alert variant="promo"></ar-alert>');
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('promo'));
+    spy.mockRestore();
+});
+
+it("n'avertit pas pour un variant connu", async () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    el = await fixture('<ar-alert variant="success"></ar-alert>');
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+});
+```
+
+- [ ] **Step 2: Lancer les tests pour vérifier l'échec**
+
+Run: `cd /Users/jon/Code/Active_projects/ariane && npm run test --workspace=packages/core -- alert.test.ts`
+Expected: FAIL — un `<svg>` est actuellement toujours rendu (fallback `DEFAULT_VARIANT`), et
+aucun `warn()` n'est émis pour un variant inconnu.
+
+- [ ] **Step 3: Implémenter le fallback + le warning**
+
+Dans `packages/core/src/components/alert/alert.ts`, remplacer `_defaultIcon()` (lignes 117-129
+actuelles) :
+
+```ts
+    protected _defaultIcon(): TemplateResult {
+        const path = ArAlert._ICON_PATHS[this.variant ?? ArAlert.DEFAULT_VARIANT];
+        return html` <svg
+            aria-hidden="true"
+            part="icon-svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+        >
+            <path stroke-linecap="round" stroke-linejoin="round" d=${path}></path>
+        </svg>`;
+    }
+```
+
+par :
+
+```ts
+    protected _defaultIcon(): TemplateResult | typeof nothing {
+        const path = ArAlert._ICON_PATHS[this.variant];
+        if (path === undefined) return nothing;
+        return html` <svg
+            aria-hidden="true"
+            part="icon-svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+        >
+            <path stroke-linecap="round" stroke-linejoin="round" d=${path}></path>
+        </svg>`;
+    }
+```
+
+Étendre `updated()` pour émettre le warning quand `variant` change vers une valeur inconnue :
+
+```ts
+    override updated(changed: Map<string, unknown>) {
+        if (changed.has('variant') || changed.has('withoutNotification') || changed.has('urgent')) {
+            this._updateRole();
+        }
+        if (changed.has('variant') && !(this.variant in ArAlert._ICON_PATHS)) {
+            warn(
+                'ar-alert',
+                `variant="${this.variant}" n'a pas d'icône par défaut, fournissez un contenu via slot="icon".`,
+            );
+        }
+    }
+```
+
+- [ ] **Step 4: Relancer les tests**
+
+Run: `cd /Users/jon/Code/Active_projects/ariane && npm run test --workspace=packages/core -- alert.test.ts`
+Expected: PASS sur tout `alert.test.ts`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/components/alert/alert.ts packages/core/src/components/alert/alert.test.ts
+git commit -m "feat(alert): supprime l'icône par défaut sur un variant custom inconnu, ajoute un warning dev"
+```
+
+---
+
+### Task 5: Génériciser les tokens CSS (styles.ts + default.css)
+
+**Files:**
+
+- Modify: `packages/core/src/components/alert/alert.styles.ts:13-47`
+- Modify: `packages/core/src/styles/themes/default.css:294-310` (light), `:600-604` (dark
+  override globale), `:660-664` (dark média query)
+- Modify: `packages/core/src/components/alert/alert.ts` (JSDoc `@cssprop`, lignes 34-45)
+
+**Interfaces:** aucune (changement purement CSS/documentation, pas de nouvelle interface JS).
+
+- [ ] **Step 1: Remplacer les 4 blocs `:host([variant='...'])` par un bloc générique**
+
+Dans `packages/core/src/components/alert/alert.styles.ts`, remplacer les lignes 13-47 :
+
+```css
+:host([variant='info']) {
+    background-color: var(--ar-alert-info-bg);
+    border-color: var(--ar-alert-info-border);
+
+    [part='icon'] {
+        color: var(--ar-alert-info-icon);
+    }
+}
+
+:host([variant='error']) {
+    background-color: var(--ar-alert-error-bg);
+    border-color: var(--ar-alert-error-border);
+
+    [part='icon'] {
+        color: var(--ar-alert-error-icon);
+    }
+}
+
+:host([variant='warning']) {
+    background-color: var(--ar-alert-warning-bg);
+    border-color: var(--ar-alert-warning-border);
+
+    [part='icon'] {
+        color: var(--ar-alert-warning-icon);
+    }
+}
+
+:host([variant='success']) {
+    background-color: var(--ar-alert-success-bg);
+    border-color: var(--ar-alert-success-border);
+
+    [part='icon'] {
+        color: var(--ar-alert-success-icon);
+    }
+}
+```
+
+par :
+
+```css
+:host {
+    background-color: var(--ar-alert-bg);
+    border-color: var(--ar-alert-border);
+}
+
+[part='icon'] {
+    color: var(--ar-alert-icon);
+}
+```
+
+(la déclaration `display: flex; ... color: var(--ar-alert-color);` du premier bloc `:host { ... }`,
+lignes 4-11, reste inchangée et fusionne avec les deux nouvelles lignes `background-color`/
+`border-color` — un seul bloc `:host { ... }` au total dans le fichier).
+
+Note : `[part='icon']` existe déjà plus bas dans le fichier (lignes 92-96, règles `flex`/
+`display`/`align-items`) — fusionner la couleur dans ce bloc existant plutôt que d'en créer un
+second :
+
+```css
+[part='icon'] {
+    color: var(--ar-alert-icon);
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+}
+```
+
+- [ ] **Step 2: Réécrire les tokens dans `default.css` avec sélecteurs d'attribut**
+
+Dans `packages/core/src/styles/themes/default.css`, remplacer les lignes 294-308 :
+
+```css
+/* alert */
+--ar-alert-color: var(--ar-color-text);
+--ar-alert-close-size: 2rem;
+--ar-alert-info-bg: var(--ar-color-info-bg);
+--ar-alert-info-border: var(--ar-color-info-bg);
+--ar-alert-info-icon: var(--ar-color-info-text);
+--ar-alert-warning-bg: var(--ar-color-warning-bg);
+--ar-alert-warning-border: var(--ar-color-warning-bg);
+--ar-alert-warning-icon: var(--ar-color-warning-text);
+--ar-alert-error-bg: var(--ar-color-danger-bg);
+--ar-alert-error-border: var(--ar-color-danger-bg);
+--ar-alert-error-icon: var(--ar-color-danger-text);
+--ar-alert-success-bg: var(--ar-color-success-bg);
+--ar-alert-success-border: var(--ar-color-success-bg);
+--ar-alert-success-icon: var(--ar-color-success-text);
+```
+
+par :
+
+```css
+/* alert */
+--ar-alert-color: var(--ar-color-text);
+--ar-alert-close-size: 2rem;
+```
+
+`--ar-alert-close-transition-duration` et `--ar-alert-hide-transition-duration` (lignes 309-310)
+restent inchangés à leur emplacement.
+
+Ajouter, après le bloc `:root { ... }` où vivaient ces tokens (donc toujours à l'intérieur de
+`:root`, à la suite de la ligne `--ar-alert-hide-transition-duration: 0.33s;`), les presets par
+sélecteur d'attribut — chercher le point d'insertion le plus proche possible du reste des
+tokens `alert` pour rester lisible :
+
+```css
+        /* alert — presets par variant */
+    }
+
+    ar-alert[variant='info'] {
+        --ar-alert-bg: var(--ar-color-info-bg);
+        --ar-alert-border: var(--ar-color-info-bg);
+        --ar-alert-icon: var(--ar-color-info-text);
+    }
+
+    ar-alert[variant='warning'] {
+        --ar-alert-bg: var(--ar-color-warning-bg);
+        --ar-alert-border: var(--ar-color-warning-bg);
+        --ar-alert-icon: var(--ar-color-warning-text);
+    }
+
+    ar-alert[variant='error'] {
+        --ar-alert-bg: var(--ar-color-danger-bg);
+        --ar-alert-border: var(--ar-color-danger-bg);
+        --ar-alert-icon: var(--ar-color-danger-text);
+    }
+
+    ar-alert[variant='success'] {
+        --ar-alert-bg: var(--ar-color-success-bg);
+        --ar-alert-border: var(--ar-color-success-bg);
+        --ar-alert-icon: var(--ar-color-success-text);
+    }
+```
+
+Attention : ces 4 blocs sortent du bloc `:root { ... }` (les sélecteurs d'attribut ciblent
+l'élément `ar-alert`, pas `:root`) — fermer `:root` juste avant (`}` ajouté ci-dessus) sans
+perturber le reste des tokens qui suivent dans le fichier (vérifier après édition que le fichier
+reste syntaxiquement valide : lancer `npm run build --workspace=packages/core` au Step 4 le
+confirmera).
+
+Ensuite, dans la section dark mode globale (lignes 600-604 actuelles) :
+
+```css
+/* Alert */
+--ar-alert-info-border: var(--ar-color-info-40);
+--ar-alert-warning-border: var(--ar-color-warning-40);
+--ar-alert-error-border: var(--ar-color-danger-40);
+--ar-alert-success-border: var(--ar-color-success-40);
+```
+
+remplacer par (les surcharges dark ciblent maintenant l'attribut, plus le suffixe nommé) :
+
+```css
+/* Alert : ces surcharges de bordure dark mode nécessitent un sélecteur d'attribut,
+           déplacées hors de ce bloc — voir les 4 règles `ar-alert[variant='...']` dupliquées
+           sous [data-theme='dark'] plus bas dans ce fichier. */
+```
+
+Puis, juste après la fermeture du bloc de sélecteur dark mode qui contenait ces 4 lignes (celui
+qui commence par le sélecteur portant `--ar-alert-info-border` etc. à la ligne ~599 d'origine),
+ajouter les 4 sélecteurs d'attribut équivalents pour le dark mode :
+
+```css
+ar-alert[variant='info'] {
+    --ar-alert-border: var(--ar-color-info-40);
+}
+ar-alert[variant='warning'] {
+    --ar-alert-border: var(--ar-color-warning-40);
+}
+ar-alert[variant='error'] {
+    --ar-alert-border: var(--ar-color-danger-40);
+}
+ar-alert[variant='success'] {
+    --ar-alert-border: var(--ar-color-success-40);
+}
+```
+
+Faire la même opération pour le second bloc dark mode (média query, lignes 660-664 actuelles,
+`--ar-alert-info-border: var(--ar-color-info-40);` etc.) : remplacer les 4 lignes de tokens
+nommés par les 4 mêmes sélecteurs d'attribut `ar-alert[variant='...'] { --ar-alert-border: ...; }`
+imbriqués dans la média query existante (`@media (prefers-color-scheme: dark)`), au même niveau
+que les autres règles déjà présentes dans cette média query.
+
+- [ ] **Step 2bis: Vérifier la syntaxe CSS du fichier après édition**
+
+Ce fichier n'a pas de test automatisé ciblé — la vérification se fait par le build (voir Step 4)
+et par une relecture manuelle : chaque accolade ouverte par `:root {` ou un sélecteur d'attribut
+doit être refermée correctement, aucun token `--ar-alert-{variant}-*` nommé ne doit subsister
+(vérifier avec `grep -n "\-\-ar-alert-\(info\|warning\|error\|success\)-" packages/core/src/styles/themes/default.css` — la commande doit ne rien retourner après l'édition).
+
+- [ ] **Step 3: Mettre à jour le JSDoc `@cssprop` de `alert.ts`**
+
+Dans `packages/core/src/components/alert/alert.ts`, remplacer les lignes 34-45 :
+
+```ts
+ * @cssprop --ar-alert-close-size - Taille (width/height) du bouton de fermeture.
+ * @cssprop --ar-alert-info-bg - Fond de l'alerte "info".
+ * @cssprop --ar-alert-info-border - Bordure de l'alerte "info".
+ * @cssprop --ar-alert-info-icon - Couleur de l'icône "info".
+ * @cssprop --ar-alert-warning-bg - Fond de l'alerte "warning".
+ * @cssprop --ar-alert-warning-border - Bordure de l'alerte "warning".
+ * @cssprop --ar-alert-warning-icon - Couleur de l'icône "warning".
+ * @cssprop --ar-alert-error-bg - Fond de l'alerte "error".
+ * @cssprop --ar-alert-error-border - Bordure de l'alerte "error".
+ * @cssprop --ar-alert-error-icon - Couleur de l'icône "error".
+ * @cssprop --ar-alert-success-bg - Fond de l'alerte "success".
+ * @cssprop --ar-alert-success-border - Bordure de l'alerte "success".
+ * @cssprop --ar-alert-success-icon - Couleur de l'icône "success".
+```
+
+par :
+
+```ts
+ * @cssprop --ar-alert-close-size - Taille (width/height) du bouton de fermeture.
+ * @cssprop --ar-alert-bg - Fond de l'alerte. Valeur définie par `default.css` selon `variant`
+ *   (`ar-alert[variant='...']`) pour les 4 presets connus ; à définir soi-même pour un variant
+ *   custom.
+ * @cssprop --ar-alert-border - Bordure de l'alerte. Même mécanisme que `--ar-alert-bg`.
+ * @cssprop --ar-alert-icon - Couleur de l'icône de variant. Même mécanisme que `--ar-alert-bg`.
+```
+
+- [ ] **Step 4: Build pour valider la syntaxe CSS et le typecheck**
+
+Run: `cd /Users/jon/Code/Active_projects/ariane && npm run build --workspace=packages/core`
+Expected: le build se termine sans erreur (aucune erreur PostCSS/esbuild sur `default.css`,
+aucune erreur `tsc` sur `alert.ts`).
+
+- [ ] **Step 5: Relancer la suite de tests unitaires complète du composant**
+
+Run: `cd /Users/jon/Code/Active_projects/ariane && npm run test --workspace=packages/core -- alert.test.ts`
+Expected: PASS (les tests unitaires ne dépendent pas de `default.css`, ce changement CSS ne doit
+rien casser côté jsdom/happy-dom).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/components/alert/alert.ts packages/core/src/components/alert/alert.styles.ts packages/core/src/styles/themes/default.css
+git commit -m "refactor(alert): généricise les tokens CSS de variant (12 tokens nommés -> 3 génériques)"
+```
+
+---
+
+### Task 6: Mettre à jour la documentation `ar-alert.mdx`
+
+**Files:**
+
+- Modify: `apps/docs/src/content/components/ar-alert.mdx`
+
+**Interfaces:** aucune.
+
+- [ ] **Step 1: Mettre à jour la section Accessibilité**
+
+Dans `apps/docs/src/content/components/ar-alert.mdx`, remplacer les lignes 43-54 :
+
+```mdx
+- `role="alert"` (interruption immédiate) ou `role="status"` (annonce polie) posé sur
+  l'hôte selon le variant — `info` → `status`, tous les autres → `alert` — conforme
+    <WcagRef
+        criterion="4.1.3"
+        summary="Status Messages : les messages de statut doivent être annoncés aux technologies d'assistance sans déplacer le focus."
+    />
+- L'icône est masquée aux lecteurs d'écran (`aria-hidden`). L'information de sévérité
+  est portée par le `role`, pas par l'icône.
+- Une icône par défaut est fournie pour chaque variant. Elle peut être remplacée via le
+  slot `icon`, mais il est déconseillé de la supprimer : elle constitue un repère visuel
+  non colorimétrique, important pour les utilisateurs daltoniens ou en environnement à
+  faible contraste.
+```
+
+par :
+
+```mdx
+- `role="alert"` (interruption immédiate) ou `role="status"` (annonce polie) posé sur
+  l'hôte selon `variant` — `error`/`warning` → `alert`, `success`/`info` → `status`, tout
+  variant custom non reconnu → `status` (défaut sûr) — conforme
+    <WcagRef
+        criterion="4.1.3"
+        summary="Status Messages : les messages de statut doivent être annoncés aux technologies d'assistance sans déplacer le focus."
+    />
+- La prop `urgent` permet de forcer ce niveau indépendamment de `variant` : sa seule
+  présence (`<ar-alert urgent>`, pas besoin de `="true"`) force `role="alert"`. Elle
+  n'est jamais forcée par son absence — sans elle, le rôle retombe sur la déduction
+  ci-dessus.
+- L'icône est masquée aux lecteurs d'écran (`aria-hidden`). L'information de sévérité
+  est portée par le `role`, pas par l'icône.
+- Une icône par défaut est fournie pour les 4 variants connus (`error`, `warning`,
+  `success`, `info`). Elle peut être remplacée via le slot `icon`, mais il est
+  déconseillé de la supprimer : elle constitue un repère visuel non colorimétrique,
+  important pour les utilisateurs daltoniens ou en environnement à faible contraste. Un
+  `variant` custom non reconnu par le composant n'affiche aucune icône par défaut (un
+  avertissement en console le rappelle en dev) — fournissez `slot="icon"` dans ce cas.
+```
+
+- [ ] **Step 2: Ajouter une note sur les tokens génériques dans "À votre charge"**
+
+Dans le même fichier, après la puce "Niveau de sévérité cohérent..." (ligne 63-65 actuelle),
+ajouter une puce :
+
+```mdx
+- **Styliser un `variant` custom.** Au-delà des 4 presets fournis par `default.css`
+  (`error`/`warning`/`success`/`info`), tout autre `variant` doit définir lui-même
+  `--ar-alert-bg`, `--ar-alert-border` et `--ar-alert-icon` (ex.
+  `ar-alert[variant='promo'] { --ar-alert-bg: ...; }`) et fournir une icône via
+  `slot="icon"`.
+```
+
+- [ ] **Step 3: Vérifier visuellement que la doc build**
+
+Run: `cd /Users/jon/Code/Active_projects/ariane && npm run build --workspace=apps/docs`
+Expected: le build Astro se termine sans erreur (frontmatter MDX valide).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/docs/src/content/components/ar-alert.mdx
+git commit -m "docs(alert): documente le nouveau mapping role/variant et la prop urgent"
+```
+
+---
+
+### Task 7: Vérification finale et ouverture de la PR
+
+**Files:** aucun nouveau fichier.
+
+- [ ] **Step 1: Lancer la suite de tests complète (unitaires + navigateur)**
+
+Run: `cd /Users/jon/Code/Active_projects/ariane && npm run test:all --workspace=packages/core`
+Expected: tous les tests passent, y compris `alert.a11y.test.ts` (aucune régression axe-core
+attendue — la structure DOM/role reste valide pour les 4 variants connus).
+
+- [ ] **Step 2: Lancer le lint**
+
+Run: `cd /Users/jon/Code/Active_projects/ariane && npm run lint --workspace=packages/core`
+Expected: aucune erreur.
+
+- [ ] **Step 3: Régénérer le manifest de composants**
+
+Run: `cd /Users/jon/Code/Active_projects/ariane && npm run build:manifest --workspace=packages/core`
+Expected: `custom-elements.json` est régénéré sans erreur, reflète la nouvelle prop `urgent` et
+les nouveaux `@cssprop`.
+
+- [ ] **Step 4: Vérifier qu'aucun fichier `dist/` n'est resté indexé**
+
+Run: `cd /Users/jon/Code/Active_projects/ariane && git status`
+Expected: seuls les fichiers source attendus (alert.ts, alert.styles.ts, alert.test.ts,
+default.css, ar-alert.mdx, custom-elements.json le cas échéant) apparaissent — aucun fichier sous
+`dist/` ou `cdn/` (cf. convention projet : ne jamais committer les artefacts de build).
+
+- [ ] **Step 5: Push et ouverture de la PR vers `dev`**
+
+```bash
+git push -u origin refactor/alert-variant-role-decoupling
+gh pr create --base dev --title "refactor(alert): découple variant et role, généricise les tokens CSS" --body "$(cat <<'EOF'
+## Summary
+- Remplace le mapping binaire `variant === 'info' ? status : alert` par une table de
+  correspondance à 4 entrées (`error`/`warning` → alert, `success`/`info` → status).
+- Ajoute une prop `urgent` pour surcharger explicitement ce mapping, y compris sur les
+  4 variants connus.
+- Remplace les 12 tokens CSS nommés par variant par 3 tokens génériques
+  (`--ar-alert-bg`, `--ar-alert-border`, `--ar-alert-icon`), les 4 presets connus
+  déplacés dans `default.css` via sélecteurs d'attribut.
+- Un `variant` custom sans preset connu n'affiche plus d'icône par défaut et émet un
+  avertissement dev invitant à fournir `slot="icon"` (WCAG 1.4.1).
+
+Design détaillé : `docs/superpowers/specs/2026-07-28-alert-variant-role-decoupling-design.md`
+
+## Test plan
+- [ ] `npm run test:all --workspace=packages/core` (unitaires + a11y navigateur)
+- [ ] `npm run lint --workspace=packages/core`
+- [ ] Vérification manuelle dans `apps/docs` : les 4 variants existants s'affichent
+      identiquement à avant (régression visuelle nulle attendue sur les presets connus).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: la commande retourne l'URL de la PR créée, base `dev`.
+
+---
+
+## Self-Review
+
+**Couverture de la spec :**
+
+- §1 (`variant` typage élargi, pas de rename) → Task 2, Step 3.
+- §2 (table `ROLE_BY_VARIANT`, prop `urgent`, priorité, nuance présence/absence) → Task 2 + 3.
+- §3 (tokens génériques, presets `default.css`) → Task 5.
+- §4 (icônes conservées pour les 4 presets, fallback + warn pour custom) → Task 4.
+- Impact périphérique (JSDoc, mdx, tests) → Task 5 Step 3, Task 6, Task 2-4 (tests).
+
+**Pas de placeholder** : chaque step contient soit le diff complet, soit une commande exacte avec
+sortie attendue.
+
+**Cohérence des types/noms** : `variant: ArAlertVariant | (string & {})` (Task 2) ; `urgent?:
+boolean` (Task 3) ; `_ROLE_BY_VARIANT` / `_updateRole()` réutilisés identiquement entre Task 2, 3
+et 4 — noms vérifiés cohérents à travers les tasks.

--- a/docs/superpowers/specs/2026-07-28-alert-variant-role-decoupling-design.md
+++ b/docs/superpowers/specs/2026-07-28-alert-variant-role-decoupling-design.md
@@ -87,11 +87,19 @@ l'override reste disponible pour la minorité de cas qui en a réellement besoin
 `withoutNotification` n'est pas modifié : il continue à supprimer entièrement l'attribut `role`,
 prioritaire sur `urgent` et sur la table.
 
-**Nuance d'implémentation** : `urgent` n'est pas réfléchi comme attribut booléen classique (la
-réflexion Lit standard ne distingue pas "non défini" de "false" côté attribut DOM, seule la
-valeur de la propriété JS le permet). La logique de rôle lit `this.urgent` (valeur JS,
-potentiellement `undefined`), pas la présence de l'attribut — cohérent avec l'usage de
-`exactOptionalPropertyTypes` déjà en place sur le projet.
+**Nuance d'implémentation — sémantique de présence, asymétrie assumée** : `urgent` est un
+booléen Lit standard, sans valeur par défaut sur le champ de classe (`urgent?: boolean;`, pas de
+`= false`). Ça donne exactement la même convention que `without-notification` : la seule
+présence de l'attribut (`<ar-alert urgent>`, pas besoin de `="true"`) force `role="alert"` ; en
+son absence, la propriété JS reste `undefined` et retombe sur `ROLE_BY_VARIANT` — elle n'est
+jamais forcée à `false`.
+
+Limite assumée : la convention HTML "attribut booléen" ne permet pas d'encoder un `false`
+explicite via le markup (`urgent="false"` serait traité comme présent donc `true`, comme
+n'importe quel attribut booléen HTML). Forcer explicitement `role="status"` sur un variant dont
+le défaut de la table est `alert` (ex. `variant="error"`) n'est donc possible que par affectation
+JS (`el.urgent = false`), pas via un attribut posé dans le markup. Asymétrie jugée acceptable —
+cas rare, et cohérente avec le comportement déjà en place pour `without-notification`.
 
 ### 3. Tokens CSS : 3 génériques au lieu de 12 nommés
 

--- a/docs/superpowers/specs/2026-07-28-alert-variant-role-decoupling-design.md
+++ b/docs/superpowers/specs/2026-07-28-alert-variant-role-decoupling-design.md
@@ -1,0 +1,171 @@
+# ar-alert — généricisation des tokens de variant + correction du mapping role
+
+## Contexte
+
+Soulevé pendant la revue finale de PR #142 (lot #129, token-vs-`::part()` sur ar-alert) : le
+composant expose 4 `variant` fermés (`info`/`warning`/`error`/`success`), chacun avec son propre
+jeu de 3 tokens CSS nommés (`--ar-alert-{variant}-{bg,border,icon}`, 12 tokens au total). Le
+`role` ARIA posé sur l'hôte ne dépend aujourd'hui que d'un test binaire sur une seule valeur
+(`variant === 'info' ? 'status' : 'alert'`, `alert.ts:110`), qui ne généralise pas à un variant
+custom (ex. un `variant="promo"` ou `variant="neutral"` hériterait d'un `role="alert"` par
+accident).
+
+Ariane se veut headless (aucun fallback cosmétique dans les composants, cf. CLAUDE.md) — les 12
+tokens nommés sont un cas où le composant impose une structure de style fermée plutôt que de la
+déléguer au thème.
+
+## Décisions
+
+### 1. `variant` : conservé tel quel, pas de renommage
+
+Le nom `variant` reste inchangé. Un renommage (`type` envisagé puis écarté) aurait été un
+changement cosmétique sans gain fonctionnel, et `type` est un terme déjà surchargé en HTML/JS
+(`input.type`, `event.type`…).
+
+**Typage** — élargi pour accepter tout string tout en gardant l'auto-complétion des 4 presets
+connus :
+
+```ts
+export type ArAlertVariant = 'success' | 'warning' | 'error' | 'info';
+
+@property({ reflect: true, type: String })
+variant: ArAlertVariant | (string & {}) = 'error';
+```
+
+Les 4 valeurs connues restent documentées en JSDoc comme presets fournis par défaut par
+`default.css`. Toute autre valeur est acceptée sans contrainte TS (HTML n'a de toute façon aucune
+notion de type sur les attributs — restreindre le type TS n'empêche jamais un consommateur non-TS
+de poser `variant="promo"` dans le markup).
+
+### 2. Rôle ARIA : table de correspondance + override explicite optionnel
+
+Le test binaire actuel est remplacé par une table couvrant les 4 variants connus, plus un défaut
+sûr pour tout variant custom, plus une prop d'override pour le cas rare où ce défaut ne convient
+pas.
+
+```ts
+const ROLE_BY_VARIANT: Record<string, 'alert' | 'status'> = {
+    error: 'alert',
+    warning: 'alert',
+    success: 'status',
+    info: 'status',
+};
+```
+
+Nouvelle prop optionnelle :
+
+```ts
+/**
+ * Force le niveau d'urgence ARIA (role="alert" si true, role="status" si false),
+ * indépendamment de `variant`. Non défini : déduit de `variant` via une table de
+ * correspondance interne (error/warning → alert, success/info → status, tout autre
+ * variant → status).
+ * @attr urgent
+ * @default undefined
+ */
+@property({ type: Boolean })
+urgent?: boolean;
+```
+
+Logique dans `updated()` :
+
+```
+withoutNotification === true         → pas de role (inchangé)
+urgent !== undefined                 → role = urgent ? 'alert' : 'status'
+variant connu dans ROLE_BY_VARIANT   → role = ROLE_BY_VARIANT[variant]
+variant custom inconnu               → role = 'status' (défaut sûr, pas de sur-interruption)
+```
+
+**Pourquoi cette forme et pas un découplage total (prop `urgent` obligatoire, sans dérivation) :**
+un rôle 100% explicite avait été envisagé puis écarté — dans la pratique, la quasi-totalité des
+consommateurs ne pense pas à la sémantique ARIA `alert`/`status` et laisserait le défaut, donc
+rendre la décision obligatoire n'aurait rien amélioré, juste ajouté une prop ignorée. La table de
+correspondance garde le bénéfice "zéro configuration pour le cas courant" tout en corrigeant le
+mapping (warning et success n'étaient pas traités correctement par le test binaire précédent), et
+l'override reste disponible pour la minorité de cas qui en a réellement besoin.
+
+`withoutNotification` n'est pas modifié : il continue à supprimer entièrement l'attribut `role`,
+prioritaire sur `urgent` et sur la table.
+
+**Nuance d'implémentation** : `urgent` n'est pas réfléchi comme attribut booléen classique (la
+réflexion Lit standard ne distingue pas "non défini" de "false" côté attribut DOM, seule la
+valeur de la propriété JS le permet). La logique de rôle lit `this.urgent` (valeur JS,
+potentiellement `undefined`), pas la présence de l'attribut — cohérent avec l'usage de
+`exactOptionalPropertyTypes` déjà en place sur le projet.
+
+### 3. Tokens CSS : 3 génériques au lieu de 12 nommés
+
+`alert.styles.ts` — remplace les 4 blocs `:host([variant='...'])` par un bloc unique :
+
+```css
+:host {
+    background-color: var(--ar-alert-bg);
+    border-color: var(--ar-alert-border);
+}
+
+[part='icon'] {
+    color: var(--ar-alert-icon);
+}
+```
+
+`default.css` — fournit les 4 presets connus via sélecteurs d'attribut (remplace les 12 tokens
+`--ar-alert-{variant}-{bg,border,icon}` actuels) :
+
+```css
+ar-alert[variant='info'] {
+    --ar-alert-bg: var(--ar-color-info-bg);
+    --ar-alert-border: var(--ar-color-info-bg);
+    --ar-alert-icon: var(--ar-color-info-text);
+}
+/* idem warning / error / success, + surcharges dark mode existantes (border uniquement) */
+```
+
+`--ar-alert-color` (texte) et `--ar-alert-close-size`/`--ar-alert-*-transition-duration`
+inchangés — déjà génériques, hors périmètre.
+
+Un consommateur qui étend `variant` avec une valeur custom définit simplement
+`ar-alert[variant='promo'] { --ar-alert-bg: ...; }` dans son propre thème, sans toucher au
+composant.
+
+### 4. Icônes : conservées pour les 4 presets, pas de défaut pour le custom
+
+`_ICON_PATHS` reste en l'état pour les 4 variants connus (contenu/comportement, pas un token CSS
+— la règle headless "pas de fallback cosmétique" s'applique aux tokens, pas au contenu par
+défaut, au même titre que l'icône de fermeture par défaut déjà slot-able).
+
+Pour un `variant` custom sans preset connu :
+
+- pas d'icône par défaut affichée (évite d'afficher une icône trompeuse ou vide de sens),
+- avertissement dev via l'infrastructure `warn()` existante, invitant à fournir `slot="icon"` —
+  rationale WCAG 1.4.1 (ne pas coder une information uniquement par la couleur).
+
+```ts
+if (!(this.variant in ArAlert._ICON_PATHS) && __DEV__) {
+    warn(
+        'ar-alert',
+        `variant="${this.variant}" n'a pas d'icône par défaut, fournissez un contenu via slot="icon".`,
+    );
+}
+```
+
+## Hors périmètre
+
+- Pas de wrapper/preset supplémentaire fourni pour un cas custom (ex. "promo", "neutral") — YAGNI,
+  aucun besoin concret actuellement, seulement le mécanisme générique qui le permettrait le jour
+  où le besoin apparaît.
+- Pas d'échappatoire pour forcer une icône par défaut sur un variant custom autrement que via
+  `slot="icon"`.
+- `ArAlertConfig.variant` (classe de config) suit le même typage élargi, sans changement de nom.
+
+## Impact périphérique (à couvrir dans le plan d'implémentation)
+
+- `alert.ts` : JSDoc `@cssprop` (3 tokens génériques au lieu de 12), nouvelle prop `urgent`
+  documentée, table `ROLE_BY_VARIANT`, logique `updated()`.
+- `alert.styles.ts` : suppression des 4 blocs `:host([variant='...'])`, ajout des 3 tokens
+  génériques.
+- `packages/core/src/styles/themes/default.css` : réécriture des presets (light + dark mode).
+- `apps/docs/src/content/components/ar-alert.mdx` : documentation `variant` (presets vs custom),
+  nouvelle prop `urgent`, nouveaux tokens.
+- `alert.test.ts` / `alert.a11y.test.ts` : couverture de la table de correspondance, de l'override
+  `urgent`, du warning dev sur variant custom sans icône.
+- Breaking change assumé sans dépréciation (alpha, aucun consommateur réel — cf. mémoire projet).

--- a/packages/core/cem.config.js
+++ b/packages/core/cem.config.js
@@ -131,7 +131,10 @@ export default {
                     for (const decl of mod.declarations ?? []) {
                         if (!decl.attributes) continue;
                         decl.attributes = decl.attributes.map((attr) => {
-                            const t = attr.type?.text ?? '';
+                            const t = (attr.type?.text ?? '').replace(
+                                /\s*\|\s*\(string\s*&\s*\{\}\)\s*$/,
+                                '',
+                            );
                             if (typeAliasMap.has(t)) {
                                 return { ...attr, type: { text: typeAliasMap.get(t) } };
                             }
@@ -152,7 +155,10 @@ export default {
                             }
 
                             // Résoudre les aliases de type avant le check isStringUnion
-                            let typeText = member.type?.text ?? '';
+                            let typeText = (member.type?.text ?? '').replace(
+                                /\s*\|\s*\(string\s*&\s*\{\}\)\s*$/,
+                                '',
+                            );
                             if (typeAliasMap.has(typeText)) {
                                 member = { ...member, type: { text: typeAliasMap.get(typeText) } };
                                 typeText = member.type.text;

--- a/packages/core/src/components/alert/alert.a11y.test.ts
+++ b/packages/core/src/components/alert/alert.a11y.test.ts
@@ -11,7 +11,7 @@ import './index.js';
 describe('ar-alert — accessibilité', () => {
     it('version "info" est accessible', async () => {
         const el = await fixture(html`
-            <ar-alert version="info">
+            <ar-alert variant="info">
                 <span slot="title">Information importante</span>
                 <span slot="content">Voici un message informatif.</span>
             </ar-alert>
@@ -21,7 +21,7 @@ describe('ar-alert — accessibilité', () => {
 
     it('version "success" est accessible', async () => {
         const el = await fixture(html`
-            <ar-alert version="success">
+            <ar-alert variant="success">
                 <span slot="title">Succès</span>
                 <span slot="content">L'opération a réussi.</span>
             </ar-alert>
@@ -31,7 +31,7 @@ describe('ar-alert — accessibilité', () => {
 
     it('version "warning" est accessible', async () => {
         const el = await fixture(html`
-            <ar-alert version="warning">
+            <ar-alert variant="warning">
                 <span slot="title">Attention</span>
                 <span slot="content">Vérifiez vos informations.</span>
             </ar-alert>
@@ -41,7 +41,7 @@ describe('ar-alert — accessibilité', () => {
 
     it('version "error" est accessible', async () => {
         const el = await fixture(html`
-            <ar-alert version="error">
+            <ar-alert variant="error">
                 <span slot="title">Erreur</span>
                 <span slot="content">Une erreur s'est produite.</span>
             </ar-alert>
@@ -53,7 +53,7 @@ describe('ar-alert — accessibilité', () => {
         const container = await fixture(html`
             <div>
                 <button id="focus-target">Retour</button>
-                <ar-alert version="warning" next-focus="focus-target">
+                <ar-alert variant="warning" next-focus="focus-target">
                     <span slot="title">Attention</span>
                     <span slot="content">Vérifiez vos informations.</span>
                 </ar-alert>

--- a/packages/core/src/components/alert/alert.styles.ts
+++ b/packages/core/src/components/alert/alert.styles.ts
@@ -8,42 +8,8 @@ export default css`
         opacity: 1;
         transform: scale(1);
         color: var(--ar-alert-color);
-    }
-
-    :host([variant='info']) {
-        background-color: var(--ar-alert-info-bg);
-        border-color: var(--ar-alert-info-border);
-
-        [part='icon'] {
-            color: var(--ar-alert-info-icon);
-        }
-    }
-
-    :host([variant='error']) {
-        background-color: var(--ar-alert-error-bg);
-        border-color: var(--ar-alert-error-border);
-
-        [part='icon'] {
-            color: var(--ar-alert-error-icon);
-        }
-    }
-
-    :host([variant='warning']) {
-        background-color: var(--ar-alert-warning-bg);
-        border-color: var(--ar-alert-warning-border);
-
-        [part='icon'] {
-            color: var(--ar-alert-warning-icon);
-        }
-    }
-
-    :host([variant='success']) {
-        background-color: var(--ar-alert-success-bg);
-        border-color: var(--ar-alert-success-border);
-
-        [part='icon'] {
-            color: var(--ar-alert-success-icon);
-        }
+        background-color: var(--ar-alert-bg);
+        border-color: var(--ar-alert-border);
     }
 
     :host([hiding]) {
@@ -90,6 +56,7 @@ export default css`
     }
 
     [part='icon'] {
+        color: var(--ar-alert-icon);
         flex: 0 0 auto;
         display: flex;
         align-items: center;

--- a/packages/core/src/components/alert/alert.test.ts
+++ b/packages/core/src/components/alert/alert.test.ts
@@ -203,6 +203,17 @@ describe('ArAlert', () => {
             expect(spy).not.toHaveBeenCalled();
             spy.mockRestore();
         });
+
+        it('n\'avertit pas pour un variant custom si slot="icon" est fourni', async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            el = await fixture(`
+                <ar-alert variant="promo">
+                    <svg slot="icon" aria-hidden="true"></svg>
+                </ar-alert>
+            `);
+            expect(spy).not.toHaveBeenCalled();
+            spy.mockRestore();
+        });
     });
 
     // ── Bouton close ──────────────────────────────────────────────────────────

--- a/packages/core/src/components/alert/alert.test.ts
+++ b/packages/core/src/components/alert/alert.test.ts
@@ -175,6 +175,25 @@ describe('ArAlert', () => {
             expect(assigned).toHaveLength(1);
             expect((assigned[0] as HTMLElement).dataset.custom).toBe('true');
         });
+
+        it("n'affiche pas d'icône par défaut pour un variant custom inconnu", async () => {
+            el = await fixture('<ar-alert variant="promo"></ar-alert>');
+            expect(requireShadow(el).querySelector('slot[name="icon"] svg')).toBeNull();
+        });
+
+        it('logue un avertissement pour un variant custom inconnu', async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            el = await fixture('<ar-alert variant="promo"></ar-alert>');
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining('promo'));
+            spy.mockRestore();
+        });
+
+        it("n'avertit pas pour un variant connu", async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            el = await fixture('<ar-alert variant="success"></ar-alert>');
+            expect(spy).not.toHaveBeenCalled();
+            spy.mockRestore();
+        });
     });
 
     // ── Bouton close ──────────────────────────────────────────────────────────

--- a/packages/core/src/components/alert/alert.test.ts
+++ b/packages/core/src/components/alert/alert.test.ts
@@ -139,6 +139,71 @@ describe('ArAlert', () => {
         });
     });
 
+    // ── Avertissement role manuel ─────────────────────────────────────────────
+
+    describe('avertissement role manuel', () => {
+        it('avertit si role est posé manuellement dans le markup initial', async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            try {
+                el = await fixture('<ar-alert role="banner" variant="error"></ar-alert>');
+                expect(spy).toHaveBeenCalledWith(expect.stringContaining('[ar-alert]'));
+                expect(spy.mock.calls[0][0]).toContain('role="banner"');
+            } finally {
+                spy.mockRestore();
+            }
+        });
+
+        it("n'avertit pas si role n'est pas posé dans le markup initial", async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            try {
+                el = await fixture('<ar-alert></ar-alert>');
+                // Le warning pour variant custom ne doit pas être appelé (pas de variant custom)
+                expect(spy).not.toHaveBeenCalled();
+            } finally {
+                spy.mockRestore();
+            }
+        });
+
+        it('role posé manuellement est bien écrasé par la logique interne malgré le warning', async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            try {
+                el = await fixture('<ar-alert role="banner" variant="info"></ar-alert>');
+                expect(el.getAttribute('role')).toBe('status');
+                expect(spy).toHaveBeenCalledWith(expect.stringContaining('[ar-alert]'));
+                expect(spy.mock.calls[0][0]).toContain('role="banner"');
+            } finally {
+                spy.mockRestore();
+            }
+        });
+
+        it("n'avertit qu'une seule fois, même si variant change ensuite", async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            try {
+                el = await fixture('<ar-alert role="banner"></ar-alert>');
+                expect(spy).toHaveBeenCalledOnce();
+                spy.mockClear();
+
+                el.variant = 'info';
+                await waitForUpdate(el);
+                expect(spy).not.toHaveBeenCalled();
+            } finally {
+                spy.mockRestore();
+            }
+        });
+
+        it("l'avertissement n'empêche pas la fermeture du role par withoutNotification", async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            try {
+                el = await fixture('<ar-alert role="banner" without-notification></ar-alert>');
+                expect(el.hasAttribute('role')).toBe(false);
+                expect(spy).toHaveBeenCalledWith(expect.stringContaining('[ar-alert]'));
+                expect(spy.mock.calls[0][0]).toContain('role="banner"');
+            } finally {
+                spy.mockRestore();
+            }
+        });
+    });
+
     // ── Icône ─────────────────────────────────────────────────────────────────
 
     describe('icône', () => {

--- a/packages/core/src/components/alert/alert.test.ts
+++ b/packages/core/src/components/alert/alert.test.ts
@@ -128,6 +128,15 @@ describe('ArAlert', () => {
             );
             expect(el.hasAttribute('role')).toBe(false);
         });
+
+        it("removeAttribute('urgent') retombe sur undefined (pas sur false)", async () => {
+            el = await fixture('<ar-alert variant="error" urgent></ar-alert>');
+            expect(el.getAttribute('role')).toBe('alert');
+            el.removeAttribute('urgent');
+            await waitForUpdate(el);
+            expect(el.urgent).toBeUndefined();
+            expect(el.getAttribute('role')).toBe('alert'); // retombe sur la table (error -> alert), pas force à status
+        });
     });
 
     // ── Icône ─────────────────────────────────────────────────────────────────

--- a/packages/core/src/components/alert/alert.test.ts
+++ b/packages/core/src/components/alert/alert.test.ts
@@ -97,6 +97,39 @@ describe('ArAlert', () => {
         });
     });
 
+    // ── Prop urgent (override du rôle) ──────────────────────────────────────
+
+    describe('prop urgent', () => {
+        it('urgent est undefined par défaut', async () => {
+            el = await fixture('<ar-alert></ar-alert>');
+            expect(el.urgent).toBeUndefined();
+        });
+
+        it('la seule présence de l\'attribut urgent force role="alert"', async () => {
+            el = await fixture('<ar-alert variant="success" urgent></ar-alert>');
+            expect(el.getAttribute('role')).toBe('alert');
+        });
+
+        it('urgent en absence ne force pas role="status" (retombe sur la table)', async () => {
+            el = await fixture('<ar-alert variant="error"></ar-alert>');
+            expect(el.getAttribute('role')).toBe('alert');
+        });
+
+        it('urgent=false (JS) force role="status" même sur un variant "error"', async () => {
+            el = await fixture('<ar-alert variant="error"></ar-alert>');
+            el.urgent = false;
+            await waitForUpdate(el);
+            expect(el.getAttribute('role')).toBe('status');
+        });
+
+        it("urgent est prioritaire sur withoutNotification=false mais pas l'inverse", async () => {
+            el = await fixture(
+                '<ar-alert variant="success" urgent without-notification></ar-alert>',
+            );
+            expect(el.hasAttribute('role')).toBe(false);
+        });
+    });
+
     // ── Icône ─────────────────────────────────────────────────────────────────
 
     describe('icône', () => {

--- a/packages/core/src/components/alert/alert.test.ts
+++ b/packages/core/src/components/alert/alert.test.ts
@@ -76,9 +76,9 @@ describe('ArAlert', () => {
             expect(el.getAttribute('role')).toBe('alert');
         });
 
-        it('variant="success" donne role="alert" au host', async () => {
+        it('variant="success" donne role="status" au host', async () => {
             el = await fixture('<ar-alert variant="success"></ar-alert>');
-            expect(el.getAttribute('role')).toBe('alert');
+            expect(el.getAttribute('role')).toBe('status');
         });
 
         it('variant="info" donne role="status" au host', async () => {
@@ -86,9 +86,13 @@ describe('ArAlert', () => {
             expect(el.getAttribute('role')).toBe('status');
         });
 
+        it('un variant custom inconnu donne role="status" (défaut sûr)', async () => {
+            el = await fixture('<ar-alert variant="promo"></ar-alert>');
+            expect(el.getAttribute('role')).toBe('status');
+        });
+
         it('without-notification supprime le role du host', async () => {
             el = await fixture('<ar-alert without-notification></ar-alert>');
-            // Lit utilise `nothing` pour ne pas rendre l'attribut du tout
             expect(el.hasAttribute('role')).toBe(false);
         });
     });

--- a/packages/core/src/components/alert/alert.test.ts
+++ b/packages/core/src/components/alert/alert.test.ts
@@ -274,6 +274,23 @@ describe('ArAlert', () => {
             el = await fixture('<ar-alert next-focus="   "></ar-alert>');
             expect(el.canBeHidden).toBe(false);
         });
+
+        it('redevient false après retrait de next-focus (attribut supprimé, pas juste vidé)', async () => {
+            el = await fixture('<ar-alert next-focus="btn-retour"></ar-alert>');
+            expect(el.canBeHidden).toBe(true);
+            el.removeAttribute('next-focus');
+            await waitForUpdate(el);
+            expect(el.nextFocus).toBeNull();
+            expect(el.canBeHidden).toBe(false);
+        });
+
+        it('ne plante pas si on ferme après que next-focus a été retiré (nextFocus null)', async () => {
+            el = await fixture('<ar-alert next-focus="btn-retour"></ar-alert>');
+            el.removeAttribute('next-focus');
+            await waitForUpdate(el);
+            // canBeHidden est false donc le bouton close n'est pas rendu — pas d'appel possible à _hide()
+            expect(getPart(el, 'close')).toBeNull();
+        });
     });
 
     // ── Fermeture ─────────────────────────────────────────────────────────────

--- a/packages/core/src/components/alert/alert.ts
+++ b/packages/core/src/components/alert/alert.ts
@@ -110,6 +110,12 @@ export class ArAlert extends LitElement {
         if (changed.has('variant') || changed.has('withoutNotification') || changed.has('urgent')) {
             this._updateRole();
         }
+        if (changed.has('variant') && !(this.variant in ArAlert._ICON_PATHS)) {
+            warn(
+                'ar-alert',
+                `variant="${this.variant}" n'a pas d'icône par défaut, fournissez un contenu via slot="icon".`,
+            );
+        }
     }
 
     private _updateRole(): void {
@@ -139,10 +145,9 @@ export class ArAlert extends LitElement {
         error: 'M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z',
     };
 
-    protected _defaultIcon(): TemplateResult {
-        const path = (ArAlert._ICON_PATHS as Record<string, string>)[
-            this.variant ?? ArAlert.DEFAULT_VARIANT
-        ];
+    protected _defaultIcon(): TemplateResult | typeof nothing {
+        const path = (ArAlert._ICON_PATHS as Record<string, string>)[this.variant];
+        if (path === undefined) return nothing;
         return html` <svg
             aria-hidden="true"
             part="icon-svg"

--- a/packages/core/src/components/alert/alert.ts
+++ b/packages/core/src/components/alert/alert.ts
@@ -126,7 +126,9 @@ export class ArAlert extends LitElement {
     };
 
     protected _defaultIcon(): TemplateResult {
-        const path = ArAlert._ICON_PATHS[this.variant ?? ArAlert.DEFAULT_VARIANT];
+        const path = (ArAlert._ICON_PATHS as Record<string, string>)[
+            this.variant ?? ArAlert.DEFAULT_VARIANT
+        ];
         return html` <svg
             aria-hidden="true"
             part="icon-svg"

--- a/packages/core/src/components/alert/alert.ts
+++ b/packages/core/src/components/alert/alert.ts
@@ -98,14 +98,32 @@ export class ArAlert extends LitElement {
     @property({ reflect: true, type: Boolean })
     protected hiding: boolean = false;
 
+    /**
+     * Indique si `role` a été posé manuellement dans le markup initial.
+     * Utilisé pour n'avertir qu'une seule fois que le composant va écraser cet attribut.
+     */
+    private _hadAuthoredRole: boolean | undefined = undefined;
+
     constructor() {
         super();
         // Lance la suppression du DOM à la fin de l'animation de fermeture
         this.addEventListener('transitionend', this._finishHide);
     }
 
+    override firstUpdated(): void {
+        // Capture si `role` a été posé en markup initial (avant que le composant ne le contrôle)
+        this._hadAuthoredRole = this.hasAttribute('role');
+    }
+
     override updated(changed: Map<string, unknown>) {
         if (changed.has('variant') || changed.has('withoutNotification') || changed.has('urgent')) {
+            if (this._hadAuthoredRole === true) {
+                warn(
+                    'ar-alert',
+                    `role="${this.getAttribute('role')}" posé manuellement sera écrasé par le composant — utilisez la prop 'urgent' pour contrôler le niveau ARIA.`,
+                );
+                this._hadAuthoredRole = false;
+            }
             this._updateRole();
         }
         if (

--- a/packages/core/src/components/alert/alert.ts
+++ b/packages/core/src/components/alert/alert.ts
@@ -31,18 +31,11 @@ export type ArAlertVariant = 'success' | 'warning' | 'error' | 'info';
  * @csspart close     - Le bouton de fermeture (présent uniquement si `next-focus` est défini).
  *
  * @cssprop --ar-alert-close-size - Taille (width/height) du bouton de fermeture.
- * @cssprop --ar-alert-info-bg - Fond de l'alerte "info".
- * @cssprop --ar-alert-info-border - Bordure de l'alerte "info".
- * @cssprop --ar-alert-info-icon - Couleur de l'icône "info".
- * @cssprop --ar-alert-warning-bg - Fond de l'alerte "warning".
- * @cssprop --ar-alert-warning-border - Bordure de l'alerte "warning".
- * @cssprop --ar-alert-warning-icon - Couleur de l'icône "warning".
- * @cssprop --ar-alert-error-bg - Fond de l'alerte "error".
- * @cssprop --ar-alert-error-border - Bordure de l'alerte "error".
- * @cssprop --ar-alert-error-icon - Couleur de l'icône "error".
- * @cssprop --ar-alert-success-bg - Fond de l'alerte "success".
- * @cssprop --ar-alert-success-border - Bordure de l'alerte "success".
- * @cssprop --ar-alert-success-icon - Couleur de l'icône "success".
+ * @cssprop --ar-alert-bg - Fond de l'alerte. Valeur définie par `default.css` selon `variant`
+ *   (`ar-alert[variant='...']`) pour les 4 presets connus ; à définir soi-même pour un variant
+ *   custom.
+ * @cssprop --ar-alert-border - Bordure de l'alerte. Même mécanisme que `--ar-alert-bg`.
+ * @cssprop --ar-alert-icon - Couleur de l'icône de variant. Même mécanisme que `--ar-alert-bg`.
  * @cssprop --ar-alert-close-transition-duration - Durée de la transition (opacity/background-color) du bouton de fermeture au survol/focus.
  * @cssprop --ar-alert-hide-transition-duration - Durée de la transition de sortie (opacity/transform) à la fermeture.
  * @cssprop --ar-alert-color - Couleur du texte de l'alerte (cascade vers --ar-color-text).

--- a/packages/core/src/components/alert/alert.ts
+++ b/packages/core/src/components/alert/alert.ts
@@ -108,7 +108,11 @@ export class ArAlert extends LitElement {
         if (changed.has('variant') || changed.has('withoutNotification') || changed.has('urgent')) {
             this._updateRole();
         }
-        if (changed.has('variant') && !(this.variant in ArAlert._ICON_PATHS)) {
+        if (
+            changed.has('variant') &&
+            !(this.variant in ArAlert._ICON_PATHS) &&
+            !this.querySelector('[slot="icon"]')
+        ) {
             warn(
                 'ar-alert',
                 `variant="${this.variant}" n'a pas d'icône par défaut, fournissez un contenu via slot="icon".`,

--- a/packages/core/src/components/alert/alert.ts
+++ b/packages/core/src/components/alert/alert.ts
@@ -75,7 +75,12 @@ export class ArAlert extends LitElement {
      * @attr urgent
      * @default undefined
      */
-    @property({ type: Boolean })
+    @property({
+        converter: {
+            fromAttribute: (value: string | null): boolean | undefined =>
+                value === null ? undefined : true,
+        },
+    })
     urgent?: boolean;
 
     /**

--- a/packages/core/src/components/alert/alert.ts
+++ b/packages/core/src/components/alert/alert.ts
@@ -76,6 +76,16 @@ export class ArAlert extends LitElement {
     withoutNotification = false;
 
     /**
+     * Force le niveau d'urgence ARIA indépendamment de `variant` : `role="alert"` si présent,
+     * sinon déduit de `variant` via une table de correspondance interne (`error`/`warning` →
+     * `alert`, `success`/`info` → `status`, tout autre variant → `status`).
+     * @attr urgent
+     * @default undefined
+     */
+    @property({ type: Boolean })
+    urgent?: boolean;
+
+    /**
      * Type d'alerte. Détermine la couleur et l'icône affichées.
      * @attr variant
      */
@@ -97,7 +107,7 @@ export class ArAlert extends LitElement {
     }
 
     override updated(changed: Map<string, unknown>) {
-        if (changed.has('variant') || changed.has('withoutNotification')) {
+        if (changed.has('variant') || changed.has('withoutNotification') || changed.has('urgent')) {
             this._updateRole();
         }
     }
@@ -105,6 +115,10 @@ export class ArAlert extends LitElement {
     private _updateRole(): void {
         if (this.withoutNotification) {
             this.removeAttribute('role');
+            return;
+        }
+        if (this.urgent !== undefined) {
+            this.role = this.urgent ? 'alert' : 'status';
             return;
         }
         this.role = ArAlert._ROLE_BY_VARIANT[this.variant] ?? 'status';

--- a/packages/core/src/components/alert/alert.ts
+++ b/packages/core/src/components/alert/alert.ts
@@ -195,7 +195,7 @@ export class ArAlert extends LitElement {
 
     /** Indique si l'alerte peut être fermée (next-focus défini et non vide) */
     get canBeHidden(): boolean {
-        return this.nextFocus !== undefined && this.nextFocus?.replaceAll(' ', '') !== '';
+        return this.nextFocus != null && this.nextFocus.replaceAll(' ', '') !== '';
     }
 
     private _shouldAnimate(): boolean {

--- a/packages/core/src/components/alert/alert.ts
+++ b/packages/core/src/components/alert/alert.ts
@@ -80,7 +80,7 @@ export class ArAlert extends LitElement {
      * @attr variant
      */
     @property({ reflect: true, type: String })
-    variant: 'success' | 'warning' | 'error' | 'info' = 'error';
+    variant: ArAlertVariant | (string & {}) = 'error';
 
     /**
      * Indique si l'alerte est en cours de fermeture (animation de sortie).
@@ -98,13 +98,24 @@ export class ArAlert extends LitElement {
 
     override updated(changed: Map<string, unknown>) {
         if (changed.has('variant') || changed.has('withoutNotification')) {
-            if (this.withoutNotification) {
-                this.removeAttribute('role');
-                return;
-            }
-            this.role = this.variant === 'info' ? 'status' : 'alert';
+            this._updateRole();
         }
     }
+
+    private _updateRole(): void {
+        if (this.withoutNotification) {
+            this.removeAttribute('role');
+            return;
+        }
+        this.role = ArAlert._ROLE_BY_VARIANT[this.variant] ?? 'status';
+    }
+
+    private static readonly _ROLE_BY_VARIANT: Record<string, 'alert' | 'status'> = {
+        error: 'alert',
+        warning: 'alert',
+        success: 'status',
+        info: 'status',
+    };
 
     private static readonly _ICON_PATHS: Record<ArAlertVariant, string> = {
         success: 'M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z',

--- a/packages/core/src/components/alert/alert.ts
+++ b/packages/core/src/components/alert/alert.ts
@@ -30,16 +30,13 @@ export type ArAlertVariant = 'success' | 'warning' | 'error' | 'info';
  * @csspart body      - Le conteneur du titre et du contenu.
  * @csspart close     - Le bouton de fermeture (présent uniquement si `next-focus` est défini).
  *
+ * @cssprop --ar-alert-bg - Fond de l'alerte.
+ * @cssprop --ar-alert-border - Bordure de l'alerte.
+ * @cssprop --ar-alert-icon - Couleur de l'icône de variant.
+ * @cssprop --ar-alert-color - Couleur du texte de l'alerte.
  * @cssprop --ar-alert-close-size - Taille (width/height) du bouton de fermeture.
- * @cssprop --ar-alert-bg - Fond de l'alerte. Valeur définie par `default.css` selon `variant`
- *   (`ar-alert[variant='...']`) pour les 4 presets connus ; à définir soi-même pour un variant
- *   custom.
- * @cssprop --ar-alert-border - Bordure de l'alerte. Même mécanisme que `--ar-alert-bg`.
- * @cssprop --ar-alert-icon - Couleur de l'icône de variant. Même mécanisme que `--ar-alert-bg`.
  * @cssprop --ar-alert-close-transition-duration - Durée de la transition (opacity/background-color) du bouton de fermeture au survol/focus.
  * @cssprop --ar-alert-hide-transition-duration - Durée de la transition de sortie (opacity/transform) à la fermeture.
- * @cssprop --ar-alert-color - Couleur du texte de l'alerte (cascade vers --ar-color-text).
-
  *
  * @event {CustomEvent} ar-alert-close - Émis après la fermeture de l'alerte (fin de transition).
  */

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -252,12 +252,16 @@
         /* États — tokens d'usage (light mode) */
         --ar-color-success-bg: var(--ar-color-success-95);
         --ar-color-success-text: var(--ar-color-success-40);
+        --ar-color-success-border: var(--ar-color-success-90);
         --ar-color-warning-bg: var(--ar-color-warning-95);
         --ar-color-warning-text: var(--ar-color-warning-40);
+        --ar-color-warning-border: var(--ar-color-warning-90);
         --ar-color-danger-bg: var(--ar-color-danger-95);
         --ar-color-danger-text: var(--ar-color-danger-40);
+        --ar-color-danger-border: var(--ar-color-danger-90);
         --ar-color-info-bg: var(--ar-color-info-95);
         --ar-color-info-text: var(--ar-color-info-40);
+        --ar-color-info-border: var(--ar-color-info-90);
 
         /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
          * 4. TOKENS GLOBAUX — TYPOGRAPHIE
@@ -299,28 +303,30 @@
     }
 
     /* alert — presets par variant */
-    ar-alert[variant='info'] {
-        --ar-alert-bg: var(--ar-color-info-bg);
-        --ar-alert-border: var(--ar-color-info-bg);
-        --ar-alert-icon: var(--ar-color-info-text);
-    }
+    ar-alert {
+        &[variant='info'] {
+            --ar-alert-bg: var(--ar-color-info-bg);
+            --ar-alert-border: var(--ar-color-info-border);
+            --ar-alert-icon: var(--ar-color-info-text);
+        }
 
-    ar-alert[variant='warning'] {
-        --ar-alert-bg: var(--ar-color-warning-bg);
-        --ar-alert-border: var(--ar-color-warning-bg);
-        --ar-alert-icon: var(--ar-color-warning-text);
-    }
+        &[variant='warning'] {
+            --ar-alert-bg: var(--ar-color-warning-bg);
+            --ar-alert-border: var(--ar-color-warning-border);
+            --ar-alert-icon: var(--ar-color-warning-text);
+        }
 
-    ar-alert[variant='error'] {
-        --ar-alert-bg: var(--ar-color-danger-bg);
-        --ar-alert-border: var(--ar-color-danger-bg);
-        --ar-alert-icon: var(--ar-color-danger-text);
-    }
+        &[variant='error'] {
+            --ar-alert-bg: var(--ar-color-danger-bg);
+            --ar-alert-border: var(--ar-color-danger-border);
+            --ar-alert-icon: var(--ar-color-danger-text);
+        }
 
-    ar-alert[variant='success'] {
-        --ar-alert-bg: var(--ar-color-success-bg);
-        --ar-alert-border: var(--ar-color-success-bg);
-        --ar-alert-icon: var(--ar-color-success-text);
+        &[variant='success'] {
+            --ar-alert-bg: var(--ar-color-success-bg);
+            --ar-alert-border: var(--ar-color-success-border);
+            --ar-alert-icon: var(--ar-color-success-text);
+        }
     }
 
     :root {
@@ -595,12 +601,16 @@
         /* États — bg sombre, texte clair */
         --ar-color-success-bg: var(--ar-color-success-10);
         --ar-color-success-text: var(--ar-color-success-70);
+        --ar-color-success-border: var(--ar-color-success-40);
         --ar-color-warning-bg: var(--ar-color-warning-10);
         --ar-color-warning-text: var(--ar-color-warning-70);
+        --ar-color-warning-border: var(--ar-color-warning-40);
         --ar-color-danger-bg: var(--ar-color-danger-10);
         --ar-color-danger-text: var(--ar-color-danger-70);
+        --ar-color-danger-border: var(--ar-color-danger-40);
         --ar-color-info-bg: var(--ar-color-info-10);
         --ar-color-info-text: var(--ar-color-info-70);
+        --ar-color-info-border: var(--ar-color-info-40);
 
         /* Button — surfaces adaptées au fond sombre */
         --ar-button-secondary-bg: var(--ar-color-neutral-30);
@@ -611,10 +621,6 @@
         --ar-button-tertiary-bg-hover: rgba(255, 255, 255, 0.15);
         --ar-button-tertiary-bg-active: rgba(255, 255, 255, 0.2);
         --ar-button-tertiary-bg-focus: rgba(255, 255, 255, 0.08);
-
-        /* Alert : ces surcharges de bordure dark mode nécessitent un sélecteur d'attribut,
-           déplacées hors de ce bloc — voir les 4 règles `ar-alert[variant='...']` dupliquées
-           sous [data-theme='dark'] plus bas dans ce fichier. */
 
         /* Tooltip — fond clair sur fond de page sombre */
         --ar-tooltip-bg: var(--ar-color-neutral-80);
@@ -632,19 +638,6 @@
         --ar-datepicker-day-selected-color: var(--ar-color-text-inverse);
 
         --ar-datepicker-input-error-border-color: var(--ar-color-red-40);
-    }
-
-    :root[data-theme='dark'] ar-alert[variant='info'] {
-        --ar-alert-border: var(--ar-color-info-40);
-    }
-    :root[data-theme='dark'] ar-alert[variant='warning'] {
-        --ar-alert-border: var(--ar-color-warning-40);
-    }
-    :root[data-theme='dark'] ar-alert[variant='error'] {
-        --ar-alert-border: var(--ar-color-danger-40);
-    }
-    :root[data-theme='dark'] ar-alert[variant='success'] {
-        --ar-alert-border: var(--ar-color-success-40);
     }
 
     @media (prefers-color-scheme: dark) {
@@ -666,12 +659,16 @@
             /* États — bg sombre, texte clair */
             --ar-color-success-bg: var(--ar-color-success-10);
             --ar-color-success-text: var(--ar-color-success-70);
+            --ar-color-success-border: var(--ar-color-success-40);
             --ar-color-warning-bg: var(--ar-color-warning-10);
             --ar-color-warning-text: var(--ar-color-warning-70);
+            --ar-color-warning-border: var(--ar-color-warning-40);
             --ar-color-danger-bg: var(--ar-color-danger-10);
             --ar-color-danger-text: var(--ar-color-danger-70);
+            --ar-color-danger-border: var(--ar-color-danger-40);
             --ar-color-info-bg: var(--ar-color-info-10);
             --ar-color-info-text: var(--ar-color-info-70);
+            --ar-color-info-border: var(--ar-color-info-40);
 
             /* Button — surfaces adaptées au fond sombre */
             --ar-button-secondary-bg: var(--ar-color-neutral-30);
@@ -703,19 +700,6 @@
             --ar-datepicker-day-selected-color: var(--ar-color-text-inverse);
 
             --ar-datepicker-input-error-border-color: var(--ar-color-red-40);
-        }
-
-        :root:not([data-theme='light']) ar-alert[variant='info'] {
-            --ar-alert-border: var(--ar-color-info-40);
-        }
-        :root:not([data-theme='light']) ar-alert[variant='warning'] {
-            --ar-alert-border: var(--ar-color-warning-40);
-        }
-        :root:not([data-theme='light']) ar-alert[variant='error'] {
-            --ar-alert-border: var(--ar-color-danger-40);
-        }
-        :root:not([data-theme='light']) ar-alert[variant='success'] {
-            --ar-alert-border: var(--ar-color-success-40);
         }
     }
 
@@ -979,10 +963,9 @@
         &::part(icon) {
             font-size: 1.5em;
         }
-    }
-
-    ar-alert[hiding] {
-        opacity: 0;
-        transform: scale(0.75);
+        &[hiding] {
+            opacity: 0;
+            transform: scale(0.75);
+        }
     }
 }

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -292,45 +292,34 @@
 
         /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
          * 6. TOKENS COMPOSANTS
-         * Enrichis au fur et à mesure de la migration.
          * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
 
-        /* alert */
-        --ar-alert-color: var(--ar-color-text);
-        --ar-alert-close-size: 2rem;
-        --ar-alert-close-transition-duration: var(--ar-button-transition-duration);
-        --ar-alert-hide-transition-duration: 0.33s;
-    }
+        /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+         * Panel
+         * Partagé - dropdown, breadcrumb, stepper
+         * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+        --ar-panel-bg: var(--ar-color-bg);
+        --ar-panel-text: var(--ar-color-text);
+        --ar-panel-border-color: var(--ar-color-border);
+        --ar-panel-radius: var(--ar-border-radius-md);
+        --ar-panel-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 10px 15px -3px rgba(0, 0, 0, 0.07);
+        --ar-panel-padding: 0.25rem;
+        --ar-panel-min-width: 18rem;
+        --ar-panel-max-width: 18rem;
+        --ar-panel-show-duration: 0.2s;
 
-    /* alert — presets par variant */
-    ar-alert {
-        &[variant='info'] {
-            --ar-alert-bg: var(--ar-color-info-bg);
-            --ar-alert-border: var(--ar-color-info-border);
-            --ar-alert-icon: var(--ar-color-info-text);
-        }
+        /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+         * Anchor
+         * Partagé — positionnement des composants ancrés / popovers)
+         * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+        /* anchor ( */
+        --ar-anchor-distance: 4px;
+        --ar-anchor-offset: 0px;
 
-        &[variant='warning'] {
-            --ar-alert-bg: var(--ar-color-warning-bg);
-            --ar-alert-border: var(--ar-color-warning-border);
-            --ar-alert-icon: var(--ar-color-warning-text);
-        }
-
-        &[variant='error'] {
-            --ar-alert-bg: var(--ar-color-danger-bg);
-            --ar-alert-border: var(--ar-color-danger-border);
-            --ar-alert-icon: var(--ar-color-danger-text);
-        }
-
-        &[variant='success'] {
-            --ar-alert-bg: var(--ar-color-success-bg);
-            --ar-alert-border: var(--ar-color-success-border);
-            --ar-alert-icon: var(--ar-color-success-text);
-        }
-    }
-
-    :root {
-        /* button */
+        /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+         * Button
+         * Partagé - breadcrumb, dialog, pagination
+         * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
         --ar-button-bg: var(--ar-color-interactive);
         --ar-button-bg-hover: var(--ar-color-interactive-hover);
         --ar-button-color: var(--ar-color-text-inverse);
@@ -358,7 +347,18 @@
         --ar-button-ratio-square-width: 2.5rem;
         --ar-button-transition-duration: 0.15s;
 
-        /* breadcrumb */
+        /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+         * Alert
+         * Voir les règles complémentaires pour les variants ci-dessous
+         * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+        --ar-alert-color: var(--ar-color-text);
+        --ar-alert-close-size: 2rem;
+        --ar-alert-close-transition-duration: var(--ar-button-transition-duration);
+        --ar-alert-hide-transition-duration: 0.33s;
+
+        /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+         * Breadcrumb
+         * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
         --ar-breadcrumb-distance: var(--ar-anchor-distance);
         --ar-breadcrumb-offset: var(--ar-anchor-offset);
         --ar-breadcrumb-color: var(--ar-color-text);
@@ -379,7 +379,9 @@
         --ar-breadcrumb-toggle-bg-pressed: var(--ar-button-tertiary-bg-active);
         --ar-breadcrumb-toggle-bg-focus: var(--ar-button-tertiary-bg-focus);
 
-        /* stepper */
+        /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+         * Stepper
+         * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
         --ar-stepper-distance: var(--ar-anchor-distance);
         --ar-stepper-offset: var(--ar-anchor-offset);
         --ar-stepper-label-color: var(--ar-color-text-muted);
@@ -398,12 +400,16 @@
         --ar-stepper-panel-bg: var(--ar-panel-bg);
         --ar-stepper-panel-border-color: var(--ar-panel-border-color);
 
-        /* progressbar */
+        /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+         * Progressbar
+         * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
         --ar-progressbar-track-color: var(--ar-color-bg-subtle);
         --ar-progressbar-fill-color: var(--ar-color-interactive);
         --ar-progressbar-percent-color: var(--ar-color-text-muted);
 
-        /* pagination */
+        /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+         * Pagination
+         * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
         --ar-pagination-active-color: var(--ar-color-interactive);
         --ar-pagination-color: var(--ar-color-text);
         --ar-pagination-bg: var(--ar-button-tertiary-bg);
@@ -412,10 +418,14 @@
         --ar-pagination-bg-focus: var(--ar-button-tertiary-bg-focus);
         --ar-pagination-active-bg: var(--ar-color-bg);
 
-        /* spinner */
+        /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+         * Spinner
+         * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
         --ar-spinner-stroke-color: currentColor;
 
-        /* tooltip */
+        /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+         * Tooltip
+         * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
         --ar-tooltip-distance: 10px;
         --ar-tooltip-offset: var(--ar-anchor-offset);
         --ar-tooltip-bg: var(--ar-color-neutral-20);
@@ -427,22 +437,9 @@
         --ar-tooltip-arrow-size: 6px;
         --ar-tooltip-show-duration: var(--ar-panel-show-duration);
 
-        /* panel (shared — dropdown, breadcrumb, stepper) */
-        --ar-panel-bg: var(--ar-color-bg);
-        --ar-panel-text: var(--ar-color-text);
-        --ar-panel-border-color: var(--ar-color-border);
-        --ar-panel-radius: var(--ar-border-radius-md);
-        --ar-panel-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 10px 15px -3px rgba(0, 0, 0, 0.07);
-        --ar-panel-padding: 0.25rem;
-        --ar-panel-min-width: 18rem;
-        --ar-panel-max-width: 18rem;
-        --ar-panel-show-duration: 0.2s;
-
-        /* anchor (partagé — positionnement des composants ancrés / popovers) */
-        --ar-anchor-distance: 4px;
-        --ar-anchor-offset: 0px;
-
-        /* dropdown */
+        /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+         * Dropdown
+         * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
         --ar-dropdown-distance: var(--ar-anchor-distance);
         --ar-dropdown-offset: var(--ar-anchor-offset);
         --ar-dropdown-bg: var(--ar-panel-bg);
@@ -457,7 +454,9 @@
         --ar-dropdown-min-width: 10rem;
         --ar-dropdown-max-width: var(--ar-panel-max-width);
 
-        /* dialog */
+        /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+         * Dialog
+         * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
         --ar-dialog-width-sm: 360px;
         --ar-dialog-width-md: 500px;
         --ar-dialog-width-lg: 800px;
@@ -484,11 +483,15 @@
         --ar-dialog-title-font-size: var(--ar-font-size-md);
         --ar-dialog-shake-outline-color: var(--ar-color-danger-text);
 
-        /* collapse */
+        /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+         * Collapse
+         * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
         --ar-collapse-duration: 0s;
         --ar-collapse-easing: ease;
 
-        /* charcounter */
+        /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+         * Charcounter
+         * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
         --ar-charcounter-color: var(--ar-color-text-muted);
         --ar-charcounter-font-size: 0.875rem;
         --ar-charcounter-warning-color: var(--ar-color-warning-text);
@@ -496,7 +499,9 @@
         --ar-charcounter-error-color: var(--ar-color-danger-text);
         --ar-charcounter-error-weight: 700;
 
-        /* table-sort */
+        /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+         * Tablesort
+         * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
         --ar-table-sort-gap: 0.375rem;
         --ar-table-sort-indicator-gap: 3px;
         --ar-table-sort-indicator-size: 0.65rem;
@@ -504,7 +509,9 @@
         --ar-table-sort-indicator-active-color: var(--ar-color-interactive, #2563eb);
         --ar-table-sort-indicator-pending-color: var(--ar-color-text-muted, #9ca3af);
 
-        /* tab */
+        /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+         * Tab
+         * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
         --ar-tab-color: var(--ar-color-text-muted);
         --ar-tab-bg: transparent;
         --ar-tab-padding-x: 1.5rem;
@@ -532,7 +539,7 @@
         --ar-tab-group-border-bottom-width: 1px;
 
         /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-         * ar-datepicker
+         * Datepicker
          * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
 
         --ar-datepicker-distance: var(--ar-anchor-distance);
@@ -583,6 +590,7 @@
      * Les composants héritent automatiquement.
      * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
 
+    /* Thème dark actif manuellement */
     :root[data-theme='dark'] {
         /* Surface */
         --ar-color-text: var(--ar-color-neutral-95);
@@ -640,6 +648,7 @@
         --ar-datepicker-input-error-border-color: var(--ar-color-red-40);
     }
 
+    /* Thème dark activé automatiquement par les préférence utilisateur */
     @media (prefers-color-scheme: dark) {
         :root:not([data-theme='light']) {
             /* Surface */
@@ -680,10 +689,6 @@
             --ar-button-tertiary-bg-active: rgba(255, 255, 255, 0.2);
             --ar-button-tertiary-bg-focus: rgba(255, 255, 255, 0.08);
 
-            /* Alert : ces surcharges de bordure dark mode nécessitent un sélecteur d'attribut,
-               déplacées hors de ce bloc — voir les 4 règles `ar-alert[variant='...']` juste
-               après la fermeture de ce sélecteur. */
-
             /* Tooltip — fond clair sur fond de page sombre */
             --ar-tooltip-bg: var(--ar-color-neutral-80);
             --ar-tooltip-color: var(--ar-color-neutral-10);
@@ -703,6 +708,11 @@
         }
     }
 
+    /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+     * THÈME COMPOSANTS
+     * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+
+    /* Datepicker */
     ar-datepicker {
         /* Variable locale à ce bloc thème, pas un token public du composant (pas de
          * préfixe --ar-datepicker-*) : couple gap et margin-bottom de ::part(label)
@@ -875,6 +885,7 @@
         }
     }
 
+    /* Stepper */
     ar-stepper {
         &::part(trigger) {
             border-radius: 0.75rem;
@@ -934,6 +945,7 @@
         }
     }
 
+    /* Alert */
     ar-alert {
         padding: 1rem;
         border-radius: 0.75rem;
@@ -941,6 +953,7 @@
         border-style: solid;
         column-gap: 0.75rem;
 
+        /* Customisation */
         &::part(close) {
             border-radius: 7px;
             color: currentColor;
@@ -966,6 +979,31 @@
         &[hiding] {
             opacity: 0;
             transform: scale(0.75);
+        }
+
+        /* presets par variant */
+        &[variant='info'] {
+            --ar-alert-bg: var(--ar-color-info-bg);
+            --ar-alert-border: var(--ar-color-info-border);
+            --ar-alert-icon: var(--ar-color-info-text);
+        }
+
+        &[variant='warning'] {
+            --ar-alert-bg: var(--ar-color-warning-bg);
+            --ar-alert-border: var(--ar-color-warning-border);
+            --ar-alert-icon: var(--ar-color-warning-text);
+        }
+
+        &[variant='error'] {
+            --ar-alert-bg: var(--ar-color-danger-bg);
+            --ar-alert-border: var(--ar-color-danger-border);
+            --ar-alert-icon: var(--ar-color-danger-text);
+        }
+
+        &[variant='success'] {
+            --ar-alert-bg: var(--ar-color-success-bg);
+            --ar-alert-border: var(--ar-color-success-border);
+            --ar-alert-icon: var(--ar-color-success-text);
         }
     }
 }

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -294,21 +294,36 @@
         /* alert */
         --ar-alert-color: var(--ar-color-text);
         --ar-alert-close-size: 2rem;
-        --ar-alert-info-bg: var(--ar-color-info-bg);
-        --ar-alert-info-border: var(--ar-color-info-bg);
-        --ar-alert-info-icon: var(--ar-color-info-text);
-        --ar-alert-warning-bg: var(--ar-color-warning-bg);
-        --ar-alert-warning-border: var(--ar-color-warning-bg);
-        --ar-alert-warning-icon: var(--ar-color-warning-text);
-        --ar-alert-error-bg: var(--ar-color-danger-bg);
-        --ar-alert-error-border: var(--ar-color-danger-bg);
-        --ar-alert-error-icon: var(--ar-color-danger-text);
-        --ar-alert-success-bg: var(--ar-color-success-bg);
-        --ar-alert-success-border: var(--ar-color-success-bg);
-        --ar-alert-success-icon: var(--ar-color-success-text);
         --ar-alert-close-transition-duration: var(--ar-button-transition-duration);
         --ar-alert-hide-transition-duration: 0.33s;
+        /* alert — presets par variant */
+    }
 
+    ar-alert[variant='info'] {
+        --ar-alert-bg: var(--ar-color-info-bg);
+        --ar-alert-border: var(--ar-color-info-bg);
+        --ar-alert-icon: var(--ar-color-info-text);
+    }
+
+    ar-alert[variant='warning'] {
+        --ar-alert-bg: var(--ar-color-warning-bg);
+        --ar-alert-border: var(--ar-color-warning-bg);
+        --ar-alert-icon: var(--ar-color-warning-text);
+    }
+
+    ar-alert[variant='error'] {
+        --ar-alert-bg: var(--ar-color-danger-bg);
+        --ar-alert-border: var(--ar-color-danger-bg);
+        --ar-alert-icon: var(--ar-color-danger-text);
+    }
+
+    ar-alert[variant='success'] {
+        --ar-alert-bg: var(--ar-color-success-bg);
+        --ar-alert-border: var(--ar-color-success-bg);
+        --ar-alert-icon: var(--ar-color-success-text);
+    }
+
+    :root {
         /* button */
         --ar-button-bg: var(--ar-color-interactive);
         --ar-button-bg-hover: var(--ar-color-interactive-hover);
@@ -597,11 +612,9 @@
         --ar-button-tertiary-bg-active: rgba(255, 255, 255, 0.2);
         --ar-button-tertiary-bg-focus: rgba(255, 255, 255, 0.08);
 
-        /* Alert */
-        --ar-alert-info-border: var(--ar-color-info-40);
-        --ar-alert-warning-border: var(--ar-color-warning-40);
-        --ar-alert-error-border: var(--ar-color-danger-40);
-        --ar-alert-success-border: var(--ar-color-success-40);
+        /* Alert : ces surcharges de bordure dark mode nécessitent un sélecteur d'attribut,
+           déplacées hors de ce bloc — voir les 4 règles `ar-alert[variant='...']` dupliquées
+           sous [data-theme='dark'] plus bas dans ce fichier. */
 
         /* Tooltip — fond clair sur fond de page sombre */
         --ar-tooltip-bg: var(--ar-color-neutral-80);
@@ -619,6 +632,19 @@
         --ar-datepicker-day-selected-color: var(--ar-color-text-inverse);
 
         --ar-datepicker-input-error-border-color: var(--ar-color-red-40);
+    }
+
+    :root[data-theme='dark'] ar-alert[variant='info'] {
+        --ar-alert-border: var(--ar-color-info-40);
+    }
+    :root[data-theme='dark'] ar-alert[variant='warning'] {
+        --ar-alert-border: var(--ar-color-warning-40);
+    }
+    :root[data-theme='dark'] ar-alert[variant='error'] {
+        --ar-alert-border: var(--ar-color-danger-40);
+    }
+    :root[data-theme='dark'] ar-alert[variant='success'] {
+        --ar-alert-border: var(--ar-color-success-40);
     }
 
     @media (prefers-color-scheme: dark) {
@@ -657,11 +683,9 @@
             --ar-button-tertiary-bg-active: rgba(255, 255, 255, 0.2);
             --ar-button-tertiary-bg-focus: rgba(255, 255, 255, 0.08);
 
-            /* Alert */
-            --ar-alert-info-border: var(--ar-color-info-40);
-            --ar-alert-warning-border: var(--ar-color-warning-40);
-            --ar-alert-error-border: var(--ar-color-danger-40);
-            --ar-alert-success-border: var(--ar-color-success-40);
+            /* Alert : ces surcharges de bordure dark mode nécessitent un sélecteur d'attribut,
+               déplacées hors de ce bloc — voir les 4 règles `ar-alert[variant='...']` juste
+               après la fermeture de ce sélecteur. */
 
             /* Tooltip — fond clair sur fond de page sombre */
             --ar-tooltip-bg: var(--ar-color-neutral-80);
@@ -679,6 +703,19 @@
             --ar-datepicker-day-selected-color: var(--ar-color-text-inverse);
 
             --ar-datepicker-input-error-border-color: var(--ar-color-red-40);
+        }
+
+        :root:not([data-theme='light']) ar-alert[variant='info'] {
+            --ar-alert-border: var(--ar-color-info-40);
+        }
+        :root:not([data-theme='light']) ar-alert[variant='warning'] {
+            --ar-alert-border: var(--ar-color-warning-40);
+        }
+        :root:not([data-theme='light']) ar-alert[variant='error'] {
+            --ar-alert-border: var(--ar-color-danger-40);
+        }
+        :root:not([data-theme='light']) ar-alert[variant='success'] {
+            --ar-alert-border: var(--ar-color-success-40);
         }
     }
 

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -296,9 +296,9 @@
         --ar-alert-close-size: 2rem;
         --ar-alert-close-transition-duration: var(--ar-button-transition-duration);
         --ar-alert-hide-transition-duration: 0.33s;
-        /* alert — presets par variant */
     }
 
+    /* alert — presets par variant */
     ar-alert[variant='info'] {
         --ar-alert-bg: var(--ar-color-info-bg);
         --ar-alert-border: var(--ar-color-info-bg);


### PR DESCRIPTION
## Summary
- Remplace le mapping binaire `variant === 'info' ? status : alert` par une table de
  correspondance à 4 entrées (`error`/`warning` → alert, `success`/`info` → status).
- Ajoute une prop `urgent` pour surcharger explicitement ce mapping, y compris sur les
  4 variants connus.
- Remplace les 12 tokens CSS nommés par variant par 3 tokens génériques
  (`--ar-alert-bg`, `--ar-alert-border`, `--ar-alert-icon`), les 4 presets connus
  déplacés dans `default.css` via sélecteurs d'attribut.
- Un `variant` custom sans preset connu n'affiche plus d'icône par défaut et émet un
  avertissement dev invitant à fournir `slot="icon"` (WCAG 1.4.1).

Design détaillé : `docs/superpowers/specs/2026-07-28-alert-variant-role-decoupling-design.md`

## Test plan
- [ ] `npm run test:all --workspace=packages/core` (unitaires + a11y navigateur)
- [ ] `npm run lint --workspace=packages/core`
- [ ] Vérification manuelle dans `apps/docs` : les 4 variants existants s'affichent
      identiquement à avant (régression visuelle nulle attendue sur les presets connus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)