### PR TITLE
docs(panel): documente publiquement les tokens --ar-panel-* partagés

### DIFF
--- a/apps/docs/src/components/ComponentApi.astro
+++ b/apps/docs/src/components/ComponentApi.astro
@@ -261,12 +261,6 @@ const ownProps = (component.cssProperties ?? []).filter((p) => !p.name.startsWit
         margin-top: 1.875rem;
     }
 
-    .code-caption {
-        font-size:     0.875rem;
-        color:         var(--doc-text-muted);
-        margin-bottom: 0.375rem;
-    }
-
     .token-example pre {
         margin:         0;
         padding:        1rem 1.25rem;

--- a/apps/docs/src/components/ComponentApi.astro
+++ b/apps/docs/src/components/ComponentApi.astro
@@ -18,6 +18,9 @@ const { component } = Astro.props;
 const publicMethods = (component.members ?? []).filter(
     (m) => m.kind === 'method' && m.privacy !== 'private' && m.privacy !== 'protected',
 );
+
+const panelProps = (component.cssProperties ?? []).filter((p) => p.name.startsWith('--ar-panel-'));
+const ownProps = (component.cssProperties ?? []).filter((p) => !p.name.startsWith('--ar-panel-'));
 ---
 
 <div class="component-api">
@@ -147,8 +150,50 @@ const publicMethods = (component.members ?? []).filter(
         </section>
     )}
 
