### PR TITLE
fix(breadcrumb): résout la collision hover/focus sur le bouton trigger (#157)

### DIFF
--- a/packages/core/src/components/breadcrumb/breadcrumb.browser.test.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.browser.test.ts
@@ -1,5 +1,5 @@
 /// <reference types="mocha" />
-import { fixture, html, expect, aTimeout } from '@open-wc/testing';
+import { fixture, html, expect, aTimeout, elementUpdated } from '@open-wc/testing';
 import './index.js';
 import '../breadcrumb-item/index.js';
 import type { ArBreadcrumb } from './breadcrumb.js';
@@ -128,6 +128,30 @@ describe('ar-breadcrumb — browser', () => {
             const computed = getComputedStyle(trigger);
             expect(parseFloat(computed.minHeight)).to.be.greaterThan(0);
             expect(parseFloat(computed.minWidth)).to.be.greaterThan(0);
+        });
+    });
+
+    // ── Collision hover/focus (#157) ─────────────────────────────────────────
+
+    describe('collision hover/focus (#157)', () => {
+        // Vérifie que :focus-visible seul (clavier, sans souris) applique bien le token
+        // bg-focus. Ne vérifie PAS la combinaison réelle hover+focus simultanés (un clic
+        // souris) : nécessiterait @web/test-runner-commands (sendMouse), non installé,
+        // hors scope de ce correctif — vérifié manuellement via Playwright contre le
+        // serveur de dev de la documentation (background attendu : token hover, pas
+        // focus, après un clic souris réel).
+        it(':focus-visible seul applique le token bg-focus, indépendamment de :hover', async () => {
+            el = await mobileBreadcrumb();
+            el.style.setProperty('--ar-breadcrumb-toggle-bg', 'rgb(1, 1, 1)');
+            el.style.setProperty('--ar-breadcrumb-toggle-bg-hover', 'rgb(2, 2, 2)');
+            el.style.setProperty('--ar-breadcrumb-toggle-bg-focus', 'rgb(3, 3, 3)');
+            const trigger = getBtn(el);
+
+            trigger.focus();
+            await elementUpdated(el);
+
+            expect(trigger.matches(':focus-visible')).to.equal(true);
+            expect(getComputedStyle(trigger).backgroundColor).to.equal('rgb(3, 3, 3)');
         });
     });
 });

--- a/packages/core/src/components/breadcrumb/breadcrumb.styles.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.styles.ts
@@ -120,6 +120,18 @@ export default css`
         width: auto;
     }
 
+    /* Ordre volontaire : :focus-visible avant :hover avant :active, à spécificité égale, pour
+       qu'un état combiné (ex. clic — hover + focus simultanés) retienne toujours le fond de
+       l'état le plus fort visuellement plutôt qu'un fond issu d'une autre origine de valeur qui
+       pourrait entrer en collision avec la couleur pilotée par :hover (cf. #157). */
+
+    [part='home']:focus-visible,
+    [part='trigger']:focus-visible {
+        background-color: var(--ar-breadcrumb-toggle-bg-focus);
+        outline: 2px solid currentColor;
+        outline-offset: 2px;
+    }
+
     [part='home']:hover,
     [part='trigger']:hover {
         background-color: var(--ar-breadcrumb-toggle-bg-hover);
@@ -128,17 +140,6 @@ export default css`
     [part='home']:active,
     [part='trigger']:active {
         background-color: var(--ar-breadcrumb-toggle-bg-pressed);
-    }
-
-    [part='home']:focus,
-    [part='trigger']:focus {
-        background-color: var(--ar-breadcrumb-toggle-bg-focus);
-    }
-
-    [part='home']:focus-visible,
-    [part='trigger']:focus-visible {
-        outline: 2px solid currentColor;
-        outline-offset: 2px;
     }
 
     @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Résumé

Sur `ar-breadcrumb` mobile, cliquer sur le bouton `part="trigger"` (ou `part="home"`) rendait l'icône invisible : au clic, le bouton est simultanément `:hover` et `:focus`, et la règle `:focus` (déclarée après `:hover`, même spécificité) l'emportait sur le fond, imposant `--ar-breadcrumb-toggle-bg-focus` (quasi blanc en thème light) alors que la couleur de l'icône restait pilotée par `::part(trigger):hover` côté thème (blanc) → icône blanche sur fond quasi blanc.

## Correctif

`breadcrumb.styles.ts` : le fond piloté par `:focus` passe sur `:focus-visible` (fusionné avec la règle d'anneau déjà existante), et l'ordre de déclaration devient `:focus-visible` → `:hover` → `:active` (spécificité égale, l'ordre source tranche). Effets :

- Un clic souris ne matche plus `:focus-visible` → seul `:hover` détermine le fond → plus de collision, fond sombre + icône blanche cohérents.
- Le focus clavier seul (sans survol souris) est inchangé : `:focus-visible` matche toujours, fond `bg-focus` + anneau, comme avant.
- Aucun token CSS ajouté/renommé — changement de sélecteur interne uniquement.

## Vérification

- Reproduit empiriquement AVANT correctif via Playwright contre le serveur de dev de la doc (`/components/breadcrumb`) : fond mesuré après clic = token rest/focus quasi blanc + couleur blanche → contraste cassé, confirmé.
- Reproduit APRÈS correctif : fond mesuré après clic = token hover (`rgba(18, 20, 55, 0.7)`) + couleur blanche → contraste correct.
- Focus clavier seul (Tab, sans souris) revérifié après correctif : `:focus-visible` matche toujours, comportement inchangé.
- `npm run test --workspace=packages/core` : 824/824 passent.
- Suite navigateur (WTR/Chromium) `breadcrumb` : 10/10 passent, dont un nouveau test régression `:focus-visible` seul applique le token bg-focus indépendamment de `:hover` (la combinaison hover+focus réelle nécessite `sendMouse`, non installé — même limitation documentée que sur `pagination`/`stepper.browser.test.ts` pour #154).
- `npm run build:manifest --workspace=packages/core` : aucune violation de garde-fou CI.

Closes #157