### PR TITLE
refactor(dropdown): migre token vs ::part(), lot 5 (#129)

### DIFF
--- a/docs/decisions/ADR-005-tokens-pilotes-par-attribut.md
+++ b/docs/decisions/ADR-005-tokens-pilotes-par-attribut.md
@@ -525,3 +525,33 @@ bg/border-color pour le fallback a11y, 4 tokens toggle-bg redéfinis, mobile-sep
 bloqué par la contrainte 3 — pseudo-élément non converti —, 2 nouveaux tokens a11y/motion) ; 10
 supprimés (5 panel cosmétiques + color + bullet-color + bullet-ring-color + active-bullet-color +
 separator-color), remplacés par des règles `::part()` littérales dans le thème.
+
+## Application — `ar-dropdown` (lot 5, 2026-07-31)
+
+Premier des 3 composants restants du lot (`dropdown`, `pagination`, `tooltip`), traité seul.
+Contrairement à `ar-breadcrumb`, le CSS d'`ar-dropdown` n'est pas hérité d'un import externe :
+travail interne (PR #62), sans dette de provenance à auditer en préalable.
+
+**Nouveau précédent établi par ce lot, absent de l'ADR jusqu'ici** : `--ar-dropdown-color` a été
+supprimé sans migration — pas transformé en règle `::part()`. Le token dupliquait, sans jamais
+diverger en pratique, un fallback déjà posé par la feuille de style partagée `panel.styles.ts`
+(`color: var(--ar-panel-text, CanvasText)` sur `[part='panel']`, consommée par
+`ar-dropdown`/`ar-breadcrumb`/`ar-stepper`). `ar-breadcrumb` et `ar-stepper` n'avaient d'ailleurs
+jamais eu ce token dédié — `ar-dropdown` était l'exception, désormais alignée sur les deux autres.
+Règle générale qui s'en dégage : quand un token duplique un fallback déjà garanti par une feuille
+de style partagée que le composant consomme, sans jamais diverger en pratique, il est supprimé
+plutôt que migré — aucune règle `::part()` de remplacement n'est nécessaire, la feuille partagée
+suffit à couvrir le cas headless.
+
+Les 5 autres tokens migrés (`border-radius`, `shadow`, `padding`, `max-width`, `min-width`)
+suivent le schéma déjà établi lot 4 : règle `ar-dropdown { &::part(panel) {...} }` dans
+`default.css`, `min-width: 10rem` porté en littéral avec son commentaire justificatif conservé
+(valeur volontairement non cascadée depuis `--ar-panel-min-width` : un menu dropdown reste plus
+étroit qu'un panel générique).
+
+**Résultat** : 10 tokens `default.css` initiaux → 4 restants (`distance`/`offset` lus en JS par
+`AnchoredController`, `bg`/`border-color` pour le fallback a11y système `Canvas`/`ButtonBorder`) ;
+6 supprimés (`color` sans remplaçant + 5 migrés vers `::part(panel)`).
+
+Détail complet : `docs/superpowers/specs/2026-07-31-dropdown-token-vs-part-129-design.md` et
+`docs/superpowers/plans/2026-07-31-dropdown-token-vs-part-129.md`.

--- a/docs/superpowers/plans/2026-07-31-dropdown-token-vs-part-129.md
+++ b/docs/superpowers/plans/2026-07-31-dropdown-token-vs-part-129.md
@@ -1,0 +1,453 @@
+# `ar-dropdown` token vs `::part()` (lot 5, #129) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrer 5 des 10 tokens `--ar-dropdown-*` (border-radius, shadow, padding, max-width,
+min-width) de `dropdown.styles.ts` vers une règle `ar-dropdown::part(panel)` littérale dans
+`default.css`, supprimer `--ar-dropdown-color` sans remplaçant (retombe sur `--ar-panel-text`
+déjà posé par `panelBaseStyles`), en gardant les 4 tokens restants (bg/border-color pour
+fallback a11y, distance/offset lus en JS) — conformément à
+`docs/superpowers/specs/2026-07-31-dropdown-token-vs-part-129-design.md`. Aligne `ar-dropdown`
+sur le pattern déjà établi par `ar-breadcrumb`/`ar-stepper` (lot 4), qui ne redéclarent que 2
+propriétés (`bg`/`border-color`) sur `[part='panel']`.
+
+**Architecture:** Aucun changement de structure DOM ni de nouveau `part` — le seul `part`
+existant (`panel`) reçoit une règle de thème externe supplémentaire. Le composant garde une
+règle `[part='panel']` réduite à 2 déclarations à fallback système ; `panelBaseStyles`
+(déjà importé) gouverne désormais `color` sans concurrence.
+
+**Tech Stack:** Lit 3, TypeScript, Vitest + WTR (browser), garde-fous CI
+(`validate-no-hardcoded-tokens.js`, custom-elements-manifest via `cem.config.js`).
+
+## Global Constraints
+
+- Prettier : 100 char, 4 spaces, single quotes (CLAUDE.md).
+- `--ar-*` cascade toujours via `var()` référençant `default.css`, jamais de valeur littérale
+  codée en dur dans un `.styles.ts` sans commentaire `a11y-fallback`/`functional-default`
+  justificatif (garde-fou `validate-no-hardcoded-tokens.js`).
+- Tout nouveau/retiré token `--ar-*` doit avoir son entrée `@cssprop` tenue à jour dans le JSDoc
+  du composant (feedback_cssprop_jsdoc).
+- Ne jamais merger sur `dev` sans confirmation explicite de l'utilisateur
+  (feedback_merge_after_autonomous_fix).
+- `npm run dev --workspace=apps/docs` seul ne reconstruit pas le JS de `packages/core/dist` —
+  rebuild explicite (`npm run build:dev --workspace=packages/core`) requis avant toute
+  vérification Playwright d'un changement de renderer (feedback_docs_dev_stale_dist).
+
+---
+
+## Task 1: Créer la branche de travail
+
+**Files:** aucun.
+
+- [ ] **Step 1: Créer la branche depuis `dev`**
+
+```bash
+git checkout dev
+git pull origin dev
+git checkout -b fix/dropdown-token-vs-part-129
+```
+
+- [ ] **Step 2: Vérifier l'état propre**
+
+Run: `git status`
+Expected: `On branch fix/dropdown-token-vs-part-129`, `nothing to commit, working tree clean`.
+
+---
+
+## Task 2: Réduire `dropdown.styles.ts` aux 3 tokens à fallback a11y
+
+**Files:**
+
+- Modify: `packages/core/src/components/dropdown/dropdown.styles.ts`
+
+**Interfaces:**
+
+- Consumes: rien (fichier autonome). `panelBaseStyles` (importé dans `dropdown.ts`, chargé avant
+  ce fichier dans `static override styles = [panelStyles, styles]`) continue de déclarer
+  `color: var(--ar-panel-text, CanvasText)` sur `[part='panel']` — plus jamais concurrencé par ce
+  fichier après ce changement.
+- Produces: `[part='panel']` réduit à `background-color`/`border-color`, consommé visuellement
+  par `default.css` (Task 3).
+
+- [ ] **Step 1: Remplacer le contenu du fichier**
+
+Contenu actuel :
+
+```ts
+import { css } from 'lit';
+
+export default css`
+    :host {
+        display: contents;
+    }
+
+    [part='panel'] {
+        /* Overrides composant — chaînent vers les tokens shared --ar-panel-* */
+        background-color: var(--ar-dropdown-bg, Canvas);
+        color: var(--ar-dropdown-color, CanvasText);
+        border-color: var(--ar-dropdown-border-color, ButtonBorder);
+        border-radius: var(--ar-dropdown-border-radius);
+        box-shadow: var(--ar-dropdown-shadow);
+        padding: var(--ar-dropdown-padding);
+        min-width: var(--ar-dropdown-min-width);
+        max-width: var(--ar-dropdown-max-width);
+    }
+`;
+```
+
+Nouveau contenu — retirer `color` (retombe sur `panelBaseStyles`, aucun remplaçant) et les 5
+lignes `border-radius`/`box-shadow`/`padding`/`min-width`/`max-width` (migrées en Task 3) :
+
+```ts
+import { css } from 'lit';
+
+export default css`
+    :host {
+        display: contents;
+    }
+
+    [part='panel'] {
+        /* Overrides composant — chaînent vers les tokens shared --ar-panel-* */
+        background-color: var(--ar-dropdown-bg, Canvas);
+        border-color: var(--ar-dropdown-border-color, ButtonBorder);
+    }
+`;
+```
+
+- [ ] **Step 2: Vérifier le format**
+
+Run: `npx prettier --check packages/core/src/components/dropdown/dropdown.styles.ts`
+Expected: pas d'erreur (ou `npx prettier --write` si besoin, puis re-check).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/src/components/dropdown/dropdown.styles.ts
+git commit -m "refactor(dropdown): retire color/border-radius/shadow/padding/min-width/max-width du composant"
+```
+
+---
+
+## Task 3: Ajouter `ar-dropdown { &::part(panel) {...} }` et retirer 6 tokens dans `default.css`
+
+**Files:**
+
+- Modify: `packages/core/src/styles/themes/default.css`
+
+**Interfaces:**
+
+- Consumes: `--ar-panel-radius`, `--ar-panel-shadow`, `--ar-panel-padding`,
+  `--ar-panel-max-width` (déjà définis dans le bloc `:root`, section « Partagé — dropdown,
+  breadcrumb, stepper »).
+- Produces: règle externe `ar-dropdown::part(panel)` consommée visuellement par le composant
+  (Task 2). Nouveau bloc `ar-dropdown { }` hors `:root`, miroir structurel de `ar-breadcrumb { }`
+  (`default.css:1058`) et `ar-stepper { }` (`default.css:881`).
+
+- [ ] **Step 1: Localiser le bloc `Dropdown` dans `:root`**
+
+Bloc actuel (repérer via `grep -n "Dropdown" packages/core/src/styles/themes/default.css`) :
+
+```css
+/* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+         * Dropdown
+         * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+--ar-dropdown-distance: var(--ar-anchor-distance);
+--ar-dropdown-offset: var(--ar-anchor-offset);
+--ar-dropdown-bg: var(--ar-panel-bg);
+--ar-dropdown-color: var(--ar-panel-text);
+--ar-dropdown-border-color: var(--ar-panel-border-color);
+--ar-dropdown-border-radius: var(--ar-panel-radius);
+--ar-dropdown-shadow: var(--ar-panel-shadow);
+--ar-dropdown-padding: var(--ar-panel-padding);
+/* Valeur propre, volontairement non cascadée depuis --ar-panel-min-width : un menu
+           dropdown reste lisible plus étroit qu'un panel de disclosure générique (breadcrumb,
+           stepper). */
+--ar-dropdown-min-width: 10rem;
+--ar-dropdown-max-width: var(--ar-panel-max-width);
+```
+
+- [ ] **Step 2: Remplacer par la version réduite (4 tokens restants — retire aussi `color`)**
+
+```css
+/* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+         * Dropdown
+         * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+--ar-dropdown-distance: var(--ar-anchor-distance);
+--ar-dropdown-offset: var(--ar-anchor-offset);
+--ar-dropdown-bg: var(--ar-panel-bg);
+--ar-dropdown-border-color: var(--ar-panel-border-color);
+```
+
+- [ ] **Step 3: Ajouter un bloc `ar-dropdown { }` hors du bloc `:root`**
+
+Repérer l'emplacement en cherchant les blocs de composant existants hors `:root` :
+`grep -n "^    ar-" packages/core/src/styles/themes/default.css` (ex. `ar-dialog { }`,
+`ar-breadcrumb { }`, `ar-stepper { }`, tous à la même profondeur d'imbrication, à l'intérieur
+d'un sélecteur englobant — lire 10 lignes de contexte autour d'un de ces blocs pour confirmer la
+profondeur exacte d'indentation avant d'insérer). Ajouter un nouveau bloc `ar-dropdown { }` à la
+suite du dernier bloc de composant du fichier, même niveau d'indentation :
+
+```css
+ar-dropdown {
+    &::part(panel) {
+        border-radius: var(--ar-panel-radius);
+        box-shadow: var(--ar-panel-shadow);
+        padding: var(--ar-panel-padding);
+        /* Valeur propre, volontairement non cascadée depuis --ar-panel-min-width : un menu
+               dropdown reste lisible plus étroit qu'un panel de disclosure générique
+               (breadcrumb, stepper). */
+        min-width: 10rem;
+        max-width: var(--ar-panel-max-width);
+    }
+}
+```
+
+- [ ] **Step 4: Vérifier le format**
+
+Run: `npx prettier --check packages/core/src/styles/themes/default.css`
+Expected: pas d'erreur.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/styles/themes/default.css
+git commit -m "refactor(dropdown): migre border-radius/shadow/padding/min-width/max-width vers ::part(panel), retire color"
+```
+
+---
+
+## Task 4: Mettre à jour le JSDoc `@cssprop` de `dropdown.ts`
+
+**Files:**
+
+- Modify: `packages/core/src/components/dropdown/dropdown.ts:34-43`
+
+**Interfaces:**
+
+- Consumes: rien.
+- Produces: JSDoc à jour, source du manifeste CEM (Task 5).
+
+- [ ] **Step 1: Retirer les 6 entrées `@cssprop` des tokens migrés/supprimés**
+
+Bloc JSDoc actuel (lignes 34-43) :
+
+```ts
+ * @cssprop --ar-dropdown-min-width - Largeur minimale du panel.
+ * @cssprop --ar-dropdown-color - Couleur du texte (cascade vers --ar-panel-text, repli système `CanvasText` si aucun thème n'est chargé).
+ * @cssprop --ar-dropdown-max-width - Largeur maximale (cascade vers --ar-panel-max-width).
+ * @cssprop --ar-dropdown-padding - Marge interne (cascade vers --ar-panel-padding).
+ * @cssprop --ar-dropdown-bg - Fond du panel (cascade vers --ar-panel-bg, repli système `Canvas` si aucun thème n'est chargé).
+ * @cssprop --ar-dropdown-border-color - Bordure (cascade vers --ar-panel-border-color, repli système `ButtonBorder` si aucun thème n'est chargé).
+ * @cssprop --ar-dropdown-border-radius - Arrondi (cascade vers --ar-panel-radius).
+ * @cssprop --ar-dropdown-shadow - Ombre (cascade vers --ar-panel-shadow).
+ * @cssprop --ar-dropdown-distance - Espacement entre le trigger et le panel (axe principal).
+ * @cssprop --ar-dropdown-offset - Décalage latéral du panel (axe transversal).
+```
+
+Nouveau bloc — retirer `min-width`/`color`/`max-width`/`padding`/`border-radius`/`shadow`,
+garder `bg`/`border-color`/`distance`/`offset` :
+
+```ts
+ * @cssprop --ar-dropdown-bg - Fond du panel (cascade vers --ar-panel-bg, repli système `Canvas` si aucun thème n'est chargé).
+ * @cssprop --ar-dropdown-border-color - Bordure (cascade vers --ar-panel-border-color, repli système `ButtonBorder` si aucun thème n'est chargé).
+ * @cssprop --ar-dropdown-distance - Espacement entre le trigger et le panel (axe principal).
+ * @cssprop --ar-dropdown-offset - Décalage latéral du panel (axe transversal).
+ * @csspart panel - Le panel flottant. Personnalisable via `::part(panel)` (color, border-radius, box-shadow, padding, min-width, max-width).
+```
+
+Le `@csspart panel` existant (ligne 32, juste avant les `@cssprop`) doit être remplacé par cette
+version enrichie plutôt que dupliqué — vérifier qu'il n'en reste qu'une seule occurrence.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/core/src/components/dropdown/dropdown.ts
+git commit -m "docs(dropdown): met à jour le JSDoc @cssprop/@csspart après migration ::part(panel)"
+```
+
+---
+
+## Task 5: Vérifier les tests existants et rebuild le manifeste
+
+**Files:**
+
+- Read-only check: `packages/core/src/components/dropdown/dropdown.test.ts`
+- Read-only check: `packages/core/src/components/dropdown/dropdown.browser.test.ts`
+- Read-only check: `packages/core/src/components/dropdown/dropdown.a11y.test.ts`
+
+**Interfaces:**
+
+- Consumes: composant modifié (Tasks 2-4).
+- Produces: confirmation verte, aucune modification de test attendue (voir Step 1).
+
+- [ ] **Step 1: Vérifier qu'aucun test n'assume une valeur calculée pour les 5 propriétés migrées**
+
+Run: `grep -n "border-radius\|boxShadow\|box-shadow\|padding\|min-width\|max-width\|minWidth\|maxWidth\|\.color\b\|getPropertyValue('color')" packages/core/src/components/dropdown/dropdown.test.ts packages/core/src/components/dropdown/dropdown.browser.test.ts packages/core/src/components/dropdown/dropdown.a11y.test.ts`
+
+Expected : aucune occurrence pertinente (déjà confirmé en amont de ce plan — seul
+`getComputedStyle(panel)` existe dans `dropdown.browser.test.ts:211`, pour une autre propriété
+que celles migrées/supprimées ; lire son contexte pour confirmer, en particulier qu'aucune
+assertion ne porte sur `color` calculé). Si une occurrence apparaît et assume une valeur par
+défaut sans thème chargé, adapter le test pour charger `default.css` avant d'asserter — sinon ne
+rien modifier.
+
+- [ ] **Step 2: Lancer la suite Vitest du composant**
+
+Run: `npm run test --workspace=packages/core -- dropdown`
+Expected: tous les tests passent (aucune régression).
+
+- [ ] **Step 3: Rebuild le manifeste CEM (déclenche les garde-fous CI)**
+
+Run: `npm run build:manifest --workspace=packages/core`
+Expected: succès, aucune erreur `validate-no-hardcoded-tokens.js` (les 2 fallbacks restants —
+`bg`/`border-color` — sont des mots-clés système whitelistés, pas besoin de commentaire) ni
+`validate-part-state-order.js` (aucun part d'état sur `panel`, non concerné).
+
+- [ ] **Step 4: Lancer la suite browser (WTR)**
+
+Run: `npm run test:all --workspace=packages/core -- dropdown` (ou la commande équivalente
+`test:browser` si `test:all` n'existe pas en scope composant — vérifier `package.json` de
+`packages/core` si la commande échoue).
+Expected: tous les tests passent, y compris `dropdown.a11y.test.ts`.
+
+- [ ] **Step 5: Commit (uniquement si le manifeste ou un test a été modifié)**
+
+```bash
+git add packages/core/custom-elements.json packages/core/src/components/dropdown/*.test.ts
+git commit -m "chore(dropdown): régénère le manifeste après migration ::part(panel)"
+```
+
+Si rien n'a changé (manifeste déjà à jour via un hook de build antérieur, aucun test modifié),
+passer directement à Task 6 sans commit.
+
+---
+
+## Task 6: Vérification visuelle manuelle (Playwright)
+
+**Files:** aucun fichier modifié — vérification uniquement.
+
+- [ ] **Step 1: Rebuild explicite de `packages/core` avant toute vérification Playwright**
+
+Run: `npm run build:dev --workspace=packages/core`
+Expected: build réussi. (Piège connu : `npm run dev --workspace=apps/docs` seul sert le CSS
+depuis la source mais pas le JS de `packages/core/dist` — un rebuild explicite est nécessaire
+pour que le renderer reflète les changements.)
+
+- [ ] **Step 2: Lancer le serveur de doc**
+
+Run: `npm run dev --workspace=apps/docs` (en arrière-plan ou dans un terminal dédié).
+
+- [ ] **Step 3: Ouvrir la page `ar-dropdown` et capturer le panel ouvert, thème chargé**
+
+Utiliser l'outillage Playwright déjà présent dans le repo
+(`apps/docs/playwright.config.ts`, `@playwright/test`) pour naviguer vers la page de démo
+`ar-dropdown`, ouvrir le panel (clic sur le trigger), capturer une screenshot. Vérifier
+visuellement : `border-radius`, `box-shadow`, `padding`, `min-width`/`max-width`, **et la couleur
+du texte** (`color`, désormais gouvernée par `panelBaseStyles` sans concurrence) du panel
+identiques au rendu d'avant migration (aucune régression attendue, les valeurs `default.css`
+sont inchangées, seul leur point de définition a changé — `color` avait déjà la même valeur
+avant/après, cf. spec).
+
+- [ ] **Step 4: Vérifier le rendu sans thème (fallback a11y)**
+
+Charger une page sans `default.css` (ou commenter temporairement son import) et confirmer que le
+panel reste utilisable : fond `Canvas`, texte `CanvasText` (toujours fourni par
+`panelBaseStyles`, inchangé par ce lot), bordure `ButtonBorder` visibles ;
+`border-radius`/`shadow`/`padding`/`min-width`/`max-width` retombent au rendu natif du navigateur
+(0/aucun, comportement attendu — ces propriétés n'ont plus de fallback interne, c'est le
+comportement voulu par la migration branche 4). Rétablir l'import après vérification.
+
+- [ ] **Step 5: Consigner le résultat**
+
+Si un écart visuel est trouvé, corriger `default.css` (Task 3) et refaire Steps 3-4. Si rien
+trouvé, continuer.
+
+---
+
+## Task 7: Revue finale de branche
+
+**Files:** aucun — revue uniquement.
+
+- [ ] **Step 1: Dispatcher une revue de branche complète sur un agent capable**
+
+Comparer l'intégralité du diff `dev...fix/dropdown-token-vs-part-129` (pas seulement les diffs
+de tâche individuels) contre `docs/decisions/ADR-005-tokens-pilotes-par-attribut.md` et
+`docs/superpowers/specs/2026-07-31-dropdown-token-vs-part-129-design.md`. Points d'attention
+spécifiques à ce lot (petit périmètre, mais vérifier quand même — les lots précédents ont
+systématiquement trouvé des bugs invisibles aux revues par tâche) :
+
+- Cohérence exacte entre les 6 tokens retirés du composant (`color` inclus) et ceux retirés de
+  `default.css` (aucun oubli, aucun résidu).
+- `color` n'a **aucun** remplaçant dans `default.css` (ni token, ni règle `::part(panel)`) —
+  confirmer qu'il retombe bien sur `panelBaseStyles` (`panel.styles.ts`) et que le rendu visuel
+  du texte du panel dropdown reste identique (Task 6).
+- Le nouveau bloc `ar-dropdown { &::part(panel) {...} }` a la même structure d'imbrication que
+  `ar-breadcrumb { }`/`ar-stepper { }` existants (pas un sélecteur plat `ar-dropdown::part(panel)`
+  isolé, incohérent avec le reste du fichier).
+- JSDoc `@cssprop`/`@csspart` cohérent avec l'implémentation finale.
+- Aucune référence résiduelle à `--ar-dropdown-color`/`-border-radius`/`-shadow`/`-padding`/
+  `-min-width`/`-max-width` ailleurs dans le repo (`grep -rn` sur ces 6 noms de tokens hors
+  `git log`).
+
+- [ ] **Step 2: Corriger les findings en une vague unique**
+
+Si des findings « Critical »/« Important » remontent, les corriger en un seul commit groupé
+plutôt qu'un commit par finding, puis relancer Task 5 Steps 2-4 pour re-vérifier.
+
+---
+
+## Task 8: Créer la Pull Request
+
+**Files:** aucun.
+
+- [ ] **Step 1: Pousser la branche**
+
+```bash
+git push -u origin fix/dropdown-token-vs-part-129
+```
+
+- [ ] **Step 2: Créer la PR vers `dev`**
+
+```bash
+gh pr create --base dev --title "refactor(dropdown): migre token vs ::part(), lot 5 (#129)" --body "$(cat <<'EOF'
+## Summary
+- Migre 5 tokens `--ar-dropdown-*` (border-radius, shadow, padding, min-width, max-width) vers une règle littérale `ar-dropdown::part(panel)` dans `default.css`.
+- Supprime `--ar-dropdown-color` sans remplaçant — retombe sur `--ar-panel-text` déjà posé par `panelBaseStyles` (partagé avec `ar-breadcrumb`/`ar-stepper`, qui n'ont jamais eu ce token).
+- Conserve `bg`/`border-color` (fallback a11y système) et `distance`/`offset` (lus en JS par `AnchoredController`).
+- Aligne `ar-dropdown` sur le pattern panel déjà établi par `ar-breadcrumb`/`ar-stepper` (lot 4) — les 3 composants consommant `panel.styles.ts` traitent désormais leur surcharge `[part='panel']` de façon identique.
+- Aucun changement de structure DOM, aucun nouveau `part`, aucun changement visuel par défaut.
+
+Spec : `docs/superpowers/specs/2026-07-31-dropdown-token-vs-part-129-design.md`
+Plan : `docs/superpowers/plans/2026-07-31-dropdown-token-vs-part-129.md`
+
+## Test plan
+- [x] `npm run test --workspace=packages/core -- dropdown`
+- [x] `npm run build:manifest --workspace=packages/core` (garde-fous CI verts)
+- [x] Suite browser (WTR) dropdown
+- [x] Vérification visuelle Playwright (avec et sans thème)
+- [x] Revue finale de branche
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Confirmer avec l'utilisateur avant tout merge**
+
+Ne pas merger sur `dev` sans confirmation explicite — signaler la PR créée et attendre la revue
+de l'utilisateur (feedback_merge_after_autonomous_fix).
+
+---
+
+## Self-Review (déjà appliqué en rédigeant ce plan)
+
+1. **Couverture de la spec** : les 3 sections de la spec (tableau des 10 tokens, changements
+   `dropdown.styles.ts`/`default.css`/JSDoc, tests) sont couvertes par Tasks 2-5. Vérification
+   visuelle (Task 6) et revue finale (Task 7) couvrent les exigences méthodologiques du chantier
+   #129 (mémoire `project_token_vs_part_generalization_129`). Branche + PR couvertes par Tasks 1
+   et 8.
+2. **Scan placeholders** : aucun « TBD »/« gérer les cas limites » — chaque step contient le
+   contenu exact à écrire ou la commande exacte à lancer.
+3. **Cohérence des noms** : `ar-dropdown::part(panel)` (Task 3) correspond exactement au
+   sélecteur `[part='panel']` déjà présent dans `dropdown.styles.ts` (Task 2) et au `@csspart
+panel` du JSDoc (Task 4) — aucune divergence de nom.

--- a/docs/superpowers/specs/2026-07-31-dropdown-token-vs-part-129-design.md
+++ b/docs/superpowers/specs/2026-07-31-dropdown-token-vs-part-129-design.md
@@ -1,0 +1,138 @@
+# `ar-dropdown` — token vs `::part()` (lot 5, issue #129)
+
+**Date :** 2026-07-31
+**Statut :** Validé, prêt pour plan d'implémentation
+
+## Contexte
+
+Suite de la généralisation du critère token-vs-part (ADR-005) : lot 1 (`ar-stepper`), lot 2
+(`ar-datepicker`), lots 3a/3b (`ar-alert`/`ar-dialog`), lot 4 (`ar-breadcrumb`). `ar-dropdown` est
+le premier des 3 composants restants (`dropdown`, `pagination`, `tooltip`), traité seul (périmètre
+plus restreint que les lots précédents).
+
+**Particularité par rapport aux lots précédents** : contrairement à `ar-breadcrumb`, le CSS
+d'`ar-dropdown` n'est pas hérité d'un import externe — c'est du travail interne récent (PR #62,
+2026-04-30, refonte du panel partagé `panel.styles.ts` consommé par `dropdown`/`breadcrumb`/
+`stepper` mobile). Aucun CSS mort trouvé, aucune classe interne redondante avec un `part` (un seul
+`part` existe déjà : `panel`), pas de dépendance à `button.styles.ts` (le composant ne rend aucun
+bouton lui-même, uniquement un trigger slotté), aucune icône décorative interne. L'audit se réduit
+donc à l'application directe du critère token-vs-part sur les 10 tokens `--ar-dropdown-*` de
+`default.css`.
+
+**Constat additionnel (comparaison avec `ar-breadcrumb`/`ar-stepper`, déjà migrés en lot 4)** :
+`ar-dropdown` importe bien `panel.styles.ts` (`dropdown.ts:8`), mais `dropdown.styles.ts`
+re-déclare `bg`/`color`/`border-color`/`border-radius`/`box-shadow`/`padding`/`min-width`/
+`max-width` sur le même sélecteur `[part='panel']`, ce qui écrase systématiquement les
+déclarations de `panelBaseStyles` (même spécificité, `dropdown.styles.ts` vient après dans
+`static override styles = [panelStyles, styles]`). `ar-breadcrumb` et `ar-stepper` ne
+re-déclarent, eux, que **2 propriétés** (`bg`, `border-color`) — `color` n'a jamais eu de token
+dédié côté breadcrumb/stepper, il retombe sur `--ar-panel-text` (fallback `CanvasText`) déjà posé
+par `panelBaseStyles`, sans jamais diverger. `ar-dropdown` garde un `--ar-dropdown-color`
+redondant (`default.css:439` : `var(--ar-panel-text)`, valeur strictement identique au fallback
+partagé, jamais consommé ailleurs — vérifié par grep). Décision : aligner `ar-dropdown` sur ce
+pattern plus étroit, pas seulement sur le traitement radius/shadow/padding/max-width/min-width.
+
+## Application du critère (10 tokens)
+
+| Token                         | Décision                                    | Raison                                                                                                                                                                                                                                                                                                                                       |
+| ----------------------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--ar-dropdown-distance`      | **Reste token**                             | Lu en JS (`AnchoredController._readCssVar` via `getComputedStyle`) — contrainte 2                                                                                                                                                                                                                                                            |
+| `--ar-dropdown-offset`        | **Reste token**                             | Idem                                                                                                                                                                                                                                                                                                                                         |
+| `--ar-dropdown-bg`            | **Reste token**                             | Fallback a11y critique (`Canvas`) sans thème — contrainte 1, même statut que `--ar-breadcrumb-panel-bg`/`--ar-stepper-panel-bg` (lot 4)                                                                                                                                                                                                      |
+| `--ar-dropdown-border-color`  | **Reste token**                             | Fallback a11y critique (`ButtonBorder`) — contrainte 1, même statut que `--ar-breadcrumb-panel-border-color`/`--ar-stepper-panel-border-color`                                                                                                                                                                                               |
+| `--ar-dropdown-color`         | **Supprimé (pas migré, pas de remplaçant)** | Duplication sans divergence jamais exercée du fallback déjà posé par `panelBaseStyles` (`--ar-panel-text`, `CanvasText`) — aligne `ar-dropdown` sur `ar-breadcrumb`/`ar-stepper`, qui n'ont jamais eu ce token. Le composant cesse de redéclarer `color` sur `[part='panel']` : la déclaration de `panelBaseStyles` s'applique telle quelle. |
+| `--ar-dropdown-border-radius` | **Migre → `::part(panel)`**                 | Aucun fallback critique, branche 4                                                                                                                                                                                                                                                                                                           |
+| `--ar-dropdown-shadow`        | **Migre → `::part(panel)`**                 | Idem                                                                                                                                                                                                                                                                                                                                         |
+| `--ar-dropdown-padding`       | **Migre → `::part(panel)`**                 | Idem                                                                                                                                                                                                                                                                                                                                         |
+| `--ar-dropdown-max-width`     | **Migre → `::part(panel)`**                 | Idem                                                                                                                                                                                                                                                                                                                                         |
+| `--ar-dropdown-min-width`     | **Migre → `::part(panel)`**                 | Valeur littérale jamais cascadée (10rem, volontairement distincte de `--ar-panel-min-width` — un menu reste plus étroit qu'un panel générique), aucun fallback critique. Même geste que `ar-stepper::part(panel) { padding: 0.75rem; }` (divergence exprimée en littéral dans la règle de thème, pas en token)                               |
+
+Symétrie stricte avec `ar-breadcrumb::part(panel)`/`ar-stepper::part(panel)` (vérifiés dans
+`default.css:902-908` et `:1106-1112`) : seuls `bg`/`border-color` gardent un token (fallback
+système), tout le reste (`color` compris, en le supprimant plutôt qu'en le migrant) devient soit
+la retombée déjà gérée par `panelBaseStyles`, soit une règle `::part(panel)` littérale dans le
+thème.
+
+## Changements
+
+### `packages/core/src/components/dropdown/dropdown.styles.ts`
+
+`[part='panel']` ne garde que les 2 propriétés à fallback a11y (symétrie exacte avec
+`breadcrumb.styles.ts`/`stepper.styles.ts`) :
+
+```css
+[part='panel'] {
+    background-color: var(--ar-dropdown-bg, Canvas);
+    border-color: var(--ar-dropdown-border-color, ButtonBorder);
+}
+```
+
+`color`, `border-radius`, `box-shadow`, `padding`, `min-width`, `max-width` retirés de ce fichier.
+`color` n'est pas remplacé — `panelBaseStyles` (`panel.styles.ts`, déjà importé) déclare
+`color: var(--ar-panel-text, CanvasText)` sur le même `[part='panel']` ; sans redéclaration côté
+`dropdown.styles.ts`, cette valeur s'applique directement. Les 5 autres propriétés deviennent une
+opinion de thème pure (section suivante).
+
+### `packages/core/src/styles/themes/default.css`
+
+Bloc `Dropdown` : les 6 tokens (`color` + les 5 migrés) retirés, nouvelle règle `::part()` ajoutée
+dans le bloc `ar-dropdown { }` existant (même structure que `ar-breadcrumb { &::part(panel) {...} }`
+et `ar-stepper { &::part(panel) {...} }`, `default.css:1058`/`:881`) — vérifier s'il existe déjà un
+bloc `ar-dropdown { }` hors `:root` ; sinon en créer un à la suite du dernier bloc de composant du
+fichier :
+
+```css
+ar-dropdown {
+    &::part(panel) {
+        border-radius: var(--ar-panel-radius);
+        box-shadow: var(--ar-panel-shadow);
+        padding: var(--ar-panel-padding);
+        /* Valeur propre, volontairement non cascadée depuis --ar-panel-min-width : un menu
+           dropdown reste lisible plus étroit qu'un panel de disclosure générique (breadcrumb,
+           stepper). */
+        min-width: 10rem;
+        max-width: var(--ar-panel-max-width);
+    }
+}
+```
+
+Le commentaire existant justifiant `min-width: 10rem` (non cascadé depuis `--ar-panel-min-width`)
+est déplacé tel quel au-dessus de cette déclaration.
+
+### `packages/core/src/components/dropdown/dropdown.ts` (JSDoc)
+
+`@cssprop` retirés pour `--ar-dropdown-color`, `--ar-dropdown-border-radius`,
+`--ar-dropdown-shadow`, `--ar-dropdown-padding`, `--ar-dropdown-max-width`,
+`--ar-dropdown-min-width` (celui-ci n'avait d'ailleurs jamais eu d'entrée `@cssprop` dédiée —
+vérifier). Les 4 `@cssprop` restants (`bg`, `border-color`, `distance`, `offset`) gardent leur
+mention de cascade vers `--ar-panel-*` là où applicable. `@csspart panel` enrichi pour mentionner
+les propriétés désormais pilotables via `::part(panel)`.
+
+### Tests
+
+`dropdown.test.ts`/`dropdown.browser.test.ts`/`dropdown.a11y.test.ts` : aucun changement de
+structure DOM ni de `part` attendu (le seul `part` existant, `panel`, n'est ni ajouté ni retiré).
+Vérifier qu'aucun test n'asserte la valeur calculée de `border-radius`/`shadow`/`padding`/
+`min-width`/`max-width` directement sur le composant sans thème chargé (peu probable, ces valeurs
+sont cosmétiques) — sinon adapter pour charger `default.css` ou cibler `::part(panel)`.
+
+## Résultat attendu
+
+- 6 tokens supprimés sur 10 (`color`, `border-radius`, `shadow`, `padding`, `max-width`,
+  `min-width` — 5 migrés vers `::part(panel)`, `color` supprimé sans remplaçant dédié), 4
+  conservés (`bg`/`border-color` pour fallback a11y, `distance`/`offset` pour lecture JS).
+- `ar-dropdown` aligné strictement sur le pattern panel déjà établi par `ar-breadcrumb`/
+  `ar-stepper` — plus de divergence de traitement entre les 3 composants consommant
+  `panel.styles.ts`.
+- Aucun changement de structure DOM, aucun nouveau `part`, aucun changement visuel par défaut
+  (le thème `default.css` reproduit exactement les valeurs actuelles, `color` y compris — la
+  valeur `--ar-panel-text` était déjà identique).
+- `--ar-dropdown-min-width` n'est plus consommé par `dropdown.styles.ts` lui-même — seul le thème
+  le fixe désormais, un consommateur override toujours via `ar-dropdown::part(panel)` (au lieu de
+  redéfinir le token, cohérent avec le reste de la migration #129).
+
+## Hors scope
+
+- `pagination`, `tooltip` — lots suivants, même grille de lecture.
+- Réflexion sur `panel.styles.ts` lui-même (partagé dropdown/breadcrumb/stepper) — inchangé, ce
+  lot ne touche que la surcharge propre à `ar-dropdown`.

--- a/packages/core/src/components/dropdown/dropdown.styles.ts
+++ b/packages/core/src/components/dropdown/dropdown.styles.ts
@@ -8,12 +8,6 @@ export default css`
     [part='panel'] {
         /* Overrides composant — chaînent vers les tokens shared --ar-panel-* */
         background-color: var(--ar-dropdown-bg, Canvas);
-        color: var(--ar-dropdown-color, CanvasText);
         border-color: var(--ar-dropdown-border-color, ButtonBorder);
-        border-radius: var(--ar-dropdown-border-radius);
-        box-shadow: var(--ar-dropdown-shadow);
-        padding: var(--ar-dropdown-padding);
-        min-width: var(--ar-dropdown-min-width);
-        max-width: var(--ar-dropdown-max-width);
     }
 `;

--- a/packages/core/src/components/dropdown/dropdown.ts
+++ b/packages/core/src/components/dropdown/dropdown.ts
@@ -29,16 +29,10 @@ export type ArDropdownPlacement =
  * @slot trigger  - Le bouton déclencheur (ignoré si `for` est défini).
  * @slot          - Contenu du panel (libre ou ar-dropdown-item pour le mode menu).
  *
- * @csspart panel - Le panel flottant.
+ * @csspart panel - Le panel flottant. Personnalisable via `::part(panel)` (color, border-radius, box-shadow, padding, min-width, max-width).
  *
- * @cssprop --ar-dropdown-min-width - Largeur minimale du panel.
- * @cssprop --ar-dropdown-color - Couleur du texte (cascade vers --ar-panel-text, repli système `CanvasText` si aucun thème n'est chargé).
- * @cssprop --ar-dropdown-max-width - Largeur maximale (cascade vers --ar-panel-max-width).
- * @cssprop --ar-dropdown-padding - Marge interne (cascade vers --ar-panel-padding).
  * @cssprop --ar-dropdown-bg - Fond du panel (cascade vers --ar-panel-bg, repli système `Canvas` si aucun thème n'est chargé).
  * @cssprop --ar-dropdown-border-color - Bordure (cascade vers --ar-panel-border-color, repli système `ButtonBorder` si aucun thème n'est chargé).
- * @cssprop --ar-dropdown-border-radius - Arrondi (cascade vers --ar-panel-radius).
- * @cssprop --ar-dropdown-shadow - Ombre (cascade vers --ar-panel-shadow).
  * @cssprop --ar-dropdown-distance - Espacement entre le trigger et le panel (axe principal).
  * @cssprop --ar-dropdown-offset - Décalage latéral du panel (axe transversal).
  *

--- a/packages/core/src/components/dropdown/dropdown.ts
+++ b/packages/core/src/components/dropdown/dropdown.ts
@@ -29,7 +29,7 @@ export type ArDropdownPlacement =
  * @slot trigger  - Le bouton déclencheur (ignoré si `for` est défini).
  * @slot          - Contenu du panel (libre ou ar-dropdown-item pour le mode menu).
  *
- * @csspart panel - Le panel flottant. Personnalisable via `::part(panel)` (color, border-radius, box-shadow, padding, min-width, max-width).
+ * @csspart panel - Le panel flottant. Le thème par défaut pilote `border-radius`, `box-shadow`, `padding`, `min-width` et `max-width` via `ar-dropdown::part(panel)` ; `background-color`, `border-color` et `color` restent eux aussi overridables via `::part(panel)` par un consommateur, mais ne sont pas redéfinis par le thème par défaut.
  *
  * @cssprop --ar-dropdown-bg - Fond du panel (cascade vers --ar-panel-bg, repli système `Canvas` si aucun thème n'est chargé).
  * @cssprop --ar-dropdown-border-color - Bordure (cascade vers --ar-panel-border-color, repli système `ButtonBorder` si aucun thème n'est chargé).

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -522,7 +522,7 @@
         /* Valeur propre, volontairement non cascadée depuis --ar-panel-max-width (bloc partagé
            dropdown/breadcrumb/stepper) : le panel calendrier datepicker a toujours nécessité une
            taille plus généreuse (25rem) que la valeur par défaut partagée (18rem) — même
-           précédent que --ar-dropdown-min-width. */
+           précédent que le min-width littéral d'ar-dropdown::part(panel) (10rem, cf. plus bas). */
         --ar-datepicker-panel-max-width: 25rem;
 
         --ar-datepicker-nav-btn-border-color: transparent;

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -436,16 +436,7 @@
         --ar-dropdown-distance: var(--ar-anchor-distance);
         --ar-dropdown-offset: var(--ar-anchor-offset);
         --ar-dropdown-bg: var(--ar-panel-bg);
-        --ar-dropdown-color: var(--ar-panel-text);
         --ar-dropdown-border-color: var(--ar-panel-border-color);
-        --ar-dropdown-border-radius: var(--ar-panel-radius);
-        --ar-dropdown-shadow: var(--ar-panel-shadow);
-        --ar-dropdown-padding: var(--ar-panel-padding);
-        /* Valeur propre, volontairement non cascadée depuis --ar-panel-min-width : un menu
-           dropdown reste lisible plus étroit qu'un panel de disclosure générique (breadcrumb,
-           stepper). */
-        --ar-dropdown-min-width: 10rem;
-        --ar-dropdown-max-width: var(--ar-panel-max-width);
 
         /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
          * Dialog
@@ -1109,6 +1100,19 @@
             border-radius: var(--ar-panel-radius);
             box-shadow: var(--ar-panel-shadow);
             padding: var(--ar-panel-padding);
+        }
+    }
+
+    ar-dropdown {
+        &::part(panel) {
+            border-radius: var(--ar-panel-radius);
+            box-shadow: var(--ar-panel-shadow);
+            padding: var(--ar-panel-padding);
+            /* Valeur propre, volontairement non cascadée depuis --ar-panel-min-width : un menu
+               dropdown reste lisible plus étroit qu'un panel de disclosure générique
+               (breadcrumb, stepper). */
+            min-width: 10rem;
+            max-width: var(--ar-panel-max-width);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Migre 5 tokens `--ar-dropdown-*` (border-radius, shadow, padding, min-width, max-width) vers une règle littérale `ar-dropdown::part(panel)` dans `default.css`.
- Supprime `--ar-dropdown-color` sans remplaçant — retombe sur `--ar-panel-text` déjà posé par `panelBaseStyles` (partagé avec `ar-breadcrumb`/`ar-stepper`, qui n'ont jamais eu ce token).
- Conserve `bg`/`border-color` (fallback a11y système) et `distance`/`offset` (lus en JS par `AnchoredController`).
- Aligne `ar-dropdown` sur le pattern panel déjà établi par `ar-breadcrumb`/`ar-stepper` (lot 4) — les 3 composants consommant `panel.styles.ts` traitent désormais leur surcharge `[part='panel']` de façon identique.
- Nouvelle section ADR-005 documentant le précédent (suppression plutôt que migration quand un token duplique un fallback partagé sans jamais diverger).
- Aucun changement de structure DOM, aucun nouveau `part`, aucun changement visuel par défaut.

Spec : `docs/superpowers/specs/2026-07-31-dropdown-token-vs-part-129-design.md`
Plan : `docs/superpowers/plans/2026-07-31-dropdown-token-vs-part-129.md`

## Test plan
- [x] `npm run test --workspace=packages/core -- dropdown` (41/41)
- [x] `npm run build:manifest --workspace=packages/core` (garde-fous CI verts)
- [x] Suite browser (WTR) dropdown (21/21)
- [x] Vérification visuelle Playwright (avec et sans thème), contrôlée indépendamment
- [x] Revue finale de branche (opus) — 0 Critical, 1 Important corrigé, re-vérifié

🤖 Generated with [Claude Code](https://claude.com/claude-code)