-    {/* ── CSS Custom Properties ── */}
-    {component.cssProperties && component.cssProperties.length > 0 && (
+    {/* ── Tokens du panel partagé (affiché en premier si présent) ── */}
+    {panelProps.length > 0 && (
+        <section>
+            <h4 id="api-panel-tokens" class="subsection-title">Tokens du panel partagé</h4>
+            <p class="hint">
+                Ce composant utilise un panel flottant partagé avec d'autres composants de la
+                librairie. Deux techniques de personnalisation sont possibles : redéfinir un ou
+                plusieurs tokens ci-dessous, scopés à ce composant uniquement (n'affecte pas les
+                autres consommateurs du panel partagé), ou surcharger n'importe quelle propriété
+                CSS via <code>::part(panel)</code>, sans passer par les tokens — utile pour une
+                propriété que le thème par défaut ne tokenise pas, ou pour un changement plus
+                large que ce que les tokens exposent.
+            </p>
+            <div class="code-block">
+                <p class="code-caption">Technique 1 — token scopé au composant :</p>
+                <pre><code class="language-css">{`${component.tagName} {\n    --ar-panel-bg: #fff;\n}`}</code></pre>
+            </div>
+            <div class="code-block">
+                <p class="code-caption">Technique 2 — <code>::part(panel)</code> :</p>
+                <pre><code class="language-css">{`${component.tagName}::part(panel) {\n    background-color: #fff;\n}`}</code></pre>
+            </div>
+            <div class="table-wrap">
+                <table>
+                    <thead>
+                        <tr>
+                            <th scope="col">Nom</th>
+                            <th scope="col">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {panelProps.map((prop) => (
+                            <tr>
+                                <td><code>{prop.name}</code></td>
+                                <td>{prop.description ?? ''}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+        </section>
+    )}
+
+    {/* ── CSS Custom Properties propres au composant ── */}
+    {ownProps.length > 0 && (
         <section>
             <h4 id="api-css-props" class="subsection-title">CSS Custom Properties</h4>
             <div class="table-wrap">
@@ -160,7 +205,7 @@ const publicMethods = (component.members ?? []).filter(
                         </tr>
                     </thead>
                     <tbody>
-                        {component.cssProperties.map((prop) => (
+                        {ownProps.map((prop) => (
                             <tr>
                                 <td><code>{prop.name}</code></td>
                                 <td>{prop.description ?? ''}</td>
@@ -213,5 +258,34 @@ const publicMethods = (component.members ?? []).filter(
         font-size:     0.875rem;
         color:         var(--doc-text-muted);
         margin-bottom: 0.75rem;
+    }
+
+    .code-block {
+        margin-bottom: 1rem;
+    }
+
+    .code-caption {
+        font-size:     0.875rem;
+        color:         var(--doc-text-muted);
+        margin-bottom: 0.375rem;
+    }
+
+    .code-block pre {
+        margin:         0;
+        padding:        1rem 1.25rem;
+        overflow-x:     auto;
+        border-radius:  0.5rem;
+        font-family:    'Fira Code', 'Cascadia Code', monospace;
+        font-size:      0.8rem;
+        line-height:    1.6;
+        background:     var(--doc-code-block-bg);
+    }
+
+    .code-block pre code {
+        font-family: inherit;
+        font-size:   inherit;
+        padding:     0;
+        background:  transparent;
+        color:       #cdd6f4;
     }
 </style>

--- a/apps/docs/src/components/ComponentApi.astro
+++ b/apps/docs/src/components/ComponentApi.astro
@@ -161,13 +161,17 @@ const ownProps = (component.cssProperties ?? []).filter((p) => !p.name.startsWit
                 autres consommateurs du panel partagé), ou surcharger n'importe quelle propriété
                 CSS via <code>::part(panel)</code>, sans passer par les tokens — utile pour une
                 propriété que le thème par défaut ne tokenise pas, ou pour un changement plus
-                large que ce que les tokens exposent.
+                large que ce que les tokens exposent. Certains composants exposent aussi leur
+                propre token plus spécifique qui prend le pas sur le token générique du panel
+                (par exemple <code>--ar-dropdown-bg</code>, <code>--ar-breadcrumb-panel-bg</code>
+                ou <code>--ar-stepper-panel-bg</code> pour le fond) — dans ce cas, utilisez ce
+                token spécifique, ou passez par la technique 2.
             </p>
-            <div class="code-block">
+            <div class="token-example">
                 <p class="code-caption">Technique 1 — token scopé au composant :</p>
-                <pre><code class="language-css">{`${component.tagName} {\n    --ar-panel-bg: #fff;\n}`}</code></pre>
+                <pre><code class="language-css">{`${component.tagName} {\n    --ar-panel-radius: 1rem;\n}`}</code></pre>
             </div>
-            <div class="code-block">
+            <div class="token-example">
                 <p class="code-caption">Technique 2 — <code>::part(panel)</code> :</p>
                 <pre><code class="language-css">{`${component.tagName}::part(panel) {\n    background-color: #fff;\n}`}</code></pre>
             </div>
@@ -260,7 +264,7 @@ const ownProps = (component.cssProperties ?? []).filter((p) => !p.name.startsWit
         margin-bottom: 0.75rem;
     }
 
-    .code-block {
+    .token-example {
         margin-bottom: 1rem;
     }
 
@@ -270,7 +274,7 @@ const ownProps = (component.cssProperties ?? []).filter((p) => !p.name.startsWit
         margin-bottom: 0.375rem;
     }
 
-    .code-block pre {
+    .token-example pre {
         margin:         0;
         padding:        1rem 1.25rem;
         overflow-x:     auto;
@@ -281,7 +285,7 @@ const ownProps = (component.cssProperties ?? []).filter((p) => !p.name.startsWit
         background:     var(--doc-code-block-bg);
     }
 
-    .code-block pre code {
+    .token-example pre code {
         font-family: inherit;
         font-size:   inherit;
         padding:     0;

--- a/apps/docs/src/components/ComponentApi.astro
+++ b/apps/docs/src/components/ComponentApi.astro
@@ -6,7 +6,7 @@
  * Toutes les sections (attributs, events, CSS parts, CSS props, slots) sont auto-générées.
  * Ajouter une annotation JSDoc dans le composant TS → apparaît ici automatiquement.
  */
-import { type CemDeclaration } from '../utils/cem-types.ts';
+import { type CemDeclaration, getPublicMethods } from '../utils/cem-types.ts';
 import { isCancelableEvent, stripCancelableMarker } from '../utils/events.ts';
 
 interface Props {
@@ -15,9 +15,7 @@ interface Props {
 
 const { component } = Astro.props;
 
-const publicMethods = (component.members ?? []).filter(
-    (m) => m.kind === 'method' && m.privacy !== 'private' && m.privacy !== 'protected',
-);
+const publicMethods = getPublicMethods(component);
 
 const panelProps = (component.cssProperties ?? []).filter((p) => p.name.startsWith('--ar-panel-'));
 const ownProps = (component.cssProperties ?? []).filter((p) => !p.name.startsWith('--ar-panel-'));
@@ -150,74 +148,61 @@ const ownProps = (component.cssProperties ?? []).filter((p) => !p.name.startsWit
         </section>
     )}
 
-    {/* ── Tokens du panel partagé (affiché en premier si présent) ── */}
-    {panelProps.length > 0 && (
-        <section>
-            <h4 id="api-panel-tokens" class="subsection-title">Tokens du panel partagé</h4>
-            <p class="hint">
-                Ce composant utilise un panel flottant partagé avec d'autres composants de la
-                librairie. Deux techniques de personnalisation sont possibles : redéfinir un ou
-                plusieurs tokens ci-dessous, scopés à ce composant uniquement (n'affecte pas les
-                autres consommateurs du panel partagé), ou surcharger n'importe quelle propriété
-                CSS via <code>::part(panel)</code>, sans passer par les tokens — utile pour une
-                propriété que le thème par défaut ne tokenise pas, ou pour un changement plus
-                large que ce que les tokens exposent. Certains composants exposent aussi leur
-                propre token plus spécifique qui prend le pas sur le token générique du panel
-                (par exemple <code>--ar-dropdown-bg</code>, <code>--ar-breadcrumb-panel-bg</code>
-                ou <code>--ar-stepper-panel-bg</code> pour le fond) — dans ce cas, utilisez ce
-                token spécifique, ou passez par la technique 2.
-            </p>
-            <div class="token-example">
-                <p class="code-caption">Technique 1 — token scopé au composant :</p>
-                <pre><code class="language-css">{`${component.tagName} {\n    --ar-panel-radius: 1rem;\n}`}</code></pre>
-            </div>
-            <div class="token-example">
-                <p class="code-caption">Technique 2 — <code>::part(panel)</code> :</p>
-                <pre><code class="language-css">{`${component.tagName}::part(panel) {\n    background-color: #fff;\n}`}</code></pre>
-            </div>
-            <div class="table-wrap">
-                <table>
-                    <thead>
-                        <tr>
-                            <th scope="col">Nom</th>
-                            <th scope="col">Description</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {panelProps.map((prop) => (
-                            <tr>
-                                <td><code>{prop.name}</code></td>
-                                <td>{prop.description ?? ''}</td>
-                            </tr>
-                        ))}
-                    </tbody>
-                </table>
-            </div>
-        </section>
-    )}
-
     {/* ── CSS Custom Properties propres au composant ── */}
-    {ownProps.length > 0 && (
+    {(ownProps.length > 0 || panelProps.length > 0) && (
         <section>
             <h4 id="api-css-props" class="subsection-title">CSS Custom Properties</h4>
-            <div class="table-wrap">
-                <table>
-                    <thead>
-                        <tr>
-                            <th scope="col">Nom</th>
-                            <th scope="col">Description</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {ownProps.map((prop) => (
+            {/* ── Tokens du panel partagé (affiché en premier si présent) ── */}
+            {panelProps.length > 0 && (
+                <p>
+                    Ce composant utilise un panel flottant, partagé avec d'autres composants, qui expose des custom properties.<br>
+                    Les thèmes peuvent redéfinir ces tokens globalement via <code>:root</code>, ou par composants comme ci-dessous.
+                </p>
+                <div class="token-example">
+                    <pre><code class="language-css">{`${component.tagName} {\n    --ar-panel-radius: 1rem;\n}`}</code></pre>
+                </div>
+                <div class="table-wrap panel-tokens-table">
+                    <table>
+                        <thead>
                             <tr>
-                                <td><code>{prop.name}</code></td>
-                                <td>{prop.description ?? ''}</td>
+                                <th scope="col">Nom</th>
+                                <th scope="col">Description</th>
                             </tr>
-                        ))}
-                    </tbody>
-                </table>
-            </div>
+                        </thead>
+                        <tbody>
+                            {panelProps.map((prop) => (
+                                <tr>
+                                    <td><code>{prop.name}</code></td>
+                                    <td>{prop.description ?? ''}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            )}
+            {(panelProps.length > 0 && ownProps.length > 0) && (
+                <p class="own-props-intro">Il expose également des custom properties propres, personnalisables directement via <code>:root</code>.</p>
+            )}
+            {ownProps.length > 0 && (
+                <div class="table-wrap">
+                    <table>
+                        <thead>
+                            <tr>
+                                <th scope="col">Nom</th>
+                                <th scope="col">Description</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {ownProps.map((prop) => (
+                                <tr>
+                                    <td><code>{prop.name}</code></td>
+                                    <td>{prop.description ?? ''}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            )}
         </section>
     )}
 
@@ -266,6 +251,14 @@ const ownProps = (component.cssProperties ?? []).filter((p) => !p.name.startsWit
 
     .token-example {
         margin-bottom: 1rem;
+    }
+
+    .panel-tokens-table {
+        margin-bottom: 1.875rem;
+    }
+
+    .own-props-intro {
+        margin-top: 1.875rem;
     }
 
     .code-caption {

--- a/apps/docs/src/pages/components/[slug].astro
+++ b/apps/docs/src/pages/components/[slug].astro
@@ -8,7 +8,12 @@ import NarrativeHeading from '../../components/NarrativeHeading.astro';
 import NarrativeSubheading from '../../components/NarrativeSubheading.astro';
 import manifest from '@cem';
 import { getSlug } from '../../utils/tag-name.ts';
-import { type CemDeclaration, getCustomElements, buildControls } from '../../utils/cem-types.ts';
+import {
+    type CemDeclaration,
+    getCustomElements,
+    getPublicMethods,
+    buildControls,
+} from '../../utils/cem-types.ts';
 
 type MdxEntry = Awaited<ReturnType<typeof getCollection<'components'>>>[number];
 
@@ -61,6 +66,33 @@ const playgroundHtml = rawPlaygroundHtml
 
 const controls = buildControls(component.members ?? []);
 
+// ─── Sous-sections de la Référence API ─────────────────────────────────────────
+//
+// Chaque entrée reflète exactement la condition d'affichage de la section
+// correspondante dans ComponentApi.astro — une section absente (ex. pas de slot)
+// ne doit pas apparaître dans la TOC.
+
+const apiTocEntries = [
+    component.attributes && component.attributes.length > 0
+        ? { id: 'api-attributs', label: 'Attributs & Propriétés', level: 2 as const }
+        : null,
+    component.events && component.events.length > 0
+        ? { id: 'api-evenements', label: 'Événements', level: 2 as const }
+        : null,
+    getPublicMethods(component).length > 0
+        ? { id: 'api-methodes', label: 'Méthodes', level: 2 as const }
+        : null,
+    component.cssParts && component.cssParts.length > 0
+        ? { id: 'api-css-parts', label: 'CSS Parts', level: 2 as const }
+        : null,
+    component.cssProperties && component.cssProperties.length > 0
+        ? { id: 'api-css-props', label: 'CSS Custom Properties', level: 2 as const }
+        : null,
+    component.slots && component.slots.length > 0
+        ? { id: 'api-slots', label: 'Slots', level: 2 as const }
+        : null,
+].filter((entry) => entry !== null);
+
 // ─── TOC ──────────────────────────────────────────────────────────────────────
 //
 // Les h2 du MDX sont automatiquement injectés en tête de TOC.
@@ -93,6 +125,7 @@ const tocEntries = [
         ? [{ id: 'playground', label: 'Playground', level: 1 as const }]
         : []),
     { id: 'reference-api', label: 'Référence API', level: 1 as const },
+    ...apiTocEntries,
 ];
 ---
 

--- a/apps/docs/src/utils/cem-types.ts
+++ b/apps/docs/src/utils/cem-types.ts
@@ -106,6 +106,13 @@ export function getCustomElements(manifest: unknown): CemDeclaration[] {
         .filter((d) => d.kind === 'class' && d.customElement === true);
 }
 
+/** Méthodes publiques d'un composant — exclut les membres privés/protégés et les non-méthodes. */
+export function getPublicMethods(component: CemDeclaration): CemMember[] {
+    return (component.members ?? []).filter(
+        (m) => m.kind === 'method' && m.privacy !== 'private' && m.privacy !== 'protected',
+    );
+}
+
 // ─── Helpers détection des contrôles playground ───────────────────────────────
 
 /** Retourne true si le type CEM est une union de string literals : 'a' | 'b' | … */

--- a/docs/superpowers/plans/2026-08-03-panel-own-tokens-removal.md
+++ b/docs/superpowers/plans/2026-08-03-panel-own-tokens-removal.md
@@ -1,0 +1,481 @@
+# Retrait des tokens panel redondants Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Retirer les 6 tokens publics redondants (`--ar-dropdown-bg`, `--ar-dropdown-border-color`,
+`--ar-breadcrumb-panel-bg`, `--ar-breadcrumb-panel-border-color`, `--ar-stepper-panel-bg`,
+`--ar-stepper-panel-border-color`) qui ne divergent jamais du générique `--ar-panel-*` et court-
+circuitaient silencieusement la technique de personnalisation documentée en PR #151 —
+conformément à `docs/superpowers/specs/2026-08-03-panel-own-tokens-removal-design.md`.
+
+**Architecture:** Aucun changement de structure DOM, aucun nouveau `part`. `ar-dropdown`,
+`ar-breadcrumb`, `ar-stepper` héritent désormais directement de `background-color`/`border-color`
+posés par `panel.styles.ts` (déjà le cas pour `ar-datepicker`) au lieu de passer par un token
+intermédiaire propre. Continuation de la même branche/PR que le chantier de documentation
+publique des tokens panel (`docs/panel-tokens-public-doc`, PR #151) — pas de nouvelle branche.
+
+**Tech Stack:** Lit 3, TypeScript, CSS custom properties, Astro, Prettier, garde-fous CI
+(`validate-cssprop-defaults.js`).
+
+## Global Constraints
+
+- Prettier : 100 char, 4 spaces, single quotes (CLAUDE.md).
+- Retrait direct sans dépréciation — projet en alpha (`0.1.0-alpha.8`), conforme à CLAUDE.md.
+- Aucune mention de `default.css`/du thème par défaut dans les descriptions `@cssprop` restantes
+  ou modifiées (cf. `feedback_jsdoc_no_default_theme_mention` — règle vérifiée applicable ici :
+  aucune nouvelle description n'est ajoutée dans ce plan, seulement des suppressions).
+- Ne jamais merger sur `dev` sans confirmation explicite de l'utilisateur
+  (feedback_merge_after_autonomous_fix).
+- `npm run dev --workspace=apps/docs` seul ne reconstruit pas le JS de `packages/core/dist` —
+  rebuild explicite (`npm run build:dev --workspace=packages/core`) requis avant toute
+  vérification Playwright (feedback_docs_dev_stale_dist).
+- On continue sur la branche `docs/panel-tokens-public-doc` (déjà poussée, PR #151 ouverte) — pas
+  de nouvelle branche à créer.
+
+---
+
+## Task 1: Retirer le bloc `[part='panel']` — `ar-dropdown`
+
+**Files:**
+
+- Modify: `packages/core/src/components/dropdown/dropdown.styles.ts`
+
+**Interfaces:**
+
+- Consumes: `panel.styles.ts` fournit désormais directement `background-color`/`border-color` du
+  panel via `var(--ar-panel-bg, Canvas)`/`var(--ar-panel-border-color, ButtonBorder)`, sans
+  interception par ce composant.
+- Produces: aucun changement de rendu — les valeurs de repli (`Canvas`/`ButtonBorder`) et le token
+  générique (`--ar-panel-bg`/`--ar-panel-border-color`) sont strictement identiques à avant.
+
+- [ ] **Step 1: Retirer le bloc entier**
+
+Contenu actuel (`dropdown.styles.ts:8-12`) :
+
+```ts
+    [part='panel'] {
+        /* Overrides composant — chaînent vers les tokens shared --ar-panel-* */
+        background-color: var(--ar-dropdown-bg, Canvas);
+        border-color: var(--ar-dropdown-border-color, ButtonBorder);
+    }
+```
+
+Retirer ces 5 lignes entièrement (accolades incluses), en gardant une seule ligne vide entre les
+règles `:host { }` et `` ` `` de fermeture du template (pas deux lignes vides consécutives).
+
+- [ ] **Step 2: Vérifier le format**
+
+Run: `npx prettier --check packages/core/src/components/dropdown/dropdown.styles.ts`
+Expected: pas d'erreur.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/src/components/dropdown/dropdown.styles.ts
+git commit -m "refactor(dropdown): retire l'override panel non divergent, hérite directement de panel.styles.ts"
+```
+
+---
+
+## Task 2: Retirer le bloc `[part='panel']` — `ar-breadcrumb`
+
+**Files:**
+
+- Modify: `packages/core/src/components/breadcrumb/breadcrumb.styles.ts`
+
+**Interfaces:**
+
+- Consumes: idem Task 1, pour `ar-breadcrumb`.
+- Produces: aucun changement de rendu.
+
+- [ ] **Step 1: Retirer le bloc entier**
+
+Contenu actuel (`breadcrumb.styles.ts:101-106`) :
+
+```ts
+    /* ── Panel flottant mobile ───────────────────────────────── */
+
+    [part='panel'] {
+        background-color: var(--ar-breadcrumb-panel-bg, Canvas);
+        border-color: var(--ar-breadcrumb-panel-border-color, ButtonBorder);
+    }
+```
+
+Retirer le bloc `[part='panel'] { ... }` (4 lignes, accolades incluses). Conserver le commentaire
+de section `/* ── Panel flottant mobile ── */` seulement s'il précède encore une autre règle liée
+au panel juste après (vérifier le fichier réel avant de trancher — s'il ne précède plus rien,
+retirer aussi le commentaire pour éviter un titre de section vide).
+
+- [ ] **Step 2: Vérifier le format**
+
+Run: `npx prettier --check packages/core/src/components/breadcrumb/breadcrumb.styles.ts`
+Expected: pas d'erreur.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/src/components/breadcrumb/breadcrumb.styles.ts
+git commit -m "refactor(breadcrumb): retire l'override panel non divergent, hérite directement de panel.styles.ts"
+```
+
+---
+
+## Task 3: Retirer le bloc `[part='panel']` — `ar-stepper`
+
+**Files:**
+
+- Modify: `packages/core/src/components/stepper/stepper.styles.ts`
+
+**Interfaces:**
+
+- Consumes: idem Task 1, pour `ar-stepper`.
+- Produces: aucun changement de rendu.
+
+- [ ] **Step 1: Retirer le bloc entier**
+
+Contenu actuel (`stepper.styles.ts:25-28`) :
+
+```ts
+    [part='panel'] {
+        background-color: var(--ar-stepper-panel-bg, Canvas);
+        border-color: var(--ar-stepper-panel-border-color, ButtonBorder);
+    }
+```
+
+Retirer ces 4 lignes entièrement (accolades incluses), garder une seule ligne vide entre la règle
+précédente et la règle suivante (`[part='list']`).
+
+- [ ] **Step 2: Vérifier le format**
+
+Run: `npx prettier --check packages/core/src/components/stepper/stepper.styles.ts`
+Expected: pas d'erreur.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/src/components/stepper/stepper.styles.ts
+git commit -m "refactor(stepper): retire l'override panel non divergent, hérite directement de panel.styles.ts"
+```
+
+---
+
+## Task 4: Retirer les `@cssprop` correspondants du JSDoc
+
+**Files:**
+
+- Modify: `packages/core/src/components/dropdown/dropdown.ts`
+- Modify: `packages/core/src/components/breadcrumb/breadcrumb.ts`
+- Modify: `packages/core/src/components/stepper/stepper.ts`
+
+**Interfaces:**
+
+- Consumes: rien.
+- Produces: le CEM manifest n'expose plus ces 6 entrées `cssProperties` — la table « CSS Custom
+  Properties propres » de `ComponentApi.astro` (PR #151, déjà mergée sur cette branche) les fait
+  disparaître automatiquement, sans changement de code côté `apps/docs`.
+
+- [ ] **Step 1: `dropdown.ts` — retirer 2 lignes**
+
+Contenu actuel (`dropdown.ts:34-35`) :
+
+```
+ * @cssprop --ar-dropdown-bg - Fond du panel (cascade vers --ar-panel-bg, repli système `Canvas` si aucun thème n'est chargé).
+ * @cssprop --ar-dropdown-border-color - Bordure (cascade vers --ar-panel-border-color, repli système `ButtonBorder` si aucun thème n'est chargé).
+```
+
+Retirer ces 2 lignes. Les lignes voisines (`--ar-dropdown-distance`, `--ar-dropdown-offset`, et les
+9 lignes `--ar-panel-*` ajoutées en PR #151) restent inchangées.
+
+- [ ] **Step 2: `breadcrumb.ts` — retirer 2 lignes**
+
+Contenu actuel (`breadcrumb.ts:50-51`) :
+
+```
+ * @cssprop --ar-breadcrumb-panel-bg - Fond du panel mobile (cascade vers --ar-panel-bg, repli système `Canvas` si aucun thème n'est chargé).
+ * @cssprop --ar-breadcrumb-panel-border-color - Couleur de bordure du panel mobile (cascade vers --ar-panel-border-color, repli système `ButtonBorder` si aucun thème n'est chargé).
+```
+
+Retirer ces 2 lignes. Les autres `@cssprop` du bloc restent inchangés.
+
+- [ ] **Step 3: `stepper.ts` — retirer 2 lignes**
+
+Contenu actuel (`stepper.ts:58-59`) :
+
+```
+ * @cssprop --ar-stepper-panel-bg - Fond du panel mobile (cascade vers --ar-panel-bg, repli système `Canvas` si aucun thème n'est chargé).
+ * @cssprop --ar-stepper-panel-border-color - Couleur de bordure du panel mobile (cascade vers --ar-panel-border-color, repli système `ButtonBorder` si aucun thème n'est chargé).
+```
+
+Retirer ces 2 lignes. Les autres `@cssprop` du bloc restent inchangés.
+
+- [ ] **Step 4: Vérifier le format des 3 fichiers**
+
+Run: `npx prettier --check packages/core/src/components/dropdown/dropdown.ts packages/core/src/components/breadcrumb/breadcrumb.ts packages/core/src/components/stepper/stepper.ts`
+Expected: pas d'erreur.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/components/dropdown/dropdown.ts packages/core/src/components/breadcrumb/breadcrumb.ts packages/core/src/components/stepper/stepper.ts
+git commit -m "docs: retire les @cssprop des 6 tokens panel redondants supprimés"
+```
+
+---
+
+## Task 5: Retirer les déclarations dans `default.css`
+
+**Files:**
+
+- Modify: `packages/core/src/styles/themes/default.css`
+
+**Interfaces:**
+
+- Consumes: rien.
+- Produces: le thème par défaut ne redéfinit plus ces 6 tokens — `ar-dropdown`/`ar-breadcrumb`/
+  `ar-stepper` reçoivent leur fond/bordure directement de `--ar-panel-bg`/`--ar-panel-border-color`
+  (déjà définis à la racine, `default.css:302-303`), valeur strictement identique.
+
+- [ ] **Step 1: Retirer les 3 paires de déclarations**
+
+Repérer et retirer (les numéros de ligne exacts peuvent avoir légèrement bougé depuis l'audit —
+localiser par grep avant de couper) :
+
+```css
+--ar-breadcrumb-panel-bg: var(--ar-panel-bg);
+--ar-breadcrumb-panel-border-color: var(--ar-panel-border-color);
+```
+
+```css
+--ar-stepper-panel-bg: var(--ar-panel-bg);
+--ar-stepper-panel-border-color: var(--ar-panel-border-color);
+```
+
+```css
+--ar-dropdown-bg: var(--ar-panel-bg);
+--ar-dropdown-border-color: var(--ar-panel-border-color);
+```
+
+Run avant de trancher : `grep -n "ar-dropdown-bg\|ar-dropdown-border-color\|ar-breadcrumb-panel-bg\|ar-breadcrumb-panel-border-color\|ar-stepper-panel-bg\|ar-stepper-panel-border-color" packages/core/src/styles/themes/default.css`
+— confirmer qu'il n'y a bien que ces 6 lignes (3 paires) à retirer, aucune autre référence
+résiduelle (ex. dans un `calc()` ou un bloc dark-mode).
+
+- [ ] **Step 2: Vérifier le format**
+
+Run: `npx prettier --check packages/core/src/styles/themes/default.css`
+Expected: pas d'erreur.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/src/styles/themes/default.css
+git commit -m "refactor(theme): retire les alias panel non divergents pour dropdown/breadcrumb/stepper"
+```
+
+---
+
+## Task 6: Corriger les commentaires des tests de fallback
+
+**Files:**
+
+- Modify: `packages/core/src/components/dropdown/dropdown.browser.test.ts`
+- Modify: `packages/core/src/components/breadcrumb/breadcrumb.browser.test.ts`
+- Modify: `packages/core/src/components/stepper/stepper.browser.test.ts`
+
+**Interfaces:**
+
+- Consumes: rien — aucune assertion ne change, ces tests vérifient que `background-color`/
+  `border-top-color` du panel ne sont ni vides ni transparents sans thème chargé. Le résultat
+  calculé est identique avant/après ce chantier (même repli `Canvas`/`ButtonBorder`, posé
+  maintenant par `panel.styles.ts` au lieu de transiter par le token du composant).
+- Produces: commentaires exacts sur l'origine réelle du repli.
+
+- [ ] **Step 1: `dropdown.browser.test.ts` — corriger le commentaire**
+
+Contenu actuel (`dropdown.browser.test.ts:211-213` environ, à localiser par le texte) :
+
+```ts
+// default.css n'est jamais chargé dans les tests (Vitest ni WTR) : ces
+// valeurs viennent uniquement du fallback système CSS4 posé dans
+// panel.styles.ts, pas d'un thème.
+```
+
+Si le commentaire mentionne déjà `panel.styles.ts`, ne rien changer (il est possible qu'il soit
+déjà correct — vérifier le texte réel avant d'éditer, ne pas éditer à l'aveugle). S'il mentionne
+`dropdown.styles.ts`, corriger en `panel.styles.ts`.
+
+- [ ] **Step 2: `breadcrumb.browser.test.ts` — corriger le commentaire**
+
+Même vérification : si le commentaire mentionne `breadcrumb.styles.ts` comme source du repli,
+corriger en `panel.styles.ts`. Sinon laisser inchangé.
+
+- [ ] **Step 3: `stepper.browser.test.ts` — corriger le commentaire**
+
+Même vérification : si le commentaire mentionne `stepper.styles.ts` comme source du repli,
+corriger en `panel.styles.ts`. Sinon laisser inchangé.
+
+- [ ] **Step 4: Vérifier le format**
+
+Run: `npx prettier --check packages/core/src/components/dropdown/dropdown.browser.test.ts packages/core/src/components/breadcrumb/breadcrumb.browser.test.ts packages/core/src/components/stepper/stepper.browser.test.ts`
+Expected: pas d'erreur.
+
+- [ ] **Step 5: Commit (uniquement si au moins un commentaire a changé)**
+
+```bash
+git add packages/core/src/components/dropdown/dropdown.browser.test.ts packages/core/src/components/breadcrumb/breadcrumb.browser.test.ts packages/core/src/components/stepper/stepper.browser.test.ts
+git commit -m "test: corrige les commentaires attribuant le repli panel au bon fichier source"
+```
+
+Si aucun commentaire n'a changé, passer directement à Task 7 sans commit.
+
+---
+
+## Task 7: Vérification — build manifest, tests, build Astro
+
+**Files:** aucun — vérification uniquement.
+
+- [ ] **Step 1: Rebuild le manifeste CEM (déclenche les garde-fous CI)**
+
+Run: `npm run build:manifest --workspace=packages/core`
+Expected: succès, aucune erreur `validate-cssprop-defaults.js` (les 6 tokens retirés ne doivent
+plus apparaître dans le manifeste).
+
+- [ ] **Step 2: Suite de tests complète**
+
+Run: `npm run test`
+Expected: tous les tests passent, en particulier les 3 tests de fallback panel (Task 6) — même
+résultat calculé qu'avant, aucune régression.
+
+- [ ] **Step 3: Suite browser (WTR) des 3 composants**
+
+Run (depuis `packages/core`) :
+`npx web-test-runner "src/components/{dropdown,breadcrumb,stepper}/*.{browser,a11y}.test.ts"`
+Expected: tous les tests passent.
+
+- [ ] **Step 4: Build Astro complet**
+
+Run: `npm run build --workspace=apps/docs`
+Expected: succès, 22 pages. Vérifier que les pages `ar-dropdown`/`ar-breadcrumb`/`ar-stepper`
+affichent toujours une table « CSS Custom Properties propres » non vide (ex. `grep -A3
+"ar-dropdown-distance" apps/docs/dist/components/dropdown/index.html`) et que les 6 tokens
+retirés n'y apparaissent plus (`grep -c "ar-dropdown-bg\|ar-dropdown-border-color"
+apps/docs/dist/components/dropdown/index.html` doit retourner `0`, idem pour les 2 autres
+composants).
+
+- [ ] **Step 5: Grep final — zéro référence résiduelle**
+
+Run: `grep -rn "ar-dropdown-bg\b\|ar-dropdown-border-color\b\|ar-breadcrumb-panel-bg\b\|ar-breadcrumb-panel-border-color\b\|ar-stepper-panel-bg\b\|ar-stepper-panel-border-color\b" packages/core/src apps/docs/src`
+Expected: aucune occurrence (le flag `\b` évite un faux positif sur un préfixe partagé avec un
+autre token). Si une occurrence apparaît, l'investiguer avant de continuer — ne pas supposer
+qu'elle est bénigne.
+
+- [ ] **Step 6: Commit (uniquement si un fix a été nécessaire)**
+
+Si les Steps 1-5 ont révélé un problème nécessitant une correction, committer séparément avec un
+message décrivant le problème trouvé. Sinon, passer directement à Task 8.
+
+---
+
+## Task 8: Vérification visuelle manuelle (Playwright)
+
+**Files:** aucun fichier modifié — vérification uniquement.
+
+- [ ] **Step 1: Rebuild explicite de `packages/core` avant toute vérification Playwright**
+
+Run: `npm run build:dev --workspace=packages/core`
+Expected: build réussi (piège connu, cf. Global Constraints).
+
+- [ ] **Step 2: Lancer le serveur de doc**
+
+Run: `npm run dev --workspace=apps/docs` (arrière-plan ou terminal dédié).
+
+- [ ] **Step 3: Capturer le panel des 3 composants, avec thème chargé**
+
+Utiliser l'outillage Playwright déjà présent (`apps/docs/playwright.config.ts`,
+`@playwright/test`) pour ouvrir le panel/menu mobile de `ar-dropdown`, `ar-breadcrumb`,
+`ar-stepper` (démo). Capturer une screenshot de chaque panel. Vérifier visuellement : fond,
+bordure — identiques au rendu d'avant ce chantier (aucune régression attendue, la valeur calculée
+est strictement identique, seule la source de la déclaration CSS a changé).
+
+- [ ] **Step 4: Consigner le résultat**
+
+Si un écart visuel est trouvé, corriger la Task concernée (1-3) et refaire Steps 3-4 de la Task 7
+et ce Step 3. Si rien trouvé, continuer.
+
+---
+
+## Task 9: Revue finale de branche
+
+**Files:** aucun — revue uniquement.
+
+- [ ] **Step 1: Dispatcher une revue de branche complète sur un agent capable**
+
+Le champ de revue est **l'ensemble de la branche `docs/panel-tokens-public-doc`** depuis `dev`
+(cette branche contient déjà le chantier de documentation publique des tokens panel, PR #151 —
+la revue doit couvrir aussi les commits de ce second chantier, pas seulement les nouveaux). Comparer
+le diff complet contre les deux specs (`docs/superpowers/specs/2026-08-03-panel-tokens-public-doc-design.md`
+et `docs/superpowers/specs/2026-08-03-panel-own-tokens-removal-design.md`). Points d'attention
+spécifiques à ce second chantier :
+
+- Les 3 blocs `[part='panel']` sont bien intégralement retirés (pas de résidu partiel, pas de
+  propriété autre que `background-color`/`border-color` supprimée par erreur — vérifier qu'aucun
+  bloc ne contenait une 3ᵉ propriété passée inaperçue).
+- Les 6 `@cssprop` retirés du JSDoc correspondent exactement aux 6 tokens retirés du CSS — pas un
+  de plus (ex. `--ar-dropdown-distance` ne doit surtout pas avoir été retiré par erreur).
+- `default.css` : les 6 lignes retirées, aucune autre référence résiduelle ailleurs dans le
+  fichier (calc(), bloc dark-mode, etc.).
+- Aucune mention de `default.css`/du thème par défaut n'a été ajoutée dans un `@cssprop` restant
+  (cf. `feedback_jsdoc_no_default_theme_mention` — ce chantier ne fait que des suppressions, donc
+  ce risque est faible, mais à vérifier explicitement puisque c'est une règle nouvellement actée).
+- `ComponentApi.astro` (déjà mergé sur cette branche par le chantier précédent) n'a besoin
+  d'aucune modification — confirmer qu'aucun commit de ce second chantier n'y touche à tort.
+- Aucun changement dans `ar-datepicker` (déjà conforme, jamais concerné par ce chantier).
+
+- [ ] **Step 2: Corriger les findings en une vague unique**
+
+Si des findings « Critical »/« Important » remontent, les corriger en un seul commit groupé, puis
+relancer Task 7 (Steps 2-5) et Task 8 Step 3 pour re-vérifier.
+
+---
+
+## Task 10: Mettre à jour la PR existante
+
+**Files:** aucun.
+
+- [ ] **Step 1: Pousser les nouveaux commits**
+
+```bash
+git push
+```
+
+(la branche `docs/panel-tokens-public-doc` est déjà suivie et associée à la PR #151 — pas de
+nouvelle PR à créer, `git push` suffit à la mettre à jour).
+
+- [ ] **Step 2: Mettre à jour la description de la PR #151**
+
+Ajouter une section décrivant ce second chantier à la description existante de la PR (via `gh pr
+edit 151 --body "..."`, en reprenant le corps existant + une nouvelle section « Retrait des tokens
+panel redondants » résumant les 6 tokens retirés et pourquoi).
+
+- [ ] **Step 3: Confirmer avec l'utilisateur avant tout merge**
+
+Ne pas merger sur `dev` sans confirmation explicite (feedback_merge_after_autonomous_fix).
+
+---
+
+## Self-Review (déjà appliqué en rédigeant ce plan)
+
+1. **Couverture de la spec** : les 5 changements de la spec (composants, JSDoc, `default.css`,
+   tests, doc générée) sont couverts par Tasks 1-6. Vérification par Tasks 7-8. Revue et mise à
+   jour de PR par Tasks 9-10. Pas de Task « créer la branche » — continuation explicite de la
+   branche/PR existante (cf. Global Constraints).
+2. **Scan placeholders** : aucun « TBD » — chaque step contient soit le contenu exact à retirer,
+   soit une commande de vérification précise avec le résultat attendu.
+3. **Cohérence des noms** : les 6 noms de tokens (Tasks 1-3, 4, 5) sont identiques partout, et
+   correspondent exactement à ceux audités dans la spec.
+4. **Point de vigilance signalé explicitement** : Task 6 ne force pas une édition si le
+   commentaire est déjà correct — évite un commit vide ou une modification inutile sur un texte
+   qui s'avérerait déjà exact à la lecture réelle du fichier.
+5. **Risque de duplication de revue** : Task 9 précise explicitement que le champ de revue couvre
+   toute la branche (pas seulement ce second chantier), pour éviter qu'un reviewer scope trop
+   étroitement et manque une interaction entre les deux chantiers (ex. `ComponentApi.astro` déjà
+   mergé qui doit rester intact).

--- a/docs/superpowers/plans/2026-08-03-panel-tokens-public-doc.md
+++ b/docs/superpowers/plans/2026-08-03-panel-tokens-public-doc.md
@@ -1,0 +1,596 @@
+# Documentation publique des tokens panel partagés Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Documenter publiquement les 9 tokens `--ar-panel-*` (source `panel.styles.ts`) sur les 4
+pages composant qui consomment le panel partagé (`ar-dropdown`, `ar-breadcrumb`, `ar-stepper`,
+`ar-datepicker`), avec un bloc dédié affiché en premier illustrant les deux techniques de
+personnalisation — conformément à
+`docs/superpowers/specs/2026-08-03-panel-tokens-public-doc-design.md`.
+
+**Architecture:** Aucun changement de structure DOM, aucun nouveau `part`, aucune nouvelle
+propriété CSS custom. Deux surfaces modifiées : (1) JSDoc `@cssprop` des 4 composants
+(`packages/core`), simple ajout de 9 lignes identiques chacun ; (2) rendu de la section « CSS
+Custom Properties » dans `ComponentApi.astro` (`apps/docs`), partition + bloc conditionnel. Les
+composants qui ne consomment pas `panel.styles.ts` (tous les autres) ne sont pas affectés.
+
+**Tech Stack:** Lit 3, TypeScript, Astro, Custom Elements Manifest (`@custom-elements-manifest/analyzer`),
+Prettier, garde-fous CI (`validate-cssprop-defaults.js`).
+
+## Global Constraints
+
+- Prettier : 100 char, 4 spaces, single quotes (CLAUDE.md).
+- Les 9 lignes `@cssprop --ar-panel-*` doivent être **texte identique** dans les 4 composants
+  (pas de dérivation automatique — convention déjà actée sur ce projet).
+- Ne jamais merger sur `dev` sans confirmation explicite de l'utilisateur
+  (feedback_merge_after_autonomous_fix).
+- `npm run dev --workspace=apps/docs` seul ne reconstruit pas le JS de `packages/core/dist` —
+  rebuild explicite (`npm run build:dev --workspace=packages/core`) requis avant toute
+  vérification Playwright (feedback_docs_dev_stale_dist).
+- `--tag-name>` dans les exemples de code doit être dynamique (`component.tagName`), jamais en
+  dur — sinon les 4 pages afficheraient le même nom de composant dans leur exemple.
+
+---
+
+## Task 1: Créer la branche de travail
+
+**Files:** aucun.
+
+- [ ] **Step 1: Créer la branche depuis `dev`**
+
+```bash
+git checkout dev
+git pull origin dev
+git checkout -b docs/panel-tokens-public-doc
+```
+
+- [ ] **Step 2: Vérifier l'état propre**
+
+Run: `git status`
+Expected: `On branch docs/panel-tokens-public-doc`, `nothing to commit, working tree clean`.
+
+- [ ] **Step 3: Commit de la spec et du plan**
+
+```bash
+git add docs/superpowers/specs/2026-08-03-panel-tokens-public-doc-design.md docs/superpowers/plans/2026-08-03-panel-tokens-public-doc.md
+git commit -m "docs(panel): spec + plan documentation publique des tokens --ar-panel-*"
+```
+
+---
+
+## Task 2: JSDoc `@cssprop` — `ar-dropdown`
+
+**Files:**
+
+- Modify: `packages/core/src/components/dropdown/dropdown.ts`
+
+**Interfaces:**
+
+- Consumes: rien (JSDoc uniquement, pas de code exécuté).
+- Produces: 9 nouvelles entrées `cssProperties` dans le CEM manifest pour `ar-dropdown`,
+  consommées par `ComponentApi.astro` (Task 6).
+
+- [ ] **Step 1: Insérer les 9 lignes après le dernier `@cssprop` existant**
+
+Contenu actuel (`dropdown.ts:34-37`) :
+
+```
+ * @cssprop --ar-dropdown-bg - Fond du panel (cascade vers --ar-panel-bg, repli système `Canvas` si aucun thème n'est chargé).
+ * @cssprop --ar-dropdown-border-color - Bordure (cascade vers --ar-panel-border-color, repli système `ButtonBorder` si aucun thème n'est chargé).
+ * @cssprop --ar-dropdown-distance - Espacement entre le trigger et le panel (axe principal).
+ * @cssprop --ar-dropdown-offset - Décalage latéral du panel (axe transversal).
+```
+
+Nouveau contenu — ajouter les 9 lignes juste après (avant la ligne vide qui précède `@event`) :
+
+```
+ * @cssprop --ar-dropdown-bg - Fond du panel (cascade vers --ar-panel-bg, repli système `Canvas` si aucun thème n'est chargé).
+ * @cssprop --ar-dropdown-border-color - Bordure (cascade vers --ar-panel-border-color, repli système `ButtonBorder` si aucun thème n'est chargé).
+ * @cssprop --ar-dropdown-distance - Espacement entre le trigger et le panel (axe principal).
+ * @cssprop --ar-dropdown-offset - Décalage latéral du panel (axe transversal).
+ * @cssprop --ar-panel-bg - Fond du panel partagé. Repli système `Canvas` si aucun thème n'est chargé.
+ * @cssprop --ar-panel-text - Couleur du texte du panel partagé. Repli système `CanvasText` si aucun thème n'est chargé.
+ * @cssprop --ar-panel-border-color - Couleur de bordure du panel partagé. Repli système `ButtonBorder` si aucun thème n'est chargé.
+ * @cssprop --ar-panel-radius - Rayon de bordure du panel partagé.
+ * @cssprop --ar-panel-shadow - Ombre portée du panel partagé.
+ * @cssprop --ar-panel-padding - Espacement interne du panel partagé.
+ * @cssprop --ar-panel-min-width - Largeur minimale du panel partagé.
+ * @cssprop --ar-panel-max-width - Largeur maximale du panel partagé.
+ * @cssprop --ar-panel-show-duration - Durée de l'animation d'ouverture du panel partagé (respecte `prefers-reduced-motion`).
+```
+
+- [ ] **Step 2: Vérifier le format**
+
+Run: `npx prettier --check packages/core/src/components/dropdown/dropdown.ts`
+Expected: pas d'erreur.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/src/components/dropdown/dropdown.ts
+git commit -m "docs(dropdown): documente les 9 tokens --ar-panel-* hérités"
+```
+
+---
+
+## Task 3: JSDoc `@cssprop` — `ar-breadcrumb`
+
+**Files:**
+
+- Modify: `packages/core/src/components/breadcrumb/breadcrumb.ts`
+
+**Interfaces:**
+
+- Consumes: rien.
+- Produces: 9 nouvelles entrées `cssProperties` dans le CEM manifest pour `ar-breadcrumb`.
+
+- [ ] **Step 1: Insérer les 9 lignes après le dernier `@cssprop` existant**
+
+Contenu actuel (`breadcrumb.ts:47-57`, dernière ligne) :
+
+```
+ * @cssprop --ar-breadcrumb-toggle-transition-duration - Durée de la transition (background-color) des boutons retour/trigger mobile.
+```
+
+Ajouter juste après (avant la ligne vide qui précède `@event`) :
+
+```
+ * @cssprop --ar-panel-bg - Fond du panel partagé. Repli système `Canvas` si aucun thème n'est chargé.
+ * @cssprop --ar-panel-text - Couleur du texte du panel partagé. Repli système `CanvasText` si aucun thème n'est chargé.
+ * @cssprop --ar-panel-border-color - Couleur de bordure du panel partagé. Repli système `ButtonBorder` si aucun thème n'est chargé.
+ * @cssprop --ar-panel-radius - Rayon de bordure du panel partagé.
+ * @cssprop --ar-panel-shadow - Ombre portée du panel partagé.
+ * @cssprop --ar-panel-padding - Espacement interne du panel partagé.
+ * @cssprop --ar-panel-min-width - Largeur minimale du panel partagé.
+ * @cssprop --ar-panel-max-width - Largeur maximale du panel partagé.
+ * @cssprop --ar-panel-show-duration - Durée de l'animation d'ouverture du panel partagé (respecte `prefers-reduced-motion`).
+```
+
+Texte strictement identique à la Task 2 (invariant du plan — vérifié en Task 9).
+
+- [ ] **Step 2: Vérifier le format**
+
+Run: `npx prettier --check packages/core/src/components/breadcrumb/breadcrumb.ts`
+Expected: pas d'erreur.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/src/components/breadcrumb/breadcrumb.ts
+git commit -m "docs(breadcrumb): documente les 9 tokens --ar-panel-* hérités"
+```
+
+---
+
+## Task 4: JSDoc `@cssprop` — `ar-stepper`
+
+**Files:**
+
+- Modify: `packages/core/src/components/stepper/stepper.ts`
+
+**Interfaces:**
+
+- Consumes: rien.
+- Produces: 9 nouvelles entrées `cssProperties` dans le CEM manifest pour `ar-stepper`.
+
+- [ ] **Step 1: Insérer les 9 lignes après le dernier `@cssprop` existant**
+
+Contenu actuel (`stepper.ts:74`, dernière ligne) :
+
+```
+ * @cssprop --ar-stepper-link-focus-outline-color - Couleur de l'anneau de focus du lien d'étape (cascade vers --ar-color-interactive).
+```
+
+Ajouter juste après (avant la ligne vide qui précède `@event`), même 9 lignes que Tasks 2-3 :
+
+```
+ * @cssprop --ar-panel-bg - Fond du panel partagé. Repli système `Canvas` si aucun thème n'est chargé.
+ * @cssprop --ar-panel-text - Couleur du texte du panel partagé. Repli système `CanvasText` si aucun thème n'est chargé.
+ * @cssprop --ar-panel-border-color - Couleur de bordure du panel partagé. Repli système `ButtonBorder` si aucun thème n'est chargé.
+ * @cssprop --ar-panel-radius - Rayon de bordure du panel partagé.
+ * @cssprop --ar-panel-shadow - Ombre portée du panel partagé.
+ * @cssprop --ar-panel-padding - Espacement interne du panel partagé.
+ * @cssprop --ar-panel-min-width - Largeur minimale du panel partagé.
+ * @cssprop --ar-panel-max-width - Largeur maximale du panel partagé.
+ * @cssprop --ar-panel-show-duration - Durée de l'animation d'ouverture du panel partagé (respecte `prefers-reduced-motion`).
+```
+
+- [ ] **Step 2: Vérifier le format**
+
+Run: `npx prettier --check packages/core/src/components/stepper/stepper.ts`
+Expected: pas d'erreur.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/src/components/stepper/stepper.ts
+git commit -m "docs(stepper): documente les 9 tokens --ar-panel-* hérités"
+```
+
+---
+
+## Task 5: JSDoc `@cssprop` — `ar-datepicker`
+
+**Files:**
+
+- Modify: `packages/core/src/components/datepicker/datepicker.ts`
+
+**Interfaces:**
+
+- Consumes: rien.
+- Produces: 9 nouvelles entrées `cssProperties` dans le CEM manifest pour `ar-datepicker`.
+
+- [ ] **Step 1: Insérer les 9 lignes après le dernier `@cssprop` existant**
+
+Contenu actuel (`datepicker.ts:71`, dernière ligne) :
+
+```
+ * @cssprop --ar-datepicker-footer-btn-focus-ring-color - Couleur de l'anneau de focus des boutons du footer (cascade vers --ar-focus-ring-color). Repli `ButtonText` si aucun thème n'est chargé (WCAG 2.4.7).
+```
+
+Ajouter juste après (avant la ligne vide qui précède `@event`), même 9 lignes que Tasks 2-4 :
+
+```
+ * @cssprop --ar-panel-bg - Fond du panel partagé. Repli système `Canvas` si aucun thème n'est chargé.
+ * @cssprop --ar-panel-text - Couleur du texte du panel partagé. Repli système `CanvasText` si aucun thème n'est chargé.
+ * @cssprop --ar-panel-border-color - Couleur de bordure du panel partagé. Repli système `ButtonBorder` si aucun thème n'est chargé.
+ * @cssprop --ar-panel-radius - Rayon de bordure du panel partagé.
+ * @cssprop --ar-panel-shadow - Ombre portée du panel partagé.
+ * @cssprop --ar-panel-padding - Espacement interne du panel partagé.
+ * @cssprop --ar-panel-min-width - Largeur minimale du panel partagé.
+ * @cssprop --ar-panel-max-width - Largeur maximale du panel partagé.
+ * @cssprop --ar-panel-show-duration - Durée de l'animation d'ouverture du panel partagé (respecte `prefers-reduced-motion`).
+```
+
+Rappel (déjà vérifié en amont de la spec) : `ar-datepicker` ne référence plus aucun token
+`--ar-panel-*` dans son propre CSS interne (`datepicker.styles.ts`) depuis PR #150 — ces 9 lignes
+documentent uniquement l'héritage du panel partagé, aucun cas particulier à gérer.
+
+- [ ] **Step 2: Vérifier le format**
+
+Run: `npx prettier --check packages/core/src/components/datepicker/datepicker.ts`
+Expected: pas d'erreur.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/src/components/datepicker/datepicker.ts
+git commit -m "docs(datepicker): documente les 9 tokens --ar-panel-* hérités"
+```
+
+---
+
+## Task 6: Restructurer la section « CSS Custom Properties » dans `ComponentApi.astro`
+
+**Files:**
+
+- Modify: `apps/docs/src/components/ComponentApi.astro`
+
+**Interfaces:**
+
+- Consumes: `component.cssProperties` (peuplé par le CEM depuis les Tasks 2-5), `component.tagName`.
+- Produces: rendu HTML restructuré pour les 4 composants avec tokens panel ; rendu strictement
+  inchangé pour tous les autres composants (`panelProps.length === 0`).
+
+- [ ] **Step 1: Remplacer le bloc « CSS Custom Properties » (lignes ~150-173)**
+
+Contenu actuel :
+
+```astro
+    {/* ── CSS Custom Properties ── */}
+    {component.cssProperties && component.cssProperties.length > 0 && (
+        <section>
+            <h4 id="api-css-props" class="subsection-title">CSS Custom Properties</h4>
+            <div class="table-wrap">
+                <table>
+                    <thead>
+                        <tr>
+                            <th scope="col">Nom</th>
+                            <th scope="col">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {component.cssProperties.map((prop) => (
+                            <tr>
+                                <td><code>{prop.name}</code></td>
+                                <td>{prop.description ?? ''}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+        </section>
+    )}
+```
+
+Nouveau contenu — calculer la partition juste avant le bloc `<div class="component-api">`
+(dans le frontmatter Astro, à la suite de `publicMethods`), puis remplacer le bloc JSX :
+
+Ajouter dans le frontmatter (après la déclaration de `publicMethods`, avant le `---` de
+fermeture) :
+
+```astro
+const panelProps = (component.cssProperties ?? []).filter((p) => p.name.startsWith('--ar-panel-'));
+const ownProps = (component.cssProperties ?? []).filter((p) => !p.name.startsWith('--ar-panel-'));
+```
+
+Remplacer le bloc JSX par :
+
+```astro
+    {/* ── Tokens du panel partagé (affiché en premier si présent) ── */}
+    {panelProps.length > 0 && (
+        <section>
+            <h4 id="api-panel-tokens" class="subsection-title">Tokens du panel partagé</h4>
+            <p class="hint">
+                Ce composant utilise un panel flottant partagé avec d'autres composants de la
+                librairie. Deux techniques de personnalisation sont possibles : redéfinir un ou
+                plusieurs tokens ci-dessous, scopés à ce composant uniquement (n'affecte pas les
+                autres consommateurs du panel partagé), ou surcharger n'importe quelle propriété
+                CSS via <code>::part(panel)</code>, sans passer par les tokens — utile pour une
+                propriété que le thème par défaut ne tokenise pas, ou pour un changement plus
+                large que ce que les tokens exposent.
+            </p>
+            <div class="code-block">
+                <p class="code-caption">Technique 1 — token scopé au composant :</p>
+                <pre><code class="language-css">{`${component.tagName} {\n    --ar-panel-bg: #fff;\n}`}</code></pre>
+            </div>
+            <div class="code-block">
+                <p class="code-caption">Technique 2 — <code>::part(panel)</code> :</p>
+                <pre><code class="language-css">{`${component.tagName}::part(panel) {\n    background-color: #fff;\n}`}</code></pre>
+            </div>
+            <div class="table-wrap">
+                <table>
+                    <thead>
+                        <tr>
+                            <th scope="col">Nom</th>
+                            <th scope="col">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {panelProps.map((prop) => (
+                            <tr>
+                                <td><code>{prop.name}</code></td>
+                                <td>{prop.description ?? ''}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+        </section>
+    )}
+
+    {/* ── CSS Custom Properties propres au composant ── */}
+    {ownProps.length > 0 && (
+        <section>
+            <h4 id="api-css-props" class="subsection-title">CSS Custom Properties</h4>
+            <div class="table-wrap">
+                <table>
+                    <thead>
+                        <tr>
+                            <th scope="col">Nom</th>
+                            <th scope="col">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {ownProps.map((prop) => (
+                            <tr>
+                                <td><code>{prop.name}</code></td>
+                                <td>{prop.description ?? ''}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+        </section>
+    )}
+```
+
+**Point d'attention** : pour un composant sans token panel, `panelProps.length === 0` (le premier
+bloc ne rend rien) et `ownProps` contient la totalité de `component.cssProperties` (identique au
+comportement actuel) — aucune régression pour les composants non concernés.
+
+- [ ] **Step 2: Ajouter les styles `.code-block`/`.code-caption` dans le `<style>` du fichier**
+
+Réutiliser le pattern de classe `.code-block` déjà présent dans `Playground.astro` (chercher
+`.code-block` dans ce fichier pour copier les règles `padding`/`background`/`border-radius`/
+`overflow-x` exactes, adaptées au contexte de `ComponentApi.astro` qui n'a pas de wrapper
+`preview-wrap` autour). Ajouter aussi `.code-caption` (petit texte au-dessus de chaque exemple,
+même traitement typographique que `.hint`) :
+
+```css
+.code-block {
+    margin-bottom: 1rem;
+}
+
+.code-caption {
+    font-size: 0.875rem;
+    color: var(--doc-text-muted);
+    margin-bottom: 0.375rem;
+}
+
+.code-block pre {
+    margin: 0;
+    overflow-x: auto;
+}
+```
+
+Vérifier après coup dans le navigateur que le rendu ne casse pas la largeur de page sur mobile
+(cf. philosophie mobile-first, CLAUDE.md) — `overflow-x: auto` sur le conteneur du `<pre>`, pas
+sur la section entière.
+
+- [ ] **Step 3: Vérifier le format**
+
+Run: `npx prettier --check apps/docs/src/components/ComponentApi.astro`
+Expected: pas d'erreur (confirmé : `.astro` fait partie du glob du script racine `npm run
+format`, Prettier gère bien ce type de fichier dans ce projet).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/docs/src/components/ComponentApi.astro
+git commit -m "feat(docs): affiche un bloc dédié aux tokens panel partagés, avant les tokens propres"
+```
+
+---
+
+## Task 7: Rebuild manifeste + build Astro complet
+
+**Files:** aucun fichier modifié — vérification uniquement.
+
+- [ ] **Step 1: Rebuild le manifeste CEM (déclenche les garde-fous CI)**
+
+Run: `npm run build:manifest --workspace=packages/core`
+Expected: succès, aucune erreur `validate-cssprop-defaults.js` (les 3 tokens `bg`/`text`/
+`border-color` avec repli système doivent matcher le format attendu par le script — mot-clé
+`Canvas`/`CanvasText`/`ButtonBorder` sans commentaire `a11y-fallback` requis, cf. le comportement
+déjà observé sur les tokens `--ar-dropdown-bg`/`--ar-breadcrumb-panel-bg` existants qui suivent
+le même format).
+
+- [ ] **Step 2: Build Astro complet (pas seulement dev)**
+
+Run: `npm run build --workspace=apps/docs`
+Expected: succès, aucune erreur de rendu sur les 4 pages composant concernées (le build statique
+génère toutes les pages — une erreur de template JSX apparaîtrait ici, contrairement au dev
+server qui peut masquer certaines erreurs).
+
+- [ ] **Step 3: Lancer la suite de tests complète**
+
+Run: `npm run test`
+Expected: tous les tests passent (804 tests core + suite docs), aucune régression. Pas de test
+dédié à `ComponentApi.astro` à ce jour (confirmé par grep en amont de la spec) — pas de nouveau
+test à écrire pour ce chantier, la vérification passe par le build + Playwright (Task 8).
+
+- [ ] **Step 4: Commit (uniquement si un fix a été nécessaire)**
+
+Si les Steps 1-3 ont nécessité une correction, committer séparément avec un message décrivant le
+problème trouvé. Sinon, passer directement à Task 8.
+
+---
+
+## Task 8: Vérification visuelle manuelle (Playwright)
+
+**Files:** aucun fichier modifié — vérification uniquement.
+
+- [ ] **Step 1: Rebuild explicite de `packages/core` avant toute vérification Playwright**
+
+Run: `npm run build:dev --workspace=packages/core`
+Expected: build réussi (piège connu, cf. Global Constraints).
+
+- [ ] **Step 2: Lancer le serveur de doc**
+
+Run: `npm run dev --workspace=apps/docs` (arrière-plan ou terminal dédié).
+
+- [ ] **Step 3: Vérifier les 4 pages composant avec tokens panel**
+
+Utiliser l'outillage Playwright déjà présent (`apps/docs/playwright.config.ts`,
+`@playwright/test`) pour naviguer vers les pages `ar-dropdown`, `ar-breadcrumb`, `ar-stepper`,
+`ar-datepicker`. Pour chacune, capturer la section « Tokens du panel partagé » et vérifier :
+
+- Le bloc apparaît **avant** le tableau « CSS Custom Properties » habituel (ou le tableau habituel
+  est absent si le composant n'a que des tokens panel — vérifier au cas par cas selon ce que
+  chaque composant a réellement).
+- Les deux exemples de code affichent le **bon nom de tag** (`ar-dropdown`, `ar-breadcrumb`,
+  `ar-stepper`, `ar-datepicker` respectivement — pas de nom en dur copié-collé entre pages).
+- Le tableau des 9 tokens panel s'affiche correctement (nom + description).
+- Aucun débordement horizontal sur mobile (viewport réduit, cf. `overflow-x: auto` de la Task 6).
+
+- [ ] **Step 4: Vérifier une page sans token panel (non-régression)**
+
+Naviguer vers `ar-alert` (ou tout autre composant sans `panel.styles.ts`). Vérifier que la section
+« CSS Custom Properties » s'affiche **exactement comme avant ce chantier** — un seul tableau,
+aucun bloc « Tokens du panel partagé », aucun texte d'intro, aucun exemple de code.
+
+- [ ] **Step 5: Consigner le résultat**
+
+Si un écart est trouvé, corriger la Task concernée (2-6) et refaire les Steps concernés. Si rien
+trouvé, continuer.
+
+---
+
+## Task 9: Revue finale de branche
+
+**Files:** aucun — revue uniquement.
+
+- [ ] **Step 1: Dispatcher une revue de branche complète sur un agent capable**
+
+Comparer l'intégralité du diff `dev...docs/panel-tokens-public-doc` contre
+`docs/superpowers/specs/2026-08-03-panel-tokens-public-doc-design.md`. Points d'attention
+spécifiques :
+
+- Les 9 lignes `@cssprop --ar-panel-*` sont **texte strictement identique** dans les 4 fichiers
+  `.ts` (diff les 4 blocs entre eux pour confirmer — aucune coquille ni divergence de formulation
+  introduite en copiant-collant).
+- `ComponentApi.astro` : le `<tag-name>` des deux exemples de code est bien dynamique
+  (`component.tagName`), aucune chaîne en dur du type `ar-dropdown` codée dans le template.
+- Ordre du rendu : bloc panel avant le tableau des tokens propres, conforme à la spec (le
+  brouillon initial avait l'ordre inverse — vérifier que la Task 6 a bien appliqué le changement
+  demandé par l'utilisateur, pas l'ordre du premier brouillon de spec).
+- Les deux techniques de personnalisation (token scopé vs `::part(panel)`) sont bien présentes et
+  clairement distinguées dans le texte d'intro, pas juste un seul exemple.
+- Composants sans token panel : `ownProps` couvre bien 100% de `component.cssProperties` dans ce
+  cas (pas de token perdu silencieusement par la partition).
+- Aucun changement dans `default.css`/`panel.styles.ts`/tests de composants (hors scope de ce
+  chantier, JSDoc + rendu Astro uniquement).
+
+- [ ] **Step 2: Corriger les findings en une vague unique**
+
+Si des findings « Critical »/« Important » remontent, les corriger en un seul commit groupé, puis
+relancer Task 7 et Task 8 Step 3-4 pour re-vérifier.
+
+---
+
+## Task 10: Créer la Pull Request
+
+**Files:** aucun.
+
+- [ ] **Step 1: Pousser la branche**
+
+```bash
+git push -u origin docs/panel-tokens-public-doc
+```
+
+- [ ] **Step 2: Créer la PR vers `dev`**
+
+```bash
+gh pr create --base dev --title "docs(panel): documente publiquement les tokens --ar-panel-* partagés" --body "$(cat <<'EOF'
+## Summary
+- Les 9 tokens `--ar-panel-*` (source `panel.styles.ts`) sont désormais documentés via `@cssprop` dans les 4 composants qui consomment le panel partagé (`ar-dropdown`, `ar-breadcrumb`, `ar-stepper`, `ar-datepicker`) — jusqu'ici invisibles sur la doc publique, seulement lisibles en fouillant les sources.
+- `ComponentApi.astro` affiche désormais un bloc dédié « Tokens du panel partagé », affiché en premier (avant les tokens propres au composant), illustrant les deux techniques de personnalisation : token scopé au composant (`ar-<tag> { --ar-panel-bg: ...; }`) ou surcharge complète via `::part(panel)`.
+- Aucun changement pour les composants qui ne consomment pas le panel partagé — rendu strictement inchangé.
+- Confirme que la détection par préfixe de nom (`--ar-panel-`) est fiable pour les 4 composants, sans cas particulier à gérer (la nuance `ar-datepicker` avait été résolue en amont, PR #150).
+
+Spec : `docs/superpowers/specs/2026-08-03-panel-tokens-public-doc-design.md`
+Plan : `docs/superpowers/plans/2026-08-03-panel-tokens-public-doc.md`
+
+## Test plan
+- [x] `npm run build:manifest --workspace=packages/core` (garde-fous CI verts)
+- [x] `npm run build --workspace=apps/docs` (build Astro complet)
+- [x] `npm run test` (aucune régression)
+- [x] Vérification visuelle Playwright sur les 4 pages concernées + 1 page non concernée (non-régression)
+- [x] Revue finale de branche
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Confirmer avec l'utilisateur avant tout merge**
+
+Ne pas merger sur `dev` sans confirmation explicite (feedback_merge_after_autonomous_fix).
+
+---
+
+## Self-Review (déjà appliqué en rédigeant ce plan)
+
+1. **Couverture de la spec** : les 3 changements de la spec (JSDoc ×4, `ComponentApi.astro`,
+   détection par préfixe) sont couverts par Tasks 2-6. Vérification et hors-scope couverts par
+   Tasks 7-9. Branche + PR couvertes par Tasks 1 et 10.
+2. **Retours de l'utilisateur intégrés** : ordre inversé (bloc panel en premier, Task 6) et deux
+   techniques de personnalisation (Task 6, deux exemples de code distincts) — vérifiés
+   explicitement en Task 9 Step 1 pour ne pas régresser vers le premier brouillon de spec.
+3. **Scan placeholders** : aucun « TBD »/« à définir » — chaque step contient le texte exact à
+   écrire, y compris les 9 lignes JSDoc répétées identiques dans Tasks 2-5.
+4. **Cohérence des noms** : `--ar-panel-*` (9 tokens) identiques dans les Tasks 2-5 et dans le
+   filtre de partition de la Task 6 (`p.name.startsWith('--ar-panel-')`) — même préfixe partout.
+5. **Linter `.astro` confirmé** : `.astro` fait partie du glob `npm run format` racine — Prettier
+   gère ce type de fichier dans ce projet, pas d'ambiguïté à lever pendant l'exécution.

--- a/docs/superpowers/specs/2026-08-03-panel-own-tokens-removal-design.md
+++ b/docs/superpowers/specs/2026-08-03-panel-own-tokens-removal-design.md
@@ -1,0 +1,127 @@
+# Retrait des tokens panel redondants (`--ar-dropdown-bg`, `--ar-breadcrumb-panel-bg`, `--ar-stepper-panel-bg` et leurs `-border-color`)
+
+**Date :** 2026-08-03
+**Statut :** Brouillon — à valider avant plan
+
+## Contexte
+
+Suite au chantier de documentation publique des tokens `--ar-panel-*` (PR #151), la revue finale
+de branche a trouvé que l'exemple « surcharger un token panel scopé au composant » était un
+no-op sur `ar-dropdown`/`ar-breadcrumb`/`ar-stepper` : ces 3 composants exposent leur propre
+token (`--ar-dropdown-bg`, `--ar-breadcrumb-panel-bg`, `--ar-stepper-panel-bg`, et leurs pendants
+`-border-color`), réaliasé à `:root` vers `--ar-panel-bg`/`--ar-panel-border-color`
+(`default.css:366-367, 393-394, 438-439`) mais qui prend le pas dans la cascade dès qu'un
+consommateur scope `--ar-panel-bg` directement sur le composant.
+
+**Discussion de fond (session courante)** : maintenant que la doc publique explique explicitement
+la technique de surcharge scopée d'un token `--ar-panel-*` existant, ces 6 tokens n'apportent plus
+rien — la portée par sélecteur (`ar-dropdown { --ar-panel-bg: ...; }`) est déjà nativement fournie
+par les custom properties CSS, sans avoir besoin d'un token intermédiaire dédié. Vérifié : ces 6
+tokens sont de purs alias 1:1, ne divergent jamais en valeur du thème par défaut, et n'ont aucune
+calibration dark-mode indépendante — ils tombent exactement sous la règle déjà actée au chantier
+#129 lot 5 (« un token qui duplique un fallback déjà garanti par une feuille de style partagée,
+sans jamais diverger, se supprime plutôt que se migre » — déjà appliquée à `--ar-dropdown-color`
+à l'époque, mais pas à `-bg`/`-border-color`, faute de justification de retrait suffisante avant
+que la doc publique n'existe).
+
+**Impact API publique** : ce sont des tokens documentés (`@cssprop`), leur retrait est un
+changement d'API. Projet en alpha (`0.1.0-alpha.8`) → retrait direct sans dépréciation, conforme à
+CLAUDE.md (« pas nécessaire en alpha »).
+
+## Décision retenue
+
+Retirer entièrement les 6 tokens : `--ar-dropdown-bg`, `--ar-dropdown-border-color`,
+`--ar-breadcrumb-panel-bg`, `--ar-breadcrumb-panel-border-color`, `--ar-stepper-panel-bg`,
+`--ar-stepper-panel-border-color`. Les 3 composants héritent alors directement de
+`background-color: var(--ar-panel-bg, Canvas)` / `border: 1px solid var(--ar-panel-border-color,
+ButtonBorder)` posés par `panel.styles.ts` (déjà le cas pour `ar-datepicker`, seul composant qui
+n'a jamais eu ce niveau d'indirection).
+
+## Changements
+
+### 1. Composants — retrait du bloc `[part='panel']` devenu vide de sens
+
+Dans chacun des 3 fichiers `.styles.ts`, le bloc ne contient que ces 2 déclarations — le retirer
+entièrement (accolades incluses) :
+
+- `packages/core/src/components/dropdown/dropdown.styles.ts:8-12`
+- `packages/core/src/components/breadcrumb/breadcrumb.styles.ts:103-106`
+- `packages/core/src/components/stepper/stepper.styles.ts:25-28`
+
+Vérifié : chacun de ces blocs ne contient **que** `background-color`/`border-color` — aucune autre
+propriété à préserver ou à redistribuer ailleurs.
+
+### 2. JSDoc — retrait des `@cssprop` correspondants
+
+- `dropdown.ts:34-35` (`--ar-dropdown-bg`, `--ar-dropdown-border-color`)
+- `breadcrumb.ts:50-51` (`--ar-breadcrumb-panel-bg`, `--ar-breadcrumb-panel-border-color`)
+- `stepper.ts:58-59` (`--ar-stepper-panel-bg`, `--ar-stepper-panel-border-color`)
+
+Ne pas toucher aux autres `@cssprop` du même bloc (ex. `--ar-dropdown-distance`/`-offset` restent).
+Les 9 lignes `@cssprop --ar-panel-*` ajoutées en PR #151 restent inchangées.
+
+### 3. `default.css` — retrait des 6 déclarations
+
+- `:366-367` (`ar-breadcrumb-panel-bg`/`-border-color`)
+- `:393-394` (`ar-stepper-panel-bg`/`-border-color`)
+- `:438-439` (`ar-dropdown-bg`/`-border-color`)
+
+Vérifier après coup qu'aucun autre endroit de `default.css` ne référence ces 6 noms (ex. dans un
+`calc()` ou un alias d'un autre composant) — un `grep` avant de conclure au retrait propre.
+
+### 4. Tests — commentaires à corriger, pas de logique cassée
+
+`dropdown.browser.test.ts:211-217`, `stepper.browser.test.ts:92-98`,
+`breadcrumb.browser.test.ts:105-111` vérifient que le panel a un `background-color`/
+`border-top-color` non vide/non transparent **sans thème chargé** (fallback système). Ces
+assertions restent vraies après le retrait — le fallback (`Canvas`/`ButtonBorder`) est désormais
+posé directement par `panel.styles.ts` au lieu de transiter par le token du composant, mais le
+résultat calculé est identique. **Seul le commentaire est à corriger** (il attribue actuellement
+le fallback à `dropdown.styles.ts`/`stepper.styles.ts`/`breadcrumb.styles.ts` — devenu inexact,
+remplacer par `panel.styles.ts`).
+
+### 5. `ComponentApi.astro` / doc générée
+
+Aucun changement de code nécessaire — la table « CSS Custom Properties propres » (PR #151) est
+entièrement pilotée par le JSDoc `@cssprop` du composant ; retirer les entrées côté JSDoc suffit à
+les faire disparaître de la doc générée. Les 3 composants gardent d'autres tokens propres
+(`--ar-dropdown-distance`/`-offset`, tokens `toggle-*` de breadcrumb, tokens `bullet`/`connector`
+de stepper) donc la table ne devient jamais vide.
+
+## Vérification
+
+- `npm run build:manifest --workspace=packages/core` (garde-fous CI, notamment
+  `validate-cssprop-defaults` qui ne doit plus rien trouver à valider pour ces 6 noms).
+- `npm run test` (suite complète — en particulier les 3 tests de fallback panel ci-dessus, dont
+  seul le commentaire change).
+- `npm run build --workspace=apps/docs` (build Astro complet, vérifier que les 3 pages composant
+  affichent toujours une table « CSS Custom Properties propres » non vide, sans les 6 tokens
+  retirés).
+- Vérification visuelle Playwright (desktop) sur `ar-dropdown`/`ar-breadcrumb`/`ar-stepper`, avec
+  et sans thème chargé (comparer le rendu du panel avant/après — aucune différence attendue, les
+  valeurs de repli et thémées sont strictement identiques par construction).
+- Grep final sur les 6 noms de tokens dans `packages/core/src/` pour confirmer zéro référence
+  résiduelle (hors historique `docs/superpowers/`, qui n'est jamais modifié après coup).
+
+## Résultat attendu
+
+- 6 tokens publics retirés, aucune perte de capacité de personnalisation réelle (déjà démontré :
+  la technique de surcharge scopée d'un token `--ar-panel-*` documentée en PR #151 couvre le même
+  besoin, de façon plus simple et sans le piège du no-op).
+- `ar-dropdown`/`ar-breadcrumb`/`ar-stepper` deviennent alignés sur `ar-datepicker` : aucun des 4
+  composants ne référence plus de token `--ar-panel-*` intermédiaire dans son propre CSS, ils
+  héritent tous directement de `panel.styles.ts`.
+- La phrase de mise en garde sur les tokens spécifiques par composant (ajoutée en fix de revue
+  finale PR #151, puis déjà retirée par la réécriture manuelle de `ComponentApi.astro` faite en
+  parallèle de ce chantier) n'a plus lieu d'être réintroduite — ce retrait la rend définitivement
+  correcte plutôt que simplement simplifiée.
+
+## Hors scope
+
+- Les tokens `--ar-dropdown-distance`/`-offset` et équivalents (positionnement du panel, pas sa
+  couleur) — non concernés, pas de redondance avec `--ar-panel-*`.
+- Toute réflexion sur `--ar-datepicker-panel-max-width` (déjà tranchée comme exception assumée,
+  valeur fonctionnelle propre, cf. mémoire `project_token_vs_part_generalization_129`) — non
+  concernée par ce chantier.
+- Autres composants du chantier #129 (`pagination`, `tooltip`, etc.) — non consommateurs de
+  `panel.styles.ts`, hors périmètre.

--- a/docs/superpowers/specs/2026-08-03-panel-tokens-public-doc-design.md
+++ b/docs/superpowers/specs/2026-08-03-panel-tokens-public-doc-design.md
@@ -1,0 +1,158 @@
+# Documentation publique des tokens panel partagés (`--ar-panel-*`)
+
+**Date :** 2026-08-03
+**Statut :** Brouillon — à valider avant plan
+
+## Contexte
+
+`packages/core/src/styles/shared/panel.styles.ts` est une feuille de style partagée, importée via
+`static override styles` par 4 composants : `ar-dropdown`, `ar-breadcrumb`, `ar-stepper`,
+`ar-datepicker`. Elle pilote `[part='panel']` via 9 tokens `--ar-panel-*` : `bg`, `text`,
+`border-color`, `radius`, `shadow`, `padding`, `min-width`, `max-width`, `show-duration`.
+
+Aujourd'hui, rien ne documente publiquement ces tokens sur les pages composant de la doc Astro
+(`apps/docs`) — seuls le JSDoc `@cssprop` et `default.css` renseignent, et **aucun des 4
+composants ne documente ces tokens hérités dans son propre JSDoc**. Un consommateur ne peut le
+découvrir qu'en fouillant les sources (`panel.styles.ts` ou `default.css`).
+
+**Nuance déjà résolue** (PR #150, 2026-08-03) : `ar-datepicker` référençait `--ar-panel-bg`
+directement dans son CSS interne (`datepicker.styles.ts`) pour un usage propre (cutout du focus
+ring), ce qui aurait pollué une détection par simple préfixe de nom. Ce token a été renommé
+`--ar-datepicker-day-focus-border-color` — `ar-datepicker` ne référence plus aucun token
+`--ar-panel-*` dans son CSS interne. **La détection par préfixe `--ar-panel-` est donc fiable pour
+les 4 composants**, sans cas particulier ni jugement de rédaction.
+
+## Décision retenue
+
+**Option 1, avec un twist** — pas de nouveau mécanisme JSDoc :
+
+1. Documenter normalement chacun des 9 tokens `--ar-panel-*` via `@cssprop` dans le JSDoc des 4
+   composants consommateurs (duplication assumée — 4× la même liste, cohérent avec la convention
+   déjà actée sur ce projet de documentation manuelle par composant, pas de dérivation
+   automatique).
+2. **Twist côté rendu** : dans `apps/docs/src/components/ComponentApi.astro`, section « CSS
+   Custom Properties », séparer les `@cssprop` en deux blocs quand le composant a des tokens
+   préfixés `--ar-panel-` : le tableau habituel (tokens propres) + un bloc dédié pour les tokens
+   hérités, avec un texte d'intro expliquant que le composant utilise un panel partagé, et un
+   exemple de code montrant comment les personnaliser via `::part(panel)`.
+3. Détection du bloc dédié : par préfixe de nom (`--ar-panel-*`), pas par un nouveau tag JSDoc.
+
+## Changements
+
+### 1. JSDoc — 4 composants
+
+Ajouter les 9 lignes suivantes (texte identique dans les 4 fichiers, juste après le dernier
+`@cssprop` existant, avant les `@event`) dans `dropdown.ts`, `breadcrumb.ts`, `stepper.ts`,
+`datepicker.ts` :
+
+```
+ * @cssprop --ar-panel-bg - Fond du panel partagé. Repli système `Canvas` si aucun thème n'est chargé.
+ * @cssprop --ar-panel-text - Couleur du texte du panel partagé. Repli système `CanvasText` si aucun thème n'est chargé.
+ * @cssprop --ar-panel-border-color - Couleur de bordure du panel partagé. Repli système `ButtonBorder` si aucun thème n'est chargé.
+ * @cssprop --ar-panel-radius - Rayon de bordure du panel partagé.
+ * @cssprop --ar-panel-shadow - Ombre portée du panel partagé.
+ * @cssprop --ar-panel-padding - Espacement interne du panel partagé.
+ * @cssprop --ar-panel-min-width - Largeur minimale du panel partagé.
+ * @cssprop --ar-panel-max-width - Largeur maximale du panel partagé.
+ * @cssprop --ar-panel-show-duration - Durée de l'animation d'ouverture du panel partagé (respecte `prefers-reduced-motion`).
+```
+
+Les 3 premiers replis (`bg`/`text`/`border-color`) reflètent les valeurs déjà posées dans
+`panel.styles.ts` (`var(--ar-panel-bg, Canvas)` etc.). Les 6 autres tokens n'ont aucun repli dans
+`panel.styles.ts` (non critiques a11y) — pas de mention de repli pour eux, pour rester honnête sur
+le comportement réel sans thème.
+
+**Composants déjà partiellement documentés** : `ar-dropdown`/`ar-breadcrumb`/`ar-stepper`
+documentent déjà leurs propres tokens `--ar-<composant>-bg`/`-border-color` qui _cascadent_ vers
+`--ar-panel-bg`/`--ar-panel-border-color` (ex. `--ar-dropdown-bg - Fond du panel (cascade vers
+--ar-panel-bg, ...)`). Ces entrées restent inchangées dans le tableau normal — elles documentent un
+point de personnalisation propre au composant, distinct du token panel générique lui-même. Les deux
+listes coexistent sans conflit (préfixes différents).
+
+### 2. `apps/docs/src/components/ComponentApi.astro`
+
+Dans la section « CSS Custom Properties » (lignes ~150-173) :
+
+- Partitionner `component.cssProperties` en `ownProps` (ne commence pas par `--ar-panel-`) et
+  `panelProps` (commence par `--ar-panel-`).
+- Si `panelProps.length > 0`, rendre **d'abord** le bloc dédié au panel partagé, **puis** le
+  tableau `ownProps` juste après (ordre inversé par rapport au brouillon initial — le panel est un
+  prérequis transverse, plus logique à lire avant les tokens propres au composant) :
+    - Titre `h5` (ou `h4` selon la hiérarchie existante) : « Tokens du panel partagé ».
+    - Texte d'intro expliquant que le composant utilise un panel flottant partagé avec d'autres
+      composants de la librairie, et que deux techniques de personnalisation sont possibles :
+        1. Redéfinir un ou plusieurs tokens `--ar-panel-*` **scopés à ce composant seulement**
+           (n'affecte pas les autres consommateurs du panel partagé).
+        2. Surcharger n'importe quelle propriété CSS via `::part(panel)`, sans passer par les
+           tokens — utile pour une propriété que le thème par défaut ne tokenise pas, ou pour un
+           changement plus large que ce que les tokens exposent.
+    - Deux exemples de code (`<pre><code class="language-css">`, même pattern que
+      `Playground.astro`), l'un après l'autre, avec une légende courte au-dessus de chacun :
+
+        Technique 1 — token scopé au composant :
+
+        ```css
+        ar-<tag-name > {
+            --ar-panel-bg: #fff;
+        }
+        ```
+
+        Technique 2 — `::part(panel)` :
+
+        ```css
+        ar-<tag-name > ::part(panel) {
+            background-color: #fff;
+        }
+        ```
+
+        `<tag-name>` doit être dynamique (`component.tagName`) dans les deux exemples, pas en dur.
+
+    - Tableau `panelProps` (même structure Nom/Description que le tableau habituel), après les
+      deux exemples.
+
+- Rendre `ownProps` dans le tableau existant (inchangé dans sa structure), après le bloc panel
+  s'il existe.
+- Si `panelProps.length === 0` (tous les autres composants), comportement strictement inchangé —
+  un seul tableau, comme aujourd'hui, sans bloc panel.
+
+### 3. Styles
+
+Réutiliser les classes déjà existantes (`.hint`, `.table-wrap`, `table`) plutôt que d'introduire de
+nouvelles règles. Pour le bloc de code, reprendre le pattern `.code-block`/`<pre><code
+class="language-css">` de `Playground.astro` (pas de nouveau composant de coloration syntaxique).
+
+## Vérification
+
+- `npm run build:manifest` (garde-fou `validate-cssprop-defaults` — les 3 tokens avec repli
+  système doivent matcher le format attendu par le script).
+- `npm run build --workspace=apps/docs` (build Astro complet, pas seulement dev, pour repérer une
+  erreur de rendu sur les 4 pages concernées).
+- Vérification visuelle Playwright (dev serveur, JS de `packages/core/dist` rebuild explicitement
+  avant — cf. piège déjà connu) sur les 4 pages composant concernées (`ar-dropdown`,
+  `ar-breadcrumb`, `ar-stepper`, `ar-datepicker`) : le bloc « Tokens du panel partagé » apparaît
+  correctement, avec le bon nom de tag dans l'exemple de code.
+- Vérifier au moins une page composant **sans** tokens panel (ex. `ar-alert`) pour confirmer
+  qu'aucune régression n'apparaît sur le tableau CSS Custom Properties habituel.
+- Tests existants (`npm run test`) : aucune assertion connue sur `ComponentApi.astro` (pas de test
+  dédié aujourd'hui) — à confirmer par grep avant de conclure qu'aucun test n'est à mettre à jour.
+
+## Résultat attendu
+
+- Les 9 tokens `--ar-panel-*` sont documentés une fois par composant consommateur (JSDoc), et
+  affichés en premier (avant les tokens propres au composant) dans un bloc dédié sur les 4 pages
+  composant concernées, avec les deux techniques de personnalisation illustrées (token scopé au
+  composant, ou `::part(panel)` complet).
+- Aucun changement pour les composants qui ne consomment pas `panel.styles.ts`.
+- Le mécanisme de détection (préfixe de nom) ne nécessite aucune exception — confirmé par la
+  résolution préalable du cas `ar-datepicker`.
+
+## Hors scope
+
+- `--ar-tooltip-show-duration: var(--ar-panel-show-duration)` (`default.css`) — `ar-tooltip`
+  n'importe pas `panel.styles.ts`, cette référence est une commodité d'auteur du thème, pas une
+  vraie dépendance du composant. Pas concerné par ce chantier (cf. règle déjà actée : une
+  consommation par `default.css` lui-même n'est pas une réutilisation par le composant).
+- Autres feuilles de style partagées du projet (`button.styles.ts`, `resetStyles`,
+  `utilitiesStyles`) — même question potentiellement applicable, pas auditée ici.
+- Le mécanisme JSDoc custom façon `@display`/`@parent` porté par `panel.styles.ts` lui-même — déjà
+  écarté comme trop lourd (cf. mémoire du chantier), pas reconsidéré ici.

--- a/docs/superpowers/specs/2026-08-03-panel-tokens-public-doc-design.md
+++ b/docs/superpowers/specs/2026-08-03-panel-tokens-public-doc-design.md
@@ -3,6 +3,10 @@
 **Date :** 2026-08-03
 **Statut :** Brouillon — à valider avant plan
 
+**Amendement (commit `efda33b`)** : la « Technique 2 » (`::part(panel)`) décrite ci-dessous a été
+retirée lors d'une réécriture manuelle du rendu — cette section documente désormais uniquement la
+surcharge de token scopée. Conservé ci-dessous pour l'historique de la décision initiale.
+
 ## Contexte
 
 `packages/core/src/styles/shared/panel.styles.ts` est une feuille de style partagée, importée via

--- a/packages/core/src/components/breadcrumb/breadcrumb.browser.test.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.browser.test.ts
@@ -106,7 +106,7 @@ describe('ar-breadcrumb — browser', () => {
 
             // default.css n'est jamais chargé dans les tests (Vitest ni WTR) : ces
             // valeurs viennent uniquement du fallback système CSS4 posé dans
-            // breadcrumb.styles.ts, pas d'un thème.
+            // panel.styles.ts, pas d'un thème.
             expect(computed.backgroundColor).to.not.equal('');
             expect(computed.backgroundColor).to.not.equal('rgba(0, 0, 0, 0)');
             expect(computed.borderTopColor).to.not.equal('');

--- a/packages/core/src/components/breadcrumb/breadcrumb.styles.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.styles.ts
@@ -98,13 +98,6 @@ export default css`
         position: relative;
     }
 
-    /* ── Panel flottant mobile ───────────────────────────────── */
-
-    [part='panel'] {
-        background-color: var(--ar-breadcrumb-panel-bg, Canvas);
-        border-color: var(--ar-breadcrumb-panel-border-color, ButtonBorder);
-    }
-
     /* ── Boutons home/trigger mobile (découplés de button.styles.ts) ────── */
 
     [part='home'],

--- a/packages/core/src/components/breadcrumb/breadcrumb.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.ts
@@ -55,6 +55,15 @@ import { AnchoredController } from '../../controllers/anchored.controller.js';
  * @cssprop --ar-breadcrumb-toggle-bg-focus - Fond du bouton retour/trigger mobile au focus.
  * @cssprop --ar-breadcrumb-toggle-min-size - Taille minimale (largeur/hauteur) du bouton retour/trigger mobile, repli WCAG 2.5.8 si aucun thème n'est chargé.
  * @cssprop --ar-breadcrumb-toggle-transition-duration - Durée de la transition (background-color) des boutons retour/trigger mobile.
+ * @cssprop --ar-panel-bg - Fond du panel partagé. Repli système `Canvas` si aucun thème n'est chargé.
+ * @cssprop --ar-panel-text - Couleur du texte du panel partagé. Repli système `CanvasText` si aucun thème n'est chargé.
+ * @cssprop --ar-panel-border-color - Couleur de bordure du panel partagé. Repli système `ButtonBorder` si aucun thème n'est chargé.
+ * @cssprop --ar-panel-radius - Rayon de bordure du panel partagé.
+ * @cssprop --ar-panel-shadow - Ombre portée du panel partagé.
+ * @cssprop --ar-panel-padding - Espacement interne du panel partagé.
+ * @cssprop --ar-panel-min-width - Largeur minimale du panel partagé.
+ * @cssprop --ar-panel-max-width - Largeur maximale du panel partagé.
+ * @cssprop --ar-panel-show-duration - Durée de l'animation d'ouverture du panel partagé (respecte `prefers-reduced-motion`).
  *
  * @event {CustomEvent} ar-breadcrumb-show           - Émis avant l'ouverture du dropdown mobile. @cancelable
  * @event {CustomEvent} ar-breadcrumb-show-prevented - Émis si ar-breadcrumb-show est annulé.

--- a/packages/core/src/components/breadcrumb/breadcrumb.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.ts
@@ -47,8 +47,6 @@ import { AnchoredController } from '../../controllers/anchored.controller.js';
  * @cssprop --ar-breadcrumb-distance - Espacement entre le trigger et le panel mobile.
  * @cssprop --ar-breadcrumb-offset - Décalage latéral du panel mobile.
  * @cssprop --ar-breadcrumb-mobile-separator-color - Couleur du connecteur pointillé vertical entre les items de la liste mobile (cascade vers --ar-color-neutral-90).
- * @cssprop --ar-breadcrumb-panel-bg - Fond du panel mobile (cascade vers --ar-panel-bg, repli système `Canvas` si aucun thème n'est chargé).
- * @cssprop --ar-breadcrumb-panel-border-color - Couleur de bordure du panel mobile (cascade vers --ar-panel-border-color, repli système `ButtonBorder` si aucun thème n'est chargé).
  * @cssprop --ar-breadcrumb-toggle-bg - Fond du bouton retour/trigger mobile.
  * @cssprop --ar-breadcrumb-toggle-bg-hover - Fond du bouton retour/trigger mobile au survol.
  * @cssprop --ar-breadcrumb-toggle-bg-pressed - Fond du bouton retour/trigger mobile pressé.

--- a/packages/core/src/components/datepicker/datepicker.ts
+++ b/packages/core/src/components/datepicker/datepicker.ts
@@ -69,6 +69,15 @@ import { warn } from '../../utils/warn.js';
  * @cssprop --ar-datepicker-input-error-border-color - Bordure input en état d'erreur.
  * @cssprop --ar-datepicker-nav-btn-focus-ring-color - Couleur de l'anneau de focus des boutons de navigation (cascade vers --ar-focus-ring-color). Repli `ButtonText` si aucun thème n'est chargé (WCAG 2.4.7).
  * @cssprop --ar-datepicker-footer-btn-focus-ring-color - Couleur de l'anneau de focus des boutons du footer (cascade vers --ar-focus-ring-color). Repli `ButtonText` si aucun thème n'est chargé (WCAG 2.4.7).
+ * @cssprop --ar-panel-bg - Fond du panel partagé. Repli système `Canvas` si aucun thème n'est chargé.
+ * @cssprop --ar-panel-text - Couleur du texte du panel partagé. Repli système `CanvasText` si aucun thème n'est chargé.
+ * @cssprop --ar-panel-border-color - Couleur de bordure du panel partagé. Repli système `ButtonBorder` si aucun thème n'est chargé.
+ * @cssprop --ar-panel-radius - Rayon de bordure du panel partagé.
+ * @cssprop --ar-panel-shadow - Ombre portée du panel partagé.
+ * @cssprop --ar-panel-padding - Espacement interne du panel partagé.
+ * @cssprop --ar-panel-min-width - Largeur minimale du panel partagé.
+ * @cssprop --ar-panel-max-width - Largeur maximale du panel partagé.
+ * @cssprop --ar-panel-show-duration - Durée de l'animation d'ouverture du panel partagé (respecte `prefers-reduced-motion`).
  *
  * @event {CustomEvent} ar-datepicker-input-change   - Valeur commitée (blur ou sélection calendrier).
  * @event {CustomEvent} ar-datepicker-input-complete - Saisie texte complète (valide ou non).

--- a/packages/core/src/components/dropdown/dropdown.styles.ts
+++ b/packages/core/src/components/dropdown/dropdown.styles.ts
@@ -4,10 +4,4 @@ export default css`
     :host {
         display: contents;
     }
-
-    [part='panel'] {
-        /* Overrides composant — chaînent vers les tokens shared --ar-panel-* */
-        background-color: var(--ar-dropdown-bg, Canvas);
-        border-color: var(--ar-dropdown-border-color, ButtonBorder);
-    }
 `;

--- a/packages/core/src/components/dropdown/dropdown.ts
+++ b/packages/core/src/components/dropdown/dropdown.ts
@@ -31,8 +31,6 @@ export type ArDropdownPlacement =
  *
  * @csspart panel - Le panel flottant. Le thème par défaut pilote `border-radius`, `box-shadow`, `padding`, `min-width` et `max-width` via `ar-dropdown::part(panel)` ; `background-color`, `border-color` et `color` restent eux aussi overridables via `::part(panel)` par un consommateur, mais ne sont pas redéfinis par le thème par défaut.
  *
- * @cssprop --ar-dropdown-bg - Fond du panel (cascade vers --ar-panel-bg, repli système `Canvas` si aucun thème n'est chargé).
- * @cssprop --ar-dropdown-border-color - Bordure (cascade vers --ar-panel-border-color, repli système `ButtonBorder` si aucun thème n'est chargé).
  * @cssprop --ar-dropdown-distance - Espacement entre le trigger et le panel (axe principal).
  * @cssprop --ar-dropdown-offset - Décalage latéral du panel (axe transversal).
  * @cssprop --ar-panel-bg - Fond du panel partagé. Repli système `Canvas` si aucun thème n'est chargé.

--- a/packages/core/src/components/dropdown/dropdown.ts
+++ b/packages/core/src/components/dropdown/dropdown.ts
@@ -35,6 +35,15 @@ export type ArDropdownPlacement =
  * @cssprop --ar-dropdown-border-color - Bordure (cascade vers --ar-panel-border-color, repli système `ButtonBorder` si aucun thème n'est chargé).
  * @cssprop --ar-dropdown-distance - Espacement entre le trigger et le panel (axe principal).
  * @cssprop --ar-dropdown-offset - Décalage latéral du panel (axe transversal).
+ * @cssprop --ar-panel-bg - Fond du panel partagé. Repli système `Canvas` si aucun thème n'est chargé.
+ * @cssprop --ar-panel-text - Couleur du texte du panel partagé. Repli système `CanvasText` si aucun thème n'est chargé.
+ * @cssprop --ar-panel-border-color - Couleur de bordure du panel partagé. Repli système `ButtonBorder` si aucun thème n'est chargé.
+ * @cssprop --ar-panel-radius - Rayon de bordure du panel partagé.
+ * @cssprop --ar-panel-shadow - Ombre portée du panel partagé.
+ * @cssprop --ar-panel-padding - Espacement interne du panel partagé.
+ * @cssprop --ar-panel-min-width - Largeur minimale du panel partagé.
+ * @cssprop --ar-panel-max-width - Largeur maximale du panel partagé.
+ * @cssprop --ar-panel-show-duration - Durée de l'animation d'ouverture du panel partagé (respecte `prefers-reduced-motion`).
  *
  * @event {CustomEvent} ar-dropdown-show           - Émis avant l'ouverture. @cancelable
  * @event {CustomEvent} ar-dropdown-show-prevented - Émis si ar-dropdown-show est annulé.

--- a/packages/core/src/components/dropdown/dropdown.ts
+++ b/packages/core/src/components/dropdown/dropdown.ts
@@ -29,7 +29,7 @@ export type ArDropdownPlacement =
  * @slot trigger  - Le bouton déclencheur (ignoré si `for` est défini).
  * @slot          - Contenu du panel (libre ou ar-dropdown-item pour le mode menu).
  *
- * @csspart panel - Le panel flottant. Le thème par défaut pilote `border-radius`, `box-shadow`, `padding`, `min-width` et `max-width` via `ar-dropdown::part(panel)` ; `background-color`, `border-color` et `color` restent eux aussi overridables via `::part(panel)` par un consommateur, mais ne sont pas redéfinis par le thème par défaut.
+ * @csspart panel - Le panel flottant.
  *
  * @cssprop --ar-dropdown-distance - Espacement entre le trigger et le panel (axe principal).
  * @cssprop --ar-dropdown-offset - Décalage latéral du panel (axe transversal).

--- a/packages/core/src/components/stepper/stepper.browser.test.ts
+++ b/packages/core/src/components/stepper/stepper.browser.test.ts
@@ -93,7 +93,7 @@ describe('ar-stepper — browser', () => {
 
             // default.css n'est jamais chargé dans les tests (Vitest ni WTR) : ces
             // valeurs viennent uniquement du fallback système CSS4 posé dans
-            // stepper.styles.ts, pas d'un thème.
+            // panel.styles.ts, pas d'un thème.
             expect(computed.backgroundColor).to.not.equal('');
             expect(computed.backgroundColor).to.not.equal('rgba(0, 0, 0, 0)');
             expect(computed.borderTopColor).to.not.equal('');

--- a/packages/core/src/components/stepper/stepper.styles.ts
+++ b/packages/core/src/components/stepper/stepper.styles.ts
@@ -22,11 +22,6 @@ export default css`
         text-align: left;
     }
 
-    [part='panel'] {
-        background-color: var(--ar-stepper-panel-bg, Canvas);
-        border-color: var(--ar-stepper-panel-border-color, ButtonBorder);
-    }
-
     [part='list'] {
         margin: 0;
         counter-reset: step;

--- a/packages/core/src/components/stepper/stepper.ts
+++ b/packages/core/src/components/stepper/stepper.ts
@@ -55,8 +55,6 @@ export interface ArStepperStepChangeDetail {
  * @csspart trigger      - Le bouton d'ouverture du panel mobile.
  * @csspart panel        - Le panel mobile flottant.
  *
- * @cssprop --ar-stepper-panel-bg - Fond du panel mobile (cascade vers --ar-panel-bg, repli système `Canvas` si aucun thème n'est chargé).
- * @cssprop --ar-stepper-panel-border-color - Couleur de bordure du panel mobile (cascade vers --ar-panel-border-color, repli système `ButtonBorder` si aucun thème n'est chargé).
  * @cssprop --ar-stepper-gap - Hauteur du connecteur entre les étapes principales.
  * @cssprop --ar-stepper-substep-gap - Hauteur du connecteur entre les sous-étapes.
  * @cssprop --ar-stepper-connector-color - Couleur du connecteur pointillé entre les étapes.

--- a/packages/core/src/components/stepper/stepper.ts
+++ b/packages/core/src/components/stepper/stepper.ts
@@ -72,6 +72,15 @@ export interface ArStepperStepChangeDetail {
  * @cssprop --ar-stepper-link-hover-label-color - Couleur du label de l'étape au survol/focus (cascade vers --ar-color-text).
  * @cssprop --ar-stepper-link-hover-bullet-text-color - Couleur du numéro affiché dans la puce au survol/focus (cascade vers --ar-color-text-inverse).
  * @cssprop --ar-stepper-link-focus-outline-color - Couleur de l'anneau de focus du lien d'étape (cascade vers --ar-color-interactive).
+ * @cssprop --ar-panel-bg - Fond du panel partagé. Repli système `Canvas` si aucun thème n'est chargé.
+ * @cssprop --ar-panel-text - Couleur du texte du panel partagé. Repli système `CanvasText` si aucun thème n'est chargé.
+ * @cssprop --ar-panel-border-color - Couleur de bordure du panel partagé. Repli système `ButtonBorder` si aucun thème n'est chargé.
+ * @cssprop --ar-panel-radius - Rayon de bordure du panel partagé.
+ * @cssprop --ar-panel-shadow - Ombre portée du panel partagé.
+ * @cssprop --ar-panel-padding - Espacement interne du panel partagé.
+ * @cssprop --ar-panel-min-width - Largeur minimale du panel partagé.
+ * @cssprop --ar-panel-max-width - Largeur maximale du panel partagé.
+ * @cssprop --ar-panel-show-duration - Durée de l'animation d'ouverture du panel partagé (respecte `prefers-reduced-motion`).
  *
  * @event {CustomEvent<{ path: string }>} ar-stepper-step-change - Émis au clic sur une étape.
  */

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -363,8 +363,6 @@
         --ar-breadcrumb-distance: var(--ar-anchor-distance);
         --ar-breadcrumb-offset: var(--ar-anchor-offset);
         --ar-breadcrumb-mobile-separator-color: var(--ar-color-neutral-90);
-        --ar-breadcrumb-panel-bg: var(--ar-panel-bg);
-        --ar-breadcrumb-panel-border-color: var(--ar-panel-border-color);
         --ar-breadcrumb-toggle-bg: rgba(26, 26, 26, 0.05);
         --ar-breadcrumb-toggle-bg-hover: rgba(18, 20, 55, 0.7);
         --ar-breadcrumb-toggle-bg-pressed: rgba(18, 20, 55, 0.8);
@@ -390,8 +388,6 @@
         --ar-stepper-gap: 1.5rem;
         --ar-stepper-substep-gap: 1rem;
         --ar-stepper-connector-color: var(--ar-color-neutral-80);
-        --ar-stepper-panel-bg: var(--ar-panel-bg);
-        --ar-stepper-panel-border-color: var(--ar-panel-border-color);
 
         /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
          * Progressbar
@@ -435,8 +431,6 @@
          * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
         --ar-dropdown-distance: var(--ar-anchor-distance);
         --ar-dropdown-offset: var(--ar-anchor-offset);
-        --ar-dropdown-bg: var(--ar-panel-bg);
-        --ar-dropdown-border-color: var(--ar-panel-border-color);
 
         /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
          * Dialog


### PR DESCRIPTION
## Summary

**Documentation publique des tokens panel partagés**
- Les 9 tokens `--ar-panel-*` (source `panel.styles.ts`) sont désormais documentés via `@cssprop` dans les 4 composants qui consomment le panel partagé (`ar-dropdown`, `ar-breadcrumb`, `ar-stepper`, `ar-datepicker`) — jusqu'ici invisibles sur la doc publique, seulement lisibles en fouillant les sources.
- `ComponentApi.astro` affiche un bloc dédié « Tokens du panel partagé », fusionné dans la section « CSS Custom Properties » et affiché en premier (avant les tokens propres au composant), illustrant la personnalisation par surcharge scopée d'un token panel existant.
- La TOC expose désormais les 6 sous-sections de « Référence API » (Attributs, Événements, Méthodes, CSS Parts, CSS Custom Properties, Slots), chacune n'apparaissant que si le composant l'expose réellement (nouveau helper `getPublicMethods()` partagé pour éviter la duplication).
- Aucun changement pour les composants qui ne consomment pas le panel partagé — rendu strictement inchangé (vérifié sur `ar-alert`).

**Retrait des tokens panel redondants**
- 6 tokens publics retirés (`--ar-dropdown-bg`/`-border-color`, `--ar-breadcrumb-panel-bg`/`-border-color`, `--ar-stepper-panel-bg`/`-border-color`) : purs alias non divergents vers `--ar-panel-bg`/`--ar-panel-border-color`, sans calibration dark-mode indépendante, qui court-circuitaient silencieusement la technique de personnalisation documentée ci-dessus.
- `ar-dropdown`/`ar-breadcrumb`/`ar-stepper` héritent désormais directement de `panel.styles.ts` (déjà le cas pour `ar-datepicker`) — aucun changement de rendu, valeurs calculées strictement identiques.
- Projet en alpha (`0.1.0-alpha.8`) → retrait direct sans dépréciation, conforme à CLAUDE.md.

**Corrections issues des 2 revues finales de branche :**
- L'exemple de personnalisation utilisait `--ar-panel-bg`, un no-op sur `ar-dropdown`/`ar-breadcrumb`/`ar-stepper` avant leur nettoyage (ces composants exposaient alors leur propre token, réaliasé à `:root`, qui prenait le pas). Remplacé par `--ar-panel-radius`.
- La classe `.code-block` entrait en collision avec les règles `:global()` de `Playground.astro`. Renommée en `.token-example`, style désormais autonome.
- `@csspart panel` de `ar-dropdown` décrivait un comportement du thème par défaut inexact et devenu contradictoire avec le nouveau bloc de doc — simplifié en un one-liner theme-agnostic, cohérent avec les 3 autres composants.
- CSS mort (`.code-caption`, reliquat d'une technique retirée manuellement) et drift de spec (note d'amendement ajoutée) nettoyés.

Specs : `docs/superpowers/specs/2026-08-03-panel-tokens-public-doc-design.md`, `docs/superpowers/specs/2026-08-03-panel-own-tokens-removal-design.md`
Plans : `docs/superpowers/plans/2026-08-03-panel-tokens-public-doc.md`, `docs/superpowers/plans/2026-08-03-panel-own-tokens-removal.md`

## Test plan
- [x] `npm run build:manifest --workspace=packages/core` (garde-fous CI verts)
- [x] `npm run build --workspace=apps/docs` (build Astro complet, 22 pages)
- [x] `npm run test` (863 tests, aucune régression)
- [x] Suite browser (WTR) dropdown/breadcrumb/stepper (41/41)
- [x] Vérification visuelle Playwright (desktop + mobile) sur les 4 pages concernées + `ar-alert` (non-régression) + panels dropdown/breadcrumb/stepper après retrait des tokens
- [x] 2 revues finales de branche (agent le plus capable) + vagues de correction + re-revues ciblées, clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
