### PR TITLE
fix(pagination,stepper): restaure le focus après activation d'un élément qui devient non focalisable (#154)

### DIFF
--- a/apps/docs/src/content/components/ar-stepper.mdx
+++ b/apps/docs/src/content/components/ar-stepper.mdx
@@ -89,6 +89,11 @@ import WcagRef from '../../components/WcagRef.astro';
 - **Les items sans `href` ne sont pas des liens.** Un item sans destination est rendu comme
   un élément non interactif — ne pas en faire la cible de `current-path` si l'utilisateur
   doit pouvoir y naviguer.
+- **Mettre à jour `current-path` de façon synchrone (ou quasi-synchrone) dans le handler de
+  `ar-stepper-step-change`.** Le focus n'est restauré sur la nouvelle étape courante que si
+  cette mise à jour arrive dans le même tick microtask que l'event (cas des frameworks
+  synchrones ou quasi-synchrones, ex. `nextTick` de Vue) — sinon le focus n'est pas restauré,
+  silencieusement.
 
 ## Comportement responsive
 

--- a/packages/core/src/a11y/focus-after-update.test.ts
+++ b/packages/core/src/a11y/focus-after-update.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { LitElement, html } from 'lit';
+import { focusAfterUpdate } from './focus-after-update.js';
+
+class FocusAfterUpdateFixture extends LitElement {
+    static override properties = { showTarget: { type: Boolean } };
+    showTarget = false;
+
+    override render() {
+        return html`
+            <button type="button" id="always">toujours là</button>
+            ${this.showTarget
+                ? html`<button type="button" id="target" tabindex="-1">cible</button>`
+                : ''}
+        `;
+    }
+}
+customElements.define('focus-after-update-fixture', FocusAfterUpdateFixture);
+
+describe('focusAfterUpdate', () => {
+    it('ne fait rien si aucun élément ne matche le sélecteur', async () => {
+        const el = document.createElement('focus-after-update-fixture') as FocusAfterUpdateFixture;
+        document.body.appendChild(el);
+        await el.updateComplete;
+
+        await expect(focusAfterUpdate(el, '#inexistant')).resolves.toBeUndefined();
+        expect(el.shadowRoot?.activeElement).toBeNull();
+
+        el.remove();
+    });
+
+    it('focalise le premier élément matchant après la fin du rendu en cours', async () => {
+        const el = document.createElement('focus-after-update-fixture') as FocusAfterUpdateFixture;
+        document.body.appendChild(el);
+        await el.updateComplete;
+
+        el.showTarget = true;
+        // Pas de await updateComplete ici — focusAfterUpdate doit gérer l'attente lui-même.
+        await focusAfterUpdate(el, '#target');
+
+        expect(el.shadowRoot?.activeElement?.id).toBe('target');
+
+        el.remove();
+    });
+});

--- a/packages/core/src/a11y/focus-after-update.ts
+++ b/packages/core/src/a11y/focus-after-update.ts
@@ -1,0 +1,10 @@
+import type { ReactiveElement } from 'lit';
+
+/**
+ * Focalise le premier élément du shadow DOM correspondant à `selector`, une fois le rendu
+ * en cours terminé. Sans effet si aucun élément ne matche.
+ */
+export async function focusAfterUpdate(host: ReactiveElement, selector: string): Promise<void> {
+    await host.updateComplete;
+    host.shadowRoot?.querySelector<HTMLElement>(selector)?.focus();
+}

--- a/packages/core/src/components/pagination/pagination.browser.test.ts
+++ b/packages/core/src/components/pagination/pagination.browser.test.ts
@@ -3,7 +3,7 @@
  * pagination.browser.test.ts
  *
  * Tests nécessitant un vrai browser (Chromium via @web/test-runner) :
- *   - Continuité du focus clavier après activation d'un lien de page (#154),
+ *   - Focus + :focus-visible après activation d'un lien de page (#154),
  *     vérifiable uniquement avec un vrai `:focus-visible` (absent de happy-dom).
  */
 import { fixture, html, expect, elementUpdated } from '@open-wc/testing';
