### PR TITLE
refactor(dialog): migre token vs ::part(), simplifie close, corrige des bugs (lot 3b, #129)

### DIFF
--- a/docs/decisions/ADR-005-tokens-pilotes-par-attribut.md
+++ b/docs/decisions/ADR-005-tokens-pilotes-par-attribut.md
@@ -427,3 +427,20 @@ s'applique à la façon dont elles composent avec un base externe (par exemple
 `ar-x:hover { color: red }` se combine sans problème avec une règle de base externe séparée),
 pas au fait de laisser une surcharge d'état seule en interne une fois que son base a quitté le
 composant.
+
+## Amendement (2026-07-29) : externalisation de la taxonomie `size` (lot 3b, #129)
+
+La section « Exception assumée : l'attribut `size` » ci-dessus est dépassée. À la lumière du
+découplage variant/role d'`ar-alert` (PR #143) et de l'application stricte du critère
+crucial-vs-cosmétique sur `ar-dialog` (lot 3b, #129), la même incohérence a été relevée :
+il n'y a pas de raison de traiter la taxonomie de tailles d'`ar-dialog` différemment de la
+taxonomie de couleurs d'`ar-alert`.
+
+Nuance par rapport à `variant` (qui est purement cosmétique) : la largeur d'un dialog est
+fonctionnelle — un dialog sans aucune contrainte de largeur peut casser le layout. Le composant
+garde donc **une seule valeur littérale de repli par mode** (`500px` modal, `720px` drawer,
+directement sur `--ar-dialog-width`, sans intermédiaire de token), tandis que les paliers nommés
+(`sm`/`lg`/`xl`) et leurs variantes drawer deviennent une opinion du thème (`default.css`),
+exactement comme les 4 presets de `variant` sur `ar-alert`. Sans thème, `size="sm"` n'a plus
+d'effet visible — symétrique avec `variant="warning"` sur `ar-alert` aujourd'hui, ce n'est plus
+un cas isolé.

--- a/docs/decisions/ADR-005-tokens-pilotes-par-attribut.md
+++ b/docs/decisions/ADR-005-tokens-pilotes-par-attribut.md
@@ -444,3 +444,34 @@ directement sur `--ar-dialog-width`, sans intermédiaire de token), tandis que l
 exactement comme les 4 presets de `variant` sur `ar-alert`. Sans thème, `size="sm"` n'a plus
 d'effet visible — symétrique avec `variant="warning"` sur `ar-alert` aujourd'hui, ce n'est plus
 un cas isolé.
+
+**Nouveau marqueur `functional-default`** : cette seule valeur littérale par mode reste, par
+construction, une assignation `--ar-*: <valeur littérale>;` dans `dialog.styles.ts` — exactement
+ce que le garde-fou `validate-no-hardcoded-tokens.js` (section « Décision » ci-dessus) est censé
+interdire. Plutôt qu'élargir la portée de `a11y-fallback` (qui documente un _fallback en
+consommation_, `var(--token, valeur)`, pas une _assignation_), un second marqueur dédié est
+introduit : `/* functional-default: <raison> */`, sur la ligne immédiatement précédente
+l'assignation, format vérifié automatiquement par `findHardcodedTokenAssignments` (même
+mécanique que `a11y-fallback` — un commentaire au format exact, pas une simple tolérance de tout
+commentaire). Il autorise une assignation `--ar-*: <valeur littérale>;` quand, et seulement
+quand, l'absence de toute valeur casserait fonctionnellement le composant en l'absence de thème
+(layout qui explose, comportement cassé) — jamais pour une préférence purement cosmétique, qui
+reste interdite sans exception. La différence avec `a11y-fallback` : ce dernier justifie une
+valeur de repli _dans un `var(--token, repli)`_, consommée en cascade avec le token — le token
+existe toujours et peut être surchargé normalement ; `functional-default` justifie une valeur
+posée directement sur le token lui-même (pas de `var()` en jeu), typiquement parce qu'aucun
+niveau supérieur ne fournit de valeur par défaut sans thème. `--ar-dialog-width` (`500px` modal,
+`720px` drawer) est le premier et seul cas à ce jour ; comme pour `a11y-fallback`, ce marqueur
+n'est pas une invitation à recoder en dur — il documente une exception vérifiée, pas un
+raccourci.
+
+**Portée de cet amendement sur les sections antérieures du document** : au-delà de la section
+« Exception assumée : l'attribut `size` » (explicitement déclarée dépassée ci-dessus), cet
+amendement rend également caduques : l'exemple `--ar-dialog-width-sm` de la section « Décision »
+(qui illustrait le pattern « chaque état a son propre token `default.css` » — ce pattern reste
+valide en général, mais n'est plus illustré par `--ar-dialog-width-sm`, qui n'existe plus) et la
+puce de « Conséquences » mentionnant « les 8 variantes de `--ar-dialog-width` (`sm`/`md`/`lg`/`xl`
+× `modal`/`drawer`) sourcées depuis `default.css` » — ces 8 tokens intermédiaires ont disparu,
+remplacés par les presets `ar-dialog[size='...']`/`ar-dialog[mode='drawer'][size='...']`
+directement dans le thème (cf. `default.css`) et la valeur de repli unique par mode portée par
+`functional-default` ci-dessus.

