### PR TITLE
fix(datepicker): renomme le token de bordure focus des jours

### DIFF
--- a/packages/core/src/components/datepicker/datepicker.styles.ts
+++ b/packages/core/src/components/datepicker/datepicker.styles.ts
@@ -131,12 +131,13 @@ export default css`
      * contrairement à :focus-visible qui ne s'active pas pour le focus programmatique.
      */
     [part='grid']:focus-within [part='day'][tabindex='0'] {
-        outline: solid
-            /* a11y-fallback: WCAG 2.4.7 (Focus Visible) — var() dans un raccourci outline invalide tout le raccourci si non résolu, y compris la largeur */
-            var(--ar-datepicker-day-focus-ring-width, 2px)
-            var(--ar-datepicker-day-focus-ring-color, ButtonText);
+        outline-style: solid;
+        /* a11y-fallback: WCAG 2.4.7 (Focus Visible) */
+        outline-width: var(--ar-datepicker-day-focus-ring-width, 2px);
+        outline-color: var(--ar-datepicker-day-focus-ring-color, ButtonText);
         outline-offset: var(--ar-datepicker-day-focus-ring-offset);
-        border-color: var(--ar-panel-bg);
+        /* a11y-fallback: transparent par défaut — l'anneau de focus (WCAG 2.4.7) reste garanti indépendamment par --ar-datepicker-day-focus-ring-* */
+        border-color: var(--ar-datepicker-day-focus-border-color, transparent);
     }
 
     [part='grid']:focus-within [part='day'][tabindex='0']:not(.selected) {

--- a/packages/core/src/components/datepicker/datepicker.ts
+++ b/packages/core/src/components/datepicker/datepicker.ts
@@ -63,12 +63,12 @@ import { warn } from '../../utils/warn.js';
  * @cssprop --ar-datepicker-day-focus-ring-color - Couleur du focus ring des jours. Repli `ButtonText` si aucun thème n'est chargé (WCAG 2.4.7).
  * @cssprop --ar-datepicker-day-focus-ring-width - Épaisseur du focus ring des jours.
  * @cssprop --ar-datepicker-day-focus-ring-offset - Décalage du focus ring des jours.
+ * @cssprop --ar-datepicker-day-focus-border-color - Couleur de bordure de la cellule jour en focus (roving tabindex). Repli transparent si aucun thème n'est chargé. Purement cosmétique : l'indicateur de focus visible (WCAG 2.4.7) reste garanti indépendamment par --ar-datepicker-day-focus-ring-color/-width/-offset. Dans le thème fourni, reprend --ar-panel-bg pour fondre la bordure dans le fond du panel ; un consommateur qui s'appuierait uniquement sur cette bordure (sans l'anneau) pour son propre design de focus est responsable du contraste WCAG 2.4.7.
  * @cssprop --ar-datepicker-day-selected-bg - Fond du jour sélectionné. Repli `Highlight` si aucun thème n'est chargé (sinon indiscernable des jours non sélectionnés).
  * @cssprop --ar-datepicker-day-selected-color - Couleur texte du jour sélectionné. Repli `HighlightText` si aucun thème n'est chargé.
  * @cssprop --ar-datepicker-input-error-border-color - Bordure input en état d'erreur.
  * @cssprop --ar-datepicker-nav-btn-focus-ring-color - Couleur de l'anneau de focus des boutons de navigation (cascade vers --ar-focus-ring-color). Repli `ButtonText` si aucun thème n'est chargé (WCAG 2.4.7).
  * @cssprop --ar-datepicker-footer-btn-focus-ring-color - Couleur de l'anneau de focus des boutons du footer (cascade vers --ar-focus-ring-color). Repli `ButtonText` si aucun thème n'est chargé (WCAG 2.4.7).
- * @cssprop --ar-panel-bg - Couleur de bordure de la cellule jour focusée dans la grille (contraste avec l'anneau de focus). Le popover pilote son fond réel via ce token (panelStyles) ; référencer --ar-color-bg directement casserait ce cutout pour un consommateur ne surchargeant que --ar-panel-bg.
  *
  * @event {CustomEvent} ar-datepicker-input-change   - Valeur commitée (blur ou sélection calendrier).
  * @event {CustomEvent} ar-datepicker-input-complete - Saisie texte complète (valide ou non).

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -545,6 +545,7 @@
         --ar-datepicker-day-focus-ring-color: var(--ar-focus-ring-color);
         --ar-datepicker-day-focus-ring-width: 2px;
         --ar-datepicker-day-focus-ring-offset: 0;
+        --ar-datepicker-day-focus-border-color: var(--ar-panel-bg);
         --ar-datepicker-day-border-color: transparent;
         --ar-datepicker-day-color: var(--ar-color-text);
         --ar-datepicker-day-bg: transparent;


### PR DESCRIPTION
## Summary
- `ar-datepicker` ne référence plus `--ar-panel-bg` directement dans son CSS interne : la bordure de la cellule jour focusée (technique de « cutout » contre l'anneau de focus) devient un token propre au composant, `--ar-datepicker-day-focus-border-color`, décrivant ce qu'il est plutôt que l'usage qu'en fait le thème par défaut.
- Ajoute le fallback `transparent` manquant sur cette déclaration (absent auparavant, ce qui rendait la bordure visible via `currentcolor` sans thème chargé) — l'anneau de focus WCAG 2.4.7 reste garanti indépendamment via `--ar-datepicker-day-focus-ring-*`.
- Nettoyage cosmétique du commentaire `a11y-fallback` du raccourci `outline` voisin (scindé en longhands `outline-style`/`outline-width`/`outline-color` pour que le commentaire s'affiche correctement au-dessus de la propriété dans l'inspecteur, sans casser le linter `validate-cssprop-defaults`).
- Confirme que la détection par préfixe `--ar-panel-*` (chantier de documentation publique des tokens panel) est désormais suffisante pour `ar-datepicker`, sans cas particulier à gérer.

## Test plan
- [x] `npm run test` (804/804, workspace core + docs)
- [x] `npm run build:manifest` (garde-fou `validate-cssprop-defaults` passe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)