@@ -11,7 +11,12 @@ import './index.js';
 
 describe('ar-pagination — browser', () => {
     describe('focus après activation (#154)', () => {
-        it("un Tab après activation clavier d'un lien de page continue depuis le nouvel élément courant", async () => {
+        // Vérifie que le focus atterrit sur le nouvel élément part="current" et que
+        // :focus-visible matche après un focus() + click() programmatiques. Ne vérifie PAS
+        // l'ordre de tabulation réel ni la distinction clavier/souris — nécessiterait
+        // @web/test-runner-commands (sendKeys/sendMouse), non installé, hors scope de ce
+        // correctif.
+        it('focalise le nouvel élément part="current" et :focus-visible matche après activation', async () => {
             const el = await fixture(html`<ar-pagination current="1" total="5"></ar-pagination>`);
             const shadowRoot = el.shadowRoot as ShadowRoot;
             const pageLink = shadowRoot.querySelector(

--- a/packages/core/src/components/pagination/pagination.browser.test.ts
+++ b/packages/core/src/components/pagination/pagination.browser.test.ts
@@ -1,0 +1,30 @@
+/// <reference types="mocha" />
+/**
+ * pagination.browser.test.ts
+ *
+ * Tests nécessitant un vrai browser (Chromium via @web/test-runner) :
+ *   - Continuité du focus clavier après activation d'un lien de page (#154),
+ *     vérifiable uniquement avec un vrai `:focus-visible` (absent de happy-dom).
+ */
+import { fixture, html, expect, elementUpdated } from '@open-wc/testing';
+import './index.js';
+
+describe('ar-pagination — browser', () => {
+    describe('focus après activation (#154)', () => {
+        it("un Tab après activation clavier d'un lien de page continue depuis le nouvel élément courant", async () => {
+            const el = await fixture(html`<ar-pagination current="1" total="5"></ar-pagination>`);
+            const shadowRoot = el.shadowRoot as ShadowRoot;
+            const pageLink = shadowRoot.querySelector(
+                '[data-ar-pagination-page="3"]',
+            ) as HTMLElement;
+
+            pageLink.focus();
+            pageLink.click();
+            await elementUpdated(el);
+
+            const current = shadowRoot.querySelector('[part~="current"]') as HTMLElement;
+            expect(shadowRoot.activeElement).to.equal(current);
+            expect(current.matches(':focus-visible')).to.equal(true);
+        });
+    });
+});

--- a/packages/core/src/components/pagination/pagination.styles.ts
+++ b/packages/core/src/components/pagination/pagination.styles.ts
@@ -41,7 +41,12 @@ export default css`
         transition:
             background-color var(--ar-pagination-transition-duration),
             color var(--ar-pagination-transition-duration);
+    }
 
+    [part~='prev'],
+    [part~='next'],
+    [part~='link'],
+    [part~='current'] {
         &:focus-visible {
             outline: 2px solid currentColor;
             outline-offset: 2px;

--- a/packages/core/src/components/pagination/pagination.test.ts
+++ b/packages/core/src/components/pagination/pagination.test.ts
@@ -291,6 +291,34 @@ describe('ArPagination', () => {
             await waitForUpdate(el);
             expect(el.current).toBe(3);
         });
+
+        it('un clic sur un lien de page focalise le nouvel élément part="current"', async () => {
+            el = await fixture('<ar-pagination current="1" total="5"></ar-pagination>');
+            const shadow = el.shadowRoot as ShadowRoot;
+            const pageLink = shadow.querySelector('[data-ar-pagination-page="3"]') as HTMLElement;
+            pageLink.click();
+            await waitForUpdate(el);
+
+            const current = shadow.querySelector('[part~="current"]') as HTMLElement;
+            expect(shadow.activeElement).toBe(current);
+        });
+
+        it('le nouvel élément part="current" porte tabindex="-1"', async () => {
+            el = await fixture('<ar-pagination current="2" total="5"></ar-pagination>');
+            const shadow = el.shadowRoot as ShadowRoot;
+            const current = shadow.querySelector('[part="current"]') as HTMLElement;
+            expect(current.getAttribute('tabindex')).toBe('-1');
+        });
+
+        it("un clic sur prev/next ne modifie pas le focus (l'élément cliqué reste focalisable)", async () => {
+            el = await fixture('<ar-pagination current="3" total="5"></ar-pagination>');
+            const nextBtn = requirePart(el, 'next') as HTMLElement;
+            nextBtn.focus();
+            nextBtn.click();
+            await waitForUpdate(el);
+
+            expect(el.shadowRoot?.activeElement).toBe(nextBtn);
+        });
     });
 
     // ── Événement ar-pagination-page-change ──────────────────────────────────

--- a/packages/core/src/components/pagination/pagination.test.ts
+++ b/packages/core/src/components/pagination/pagination.test.ts
@@ -189,6 +189,11 @@ describe('ArPagination', () => {
         it('la page courante utilise part="current" (span, non cliquable)', async () => {
             el = await fixture('<ar-pagination current="2" total="5"></ar-pagination>');
             const shadow = el.shadowRoot as ShadowRoot;
+            // Volontairement `=` strict (pas `~=`) : happy-dom (Vitest) a une implémentation
+            // non conforme de `~=` qui matche aussi "item--current" pour le token "current"
+            // (cf. mise en garde dans test-utils.ts) — un vrai navigateur ne matcherait pas
+            // le <li part="item item--current"> ici, mais happy-dom le ferait et casserait
+            // la distinction span/li que ce test vérifie précisément.
             const currentPage = shadow.querySelector('[part="current"]') as Element;
             expect(currentPage.tagName.toLowerCase()).toBe('span');
         });

--- a/packages/core/src/components/pagination/pagination.ts
+++ b/packages/core/src/components/pagination/pagination.ts
@@ -180,7 +180,7 @@ export class ArPagination extends LitElement {
         if (active) {
             return html` <span
                 part="current"
-                tabindex=${'-1'}
+                tabindex="-1"
                 aria-current="true"
                 data-ar-pagination-page="${page}"
             >

--- a/packages/core/src/components/pagination/pagination.ts
+++ b/packages/core/src/components/pagination/pagination.ts
@@ -6,6 +6,7 @@ import resetStyles from '../../styles/components/reset.styles.js';
 import styles from './pagination.styles.js';
 import { _calculatePages, _clamp } from './pagination.utils.js';
 import { announceA11y } from '../../a11y/announce-a11y.js';
+import { focusAfterUpdate } from '../../a11y/focus-after-update.js';
 import { warn } from '../../utils/warn.js';
 
 /** Objet de configuration d'un webcomposant ArPagination */
@@ -177,7 +178,12 @@ export class ArPagination extends LitElement {
     /** Génère le lien ou le span (si page active) d'une page */
     protected renderPageLink(page: number, active: boolean): TemplateResult {
         if (active) {
-            return html` <span part="current" aria-current="true" data-ar-pagination-page="${page}">
+            return html` <span
+                part="current"
+                tabindex=${'-1'}
+                aria-current="true"
+                data-ar-pagination-page="${page}"
+            >
                 ${this.renderPageLabel(page)}
             </span>`;
         }
@@ -215,6 +221,7 @@ export class ArPagination extends LitElement {
         this.current = parseInt(page);
         this._emit({ from, to: this.current });
         this._announcePageChange();
+        void focusAfterUpdate(this, '[part~="current"]');
     }
 
     private _emit(detail: ArPaginationPageChangeDetail): void {

--- a/packages/core/src/components/stepper/stepper.browser.test.ts
+++ b/packages/core/src/components/stepper/stepper.browser.test.ts
@@ -6,7 +6,7 @@
  *   - API Popover native (showPopover / hidePopover / :popover-open)
  *   - Chargement initial en mode mobile (régression : attach différé)
  */
-import { fixture, html, expect, aTimeout } from '@open-wc/testing';
+import { fixture, html, expect, aTimeout, elementUpdated } from '@open-wc/testing';
 import type { ArStepper } from './stepper.js';
 import './index.js';
 import '../stepper-item/index.js';
@@ -99,6 +99,39 @@ describe('ar-stepper — browser', () => {
             expect(computed.borderTopColor).to.not.equal('');
             expect(computed.borderTopColor).to.not.equal('rgba(0, 0, 0, 0)');
             expect(computed.borderTopWidth).to.equal('1px');
+        });
+    });
+
+    describe('focus après activation (#154)', () => {
+        it('focalise le nouvel élément courant quand le consommateur répond à ar-stepper-step-change', async () => {
+            // desktop-from="0" force le mode desktop : évite le chemin mobile (attach du
+            // popover de navigation), qui ré-exécute `void this.updateComplete.then(...)`
+            // sur chaque cycle tant que le dropdown n'est pas attaché — un pattern
+            // réentrant équivalent à celui corrigé pour le focus (#154), non lié au
+            // scénario testé ici. Le forcer en desktop isole le comportement vérifié.
+            el = await fixture<ArStepper>(html`
+                <ar-stepper current-path="/b" desktop-from="0">
+                    <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
+                    <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
+                </ar-stepper>
+            `);
+            await elementUpdated(el);
+            await elementUpdated(el);
+
+            el.addEventListener('ar-stepper-step-change', (event: Event) => {
+                el.currentPath = (event as CustomEvent<{ path: string }>).detail.path;
+            });
+
+            const shadowRoot = el.shadowRoot as ShadowRoot;
+            const linkA = shadowRoot.querySelector('a[data-path="/a"]') as HTMLElement;
+            linkA.focus();
+            linkA.click();
+            await elementUpdated(el);
+
+            const newCurrent = shadowRoot.querySelector('[data-path="/a"]') as HTMLElement;
+            expect(newCurrent.tagName.toLowerCase()).to.equal('div');
+            expect(shadowRoot.activeElement).to.equal(newCurrent);
+            expect(newCurrent.matches(':focus-visible')).to.equal(true);
         });
     });
 });

--- a/packages/core/src/components/stepper/stepper.browser.test.ts
+++ b/packages/core/src/components/stepper/stepper.browser.test.ts
@@ -103,7 +103,13 @@ describe('ar-stepper — browser', () => {
     });
 
     describe('focus après activation (#154)', () => {
-        it('focalise le nouvel élément courant quand le consommateur répond à ar-stepper-step-change', async () => {
+        // Vérifie que le focus atterrit sur le nouvel élément data-path courant et que
+        // :focus-visible matche après un focus() + click() programmatiques, quand le
+        // consommateur répond à ar-stepper-step-change. Ne vérifie PAS l'ordre de
+        // tabulation réel ni la distinction clavier/souris — nécessiterait
+        // @web/test-runner-commands (sendKeys/sendMouse), non installé, hors scope de ce
+        // correctif.
+        it('focalise le nouvel élément data-path courant et :focus-visible matche après activation', async () => {
             // desktop-from="0" force le mode desktop : évite le chemin mobile (attach du
             // popover de navigation), qui ré-exécute `void this.updateComplete.then(...)`
             // sur chaque cycle tant que le dropdown n'est pas attaché — un pattern

--- a/packages/core/src/components/stepper/stepper.renderer.ts
+++ b/packages/core/src/components/stepper/stepper.renderer.ts
@@ -84,7 +84,7 @@ function renderSubStep(
                       </a>
                   `
                 : html`
-                      <div class="item-header">
+                      <div class="item-header" data-path=${sub.path} tabindex="-1">
                           ${renderStepText(sub.label, order, isCurrent, true)}
                       </div>
                   `}
@@ -123,7 +123,9 @@ function renderStep(
                       </a>
                   `
                 : html`
-                      <div class="item-header">${renderStepText(step.label, order, isCurrent)}</div>
+                      <div class="item-header" data-path=${step.path} tabindex="-1">
+                          ${renderStepText(step.label, order, isCurrent)}
+                      </div>
                   `}
             ${(isCurrent || mode === 'edit') && step.children.length
                 ? html`

--- a/packages/core/src/components/stepper/stepper.styles.ts
+++ b/packages/core/src/components/stepper/stepper.styles.ts
@@ -89,11 +89,11 @@ export default css`
                 box-shadow: none;
             }
         }
+    }
 
-        &:focus {
-            outline-offset: 4px;
-            outline-color: var(--ar-stepper-link-focus-outline-color);
-        }
+    .item-header:focus-visible {
+        outline-offset: 4px;
+        outline-color: var(--ar-stepper-link-focus-outline-color);
     }
 
     .current > .item-header {

--- a/packages/core/src/components/stepper/stepper.test.ts
+++ b/packages/core/src/components/stepper/stepper.test.ts
@@ -439,6 +439,38 @@ describe('ArStepper', () => {
 
             expect(shadow(el).activeElement).not.toBe(shadow(el).querySelector('[data-path="/a"]'));
         });
+
+        it('focalise le <div> de la SOUS-étape cliquée, pas celui du step parent (les deux deviennent .item.current simultanément via isGroupCurrent())', async () => {
+            const el = await fixtureWithItems(`
+                    <ar-stepper current-path="/a/2">
+                        <ar-stepper-item path="/a" label="Étape A">
+                            <ar-stepper-item path="/a/1" label="Sous-étape 1"></ar-stepper-item>
+                            <ar-stepper-item path="/a/2" label="Sous-étape 2"></ar-stepper-item>
+                        </ar-stepper-item>
+                        <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
+                    </ar-stepper>
+                `);
+
+            // /a/1 est complétée (avant la sous-étape courante /a/2) : rendue comme lien cliquable.
+            const linkSub1 = requireQuery<HTMLAnchorElement>(shadow(el), 'a[data-path="/a/1"]');
+            linkSub1.click();
+
+            // Le consommateur répond en mettant à jour currentPath vers la sous-étape cliquée.
+            el.currentPath = '/a/1';
+            await waitForUpdate(el);
+
+            // isGroupCurrent() fait que le step parent /a ET la sous-étape /a/1 sont
+            // simultanément .item.current — un sélecteur par classe seule matcherait les deux.
+            const currentItems = shadow(el).querySelectorAll('li.item.current');
+            expect(currentItems.length).toBe(2);
+
+            const subStepHeader = shadow(el).querySelector<HTMLDivElement>('[data-path="/a/1"]');
+            expect(subStepHeader?.tagName.toLowerCase()).toBe('div');
+            expect(shadow(el).activeElement).toBe(subStepHeader);
+
+            const parentHeader = shadow(el).querySelector<HTMLDivElement>('[data-path="/a"]');
+            expect(shadow(el).activeElement).not.toBe(parentHeader);
+        });
     });
 
     // ── Téléportation ─────────────────────────────────────────────────────────

--- a/packages/core/src/components/stepper/stepper.test.ts
+++ b/packages/core/src/components/stepper/stepper.test.ts
@@ -362,6 +362,85 @@ describe('ArStepper', () => {
         });
     });
 
+    // ── Focus après activation (#154) ───────────────────────────────────────
+
+    describe("focus après activation d'un lien", () => {
+        it("porte data-path sur le <div> de remplacement de l'étape courante", async () => {
+            const el = await fixtureWithItems(`
+                    <ar-stepper current-path="/b">
+                        <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
+                        <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
+                    </ar-stepper>
+                `);
+
+            const currentHeader = requireQuery<HTMLDivElement>(
+                shadow(el),
+                'li.item.current > .item-header',
+            );
+            expect(currentHeader.tagName.toLowerCase()).toBe('div');
+            expect(currentHeader.getAttribute('data-path')).toBe('/b');
+        });
+
+        it("focalise le <div> de l'étape cliquée quand le consommateur répond en mettant à jour currentPath", async () => {
+            const el = await fixtureWithItems(`
+                    <ar-stepper current-path="/b">
+                        <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
+                        <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
+                    </ar-stepper>
+                `);
+
+            const linkA = requireQuery<HTMLAnchorElement>(shadow(el), 'a[data-path="/a"]');
+            linkA.click();
+
+            // Le composant est contrôlé : le consommateur répond à l'event en réassignant
+            // currentPath (pattern déjà utilisé par les tests existants du fichier).
+            el.currentPath = '/a';
+            await waitForUpdate(el);
+
+            const newCurrentHeader = shadow(el).querySelector<HTMLDivElement>('[data-path="/a"]');
+            expect(newCurrentHeader?.tagName.toLowerCase()).toBe('div');
+            expect(shadow(el).activeElement).toBe(newCurrentHeader);
+            expect(newCurrentHeader?.getAttribute('tabindex')).toBe('-1');
+        });
+
+        it('ne vole pas le focus si currentPath change sans rapport avec le dernier clic (ex. scroll-follow)', async () => {
+            const el = await fixtureWithItems(`
+                    <ar-stepper current-path="/a" follow-scroll>
+                        <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
+                        <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
+                    </ar-stepper>
+                `);
+
+            // Simule un changement de currentPath déclenché par le scroll-follow, sans clic
+            // préalable sur aucun lien.
+            el.currentPath = '/b';
+            await waitForUpdate(el);
+
+            expect(shadow(el).activeElement).not.toBe(shadow(el).querySelector('[data-path="/b"]'));
+        });
+
+        it("n'affecte plus le focus au cycle de rendu suivant un clic (fenêtre bornée à un seul cycle)", async () => {
+            const el = await fixtureWithItems(`
+                    <ar-stepper current-path="/c">
+                        <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
+                        <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
+                        <ar-stepper-item path="/c" label="Étape C"></ar-stepper-item>
+                    </ar-stepper>
+                `);
+
+            const linkA = requireQuery<HTMLAnchorElement>(shadow(el), 'a[data-path="/a"]');
+            linkA.click();
+
+            // Le consommateur ignore l'event (currentPath ne change pas tout de suite) puis,
+            // un cycle plus tard, une cause sans rapport (scroll-follow) amène sur /a.
+            await waitForUpdate(el);
+            el.currentPath = '/a';
+            await waitForUpdate(el);
+
+            expect(shadow(el).activeElement).not.toBe(shadow(el).querySelector('[data-path="/a"]'));
+        });
+    });
+
     // ── Téléportation ─────────────────────────────────────────────────────────
 
     describe('téléportation', () => {

--- a/packages/core/src/components/stepper/stepper.ts
+++ b/packages/core/src/components/stepper/stepper.ts
@@ -460,10 +460,6 @@ export class ArStepper extends LitElement {
         if (!path) return;
 
         this._pendingFocusPath = path;
-        // Force un cycle de rendu même si aucune propriété réactive ne change : c'est ce
-        // cycle qui, dans updated(), valide (ou expire) l'intention de focus — garantit la
-        // fenêtre "un seul cycle" même si le consommateur ignore l'event.
-        this.requestUpdate();
 
         const node = this.navigation.tree
             .flatMap((s) => [s, ...s.children])
@@ -483,6 +479,13 @@ export class ArStepper extends LitElement {
         this.dispatchEvent(
             new CustomEvent('ar-stepper-step-change', { bubbles: true, composed: true, detail }),
         );
+
+        // Force un cycle de rendu même si aucune propriété réactive ne change : c'est ce
+        // cycle qui, dans updated(), valide (ou expire) l'intention de focus — garantit la
+        // fenêtre "un seul cycle" même si le consommateur ignore l'event. Placé après le
+        // dispatchEvent pour laisser une chance à une mutation synchrone/quasi-synchrone
+        // (ex. Vue nextTick) du consommateur d'être planifiée dans le même cycle Lit.
+        this.requestUpdate();
 
         announceA11y(node?.label ?? path, 'polite');
     };

--- a/packages/core/src/components/stepper/stepper.ts
+++ b/packages/core/src/components/stepper/stepper.ts
@@ -155,7 +155,7 @@ export class ArStepper extends LitElement {
     private _mediaQueryList: MediaQueryList | undefined;
     private _responsiveQuery: string | undefined;
     private _dropdownAttached = false;
-    private _pendingFocusPath?: string;
+    private _pendingFocusPath: string | undefined;
     private readonly _onMediaQueryChange = (event: MediaQueryListEvent) => {
         this.applyResponsiveMode(event.matches);
     };

--- a/packages/core/src/components/stepper/stepper.ts
+++ b/packages/core/src/components/stepper/stepper.ts
@@ -15,6 +15,7 @@ import styles from './stepper.styles.js';
 
 import { stepperContext, type StepperRegistry } from '../../context/stepper.context.js';
 import { announceA11y } from '../../a11y/announce-a11y.js';
+import { focusAfterUpdate } from '../../a11y/focus-after-update.js';
 import { NavigationTreeController } from '../../controllers/navigation-tree.controller.js';
 import { ScrollFollowController } from '../../controllers/scroll-follow.controller.js';
 import { AnchoredController } from '../../controllers/anchored.controller.js';
@@ -155,6 +156,7 @@ export class ArStepper extends LitElement {
     private _mediaQueryList: MediaQueryList | undefined;
     private _responsiveQuery: string | undefined;
     private _dropdownAttached = false;
+    private _pendingFocusPath?: string;
     private readonly _onMediaQueryChange = (event: MediaQueryListEvent) => {
         this.applyResponsiveMode(event.matches);
     };
@@ -254,6 +256,10 @@ export class ArStepper extends LitElement {
                 });
             }
         }
+        if (changed.has('currentPath') && this.currentPath === this._pendingFocusPath) {
+            void focusAfterUpdate(this, `[data-path="${this._pendingFocusPath}"]`);
+        }
+        this._pendingFocusPath = undefined;
     }
 
     private _attachDropdown(): boolean {
@@ -451,6 +457,12 @@ export class ArStepper extends LitElement {
     private onClickLink = (event: MouseEvent): void => {
         const path = (event.target as HTMLElement).closest('a')?.dataset['path'];
         if (!path) return;
+
+        this._pendingFocusPath = path;
+        // Force un cycle de rendu même si aucune propriété réactive ne change : c'est ce
+        // cycle qui, dans updated(), valide (ou expire) l'intention de focus — garantit la
+        // fenêtre "un seul cycle" même si le consommateur ignore l'event.
+        this.requestUpdate();
 
         const node = this.navigation.tree
             .flatMap((s) => [s, ...s.children])

--- a/packages/core/src/components/stepper/stepper.ts
+++ b/packages/core/src/components/stepper/stepper.ts
@@ -15,7 +15,6 @@ import styles from './stepper.styles.js';
 
 import { stepperContext, type StepperRegistry } from '../../context/stepper.context.js';
 import { announceA11y } from '../../a11y/announce-a11y.js';
-import { focusAfterUpdate } from '../../a11y/focus-after-update.js';
 import { NavigationTreeController } from '../../controllers/navigation-tree.controller.js';
 import { ScrollFollowController } from '../../controllers/scroll-follow.controller.js';
 import { AnchoredController } from '../../controllers/anchored.controller.js';
@@ -257,7 +256,9 @@ export class ArStepper extends LitElement {
             }
         }
         if (changed.has('currentPath') && this.currentPath === this._pendingFocusPath) {
-            void focusAfterUpdate(this, `[data-path="${this._pendingFocusPath}"]`);
+            this.shadowRoot
+                ?.querySelector<HTMLElement>(`[data-path="${this._pendingFocusPath}"]`)
+                ?.focus();
         }
         this._pendingFocusPath = undefined;
     }


### PR DESCRIPTION
## Summary
- `ar-pagination` : un clic/activation clavier sur un numéro de page focalise désormais le nouvel élément `part="current"` (`tabindex="-1"` + `focus()` programmatique) au lieu de perdre le focus sur `<body>`.
- `ar-stepper` : même correctif pour le `<div>` de remplacement d'un lien d'étape (top-level et sous-étape) — plus délicat car `currentPath` est contrôlé par le consommateur ; le focus n'est posé que si `currentPath` matche le `path` cliqué au cycle de rendu immédiatement suivant (ne vole jamais le focus lors d'un changement de `currentPath` sans rapport, ex. scroll-follow). Le contrat de réponse synchrone est documenté dans `ar-stepper.mdx`.
- Nouvel utilitaire partagé `focusAfterUpdate()` (`packages/core/src/a11y/`), même niveau d'abstraction que `announceA11y()`.
- Indicateur de focus en `:focus-visible` (pas `:focus`) sur les deux composants — n'apparaît qu'après une activation clavier, jamais après un clic souris.
- **Bug réel trouvé et corrigé pendant l'implémentation** : un premier essai appelait `focusAfterUpdate` (qui attend `updateComplete`) depuis l'intérieur même du cycle `updated()` d'`ar-stepper` — un `await` réentrant qui gelait Chromium de façon déterministe (trouvé par les tests navigateur réels, invisible en Vitest/happy-dom et non détecté par deux revues de code). Corrigé par un accès DOM direct et synchrone, le DOM étant déjà à jour à ce point du cycle.
- **Second bug pré-existant trouvé en marge** (même famille, gel navigateur potentiel sur l'attache du dropdown mobile d'`ar-stepper`) — hors scope de ce correctif, tracké séparément en [#158](https://github.com/jogo-labs/ariane/issues/158).

Closes #154

Spec : `docs/superpowers/specs/2026-08-04-focus-after-activation-154-design.md`
Plan : `docs/superpowers/plans/2026-08-04-focus-after-activation-154.md`

## Test plan
- [x] `npm run test --workspace=packages/core` (824/824)
- [x] Suite browser (WTR) complète (232/232)
- [x] `npm run build:manifest --workspace=packages/core` (garde-fous CI verts)
- [x] Vérification visuelle Playwright (clavier + souris, pagination + stepper top-level/sous-étape)
- [x] Revue finale de branche (1 vague de fix, tout adressé/justifié, re-vérifié)

🤖 Generated with [Claude Code](https://claude.com/claude-code)