--- a/docs/superpowers/plans/2026-07-29-dialog-token-vs-part-129.md
+++ b/docs/superpowers/plans/2026-07-29-dialog-token-vs-part-129.md
@@ -1,0 +1,1198 @@
+# Migration token vs ::part() — ar-dialog (issue #129, lot 3b) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Appliquer à `ar-dialog` le critère token-vs-`::part()` déjà appliqué à `ar-stepper`/`ar-datepicker`/`ar-alert` (#129), en poussant l'audit au-delà du seul axe token-vs-part : chaque déclaration cosmétique est aussi testée contre le rendu natif du navigateur (supprimer purement si redondant), et deux bugs réels découverts pendant l'audit sont corrigés dans la foulée (backdrop invisible sans thème, largeur non mobile-first). Le bouton de fermeture est entièrement repensé sur le modèle du bouton close d'`ar-alert` (bien plus simple que le `.btn.btn-tertiary` actuel), et la taxonomie `size` suit le même chemin que le `variant` d'`ar-alert` (PR #143) : seule une taille par défaut reste dans le composant, les paliers nommés deviennent une opinion du thème.
+
+**Architecture:**
+
+- **Bug fix a11y** : `--ar-dialog-backdrop` n'a aujourd'hui aucun fallback — sans thème, le voile derrière la modale est invisible (`::backdrop` natif = transparent par défaut). Ajout d'un fallback `rgba(0, 0, 0, 0.5)` justifié `a11y-fallback`.
+- **Bug fix mobile-first** : la largeur du dialog (modal et drawer) n'atteint jamais 100% du viewport sur mobile aujourd'hui (marge artificielle de 2rem en modal, tokens de taille drawer parfois inférieurs au viewport). Conformément à CLAUDE.md (« toute décision... part du cas mobile »), le comportement par défaut (sans media query) devient plein écran, et le palier `@media (min-width: 576px)` (convention déjà utilisée par `progressbar.styles.ts:48`) réintroduit le comportement actuel (largeur contrainte par palier/marge).
+- **Refonte du bouton close** : `buttonStyles`/`.btn.btn-tertiary.btn-ratio-square` retirés (n'étaient utilisés que par ce bouton) au profit d'un `[part='close']` bespoke, sur le modèle exact d'`ar-alert::part(close)` — taille tokenisée avec fallback WCAG 2.5.8 (`--ar-dialog-close-size, 2.5rem`), `outline` focus-visible autonome (pas de dépendance à `--ar-button-focus-ring-color`), fond en `color-mix(currentColor)` migré dans le thème. Les 4 tokens `--ar-dialog-close-bg*` (alias directs des tokens globaux `--ar-button-tertiary-*`, sans customisation propre) disparaissent — remplacés par 2 règles `::part(close)`/`::part(close):hover` dans `default.css`. Les gardes `:not(:disabled):not(.disabled):not([aria-disabled='true'])` disparaissent (le bouton n'est jamais désactivable, code mort confirmé par grep). Le commentaire `@EvolutionDesign` (résidu isolé, un seul hit dans tout le repo) disparaît. Ajout d'un `<slot name="close-icon">` (SVG par défaut en fallback), sur le modèle exact d'`ar-alert`, pour permettre le remplacement de l'icône — jusqu'ici impossible sur `ar-dialog`.
+- **Migrations token → `::part()`** (candidats de l'audit initial, inchangés) : `shadow` → `::part(dialog)` ; `border-radius` → `::part(dialog)` en mode modal uniquement (`:not([mode='drawer'])`) ; `title-font-size` → `::part(title)`.
+- **Suppression pure (pas de migration, ni composant ni thème)** : `font-weight`/`line-height`/`color` du `h1` — redondants avec le rendu natif (UA applique déjà `font-weight: bold`, aucune couleur explicite donc héritage déjà natif). Seul `margin: 0` reste (nécessaire, la marge UA du `h1` casserait l'alignement flex du header).
+- **Étape 0 (valeurs littérales jamais tokenisées)** : `gap`/`padding` de `header` et `footer` → `::part(header)`/`::part(footer)`.
+- **Externalisation de la taxonomie `size`** (nouveau, aligné sur `ar-alert` PR #143 découplage variant/role) : le composant ne garde qu'**une valeur littérale de repli par mode** (`500px` modal, `720px` drawer — pas de référence aux tokens `--ar-dialog-width-md`/`--ar-dialog-drawer-width-md` supprimés). Les 8 tokens `--ar-dialog-width-sm/md/lg/xl` et `--ar-dialog-drawer-width-sm/md/lg/xl` et les 8 règles `:host([size=...])`/`:host([mode='drawer'][size=...])` du composant disparaissent, remplacés par 6 règles `&[size='sm'/'lg'/'xl']`/`&[mode='drawer'][size='sm'/'lg'/'xl']` dans le thème (aucune règle `md` nécessaire, déjà la valeur de repli du composant). Sans thème, `size="sm"` n'a plus d'effet visible — symétrique avec `variant="warning"` sur `ar-alert` aujourd'hui, plus une exception isolée. Met à jour ADR-005 (section « Exception assumée : l'attribut `size` », désormais dépassée par un amendement).
+- **Hors périmètre, tracé séparément** : les durées d'animation (ouverture/fermeture modal+drawer, shake) ne peuvent pas être externalisées par un simple split de shorthand — `::part()` ne peut pas être suivi d'un sélecteur de classe (`::part(dialog).opening` invalide), ce qui nécessiterait le pattern « part d'état » et des changements JS dans `_show()`/`_close()`/`_shake()`. Tracé dans [issue #144](https://github.com/jogo-labs/ariane/issues/144), pas dans ce lot.
+
+**Tech Stack:** Lit 3, TypeScript, CSS natif avec nesting (`&::part()`, `&[attr]`), Vitest, `@web/test-runner` (navigateur réel), garde-fous CEM (`packages/core/scripts/validate-cssprop-defaults.js`, `validate-no-hardcoded-tokens.js`).
+
+## Global Constraints
+
+- Prettier : 100 caractères, 4 espaces, quotes simples (CLAUDE.md).
+- Aucune valeur de design en dur dans `*.styles.ts` (`validate-no-hardcoded-tokens.js` fait échouer `npm run build:manifest` sinon) — toute valeur migrée doit disparaître entièrement de `dialog.styles.ts`, pas juste être renommée. Les fallbacks structurels/a11y littéraux (`500px`, `720px`, `2.5rem`, `rgba(0, 0, 0, 0.5)`) nécessitent le commentaire `a11y-fallback` immédiatement au-dessus **uniquement** quand ils accompagnent un `var(--ar-*, fallback)` — les valeurs de repli posées directement sur `--ar-dialog-width` (pas dans un `var()`) ne sont pas concernées par ce garde-fou (il cible les fallbacks de consommation `var(--x, y)`, pas les valeurs initiales de custom properties).
+- Tout token `:root` de `default.css` appartenant à un composant doit avoir une entrée `@cssprop` dans son JSDoc (`validate-cssprop-defaults.js`) — mettre à jour `dialog.ts` en conséquence à chaque token ajouté/retiré.
+- `npm run test --workspace=packages/core` et `npm run test:all` doivent passer avant toute revue finale.
+- Ne jamais merger sur `dev` sans confirmation explicite de l'utilisateur (cf. `[[feedback_merge_after_autonomous_fix]]`, incident PR #137).
+- Rebuild explicite (`npm run build:dev --workspace=packages/core`) obligatoire avant toute vérification Playwright d'un changement de renderer/thème (cf. `[[feedback_docs_dev_stale_dist]]`).
+
+---
+
+### Task 1 : Créer la branche et vérifier l'état de départ
+
+**Files:** aucun fichier modifié dans cette tâche.
+
+- [ ] **Step 1: Vérifier que `dev` est à jour et propre**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git status
+git checkout dev
+git pull origin dev
+```
+
+Expected: `git status` ne montre aucun fichier modifié avant le checkout ; `dev` à jour après le pull.
+
+- [ ] **Step 2: Créer la branche de travail**
+
+```bash
+git checkout -b fix/dialog-token-vs-part-129
+```
+
+Expected: bascule sur la nouvelle branche, confirmé par `git branch --show-current`.
+
+- [ ] **Step 3: Faire tourner la suite de tests existante comme référence avant modification**
+
+```bash
+npm run test --workspace=packages/core
+```
+
+Expected: tous les tests passent (baseline verte avant toute modification).
+
+---
+
+### Task 2 : Corriger le bug d'accessibilité — backdrop invisible sans thème
+
+**Files:**
+
+- Modify: `packages/core/src/components/dialog/dialog.styles.ts:49-53` (bloc `dialog::backdrop`)
+
+**Interfaces:** aucune, tâche isolée.
+
+Contexte : `background: var(--ar-dialog-backdrop);` n'a aujourd'hui aucun fallback. Sans thème chargé, `::backdrop` reste transparent (comportement UA par défaut) — la modale n'a alors aucune indication visuelle de voile derrière elle, ce qui est un vrai trou a11y/UX (perte de l'indication de modalité), pas juste un défaut esthétique.
+
+- [ ] **Step 1 : Ajouter le fallback**
+
+Bloc actuel (`dialog.styles.ts:49-53`) :
+
+```css
+dialog::backdrop {
+    background: var(--ar-dialog-backdrop);
+    opacity: 0;
+    transition: opacity 0.25s ease;
+}
+```
+
+Remplacer par :
+
+```css
+dialog::backdrop {
+    /* a11y-fallback: sans thème chargé, le backdrop serait transparent (défaut UA de ::backdrop) — perte de l'indication visuelle de modalité */
+    background: var(--ar-dialog-backdrop, rgba(0, 0, 0, 0.5));
+    opacity: 0;
+    transition: opacity 0.25s ease;
+}
+```
+
+- [ ] **Step 2 : Régénérer le manifest**
+
+```bash
+npm run build:manifest --workspace=packages/core
+```
+
+Expected: succès — le commentaire `a11y-fallback` est détecté par le garde-fou `validate-no-hardcoded-tokens`, pas d'échec.
+
+- [ ] **Step 3 : Commit**
+
+```bash
+git add packages/core/src/components/dialog/dialog.styles.ts packages/core/dist/custom-elements.json
+git commit -m "fix(dialog): ajoute le fallback a11y manquant sur le backdrop (#129)"
+```
+
+---
+
+### Task 3 : Corriger le bug mobile-first — largeur non pleine sur petit écran
+
+**Files:**
+
+- Modify: `packages/core/src/components/dialog/dialog.styles.ts:71-80` (bloc de base `dialog`)
+- Modify: `packages/core/src/components/dialog/dialog.styles.ts:82-89` (bloc modal `:host(:not([mode='drawer'])) dialog`)
+- Modify: `packages/core/src/components/dialog/dialog.styles.ts:99-108` (bloc drawer `:host([mode='drawer']) dialog`)
+
+**Interfaces:** aucune interface consommée par une tâche suivante — indépendant du reste du plan.
+
+Contexte : actuellement, le modal ne dépasse jamais `calc(100vw - 2rem)` (marge artificielle même sur mobile) et le drawer utilise `min(var(--ar-dialog-width), 100vw)` qui n'atteint pas 100% si le palier de taille (ex. `sm` = 360px) est inférieur au viewport (ex. 375px). Conformément au mobile-first de CLAUDE.md, le comportement par défaut (sans media query) doit être plein écran ; la marge/le plafond de taille devient une amélioration progressive au-delà de 576px (même convention que `progressbar.styles.ts:48`). `width: 100vw` étant identique pour les deux modes en dessous de 576px, cette portion commune est mutualisée dans la règle de base `dialog { }` plutôt que dupliquée dans les deux blocs spécifiques au mode.
+
+- [ ] **Step 1 : Mutualiser `width: 100vw` dans la règle de base `dialog`**
+
+Bloc actuel (`dialog.styles.ts:71-80`) :
+
+```css
+dialog {
+    display: flex;
+    flex-direction: column;
+    border: none;
+    padding: 0;
+    overflow: hidden;
+    background: var(--ar-dialog-bg, Canvas);
+    color: var(--ar-dialog-color, CanvasText);
+    box-shadow: var(--ar-dialog-shadow);
+}
+```
+
+Remplacer par (ajout de `width: 100vw`, commun aux deux modes en dessous de 576px — `box-shadow` est toujours présent à ce stade, il sera retiré en Task 6, ne pas y toucher ici) :
+
+```css
+dialog {
+    display: flex;
+    flex-direction: column;
+    border: none;
+    padding: 0;
+    overflow: hidden;
+    background: var(--ar-dialog-bg, Canvas);
+    color: var(--ar-dialog-color, CanvasText);
+    box-shadow: var(--ar-dialog-shadow);
+    /* Mobile-first : plein écran par défaut, commun aux deux modes. */
+    width: 100vw;
+}
+```
+
+- [ ] **Step 2 : Retirer la largeur dupliquée du bloc modal, garder ce qui est spécifique au mode**
+
+Bloc actuel (`dialog.styles.ts:84-89`, après la Task précédente ce sera `82-89` sans le radius, cf. Task 5) :
+
+```css
+:host(:not([mode='drawer'])) dialog {
+    border-radius: var(--ar-dialog-border-radius);
+    /* max-width artificiel : la modale ne prend jamais toute la largeur même sur mobile */
+    width: min(var(--ar-dialog-width), calc(100vw - 2rem));
+    max-height: min(90vh, calc(100dvh - 2rem));
+}
+```
+
+Remplacer (à ce stade `border-radius` est toujours présent — il sera retiré en Task 5, ne pas y toucher ici) par :
+
+```css
+:host(:not([mode='drawer'])) dialog {
+    border-radius: var(--ar-dialog-border-radius);
+    max-height: 100dvh;
+}
+
+@media (min-width: 576px) {
+    :host(:not([mode='drawer'])) dialog {
+        /* max-width artificiel : au-delà du mobile, la modale ne prend jamais toute la
+           largeur — utile pour les paliers lg/xl sur les viewports moyens (tablette
+           portrait, fenêtre desktop réduite) où le token de taille dépasse le viewport ;
+           sans effet pratique sur sm/md, déjà plus étroits que calc(100vw - 2rem) à 576px. */
+        width: min(var(--ar-dialog-width), calc(100vw - 2rem));
+        max-height: min(90vh, calc(100dvh - 2rem));
+    }
+}
+```
+
+- [ ] **Step 3 : Retirer la largeur dupliquée du bloc drawer, garder ce qui est spécifique au mode**
+
+Bloc actuel (`dialog.styles.ts:101-108`) :
+
+```css
+:host([mode='drawer']) dialog {
+    /* Sur petit écran, le drawer peut occuper 100% de la largeur */
+    width: min(var(--ar-dialog-width), 100vw);
+    height: 100dvh;
+    /* max-height: override le défaut UA qui plafonne à calc(100% - 6px - 2em) */
+    max-height: 100dvh;
+    margin: 0;
+}
+```
+
+Remplacer par :
+
+```css
+:host([mode='drawer']) dialog {
+    height: 100dvh;
+    /* max-height: override le défaut UA qui plafonne à calc(100% - 6px - 2em) */
+    max-height: 100dvh;
+    margin: 0;
+}
+
+@media (min-width: 576px) {
+    :host([mode='drawer']) dialog {
+        width: min(var(--ar-dialog-width), 100vw);
+    }
+}
+```
+
+- [ ] **Step 4 : Régénérer le manifest**
+
+```bash
+npm run build:manifest --workspace=packages/core
+```
+
+Expected: succès, aucune erreur de garde-fou CEM.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add packages/core/src/components/dialog/dialog.styles.ts packages/core/dist/custom-elements.json
+git commit -m "fix(dialog): rend modal et drawer réellement plein écran sur mobile (#129)"
+```
+
+---
+
+### Task 4 : Refondre le bouton de fermeture (retrait de `.btn`, slot d'icône, simplification)
+
+**Files:**
+
+- Modify: `packages/core/src/components/dialog/dialog.ts:12` (retrait de l'import `buttonStyles`)
+- Modify: `packages/core/src/components/dialog/dialog.ts:101` (retrait de `buttonStyles` du tableau `styles`)
+- Modify: `packages/core/src/components/dialog/dialog.ts:51-87` (JSDoc classe — nouveau `@slot`, nouveaux/retirés `@cssprop`)
+- Modify: `packages/core/src/components/dialog/dialog.ts:266-286` (template du bouton close)
+- Modify: `packages/core/src/components/dialog/dialog.styles.ts:136-166` (header/button/svg) et `:190-211` (bloc close actuel, supprimé)
+- Modify: `packages/core/src/components/dialog/dialog.styles.ts` (bloc `@media (prefers-reduced-motion: reduce)`, ajout de `[part='close']`)
+- Modify: `packages/core/src/styles/themes/default.css` (retrait de 4 tokens `close-bg*`, ajout de 2 tokens `close-size`/`close-transition-duration`, création du bloc `ar-dialog { }` avec les règles `::part(close)`)
+
+**Interfaces:**
+
+- Consumes: rien d'une tâche précédente.
+- Produces: bloc `ar-dialog { }` dans `default.css`, réutilisé par les Tasks 5-6-7-9.
+
+- [ ] **Step 1 : Retirer l'import et l'usage de `buttonStyles`**
+
+Dans `dialog.ts`, ligne 12, supprimer :
+
+```ts
+import buttonStyles from '../../styles/components/button.styles.js';
+```
+
+Ligne 101, remplacer :
+
+```ts
+static override styles: CSSResultGroup = [utilitiesStyles, resetStyles, buttonStyles, styles];
+```
+
+par :
+
+```ts
+static override styles: CSSResultGroup = [utilitiesStyles, resetStyles, styles];
+```
+
+- [ ] **Step 2 : Simplifier le template du bouton close et ajouter le slot d'icône**
+
+Bloc actuel (`dialog.ts:266-286`) :
+
+```html
+<button part="close" type="button" class="btn btn-tertiary btn-ratio-square" data-ar-dismiss>
+    <svg
+        aria-hidden="true"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke-width="1.5"
+        stroke="currentColor"
+    >
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"></path>
+    </svg>
+    <span class="btn-content sr-only">${this.closeLabel}</span>
+</button>
+```
+
+Remplacer par (sur le modèle exact d'`ar-alert` — `<slot name="close-icon">` avec le SVG par défaut en fallback) :
+
+```html
+<button part="close" type="button" data-ar-dismiss>
+    <slot name="close-icon">
+        <svg
+            aria-hidden="true"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+        >
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"></path>
+        </svg>
+    </slot>
+    <span class="sr-only">${this.closeLabel}</span>
+</button>
+```
+
+- [ ] **Step 3 : Documenter le nouveau slot et les tokens dans le JSDoc de la classe**
+
+Dans `dialog.ts`, ajouter après la ligne `* @slot footer - ...` (ligne 56) :
+
+```
+ * @slot close-icon - Icône du bouton de fermeture. Remplace le SVG "×" par défaut.
+```
+
+Retirer les 4 lignes (fond du bouton close, remplacées par le nouveau design) :
+
+```
+ * @cssprop --ar-dialog-close-bg - Fond du bouton de fermeture.
+ * @cssprop --ar-dialog-close-bg-hover - Fond du bouton de fermeture au survol.
+ * @cssprop --ar-dialog-close-bg-pressed - Fond du bouton de fermeture pressé.
+ * @cssprop --ar-dialog-close-bg-focus - Fond du bouton de fermeture au focus.
+```
+
+Ajouter à leur place :
+
+```
+ * @cssprop --ar-dialog-close-size - Taille (width/height) du bouton de fermeture.
+ * @cssprop --ar-dialog-close-transition-duration - Durée de la transition (background-color) du bouton de fermeture au survol.
+```
+
+- [ ] **Step 4 : Remplacer le CSS du bouton et du SVG dans `dialog.styles.ts`**
+
+Bloc actuel (`dialog.styles.ts:155-166`, à l'intérieur de la section header) :
+
+```css
+button {
+    flex-shrink: 0;
+    align-self: flex-start;
+    /* @EvolutionDesign: taille forcée à 40×40 en attendant la migration vers la nouvelle charte */
+    min-height: 2.5rem;
+}
+
+svg {
+    width: 1.25rem;
+    height: 1.25rem;
+    flex-shrink: 0;
+}
+```
+
+Remplacer par :
+
+```css
+[part='close'] {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    align-self: flex-start;
+    flex-shrink: 0;
+    /* a11y-fallback: WCAG 2.5.8 (Target Size Minimum) — sans thème chargé, le bouton perdrait sa taille de cible tactile */
+    width: var(--ar-dialog-close-size, 2.5rem);
+    /* a11y-fallback: WCAG 2.5.8 (Target Size Minimum) — sans thème chargé, le bouton perdrait sa taille de cible tactile */
+    height: var(--ar-dialog-close-size, 2.5rem);
+    padding: 0;
+    border: none;
+    cursor: pointer;
+    transition: background-color var(--ar-dialog-close-transition-duration);
+}
+
+[part='close']:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
+}
+
+svg {
+    width: 1.25rem;
+    height: 1.25rem;
+    flex-shrink: 0;
+}
+```
+
+- [ ] **Step 5 : Retirer entièrement l'ancien bloc `[part='close'].btn.btn-tertiary`**
+
+Bloc actuel (`dialog.styles.ts:190-211`) :
+
+```css
+/* ── Bouton de fermeture (tokens scopés au composant) ────────────────────
+ * Sélecteurs volontairement plus spécifiques que .btn-tertiary dans
+ * button.styles.ts (ajout de [part='close'].btn) pour gagner la cascade
+ * indépendamment de l'ordre des styles. */
+
+[part='close'].btn.btn-tertiary {
+    background-color: var(--ar-dialog-close-bg);
+}
+
+[part='close'].btn.btn-tertiary:hover {
+    background-color: var(--ar-dialog-close-bg-hover);
+}
+
+[part='close'].btn.btn-tertiary:not(:disabled):not(.disabled):not([aria-disabled='true']):active {
+    background-color: var(--ar-dialog-close-bg-pressed);
+}
+
+[part='close'].btn.btn-tertiary:focus {
+    background-color: var(--ar-dialog-close-bg-focus);
+}
+```
+
+Supprimer ce bloc entièrement.
+
+- [ ] **Step 6 : Ajouter `[part='close']` à la garde `prefers-reduced-motion`**
+
+Bloc actuel (`dialog.styles.ts`, section `@media (prefers-reduced-motion: reduce)`) :
+
+```css
+@media (prefers-reduced-motion: reduce) {
+    dialog,
+    dialog::backdrop {
+        animation: none !important;
+        transition: none !important;
+    }
+
+    dialog.shake {
+        animation: none;
+        outline: 3px solid var(--ar-dialog-shake-outline-color);
+        outline-offset: 2px;
+    }
+}
+```
+
+Remplacer par (ajout de `[part='close']` à la liste qui neutralise les transitions) :
+
+```css
+@media (prefers-reduced-motion: reduce) {
+    dialog,
+    dialog::backdrop,
+    [part='close'] {
+        animation: none !important;
+        transition: none !important;
+    }
+
+    dialog.shake {
+        animation: none;
+        outline: 3px solid var(--ar-dialog-shake-outline-color);
+        outline-offset: 2px;
+    }
+}
+```
+
+- [ ] **Step 7 : Retirer les 4 tokens `close-bg*` et ajouter les 2 nouveaux tokens dans `default.css`**
+
+Dans le bloc `/* Dialog */` de `:root`, supprimer :
+
+```css
+--ar-dialog-close-bg: var(--ar-button-tertiary-bg);
+--ar-dialog-close-bg-hover: var(--ar-button-tertiary-bg-hover);
+--ar-dialog-close-bg-pressed: var(--ar-button-tertiary-bg-active);
+--ar-dialog-close-bg-focus: var(--ar-button-tertiary-bg-focus);
+```
+
+Ajouter à leur place :
+
+```css
+--ar-dialog-close-size: 2.5rem;
+--ar-dialog-close-transition-duration: var(--ar-button-transition-duration);
+```
+
+- [ ] **Step 8 : Créer le bloc `ar-dialog { }` en fin de `default.css` avec le design du bouton close**
+
+Le fichier se termine actuellement par le bloc `ar-alert { ... }` puis la dernière accolade fermante de `@layer ariane.theme { :root { ... } ... }`. Insérer un nouveau bloc `ar-dialog { }` juste après la fermeture du bloc `ar-alert` (avant la dernière accolade fermante du `@layer`), sur le modèle exact d'`ar-alert::part(close)` :
+
+```css
+    ar-dialog {
+        &::part(close) {
+            color: currentColor;
+            background-color: color-mix(in srgb, currentColor 8%, transparent);
+        }
+
+        &::part(close):hover {
+            background-color: color-mix(in srgb, currentColor 20%, transparent);
+        }
+    }
+}
+```
+
+(la dernière accolade `}` ci-dessus est celle, déjà existante, qui ferme `@layer ariane.theme`.)
+
+- [ ] **Step 9 : Régénérer le manifest**
+
+```bash
+npm run build:manifest --workspace=packages/core
+```
+
+Expected: succès, aucune erreur de garde-fou CEM.
+
+- [ ] **Step 10 : Commit**
+
+```bash
+git add packages/core/src/components/dialog/dialog.ts \
+        packages/core/src/components/dialog/dialog.styles.ts \
+        packages/core/src/styles/themes/default.css \
+        packages/core/dist/custom-elements.json
+git commit -m "refactor(dialog): simplifie le bouton close (retrait .btn, slot close-icon) (#129)"
+```
+
+---
+
+### Task 5 : Migrer `--ar-dialog-border-radius` vers `::part(dialog)` (modal uniquement)
+
+**Files:**
+
+- Modify: `packages/core/src/components/dialog/dialog.styles.ts` (bloc `:host(:not([mode='drawer'])) dialog`, cf. Task 3)
+- Modify: `packages/core/src/components/dialog/dialog.ts` (retrait de l'entrée `@cssprop --ar-dialog-border-radius`)
+- Modify: `packages/core/src/styles/themes/default.css` (retrait du token `:root`, ajout de `&:not([mode='drawer'])::part(dialog) { border-radius: ...; }` dans le bloc `ar-dialog { }` créé en Task 4)
+
+**Interfaces:**
+
+- Consumes: bloc `ar-dialog { }` créé en Task 4 (Step 8).
+- Produces: aucune interface consommée par une tâche suivante.
+
+Contexte : après la Task 3, le bloc modal est désormais (le `width: 100vw` mobile-first a été mutualisé dans la règle de base `dialog { }`, ce bloc ne garde que ce qui est spécifique au mode modal) :
+
+```css
+:host(:not([mode='drawer'])) dialog {
+    border-radius: var(--ar-dialog-border-radius);
+    max-height: 100dvh;
+}
+```
+
+- [ ] **Step 1 : Retirer `border-radius` de ce bloc**
+
+```css
+:host(:not([mode='drawer'])) dialog {
+    max-height: 100dvh;
+}
+```
+
+- [ ] **Step 2 : Retirer le token de `default.css`**
+
+Supprimer la ligne `--ar-dialog-border-radius: var(--ar-border-radius-lg);` du bloc `/* Dialog */` de `:root`.
+
+- [ ] **Step 3 : Ajouter la règle `::part(dialog)` conditionnelle dans le bloc `ar-dialog { }`**
+
+Le bloc créé en Task 4 devient (ajout en tête, avant `&::part(close)`) :
+
+```css
+ar-dialog {
+    &:not([mode='drawer'])::part(dialog) {
+        border-radius: var(--ar-border-radius-lg);
+    }
+
+    &::part(close) {
+        color: currentColor;
+        background-color: color-mix(in srgb, currentColor 8%, transparent);
+    }
+
+    /* ... reste du bloc de la Task 4 inchangé ... */
+}
+```
+
+- [ ] **Step 4 : Retirer l'entrée `@cssprop --ar-dialog-border-radius` du JSDoc de `dialog.ts`**
+
+Supprimer la ligne :
+
+```
+ * @cssprop --ar-dialog-border-radius - Border-radius du dialog en mode modal (non-drawer) (cascade vers --ar-border-radius-lg).
+```
+
+- [ ] **Step 5 : Régénérer le manifest**
+
+```bash
+npm run build:manifest --workspace=packages/core
+```
+
+Expected: succès, aucune erreur de garde-fou CEM.
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git add packages/core/src/components/dialog/dialog.styles.ts \
+        packages/core/src/components/dialog/dialog.ts \
+        packages/core/src/styles/themes/default.css \
+        packages/core/dist/custom-elements.json
+git commit -m "refactor(dialog): migre border-radius vers ::part(dialog), mode modal uniquement (#129)"
+```
+
+---
+
+### Task 6 : Migrer `--ar-dialog-shadow` vers `::part(dialog)`
+
+**Files:**
+
+- Modify: `packages/core/src/components/dialog/dialog.styles.ts:71-80` (bloc `dialog`)
+- Modify: `packages/core/src/components/dialog/dialog.ts` (retrait de l'entrée `@cssprop --ar-dialog-shadow`)
+- Modify: `packages/core/src/styles/themes/default.css` (retrait du token `:root`, ajout de `&::part(dialog) { box-shadow: ...; }` dans le bloc `ar-dialog { }`)
+
+**Interfaces:**
+
+- Consumes: bloc `ar-dialog { }` créé en Task 4.
+- Produces: aucune interface consommée par une tâche suivante.
+
+- [ ] **Step 1 : Retirer `box-shadow` du bloc `dialog` de `dialog.styles.ts`**
+
+Bloc actuel (`dialog.styles.ts:71-80`) :
+
+```css
+dialog {
+    display: flex;
+    flex-direction: column;
+    border: none;
+    padding: 0;
+    overflow: hidden;
+    background: var(--ar-dialog-bg, Canvas);
+    color: var(--ar-dialog-color, CanvasText);
+    box-shadow: var(--ar-dialog-shadow);
+}
+```
+
+Remplacer par :
+
+```css
+dialog {
+    display: flex;
+    flex-direction: column;
+    border: none;
+    padding: 0;
+    overflow: hidden;
+    background: var(--ar-dialog-bg, Canvas);
+    color: var(--ar-dialog-color, CanvasText);
+}
+```
+
+- [ ] **Step 2 : Retirer le token de `default.css`**
+
+Supprimer la ligne `--ar-dialog-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 20px 50px -8px rgba(0, 0, 0, 0.2);` du bloc `/* Dialog */` de `:root`.
+
+- [ ] **Step 3 : Ajouter la règle `::part(dialog)` dans le bloc `ar-dialog { }`**
+
+Ajouter, après `&:not([mode='drawer'])::part(dialog) { border-radius: ... }` (Task 5) et avant `&::part(close)` (Task 4) :
+
+```css
+&::part(dialog) {
+    box-shadow:
+        0 4px 6px -1px rgba(0, 0, 0, 0.1),
+        0 20px 50px -8px rgba(0, 0, 0, 0.2);
+}
+```
+
+- [ ] **Step 4 : Retirer l'entrée `@cssprop --ar-dialog-shadow` du JSDoc de `dialog.ts`**
+
+Supprimer la ligne :
+
+```
+ * @cssprop --ar-dialog-shadow - Ombre portée du dialog.
+```
+
+- [ ] **Step 5 : Régénérer le manifest**
+
+```bash
+npm run build:manifest --workspace=packages/core
+```
+
+Expected: succès, aucune erreur de garde-fou CEM.
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git add packages/core/src/components/dialog/dialog.styles.ts \
+        packages/core/src/components/dialog/dialog.ts \
+        packages/core/src/styles/themes/default.css \
+        packages/core/dist/custom-elements.json
+git commit -m "refactor(dialog): migre shadow vers ::part(dialog) (#129)"
+```
+
+---
+
+### Task 7 : Migrer `title-font-size` vers `::part(title)` et supprimer le style cosmétique redondant du `h1`
+
+**Files:**
+
+- Modify: `packages/core/src/components/dialog/dialog.styles.ts:147-153` (bloc `h1`)
+- Modify: `packages/core/src/components/dialog/dialog.ts` (retrait de l'entrée `@cssprop --ar-dialog-title-font-size`)
+- Modify: `packages/core/src/styles/themes/default.css` (retrait du token `:root`, ajout de `&::part(title) { font-size: ...; }` dans le bloc `ar-dialog { }`)
+
+**Interfaces:**
+
+- Consumes: bloc `ar-dialog { }` créé en Task 4.
+- Produces: aucune interface consommée par une tâche suivante.
+
+Contexte : `font-weight: 600`, `line-height: 1.4` et `color: inherit` sont supprimés **purement** (ni composant, ni thème) — redondants avec le rendu natif (`h1` est `bold` par défaut dans tous les navigateurs ; aucune règle UA ne fixe de couleur sur `h1`, l'héritage est déjà natif). Seuls `margin: 0` (nécessaire à l'alignement flex du header) et `font-size` (migré vers `::part(title)`) sont conservés/migrés.
+
+- [ ] **Step 1 : Simplifier le bloc `h1`**
+
+Bloc actuel (`dialog.styles.ts:147-153`) :
+
+```css
+h1 {
+    margin: 0;
+    font-size: var(--ar-dialog-title-font-size);
+    font-weight: 600;
+    line-height: 1.4;
+    color: inherit;
+}
+```
+
+Remplacer par :
+
+```css
+h1 {
+    margin: 0;
+}
+```
+
+- [ ] **Step 2 : Retirer le token de `default.css`**
+
+Supprimer la ligne `--ar-dialog-title-font-size: var(--ar-font-size-md);` du bloc `/* Dialog */` de `:root`.
+
+- [ ] **Step 3 : Ajouter la règle `::part(title)` dans le bloc `ar-dialog { }`**
+
+Ajouter, dans le bloc `ar-dialog { }` :
+
+```css
+&::part(title) {
+    font-size: var(--ar-font-size-md);
+}
+```
+
+- [ ] **Step 4 : Retirer l'entrée `@cssprop --ar-dialog-title-font-size` du JSDoc de `dialog.ts`**
+
+Supprimer la ligne :
+
+```
+ * @cssprop --ar-dialog-title-font-size - Taille de police du titre (h1) (cascade vers --ar-font-size-md).
+```
+
+- [ ] **Step 5 : Régénérer le manifest**
+
+```bash
+npm run build:manifest --workspace=packages/core
+```
+
+Expected: succès, aucune erreur de garde-fou CEM.
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git add packages/core/src/components/dialog/dialog.styles.ts \
+        packages/core/src/components/dialog/dialog.ts \
+        packages/core/src/styles/themes/default.css \
+        packages/core/dist/custom-elements.json
+git commit -m "refactor(dialog): migre title-font-size vers ::part(title), retire le style h1 redondant avec le natif (#129)"
+```
+
+---
+
+### Task 8 : Étape 0 — migrer les valeurs littérales jamais tokenisées de `header`/`footer`
+
+**Files:**
+
+- Modify: `packages/core/src/components/dialog/dialog.styles.ts:138-145` (bloc `header`)
+- Modify: `packages/core/src/components/dialog/dialog.styles.ts:180-188` (bloc `footer`)
+- Modify: `packages/core/src/styles/themes/default.css` (ajout de `&::part(header) { gap; padding; }` et `&::part(footer) { gap; padding; }` dans le bloc `ar-dialog { }`)
+
+**Interfaces:**
+
+- Consumes: bloc `ar-dialog { }` créé en Task 4.
+- Produces: aucune interface consommée par une tâche suivante.
+
+Contexte : `gap`/`padding` de `header` et `footer` n'ont jamais été des tokens `--ar-*` (valeurs littérales), mais l'étape 0 du critère ADR-005 impose de les relire au même titre que les tokens déjà nommés — cf. le précédent `ar-datepicker` (gap/weekday migrés en lot 2 alors qu'ils n'étaient pas dans l'audit initial). Ni réutilisées ≥2×, ni lues en JS, ni calibrées différemment en dark mode : candidates à la migration.
+
+- [ ] **Step 1 : Retirer `gap`/`padding` du bloc `header` de `dialog.styles.ts`**
+
+Bloc actuel (`dialog.styles.ts:138-145`) :
+
+```css
+header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 1.25rem 1.25rem 0;
+    flex-shrink: 0;
+}
+```
+
+Remplacer par :
+
+```css
+header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-shrink: 0;
+}
+```
+
+- [ ] **Step 2 : Retirer `gap`/`padding` du bloc `footer` de `dialog.styles.ts`**
+
+Bloc actuel (`dialog.styles.ts:180-188`) :
+
+```css
+footer {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    padding: 0 1.25rem 1.25rem;
+    flex-shrink: 0;
+}
+```
+
+Remplacer par :
+
+```css
+footer {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    flex-shrink: 0;
+}
+```
+
+- [ ] **Step 3 : Ajouter les règles `::part(header)`/`::part(footer)` dans le bloc `ar-dialog { }`**
+
+Ajouter, dans le bloc `ar-dialog { }` :
+
+```css
+&::part(header) {
+    gap: 0.75rem;
+    padding: 1.25rem 1.25rem 0;
+}
+
+&::part(footer) {
+    gap: 0.75rem;
+    padding: 0 1.25rem 1.25rem;
+}
+```
+
+- [ ] **Step 4 : Régénérer le manifest**
+
+```bash
+npm run build:manifest --workspace=packages/core
+```
+
+Expected: succès, aucune erreur de garde-fou CEM (aucun `@cssprop` à retirer ici — ces valeurs n'ont jamais été des tokens documentés).
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add packages/core/src/components/dialog/dialog.styles.ts \
+        packages/core/src/styles/themes/default.css \
+        packages/core/dist/custom-elements.json
+git commit -m "refactor(dialog): migre gap/padding de header et footer vers ::part() (#129)"
+```
+
+---
+
+### Task 9 : Externaliser la taxonomie `size` vers le thème (aligné sur `variant` d'`ar-alert`, PR #143)
+
+**Files:**
+
+- Modify: `packages/core/src/components/dialog/dialog.styles.ts:7-45` (bloc `:host` et tailles)
+- Modify: `packages/core/src/components/dialog/dialog.ts:148-156` (JSDoc de la propriété `size`)
+- Modify: `packages/core/src/components/dialog/dialog.ts` (JSDoc classe — retrait de 8 `@cssprop`)
+- Modify: `packages/core/src/styles/themes/default.css` (retrait de 8 tokens `:root`, ajout de 6 règles `&[size=...]`/`&[mode='drawer'][size=...]` dans le bloc `ar-dialog { }`)
+- Modify: `docs/decisions/ADR-005-tokens-pilotes-par-attribut.md` (amendement de la section « Exception assumée : l'attribut `size` »)
+
+**Interfaces:**
+
+- Consumes: bloc `ar-dialog { }` créé en Task 4.
+- Produces: aucune interface consommée par une tâche suivante.
+
+Contexte : comme le `variant` d'`ar-alert` (PR #143), la taxonomie de tailles nommées (`sm`/`lg`/`xl`) devient une opinion du thème — le composant ne garde qu'**une seule valeur de repli littérale par mode** (fonctionnelle, pas cosmétique : contrairement au `variant` d'alert qui est purement une couleur, une largeur de dialog non contrainte casserait le layout, d'où la nécessité de garder un repli, contrairement à une suppression pure).
+
+- [ ] **Step 1 : Simplifier le bloc `:host` de `dialog.styles.ts`**
+
+Bloc actuel (`dialog.styles.ts:7-45`) :
+
+```css
+:host {
+    display: block;
+
+    /* Taille modale par défaut (md). Surchargeable par --ar-dialog-width sur l'instance. */
+    --ar-dialog-width: var(--ar-dialog-width-md);
+}
+
+/* Tailles modal */
+:host([size='sm']) {
+    --ar-dialog-width: var(--ar-dialog-width-sm);
+}
+:host([size='md']) {
+    --ar-dialog-width: var(--ar-dialog-width-md);
+}
+:host([size='lg']) {
+    --ar-dialog-width: var(--ar-dialog-width-lg);
+}
+:host([size='xl']) {
+    --ar-dialog-width: var(--ar-dialog-width-xl);
+}
+
+/* Tailles drawer — ont priorité sur les valeurs modal via la spécificité */
+:host([mode='drawer']) {
+    --ar-dialog-width: var(--ar-dialog-drawer-width-md);
+}
+:host([mode='drawer'][size='sm']) {
+    --ar-dialog-width: var(--ar-dialog-drawer-width-sm);
+}
+:host([mode='drawer'][size='md']) {
+    --ar-dialog-width: var(--ar-dialog-drawer-width-md);
+}
+:host([mode='drawer'][size='lg']) {
+    --ar-dialog-width: var(--ar-dialog-drawer-width-lg);
+}
+:host([mode='drawer'][size='xl']) {
+    --ar-dialog-width: var(--ar-dialog-drawer-width-xl);
+}
+```
+
+Remplacer par :
+
+```css
+:host {
+    display: block;
+
+    /* Taille par défaut (repli fonctionnel sans thème) — les paliers sm/lg/xl sont
+       une taxonomie fournie par default.css, pas une exigence du composant. */
+    --ar-dialog-width: 500px;
+}
+
+/* Taille par défaut du drawer — a priorité sur la valeur modal via la spécificité */
+:host([mode='drawer']) {
+    --ar-dialog-width: 720px;
+}
+```
+
+- [ ] **Step 2 : Retirer les 8 tokens de taille de `default.css` (`:root`)**
+
+Supprimer ces 8 lignes du bloc `/* Dialog */` :
+
+```css
+--ar-dialog-width-sm: 360px;
+--ar-dialog-width-md: 500px;
+--ar-dialog-width-lg: 800px;
+--ar-dialog-width-xl: 1140px;
+--ar-dialog-drawer-width-sm: 360px;
+--ar-dialog-drawer-width-md: 720px;
+--ar-dialog-drawer-width-lg: 960px;
+--ar-dialog-drawer-width-xl: 1440px;
+```
+
+- [ ] **Step 3 : Ajouter les 6 règles de taxonomie dans le bloc `ar-dialog { }`**
+
+Ajouter, dans le bloc `ar-dialog { }` (aucune règle `md` nécessaire — déjà la valeur de repli du composant) :
+
+```css
+&[size='sm'] {
+    --ar-dialog-width: 360px;
+}
+&[size='lg'] {
+    --ar-dialog-width: 800px;
+}
+&[size='xl'] {
+    --ar-dialog-width: 1140px;
+}
+
+&[mode='drawer'][size='sm'] {
+    --ar-dialog-width: 360px;
+}
+&[mode='drawer'][size='lg'] {
+    --ar-dialog-width: 960px;
+}
+&[mode='drawer'][size='xl'] {
+    --ar-dialog-width: 1440px;
+}
+```
+
+- [ ] **Step 4 : Retirer les 8 entrées `@cssprop` correspondantes du JSDoc de `dialog.ts`**
+
+Supprimer :
+
+```
+ * @cssprop --ar-dialog-width-sm - Largeur du dialog modal, taille `sm`.
+ * @cssprop --ar-dialog-width-md - Largeur du dialog modal, taille `md`.
+ * @cssprop --ar-dialog-width-lg - Largeur du dialog modal, taille `lg`.
+ * @cssprop --ar-dialog-width-xl - Largeur du dialog modal, taille `xl`.
+ * @cssprop --ar-dialog-drawer-width-sm - Largeur du drawer, taille `sm`.
+ * @cssprop --ar-dialog-drawer-width-md - Largeur du drawer, taille `md`.
+ * @cssprop --ar-dialog-drawer-width-lg - Largeur du drawer, taille `lg`.
+ * @cssprop --ar-dialog-drawer-width-xl - Largeur du drawer, taille `xl`.
+```
+
+(`--ar-dialog-width` reste documenté, inchangé — c'est toujours le point de surcharge direct.)
+
+- [ ] **Step 5 : Mettre à jour le JSDoc de la propriété `size`**
+
+Bloc actuel (`dialog.ts:148-156`) :
+
+```ts
+/**
+ * Taille du dialog. Les valeurs correspondent à des largeurs CSS prédéfinies.
+ * Utilisez `--ar-dialog-width` pour une valeur personnalisée.
+ *
+ * @attr size
+ * @default 'md'
+ */
+@property({ reflect: true, type: String })
+size: 'sm' | 'md' | 'lg' | 'xl' = 'md';
+```
+
+Remplacer le commentaire par :
+
+```ts
+/**
+ * Taille du dialog. Les paliers `sm`/`lg`/`xl` sont définis par le thème —
+ * sans thème chargé, seule la taille par défaut du composant s'applique.
+ * Utilisez `--ar-dialog-width` pour une valeur personnalisée, indépendamment du thème.
+ *
+ * @attr size
+ * @default 'md'
+ */
+@property({ reflect: true, type: String })
+size: 'sm' | 'md' | 'lg' | 'xl' = 'md';
+```
+
+- [ ] **Step 6 : Amender ADR-005 — la section « Exception assumée » est dépassée**
+
+Dans `docs/decisions/ADR-005-tokens-pilotes-par-attribut.md`, ajouter en toute fin de fichier (après le dernier amendement existant) :
+
+```markdown
+## Amendement (2026-07-29) : externalisation de la taxonomie `size` (lot 3b, #129)
+
+La section « Exception assumée : l'attribut `size` » ci-dessus est dépassée. À la lumière du
+découplage variant/role d'`ar-alert` (PR #143) et de l'application stricte du critère
+crucial-vs-cosmétique sur `ar-dialog` (lot 3b, #129), la même incohérence a été relevée :
+il n'y a pas de raison de traiter la taxonomie de tailles d'`ar-dialog` différemment de la
+taxonomie de couleurs d'`ar-alert`.
+
+Nuance par rapport à `variant` (qui est purement cosmétique) : la largeur d'un dialog est
+fonctionnelle — un dialog sans aucune contrainte de largeur peut casser le layout. Le composant
+garde donc **une seule valeur littérale de repli par mode** (`500px` modal, `720px` drawer,
+directement sur `--ar-dialog-width`, sans intermédiaire de token), tandis que les paliers nommés
+(`sm`/`lg`/`xl`) et leurs variantes drawer deviennent une opinion du thème (`default.css`),
+exactement comme les 4 presets de `variant` sur `ar-alert`. Sans thème, `size="sm"` n'a plus
+d'effet visible — symétrique avec `variant="warning"` sur `ar-alert` aujourd'hui, ce n'est plus
+un cas isolé.
+```
+
+- [ ] **Step 7 : Régénérer le manifest**
+
+```bash
+npm run build:manifest --workspace=packages/core
+```
+
+Expected: succès, aucune erreur de garde-fou CEM.
+
+- [ ] **Step 8 : Commit**
+
+```bash
+git add packages/core/src/components/dialog/dialog.styles.ts \
+        packages/core/src/components/dialog/dialog.ts \
+        packages/core/src/styles/themes/default.css \
+        docs/decisions/ADR-005-tokens-pilotes-par-attribut.md \
+        packages/core/dist/custom-elements.json
+git commit -m "refactor(dialog): externalise la taxonomie size vers le theme, aligne sur variant d'alert (#129)"
+```
+
+---
+
+### Task 10 : Vérification visuelle Playwright et suite de tests complète
+
+**Files:** aucun fichier de code modifié — vérification uniquement (des tests existants peuvent nécessiter des ajustements si `dialog.test.ts` référence les classes `.btn`/`.btn-tertiary` retirées en Task 4).
+
+**Interfaces:**
+
+- Consumes: l'ensemble des changements des Tasks 2-9.
+
+- [ ] **Step 1 : Rebuild explicite du JS de `packages/core` avant toute vérification navigateur**
+
+```bash
+npm run build:dev --workspace=packages/core
+```
+
+Expected: build réussi.
+
+- [ ] **Step 2 : Lancer le site de doc et vérifier visuellement `ar-dialog` (modal ET drawer, mobile ET desktop)**
+
+```bash
+npm run dev --workspace=apps/docs
+```
+
+Ouvrir `http://localhost:4321/components/ar-dialog` (ou le port affiché) et vérifier à l'œil, en réduisant la fenêtre sous 576px de large ET au-dessus :
+
+- **Mobile (< 576px)** : modal et drawer occupent 100% de la largeur (édge-to-edge), aucune marge résiduelle.
+- **Desktop (≥ 576px)** : modal et drawer retrouvent leur comportement actuel (marge de 2rem en modal, paliers de taille en drawer).
+- **Backdrop** : voile semi-transparent visible même en désactivant `default.css` (DevTools → désactiver la feuille de style) — vérifier que le fallback fonctionne.
+- **Bouton de fermeture** : taille, fond au repos/survol, focus-visible (anneau `outline`) identiques visuellement à avant ; tester la personnalisation via `slot="close-icon"` sur une instance de test.
+- **Titre** : taille de police identique à avant ; poids de police désormais celui du navigateur (`bold` natif au lieu de `600` — différence subtile attendue, pas une régression).
+- **Tailles (`size="sm"/"lg"/"xl"`)** : identiques visuellement à avant (valeurs reprises telles quelles dans le thème) ; désactiver `default.css` et vérifier que `size="sm"` n'a alors plus d'effet (comportement attendu, symétrique à `variant` sur `ar-alert`).
+- Vérifier dans les DevTools (`getComputedStyle`) que `::part(dialog)`, `::part(header)`, `::part(footer)`, `::part(title)`, `::part(close)` résolvent bien aux valeurs attendues.
+
+Expected: aucune régression visuelle en desktop ; comportement plein écran correct en mobile ; dégradation gracieuse cohérente sans thème.
+
+- [ ] **Step 3 : Faire tourner la suite de tests complète, ajuster les tests cassés par le retrait des classes `.btn`**
+
+```bash
+npm run test --workspace=packages/core
+npm run test:all
+```
+
+Si `dialog.test.ts`/`dialog.browser.test.ts`/`dialog.a11y.test.ts` contiennent des assertions sur `class="btn btn-tertiary btn-ratio-square"` ou `class="btn-content sr-only"` sur le bouton close, les mettre à jour pour refléter le nouveau template (`<span class="sr-only">`, plus de classes `.btn*`).
+
+Expected: tous les tests passent (Vitest + WTR navigateur) après ajustement éventuel.
+
+- [ ] **Step 4 : Vérifier qu'aucune référence morte aux tokens/classes retirés ne subsiste**
+
+```bash
+grep -rn -- "--ar-dialog-shadow\|--ar-dialog-border-radius\|--ar-dialog-title-font-size\|--ar-dialog-close-bg\|--ar-dialog-width-sm\|--ar-dialog-width-md\|--ar-dialog-width-lg\|--ar-dialog-width-xl\|--ar-dialog-drawer-width" packages/core/src apps/docs/src
+grep -rn "btn-tertiary\|btn-ratio-square\|btn-content" packages/core/src/components/dialog
+```
+
+Expected: aucune occurrence.
+
+---
+
+### Task 11 : Revue finale de branche et ouverture de la PR
+
+**Files:** aucun nouveau fichier — revue + PR.
+
+- [ ] **Step 1 : Diff complet de la branche pour auto-revue**
+
+```bash
+git diff dev...fix/dialog-token-vs-part-129
+```
+
+Vérifier : tous les tokens supprimés du `:root` de `default.css` correspondent aux entrées `@cssprop` supprimées de `dialog.ts` ; le bloc `ar-dialog { }` reproduit exactement les valeurs d'origine ; les deux media queries `@media (min-width: 576px)` (modal + drawer) restaurent bien le comportement pré-existant au-delà du mobile ; `--ar-dialog-spacing`, `--ar-dialog-backdrop` (avec son nouveau fallback), `--ar-dialog-bg`, `--ar-dialog-color`, `--ar-dialog-shake-outline-color` sont inchangés hormis le fallback backdrop.
+
+- [ ] **Step 2 : Pousser la branche et ouvrir la PR vers `dev`**
+
+```bash
+git push -u origin fix/dialog-token-vs-part-129
+gh pr create --base dev --title "refactor(dialog): migre token vs ::part(), simplifie close, corrige 2 bugs (lot 3b, #129)" --body "$(cat <<'EOF'
+## Résumé
+
+- **2 bugs corrigés** : backdrop invisible sans thème (fallback a11y manquant), largeur non mobile-first (modal/drawer n'atteignaient jamais 100% sur petit écran — comportement par défaut désormais plein écran, contraint à partir de 576px).
+- **Bouton de fermeture entièrement repensé** : retrait de `.btn.btn-tertiary.btn-ratio-square`/`buttonStyles` (n'étaient utilisés que par ce bouton, dette confirmée — gardes `disabled`/`aria-disabled` jamais atteignables), remplacé par un `[part='close']` bespoke sur le modèle exact d'`ar-alert::part(close)` (taille tokenisée + fallback WCAG 2.5.8, focus-visible autonome). Ajout d'un `slot="close-icon"` (absent jusqu'ici, incohérent avec `ar-alert`).
+- **Migrations token → `::part()`** : `shadow`, `border-radius` (mode modal), `title-font-size`, `gap`/`padding` de `header`/`footer` (jamais tokenisés, étape 0 de l'audit).
+- **Suppression pure** (ni composant ni thème) : `font-weight`/`line-height`/`color` du `h1`, redondants avec le rendu natif du navigateur.
+- **Taxonomie `size` externalisée vers le thème**, alignée sur le découplage `variant`/`role` d'`ar-alert` (PR #143) : le composant garde une seule taille de repli par mode (500px modal/720px drawer), les paliers `sm`/`lg`/`xl` sont désormais une opinion de `default.css`. ADR-005 amendé en conséquence.
+- **Hors périmètre** (tracé séparément) : durées d'animation, cf. [issue #144](https://github.com/jogo-labs/ariane/issues/144) — nécessite le pattern « part d'état » et touche la logique JS de `_show`/`_close`/`_shake`.
+
+## Test plan
+
+- [ ] `npm run test --workspace=packages/core` vert
+- [ ] `npm run test:all` vert
+- [ ] `npm run build:manifest --workspace=packages/core` sans erreur de garde-fou
+- [ ] Vérification visuelle mobile + desktop, modal + drawer, thémé + non-thémé (aucune régression, comportement plein écran mobile correct)
+EOF
+)"
+```
+
+Expected: PR créée, lien affiché.
+
+- [ ] **Step 3 : Attendre la confirmation explicite de l'utilisateur avant tout merge**
+
+Ne pas merger sur `dev` sans confirmation explicite — règle permanente depuis l'incident PR #137.
+
+---
+
+## Self-Review
+
+**Spec coverage** :
+
+- Bug backdrop → Task 2. ✅
+- Bug mobile-first (modal + drawer) → Task 3. ✅
+- Refonte bouton close (retrait `.btn`, slot icône, simplification) → Task 4. ✅
+- Migration `border-radius` → Task 5. ✅
+- Migration `shadow` → Task 6. ✅
+- Migration `title-font-size` + suppression pure `font-weight`/`line-height`/`color` → Task 7. ✅
+- Étape 0 (gap/padding header/footer) → Task 8. ✅
+- Externalisation `size` + amendement ADR-005 → Task 9. ✅
+- Durées d'animation explicitement hors périmètre, tracées en issue #144 → mentionné dans le header du plan et le corps de PR (Task 11), aucune tâche de code. ✅
+- Vérification visuelle (mobile/desktop, thémé/non-thémé) + tests + ajustement des tests cassés par le retrait de `.btn` → Task 10. ✅
+- Branche en Task 1, PR en dernière tâche → conforme à la convention du projet. ✅
+
+**Placeholder scan** : aucun "TBD"/"implement later" — chaque step contient le code exact à écrire/retirer.
+
+**Type consistency** : les noms de tokens (`--ar-dialog-close-size`, `--ar-dialog-close-transition-duration`, `--ar-dialog-border-radius`, `--ar-dialog-shadow`, `--ar-dialog-title-font-size`, `--ar-dialog-width*`, `--ar-dialog-drawer-width*`) et le nouveau slot `close-icon` sont utilisés de façon cohérente entre toutes les tâches ; le bloc `ar-dialog { }` de `default.css` est introduit en Task 4 et complété en Tasks 5/6/7/8/9 sans redéfinition contradictoire.

--- a/packages/core/scripts/validate-no-hardcoded-tokens.js
+++ b/packages/core/scripts/validate-no-hardcoded-tokens.js
@@ -44,6 +44,18 @@ const SYSTEM_COLOR_KEYWORDS = new Set([
 // commentaire a11y-fallback.
 const STRUCTURAL_LITERAL_KEYWORDS = new Set(['0px']);
 
+// Commentaire de justification requis, sur la ligne immédiatement précédente,
+// pour autoriser une assignation littérale documentée comme repli fonctionnel
+// (pas une simple valeur de design) — même principe que le marqueur
+// a11y-fallback ci-dessous, appliqué ici côté assignation plutôt que
+// consommation. Cf. ADR-005, amendement 2026-07-29 (#129, lot 3b) :
+// `--ar-dialog-width` garde une seule valeur littérale de repli par mode
+// (`500px` modal, `720px` drawer) directement dans `dialog.styles.ts`, la
+// largeur d'un dialog étant fonctionnelle (casse le layout sans contrainte)
+// et non purement cosmétique — contrairement aux paliers nommés sm/lg/xl,
+// qui restent une opinion du thème dans `default.css`.
+const FUNCTIONAL_DEFAULT_COMMENT_RE = /^\s*\/\* functional-default: .+ \*\/\s*$/;
+
 // Un fallback qui est lui-même une référence nue à un autre token --ar-* (sans son
 // propre fallback) n'est pas une valeur de design codée en dur — c'est une cascade
 // token-à-token déjà légitime dans le modèle actuel (ex. dialog.styles.ts:174-175,
@@ -83,12 +95,17 @@ export function findHardcodedTokenAssignments(filePath, source) {
     const withoutComments = source.replace(/\/\*[\s\S]*?\*\//g, (comment) =>
         comment.replace(/[^\n]/g, ' '),
     );
+    const rawLines = source.split('\n');
 
     const errors = [];
     HARDCODED_ASSIGNMENT_RE.lastIndex = 0;
     let match;
     while ((match = HARDCODED_ASSIGNMENT_RE.exec(withoutComments)) !== null) {
         const line = withoutComments.slice(0, match.index).split('\n').length;
+
+        const precedingLine = rawLines[line - 2] ?? '';
+        if (FUNCTIONAL_DEFAULT_COMMENT_RE.test(precedingLine)) continue;
+
         errors.push(
             `${filePath}:${line} — ${match[1]} codé en dur, doit référencer un token default.css via var()`,
         );

--- a/packages/core/scripts/validate-no-hardcoded-tokens.test.js
+++ b/packages/core/scripts/validate-no-hardcoded-tokens.test.js
@@ -37,7 +37,7 @@ describe('findHardcodedTokenAssignments', () => {
     it("n'agit pas sur une référence var()", () => {
         const source = `
             :host {
-                --ar-dialog-width: var(--ar-dialog-width-md);
+                --ar-dialog-width: var(--ar-dialog-shadow);
             }
         `;
         expect(findHardcodedTokenAssignments('dialog.styles.ts', source)).toEqual([]);
@@ -47,7 +47,7 @@ describe('findHardcodedTokenAssignments', () => {
         const source = `
             /* Surchargeable par --ar-dialog-width: 500px si besoin. */
             :host {
-                --ar-dialog-width: var(--ar-dialog-width-md);
+                --ar-dialog-width: var(--ar-dialog-shadow);
             }
         `;
         expect(findHardcodedTokenAssignments('dialog.styles.ts', source)).toEqual([]);
@@ -69,6 +69,41 @@ describe('findHardcodedTokenAssignments', () => {
             }
         `;
         expect(findHardcodedTokenAssignments('dialog.styles.ts', source)).toHaveLength(2);
+    });
+
+    it('accepte une assignation littérale précédée du commentaire functional-default correctement formé', () => {
+        const source = [
+            ':host {',
+            '    /* functional-default: largeur non contrainte casserait le layout sans thème */',
+            '    --ar-dialog-width: 500px;',
+            '}',
+        ].join('\n');
+        expect(findHardcodedTokenAssignments('dialog.styles.ts', source)).toEqual([]);
+    });
+
+    it('rejette une assignation littérale dont le commentaire est hors format (espace au lieu du deux-points)', () => {
+        const source = [
+            ':host {',
+            '    /* functional default: largeur non contrainte casserait le layout sans thème */',
+            '    --ar-dialog-width: 500px;',
+            '}',
+        ].join('\n');
+        const errors = findHardcodedTokenAssignments('dialog.styles.ts', source);
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('--ar-dialog-width');
+    });
+
+    it("rejette une assignation littérale dont le commentaire n'est pas sur la ligne immédiatement précédente", () => {
+        const source = [
+            ':host {',
+            '    /* functional-default: largeur non contrainte casserait le layout sans thème */',
+            '',
+            '    --ar-dialog-width: 500px;',
+            '}',
+        ].join('\n');
+        const errors = findHardcodedTokenAssignments('dialog.styles.ts', source);
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('--ar-dialog-width');
     });
 });
 

--- a/packages/core/src/components/dialog/dialog.styles.ts
+++ b/packages/core/src/components/dialog/dialog.styles.ts
@@ -168,11 +168,25 @@ export default [
             color: inherit;
         }
 
-        button {
-            flex-shrink: 0;
+        [part='close'] {
+            display: flex;
+            align-items: center;
+            justify-content: center;
             align-self: flex-start;
-            /* @EvolutionDesign: taille forcée à 40×40 en attendant la migration vers la nouvelle charte */
-            min-height: 2.5rem;
+            flex-shrink: 0;
+            /* a11y-fallback: WCAG 2.5.8 (Target Size Minimum) — sans thème chargé, le bouton perdrait sa taille de cible tactile */
+            width: var(--ar-dialog-close-size, 2.5rem);
+            /* a11y-fallback: WCAG 2.5.8 (Target Size Minimum) — sans thème chargé, le bouton perdrait sa taille de cible tactile */
+            height: var(--ar-dialog-close-size, 2.5rem);
+            padding: 0;
+            border: none;
+            cursor: pointer;
+            transition: background-color var(--ar-dialog-close-transition-duration);
+        }
+
+        [part='close']:focus-visible {
+            outline: 2px solid currentColor;
+            outline-offset: 2px;
         }
 
         svg {
@@ -203,29 +217,6 @@ export default [
             flex-shrink: 0;
         }
 
-        /* ── Bouton de fermeture (tokens scopés au composant) ────────────────────
-         * Sélecteurs volontairement plus spécifiques que .btn-tertiary dans
-         * button.styles.ts (ajout de [part='close'].btn) pour gagner la cascade
-         * indépendamment de l'ordre des styles. */
-
-        [part='close'].btn.btn-tertiary {
-            background-color: var(--ar-dialog-close-bg);
-        }
-
-        [part='close'].btn.btn-tertiary:hover {
-            background-color: var(--ar-dialog-close-bg-hover);
-        }
-
-        [part='close'].btn.btn-tertiary:not(:disabled):not(.disabled):not(
-                [aria-disabled='true']
-            ):active {
-            background-color: var(--ar-dialog-close-bg-pressed);
-        }
-
-        [part='close'].btn.btn-tertiary:focus {
-            background-color: var(--ar-dialog-close-bg-focus);
-        }
-
         /* ── Shake (fermeture bloquée) ────────────────────────────────────────── */
 
         dialog.shake {
@@ -236,7 +227,8 @@ export default [
 
         @media (prefers-reduced-motion: reduce) {
             dialog,
-            dialog::backdrop {
+            dialog::backdrop,
+            [part='close'] {
                 animation: none !important;
                 transition: none !important;
             }

--- a/packages/core/src/components/dialog/dialog.styles.ts
+++ b/packages/core/src/components/dialog/dialog.styles.ts
@@ -54,8 +54,12 @@ export default [
             overflow: hidden;
             background: var(--ar-dialog-bg, Canvas);
             color: var(--ar-dialog-color, CanvasText);
-            /* Mobile-first : plein écran par défaut, commun aux deux modes. */
-            width: 100vw;
+            /* Mobile-first : plein écran par défaut, commun aux deux modes. 100% (pas
+               100vw) pour résoudre contre le containing block du <dialog> plutôt que le
+               viewport brut — évite un débordement horizontal de la largeur de la
+               gouttière de scrollbar sur les plateformes où elle occupe un espace de
+               layout. */
+            width: 100%;
         }
 
         /* ── Modal ────────────────────────────────────────────────────────────── */
@@ -94,7 +98,10 @@ export default [
 
         @media (min-width: 576px) {
             :host([mode='drawer']) dialog {
-                width: min(var(--ar-dialog-width), 100vw);
+                /* 100% (pas 100vw) : même raison que la largeur mobile-first ci-dessus —
+                   évite de dépasser la largeur visible sur les plateformes où la
+                   scrollbar occupe un espace de layout. */
+                width: min(var(--ar-dialog-width), 100%);
             }
         }
 

--- a/packages/core/src/components/dialog/dialog.styles.ts
+++ b/packages/core/src/components/dialog/dialog.styles.ts
@@ -153,8 +153,6 @@ export default [
             display: flex;
             align-items: center;
             justify-content: space-between;
-            gap: 0.75rem;
-            padding: 1.25rem 1.25rem 0;
             flex-shrink: 0;
         }
 
@@ -206,8 +204,6 @@ export default [
             align-items: center;
             justify-content: flex-end;
             flex-wrap: wrap;
-            gap: 0.75rem;
-            padding: 0 1.25rem 1.25rem;
             flex-shrink: 0;
         }
 

--- a/packages/core/src/components/dialog/dialog.styles.ts
+++ b/packages/core/src/components/dialog/dialog.styles.ts
@@ -54,33 +54,22 @@ export default [
             overflow: hidden;
             background: var(--ar-dialog-bg, Canvas);
             color: var(--ar-dialog-color, CanvasText);
-            /* Mobile-first : plein écran par défaut, commun aux deux modes. 100% (pas
-               100vw) pour résoudre contre le containing block du <dialog> plutôt que le
-               viewport brut — évite un débordement horizontal de la largeur de la
-               gouttière de scrollbar sur les plateformes où elle occupe un espace de
-               layout. */
-            width: 100%;
             /* max-width: override le défaut UA qui plafonne à calc(100% - 6px - 2em) —
-               même raison que l'override de max-height plus bas, sinon la largeur
-               plein écran ci-dessus reste invisiblement bridée par ce défaut natif. */
+               même raison que l'override de max-height plus bas. Posé ici (commun aux deux
+               modes) car chaque mode a sa propre logique de width ci-dessous, mais tous
+               deux ont besoin de désactiver ce plafond natif pour que leur propre valeur
+               s'applique sans interférence. */
             max-width: 100%;
         }
 
         /* ── Modal ────────────────────────────────────────────────────────────── */
 
         :host(:not([mode='drawer'])) dialog {
-            max-height: 100dvh;
-        }
-
-        @media (min-width: 576px) {
-            :host(:not([mode='drawer'])) dialog {
-                /* max-width artificiel : au-delà du mobile, la modale ne prend jamais toute la
-                   largeur — utile pour les paliers lg/xl sur les viewports moyens (tablette
-                   portrait, fenêtre desktop réduite) où le token de taille dépasse le viewport ;
-                   sans effet pratique sur sm/md, déjà plus étroits que calc(100vw - 2rem) à 576px. */
-                width: min(var(--ar-dialog-width), calc(100vw - 2rem));
-                max-height: min(90vh, calc(100dvh - 2rem));
-            }
+            /* Marge latérale conservée à toutes les tailles d'écran, y compris mobile :
+               un modal flotte au centre de la page (contrairement au drawer, ancré à un
+               bord) — un plein écran collé aux bords rend mal visuellement dans ce cas. */
+            width: min(var(--ar-dialog-width), calc(100vw - 2rem));
+            max-height: min(90vh, calc(100dvh - 2rem));
         }
 
         :host(:not([mode='drawer'])) dialog.opening {
@@ -94,6 +83,10 @@ export default [
         /* ── Drawer ───────────────────────────────────────────────────────────── */
 
         :host([mode='drawer']) dialog {
+            /* Mobile-first : plein écran par défaut. Contrairement au modal, le drawer est
+               ancré à un bord de l'écran — le plein écran reste cohérent visuellement, pas
+               besoin d'y conserver de marge latérale. */
+            width: 100%;
             height: 100dvh;
             /* max-height: override le défaut UA qui plafonne à calc(100% - 6px - 2em) */
             max-height: 100dvh;

--- a/packages/core/src/components/dialog/dialog.styles.ts
+++ b/packages/core/src/components/dialog/dialog.styles.ts
@@ -160,10 +160,6 @@ export default [
 
         h1 {
             margin: 0;
-            font-size: var(--ar-dialog-title-font-size);
-            font-weight: 600;
-            line-height: 1.4;
-            color: inherit;
         }
 
         [part='close'] {

--- a/packages/core/src/components/dialog/dialog.styles.ts
+++ b/packages/core/src/components/dialog/dialog.styles.ts
@@ -78,15 +78,26 @@ export default [
             background: var(--ar-dialog-bg, Canvas);
             color: var(--ar-dialog-color, CanvasText);
             box-shadow: var(--ar-dialog-shadow);
+            /* Mobile-first : plein écran par défaut, commun aux deux modes. */
+            width: 100vw;
         }
 
         /* ── Modal ────────────────────────────────────────────────────────────── */
 
         :host(:not([mode='drawer'])) dialog {
             border-radius: var(--ar-dialog-border-radius);
-            /* max-width artificiel : la modale ne prend jamais toute la largeur même sur mobile */
-            width: min(var(--ar-dialog-width), calc(100vw - 2rem));
-            max-height: min(90vh, calc(100dvh - 2rem));
+            max-height: 100dvh;
+        }
+
+        @media (min-width: 576px) {
+            :host(:not([mode='drawer'])) dialog {
+                /* max-width artificiel : au-delà du mobile, la modale ne prend jamais toute la
+                   largeur — utile pour les paliers lg/xl sur les viewports moyens (tablette
+                   portrait, fenêtre desktop réduite) où le token de taille dépasse le viewport ;
+                   sans effet pratique sur sm/md, déjà plus étroits que calc(100vw - 2rem) à 576px. */
+                width: min(var(--ar-dialog-width), calc(100vw - 2rem));
+                max-height: min(90vh, calc(100dvh - 2rem));
+            }
         }
 
         :host(:not([mode='drawer'])) dialog.opening {
@@ -100,12 +111,16 @@ export default [
         /* ── Drawer ───────────────────────────────────────────────────────────── */
 
         :host([mode='drawer']) dialog {
-            /* Sur petit écran, le drawer peut occuper 100% de la largeur */
-            width: min(var(--ar-dialog-width), 100vw);
             height: 100dvh;
             /* max-height: override le défaut UA qui plafonne à calc(100% - 6px - 2em) */
             max-height: 100dvh;
             margin: 0;
+        }
+
+        @media (min-width: 576px) {
+            :host([mode='drawer']) dialog {
+                width: min(var(--ar-dialog-width), 100vw);
+            }
         }
 
         /* Placement droite (défaut du composant) */

--- a/packages/core/src/components/dialog/dialog.styles.ts
+++ b/packages/core/src/components/dialog/dialog.styles.ts
@@ -47,7 +47,8 @@ export default [
         /* ── Backdrop ─────────────────────────────────────────────────────────── */
 
         dialog::backdrop {
-            background: var(--ar-dialog-backdrop);
+            /* a11y-fallback: sans thème chargé, le backdrop serait transparent (défaut UA de ::backdrop) — perte de l'indication visuelle de modalité */
+            background: var(--ar-dialog-backdrop, rgba(0, 0, 0, 0.5));
             opacity: 0;
             transition: opacity 0.25s ease;
         }

--- a/packages/core/src/components/dialog/dialog.styles.ts
+++ b/packages/core/src/components/dialog/dialog.styles.ts
@@ -85,7 +85,6 @@ export default [
         /* ── Modal ────────────────────────────────────────────────────────────── */
 
         :host(:not([mode='drawer'])) dialog {
-            border-radius: var(--ar-dialog-border-radius);
             max-height: 100dvh;
         }
 

--- a/packages/core/src/components/dialog/dialog.styles.ts
+++ b/packages/core/src/components/dialog/dialog.styles.ts
@@ -83,23 +83,16 @@ export default [
         /* ── Drawer ───────────────────────────────────────────────────────────── */
 
         :host([mode='drawer']) dialog {
-            /* Mobile-first : plein écran par défaut. Contrairement au modal, le drawer est
-               ancré à un bord de l'écran — le plein écran reste cohérent visuellement, pas
-               besoin d'y conserver de marge latérale. */
-            width: 100%;
+            /* min() encode nativement le mobile-first, sans media query : quand
+               --ar-dialog-width dépasse 100% (petit écran), le drawer occupe toute la
+               largeur (ancré à un bord, le plein écran y reste cohérent contrairement au
+               modal) ; au-delà, il est contraint à sa taille de palier. Le calcul est
+               déjà continu et réactif au redimensionnement, pas besoin de palier fixe. */
+            width: min(var(--ar-dialog-width), 100%);
             height: 100dvh;
             /* max-height: override le défaut UA qui plafonne à calc(100% - 6px - 2em) */
             max-height: 100dvh;
             margin: 0;
-        }
-
-        @media (min-width: 576px) {
-            :host([mode='drawer']) dialog {
-                /* 100% (pas 100vw) : même raison que la largeur mobile-first ci-dessus —
-                   évite de dépasser la largeur visible sur les plateformes où la
-                   scrollbar occupe un espace de layout. */
-                width: min(var(--ar-dialog-width), 100%);
-            }
         }
 
         /* Placement droite (défaut du composant) */

--- a/packages/core/src/components/dialog/dialog.styles.ts
+++ b/packages/core/src/components/dialog/dialog.styles.ts
@@ -9,39 +9,16 @@ export default [
         :host {
             display: block;
 
-            /* Taille modale par défaut (md). Surchargeable par --ar-dialog-width sur l'instance. */
-            --ar-dialog-width: var(--ar-dialog-width-md);
+            /* Taille par défaut (repli fonctionnel sans thème) — les paliers sm/lg/xl sont
+               une taxonomie fournie par default.css, pas une exigence du composant. */
+            /* functional-default: largeur modale non contrainte casserait le layout sans thème (ADR-005, amendement 2026-07-29) */
+            --ar-dialog-width: 500px;
         }
 
-        /* Tailles modal */
-        :host([size='sm']) {
-            --ar-dialog-width: var(--ar-dialog-width-sm);
-        }
-        :host([size='md']) {
-            --ar-dialog-width: var(--ar-dialog-width-md);
-        }
-        :host([size='lg']) {
-            --ar-dialog-width: var(--ar-dialog-width-lg);
-        }
-        :host([size='xl']) {
-            --ar-dialog-width: var(--ar-dialog-width-xl);
-        }
-
-        /* Tailles drawer — ont priorité sur les valeurs modal via la spécificité */
+        /* Taille par défaut du drawer — a priorité sur la valeur modal via la spécificité */
         :host([mode='drawer']) {
-            --ar-dialog-width: var(--ar-dialog-drawer-width-md);
-        }
-        :host([mode='drawer'][size='sm']) {
-            --ar-dialog-width: var(--ar-dialog-drawer-width-sm);
-        }
-        :host([mode='drawer'][size='md']) {
-            --ar-dialog-width: var(--ar-dialog-drawer-width-md);
-        }
-        :host([mode='drawer'][size='lg']) {
-            --ar-dialog-width: var(--ar-dialog-drawer-width-lg);
-        }
-        :host([mode='drawer'][size='xl']) {
-            --ar-dialog-width: var(--ar-dialog-drawer-width-xl);
+            /* functional-default: largeur drawer non contrainte casserait le layout sans thème (ADR-005, amendement 2026-07-29) */
+            --ar-dialog-width: 720px;
         }
 
         /* ── Backdrop ─────────────────────────────────────────────────────────── */

--- a/packages/core/src/components/dialog/dialog.styles.ts
+++ b/packages/core/src/components/dialog/dialog.styles.ts
@@ -60,6 +60,10 @@ export default [
                gouttière de scrollbar sur les plateformes où elle occupe un espace de
                layout. */
             width: 100%;
+            /* max-width: override le défaut UA qui plafonne à calc(100% - 6px - 2em) —
+               même raison que l'override de max-height plus bas, sinon la largeur
+               plein écran ci-dessus reste invisiblement bridée par ce défaut natif. */
+            max-width: 100%;
         }
 
         /* ── Modal ────────────────────────────────────────────────────────────── */

--- a/packages/core/src/components/dialog/dialog.styles.ts
+++ b/packages/core/src/components/dialog/dialog.styles.ts
@@ -77,7 +77,6 @@ export default [
             overflow: hidden;
             background: var(--ar-dialog-bg, Canvas);
             color: var(--ar-dialog-color, CanvasText);
-            box-shadow: var(--ar-dialog-shadow);
             /* Mobile-first : plein écran par défaut, commun aux deux modes. */
             width: 100vw;
         }

--- a/packages/core/src/components/dialog/dialog.test.ts
+++ b/packages/core/src/components/dialog/dialog.test.ts
@@ -623,13 +623,28 @@ describe('ArDialog', () => {
             presetStyle?.remove();
         });
 
-        it('la sélection de taille pilote --ar-dialog-width', async () => {
-            // happy-dom ne charge pas default.css : on simule les tokens de préréglage
-            // que le thème fournit normalement, pour vérifier que la résolution en
-            // cascade fonctionne réellement (et pas seulement que la chaîne var()
-            // est présente dans le CSS du composant).
+        it('sans thème, --ar-dialog-width vaut le repli littéral du composant (500px, mode modal)', async () => {
+            el = await fixture('<ar-dialog size="sm"></ar-dialog>');
+
+            // La taxonomie sm/lg/xl est désormais une opinion du thème (default.css) —
+            // sans thème chargé, size="sm" n'a plus d'effet, seul le repli littéral du
+            // composant s'applique (cf. ADR-005, amendement 2026-07-29, #129 lot 3b).
+            expect(getComputedStyle(el).getPropertyValue('--ar-dialog-width').trim()).toBe('500px');
+        });
+
+        it('sans thème, le mode drawer pilote --ar-dialog-width vers son propre repli littéral (720px)', async () => {
+            el = await fixture('<ar-dialog mode="drawer" size="sm"></ar-dialog>');
+
+            expect(getComputedStyle(el).getPropertyValue('--ar-dialog-width').trim()).toBe('720px');
+        });
+
+        it('quand le thème fournit la taxonomie de taille, la règle externe pilote --ar-dialog-width', async () => {
+            // happy-dom ne charge pas default.css : on simule la règle d'attribut que
+            // le thème fournit normalement dans le bloc ar-dialog { &[size='sm'] { ... } },
+            // pour vérifier que la cascade externe l'emporte réellement (et pas
+            // seulement que le composant expose --ar-dialog-width).
             presetStyle = document.createElement('style');
-            presetStyle.textContent = ':root { --ar-dialog-width-sm: 360px; }';
+            presetStyle.textContent = "ar-dialog[size='sm'] { --ar-dialog-width: 360px; }";
             document.head.appendChild(presetStyle);
 
             el = await fixture('<ar-dialog size="sm"></ar-dialog>');
@@ -637,9 +652,10 @@ describe('ArDialog', () => {
             expect(getComputedStyle(el).getPropertyValue('--ar-dialog-width').trim()).toBe('360px');
         });
 
-        it('le mode drawer pilote --ar-dialog-width via son propre préréglage', async () => {
+        it('quand le thème fournit la taxonomie de taille du drawer, la règle externe pilote --ar-dialog-width', async () => {
             presetStyle = document.createElement('style');
-            presetStyle.textContent = ':root { --ar-dialog-drawer-width-sm: 280px; }';
+            presetStyle.textContent =
+                "ar-dialog[mode='drawer'][size='sm'] { --ar-dialog-width: 280px; }";
             document.head.appendChild(presetStyle);
 
             el = await fixture('<ar-dialog mode="drawer" size="sm"></ar-dialog>');

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -62,7 +62,7 @@ if (typeof document !== 'undefined') {
  * @csspart body - La zone de contenu principale.
  * @csspart footer - La zone d'actions (absente du DOM si slot non utilisé).
  *
- * @cssprop --ar-dialog-width - Largeur du dialog. Prend le pas sur les tailles prédéfinies.
+ * @cssprop --ar-dialog-width - Largeur du dialog. Prend le pas sur les tailles prédéfinies pour une règle au moins aussi spécifique que `[size='...']` (ex. `ar-dialog[size='sm']`) — un simple `ar-dialog { }` est moins spécifique et perd face au preset de thème quand `size` est défini.
  * @cssprop --ar-dialog-spacing - Padding interne (block et inline) de la zone de contenu.
  * @cssprop --ar-dialog-spacing-block - Padding haut/bas. Prend le pas sur `--ar-dialog-spacing` si défini.
  * @cssprop --ar-dialog-spacing-inline - Padding gauche/droite. Prend le pas sur `--ar-dialog-spacing` si défini.
@@ -135,7 +135,9 @@ export class ArDialog extends LitElement {
     /**
      * Taille du dialog. Les paliers `sm`/`lg`/`xl` sont définis par le thème —
      * sans thème chargé, seule la taille par défaut du composant s'applique.
-     * Utilisez `--ar-dialog-width` pour une valeur personnalisée, indépendamment du thème.
+     * Utilisez `--ar-dialog-width` pour une valeur personnalisée. Un `ar-dialog { }` non qualifié
+     * doit néanmoins être au moins aussi spécifique que `[size='...']` (ou utiliser `!important`,
+     * ou omettre `size`) pour l'emporter de façon fiable sur un palier de thème.
      *
      * @attr size
      * @default 'md'

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -80,7 +80,6 @@ if (typeof document !== 'undefined') {
  * @cssprop --ar-dialog-close-transition-duration - Durée de la transition (background-color) du bouton de fermeture au survol.
  * @cssprop --ar-dialog-bg - Fond du dialog (cascade vers --ar-color-bg). Repli `Canvas` si aucun thème n'est chargé — sans thème et sans bordure (le dialog natif perd son style UA par défaut), le contenu flotte sinon sans surface visible.
  * @cssprop --ar-dialog-color - Couleur du texte du dialog (cascade vers --ar-color-text). Repli `CanvasText` si aucun thème n'est chargé.
- * @cssprop --ar-dialog-border-radius - Border-radius du dialog en mode modal (non-drawer) (cascade vers --ar-border-radius-lg).
  * @cssprop --ar-dialog-title-font-size - Taille de police du titre (h1) (cascade vers --ar-font-size-md).
  * @cssprop --ar-dialog-shake-outline-color - Couleur de l'anneau de mise en évidence (`outline`) affiché à la place du shake en `prefers-reduced-motion: reduce` (cascade vers --ar-color-danger-text).
  *

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -9,7 +9,6 @@ import {
 import { property, query, state } from 'lit/decorators.js';
 import utilitiesStyles from '../../styles/utilities.styles.js';
 import resetStyles from '../../styles/components/reset.styles.js';
-import buttonStyles from '../../styles/components/button.styles.js';
 import styles from './dialog.styles.js';
 import { announceA11y } from '../../a11y/announce-a11y.js';
 import { HasSlotController } from '../../controllers/has-slot.controller.js';
@@ -54,6 +53,7 @@ if (typeof document !== 'undefined') {
  * @slot label - Titre du dialog. Remplace la propriété `label` si du HTML est nécessaire.
  * @slot - Contenu principal du dialog.
  * @slot footer - Actions du dialog (boutons). Absent du DOM si non fourni.
+ * @slot close-icon - Icône du bouton de fermeture. Remplace le SVG "×" par défaut.
  *
  * @csspart dialog - L'élément <dialog> racine.
  * @csspart header - L'en-tête contenant le titre et le bouton de fermeture.
@@ -76,10 +76,8 @@ if (typeof document !== 'undefined') {
  * @cssprop --ar-dialog-spacing-inline - Padding gauche/droite. Prend le pas sur `--ar-dialog-spacing` si défini.
  * @cssprop --ar-dialog-shadow - Ombre portée du dialog.
  * @cssprop --ar-dialog-backdrop - Couleur de fond du voile derrière le dialog (mode modal).
- * @cssprop --ar-dialog-close-bg - Fond du bouton de fermeture.
- * @cssprop --ar-dialog-close-bg-hover - Fond du bouton de fermeture au survol.
- * @cssprop --ar-dialog-close-bg-pressed - Fond du bouton de fermeture pressé.
- * @cssprop --ar-dialog-close-bg-focus - Fond du bouton de fermeture au focus.
+ * @cssprop --ar-dialog-close-size - Taille (width/height) du bouton de fermeture.
+ * @cssprop --ar-dialog-close-transition-duration - Durée de la transition (background-color) du bouton de fermeture au survol.
  * @cssprop --ar-dialog-bg - Fond du dialog (cascade vers --ar-color-bg). Repli `Canvas` si aucun thème n'est chargé — sans thème et sans bordure (le dialog natif perd son style UA par défaut), le contenu flotte sinon sans surface visible.
  * @cssprop --ar-dialog-color - Couleur du texte du dialog (cascade vers --ar-color-text). Repli `CanvasText` si aucun thème n'est chargé.
  * @cssprop --ar-dialog-border-radius - Border-radius du dialog en mode modal (non-drawer) (cascade vers --ar-border-radius-lg).
@@ -98,7 +96,7 @@ if (typeof document !== 'undefined') {
  * @event {CustomEvent} ar-dialog-accepted-prevented - Émis si ar-dialog-accepted est annulé.
  */
 export class ArDialog extends LitElement {
-    static override styles: CSSResultGroup = [utilitiesStyles, resetStyles, buttonStyles, styles];
+    static override styles: CSSResultGroup = [utilitiesStyles, resetStyles, styles];
 
     // ── Public properties ──────────────────────────────────────────────────────
 
@@ -264,26 +262,23 @@ export class ArDialog extends LitElement {
                             ? html`<slot name="label"></slot>`
                             : headingLabel}
                     </h1>
-                    <button
-                        part="close"
-                        type="button"
-                        class="btn btn-tertiary btn-ratio-square"
-                        data-ar-dismiss
-                    >
-                        <svg
-                            aria-hidden="true"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke-width="1.5"
-                            stroke="currentColor"
-                        >
-                            <path
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                d="M6 18 18 6M6 6l12 12"
-                            ></path>
-                        </svg>
-                        <span class="btn-content sr-only">${this.closeLabel}</span>
+                    <button part="close" type="button" data-ar-dismiss>
+                        <slot name="close-icon">
+                            <svg
+                                aria-hidden="true"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke-width="1.5"
+                                stroke="currentColor"
+                            >
+                                <path
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    d="M6 18 18 6M6 6l12 12"
+                                ></path>
+                            </svg>
+                        </slot>
+                        <span class="sr-only">${this.closeLabel}</span>
                     </button>
                 </header>
                 <div part="body" id="dialog-body">

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -63,14 +63,6 @@ if (typeof document !== 'undefined') {
  * @csspart footer - La zone d'actions (absente du DOM si slot non utilisé).
  *
  * @cssprop --ar-dialog-width - Largeur du dialog. Prend le pas sur les tailles prédéfinies.
- * @cssprop --ar-dialog-width-sm - Largeur du dialog modal, taille `sm`.
- * @cssprop --ar-dialog-width-md - Largeur du dialog modal, taille `md`.
- * @cssprop --ar-dialog-width-lg - Largeur du dialog modal, taille `lg`.
- * @cssprop --ar-dialog-width-xl - Largeur du dialog modal, taille `xl`.
- * @cssprop --ar-dialog-drawer-width-sm - Largeur du drawer, taille `sm`.
- * @cssprop --ar-dialog-drawer-width-md - Largeur du drawer, taille `md`.
- * @cssprop --ar-dialog-drawer-width-lg - Largeur du drawer, taille `lg`.
- * @cssprop --ar-dialog-drawer-width-xl - Largeur du drawer, taille `xl`.
  * @cssprop --ar-dialog-spacing - Padding interne (block et inline) de la zone de contenu.
  * @cssprop --ar-dialog-spacing-block - Padding haut/bas. Prend le pas sur `--ar-dialog-spacing` si défini.
  * @cssprop --ar-dialog-spacing-inline - Padding gauche/droite. Prend le pas sur `--ar-dialog-spacing` si défini.
@@ -141,8 +133,9 @@ export class ArDialog extends LitElement {
     placement: 'left' | 'right' = 'right';
 
     /**
-     * Taille du dialog. Les valeurs correspondent à des largeurs CSS prédéfinies.
-     * Utilisez `--ar-dialog-width` pour une valeur personnalisée.
+     * Taille du dialog. Les paliers `sm`/`lg`/`xl` sont définis par le thème —
+     * sans thème chargé, seule la taille par défaut du composant s'applique.
+     * Utilisez `--ar-dialog-width` pour une valeur personnalisée, indépendamment du thème.
      *
      * @attr size
      * @default 'md'

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -79,7 +79,6 @@ if (typeof document !== 'undefined') {
  * @cssprop --ar-dialog-close-transition-duration - Durée de la transition (background-color) du bouton de fermeture au survol.
  * @cssprop --ar-dialog-bg - Fond du dialog (cascade vers --ar-color-bg). Repli `Canvas` si aucun thème n'est chargé — sans thème et sans bordure (le dialog natif perd son style UA par défaut), le contenu flotte sinon sans surface visible.
  * @cssprop --ar-dialog-color - Couleur du texte du dialog (cascade vers --ar-color-text). Repli `CanvasText` si aucun thème n'est chargé.
- * @cssprop --ar-dialog-title-font-size - Taille de police du titre (h1) (cascade vers --ar-font-size-md).
  * @cssprop --ar-dialog-shake-outline-color - Couleur de l'anneau de mise en évidence (`outline`) affiché à la place du shake en `prefers-reduced-motion: reduce` (cascade vers --ar-color-danger-text).
  *
  * @event {CustomEvent} ar-dialog-show - Émis avant l'ouverture. @cancelable

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -74,7 +74,6 @@ if (typeof document !== 'undefined') {
  * @cssprop --ar-dialog-spacing - Padding interne (block et inline) de la zone de contenu.
  * @cssprop --ar-dialog-spacing-block - Padding haut/bas. Prend le pas sur `--ar-dialog-spacing` si défini.
  * @cssprop --ar-dialog-spacing-inline - Padding gauche/droite. Prend le pas sur `--ar-dialog-spacing` si défini.
- * @cssprop --ar-dialog-shadow - Ombre portée du dialog.
  * @cssprop --ar-dialog-backdrop - Couleur de fond du voile derrière le dialog (mode modal).
  * @cssprop --ar-dialog-close-size - Taille (width/height) du bouton de fermeture.
  * @cssprop --ar-dialog-close-transition-duration - Durée de la transition (background-color) du bouton de fermeture au survol.

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -475,10 +475,8 @@
         --ar-dialog-backdrop: rgba(0, 0, 0, 0.5);
         --ar-dialog-bg: var(--ar-color-bg);
         --ar-dialog-color: var(--ar-color-text);
-        --ar-dialog-close-bg: var(--ar-button-tertiary-bg);
-        --ar-dialog-close-bg-hover: var(--ar-button-tertiary-bg-hover);
-        --ar-dialog-close-bg-pressed: var(--ar-button-tertiary-bg-active);
-        --ar-dialog-close-bg-focus: var(--ar-button-tertiary-bg-focus);
+        --ar-dialog-close-size: 2.5rem;
+        --ar-dialog-close-transition-duration: var(--ar-button-transition-duration);
         --ar-dialog-border-radius: var(--ar-border-radius-lg);
         --ar-dialog-title-font-size: var(--ar-font-size-md);
         --ar-dialog-shake-outline-color: var(--ar-color-danger-text);
@@ -1004,6 +1002,17 @@
             --ar-alert-bg: var(--ar-color-success-bg);
             --ar-alert-border: var(--ar-color-success-border);
             --ar-alert-icon: var(--ar-color-success-text);
+        }
+    }
+
+    ar-dialog {
+        &::part(close) {
+            color: currentColor;
+            background-color: color-mix(in srgb, currentColor 8%, transparent);
+        }
+
+        &::part(close):hover {
+            background-color: color-mix(in srgb, currentColor 20%, transparent);
         }
     }
 }

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -457,14 +457,6 @@
         /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
          * Dialog
          * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
-        --ar-dialog-width-sm: 360px;
-        --ar-dialog-width-md: 500px;
-        --ar-dialog-width-lg: 800px;
-        --ar-dialog-width-xl: 1140px;
-        --ar-dialog-drawer-width-sm: 360px;
-        --ar-dialog-drawer-width-md: 720px;
-        --ar-dialog-drawer-width-lg: 960px;
-        --ar-dialog-drawer-width-xl: 1440px;
         --ar-dialog-spacing: 1.25rem;
         /* --ar-dialog-spacing-block / --ar-dialog-spacing-inline : points d'extension
            optionnels, consommés avec fallback dans dialog.styles.ts (padding-block/-inline
@@ -1034,6 +1026,26 @@
         &::part(footer) {
             gap: 0.75rem;
             padding: 0 1.25rem 1.25rem;
+        }
+
+        &[size='sm'] {
+            --ar-dialog-width: 360px;
+        }
+        &[size='lg'] {
+            --ar-dialog-width: 800px;
+        }
+        &[size='xl'] {
+            --ar-dialog-width: 1140px;
+        }
+
+        &[mode='drawer'][size='sm'] {
+            --ar-dialog-width: 360px;
+        }
+        &[mode='drawer'][size='lg'] {
+            --ar-dialog-width: 960px;
+        }
+        &[mode='drawer'][size='xl'] {
+            --ar-dialog-width: 1440px;
         }
     }
 }

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -476,7 +476,6 @@
         --ar-dialog-color: var(--ar-color-text);
         --ar-dialog-close-size: 2.5rem;
         --ar-dialog-close-transition-duration: var(--ar-button-transition-duration);
-        --ar-dialog-title-font-size: var(--ar-font-size-md);
         --ar-dialog-shake-outline-color: var(--ar-color-danger-text);
 
         /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -1021,6 +1020,10 @@
 
         &::part(close):hover {
             background-color: color-mix(in srgb, currentColor 20%, transparent);
+        }
+
+        &::part(title) {
+            font-size: var(--ar-font-size-md);
         }
     }
 }

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -471,7 +471,6 @@
            de [part='body']). Volontairement non déclarés ici — --ar-dialog-spacing suffit
            par défaut ; les définir permet de différencier le padding vertical/horizontal
            sans surcharge globale de --ar-dialog-spacing. */
-        --ar-dialog-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 20px 50px -8px rgba(0, 0, 0, 0.2);
         --ar-dialog-backdrop: rgba(0, 0, 0, 0.5);
         --ar-dialog-bg: var(--ar-color-bg);
         --ar-dialog-color: var(--ar-color-text);
@@ -1007,6 +1006,12 @@
     ar-dialog {
         &:not([mode='drawer'])::part(dialog) {
             border-radius: var(--ar-border-radius-lg);
+        }
+
+        &::part(dialog) {
+            box-shadow:
+                0 4px 6px -1px rgba(0, 0, 0, 0.1),
+                0 20px 50px -8px rgba(0, 0, 0, 0.2);
         }
 
         &::part(close) {

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -1006,6 +1006,7 @@
         }
 
         &::part(close) {
+            border-radius: 7px;
             color: currentColor;
             background-color: color-mix(in srgb, currentColor 8%, transparent);
         }

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -477,7 +477,6 @@
         --ar-dialog-color: var(--ar-color-text);
         --ar-dialog-close-size: 2.5rem;
         --ar-dialog-close-transition-duration: var(--ar-button-transition-duration);
-        --ar-dialog-border-radius: var(--ar-border-radius-lg);
         --ar-dialog-title-font-size: var(--ar-font-size-md);
         --ar-dialog-shake-outline-color: var(--ar-color-danger-text);
 
@@ -1006,6 +1005,10 @@
     }
 
     ar-dialog {
+        &:not([mode='drawer'])::part(dialog) {
+            border-radius: var(--ar-border-radius-lg);
+        }
+
         &::part(close) {
             color: currentColor;
             background-color: color-mix(in srgb, currentColor 8%, transparent);

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -1025,5 +1025,15 @@
         &::part(title) {
             font-size: var(--ar-font-size-md);
         }
+
+        &::part(header) {
+            gap: 0.75rem;
+            padding: 1.25rem 1.25rem 0;
+        }
+
+        &::part(footer) {
+            gap: 0.75rem;
+            padding: 0 1.25rem 1.25rem;
+        }
     }
 }

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -995,14 +995,14 @@
     }
 
     ar-dialog {
-        &:not([mode='drawer'])::part(dialog) {
-            border-radius: var(--ar-border-radius-lg);
-        }
-
         &::part(dialog) {
             box-shadow:
                 0 4px 6px -1px rgba(0, 0, 0, 0.1),
                 0 20px 50px -8px rgba(0, 0, 0, 0.2);
+        }
+
+        &:not([mode='drawer'])::part(dialog) {
+            border-radius: var(--ar-border-radius-lg);
         }
 
         &::part(close) {

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -942,7 +942,7 @@
 
         /* Customisation */
         &::part(close) {
-            border-radius: 7px;
+            border-radius: var(--ar-border-radius-md);
             color: currentColor;
             background-color: color-mix(in srgb, currentColor 8%, transparent);
             opacity: 0.75;
@@ -1006,7 +1006,7 @@
         }
 
         &::part(close) {
-            border-radius: 7px;
+            border-radius: var(--ar-border-radius-md);
             color: currentColor;
             background-color: color-mix(in srgb, currentColor 8%, transparent);
         }


### PR DESCRIPTION
## Résumé

- **3 bugs corrigés** : backdrop invisible sans thème (fallback a11y manquant), largeur non mobile-first (drawer n'atteignait jamais 100% sur petit écran — silencieusement bridé par le `max-width` UA natif du `<dialog>`, jamais neutralisé contrairement à `max-height`), et border-radius du bouton close perdu pendant la refonte (restauré).
- **Comportement mobile dissocié entre modal et drawer** : après vérification visuelle réelle, le plein écran mobile ne convenait qu'au drawer (ancré à un bord de l'écran) — le modal (flottant au centre) garde une marge latérale à toutes les tailles d'écran, comme avant.
- **Bouton de fermeture entièrement repensé** : retrait de `.btn.btn-tertiary.btn-ratio-square`/`buttonStyles` (n'étaient utilisés que par ce bouton, dette confirmée — gardes `disabled`/`aria-disabled` jamais atteignables), remplacé par un `[part='close']` bespoke sur le modèle exact d'`ar-alert::part(close)` (taille tokenisée + fallback WCAG 2.5.8, focus-visible autonome, border-radius). Ajout d'un `slot="close-icon"` (absent jusqu'ici, incohérent avec `ar-alert`).
- **Migrations token → `::part()`** : `shadow`, `border-radius` (mode modal), `title-font-size`, `gap`/`padding` de `header`/`footer` (jamais tokenisés, étape 0 de l'audit).
- **Suppression pure** (ni composant ni thème) : `font-weight`/`line-height`/`color` du `h1`, redondants avec le rendu natif du navigateur.
- **Taxonomie `size` externalisée vers le thème**, alignée sur le découplage `variant`/`role` d'`ar-alert` (PR #143) : le composant garde une seule taille de repli par mode (500px modal/720px drawer), les paliers `sm`/`lg`/`xl` sont désormais une opinion de `default.css`. ADR-005 amendé en conséquence (+ nouvelle convention `functional-default` documentée et testée dans le garde-fou CI partagé).
- **Hors périmètre** (tracé séparément) : durées d'animation, cf. [issue #144](https://github.com/jogo-labs/ariane/issues/144) — nécessite le pattern « part d'état » et touche la logique JS de `_show`/`_close`/`_shake`. Personnalisation du header (actions, titre optionnel, header absent), cf. [issue #145](https://github.com/jogo-labs/ariane/issues/145).

## Vérification

- `npm run test --workspace=packages/core` : 799/799 ✅
- `npm run test:all` (Vitest + WTR navigateur) : 227/227 ✅
- `npm run build:manifest --workspace=packages/core` : sans erreur de garde-fou ✅
- Revue finale de branche (agent, modèle le plus capable) : 0 critique, 3 « Important » corrigés (doc ADR-005, tests du garde-fou `functional-default`, JSDoc `--ar-dialog-width`)
- **Vérification visuelle réelle effectuée** (Playwright, `apps/docs` en dev, captures desktop/mobile modal+drawer, thémé) — a permis de trouver et corriger 2 régressions supplémentaires manquées par la suite automatisée (border-radius du bouton close, `max-width` UA non neutralisé en mobile), puis un ajustement de comportement suite à retour visuel humain (marge modal conservée en mobile)

## Test plan

- [x] Tests unitaires + navigateur verts
- [x] Vérification visuelle mobile + desktop, modal + drawer (capturée via Playwright)
- [ ] Revue humaine avant merge