### PR TITLE
refactor(tooltip): migre token vs ::part(), dernier lot du périmètre initial (#129)

### DIFF
--- a/docs/decisions/ADR-005-tokens-pilotes-par-attribut.md
+++ b/docs/decisions/ADR-005-tokens-pilotes-par-attribut.md
@@ -476,6 +476,46 @@ remplacés par les presets `ar-dialog[size='...']`/`ar-dialog[mode='drawer'][siz
 directement dans le thème (cf. `default.css`) et la valeur de repli unique par mode portée par
 `functional-default` ci-dessus.
 
+## Amendement (2026-08-05) : `!important` comme verrou contre la surcharge consommateur
+
+Réflexion ouverte à l'occasion de l'audit qualité `ar-tooltip` (préparation du dernier lot #129),
+en marge de la migration elle-même : jusqu'où la librairie doit-elle garder la maîtrise d'une
+propriété interne, et avec quel mécanisme ?
+
+**Constat** : le mécanisme « l'externe l'emporte toujours » documenté dans tout ce chantier
+(amendements du 2026-07-25 et suivants) n'est vrai que pour les déclarations normales. Vérifié
+par la spécification CSS Cascade (relayée par CSS Shadow Parts Module Level 1) : pour les
+déclarations `!important`, l'ordre s'inverse — une règle `!important` posée dans la feuille de
+style interne du composant (shadow tree) l'emporte sur une règle externe `::part()`, **même si
+celle-ci est elle-même `!important`**. C'est donc le seul levier technique qui verrouille
+réellement une propriété contre toute surcharge consommateur ; l'absence de `part`/token ne fait
+que rendre la surcharge malcommode (une propriété posée sur un élément qui porte déjà un `part`
+reste atteignable via `::part()`, y compris les resets structurels jamais documentés en
+`@cssprop`, ex. `overflow`/`position`/`border` sur `[part='bubble']` d'`ar-tooltip`).
+
+**Décision** : ne pas recourir à `!important` par défaut. Ariane se définit dans CLAUDE.md comme
+une fondation headless, pas un design system — la posture par défaut reste permissive, un
+consommateur doit pouvoir tout casser visuellement s'il le souhaite. `!important` est réservé aux
+cas où une surcharge externe casserait un **contrat fonctionnel** du composant, pas une
+préférence esthétique :
+
+- positionnement dont dépend un controller JS (`AnchoredController`/`TooltipController`, calculs
+  Floating UI) ;
+- garantie WCAG explicite déjà couverte par ce document (fallback de contraste de l'amendement
+  du 2026-07-22, garde `prefers-reduced-motion` de la contrainte 6 de l'amendement du 2026-07-24).
+
+Une dégradation purement visuelle (bordure, radius, padding, typographie) n'est jamais une raison
+suffisante — cohérent avec le rejet déjà exprimé de `!important` comme mécanisme de mutualisation
+de la garde `prefers-reduced-motion` (issue #155, écarté comme « changement de mécanisme » par
+rapport au pattern « externe > interne » déjà établi).
+
+**Trade-off assumé, pas corrigé** : les resets structurels posés sur un élément qui porte un
+`part` (ex. `overflow: visible`, `position`/`inset`/`margin`, `border: none` sur
+`[part='bubble']` d'`ar-tooltip`) restent techniquement atteignables via `::part()` sans qu'aucun
+verrou ne les protège — situation partagée par tous les composants déjà migrés dans ce chantier,
+pas spécifique à `ar-tooltip`. Accepté comme trade-off du modèle headless plutôt que traité au cas
+par cas ; à reconsidérer seulement si une régression réelle est signalée (constat, pas hypothèse).
+
 ## Application — `ar-breadcrumb` (lot 4, 2026-07-30)
 
 Premier des 4 composants du lot 4 (`breadcrumb`, `dropdown`, `pagination`, `tooltip`). Précédé

--- a/docs/superpowers/plans/2026-08-05-tooltip-token-vs-part-129.md
+++ b/docs/superpowers/plans/2026-08-05-tooltip-token-vs-part-129.md
@@ -1,0 +1,377 @@
+# `ar-tooltip` token vs `::part()` (dernier composant du périmètre initial, #129) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrer 4 des 10 tokens `--ar-tooltip-*` (`border-radius`, `font-size`, `padding`,
+`max-width`) plus une valeur jamais tokenisée (`line-height: 1.4`) vers une nouvelle règle
+littérale `ar-tooltip::part(bubble)` dans `default.css`, en gardant les 6 tokens restants
+(`bg`/`color` — fallback a11y + calibration dark, `arrow-size` — réutilisé en interne,
+`show-duration` — garde `prefers-reduced-motion`, `distance`/`offset` — lus en JS), conformément à
+`docs/superpowers/specs/2026-08-05-tooltip-token-vs-part-129-design.md`. Dernier composant du
+périmètre initial de l'audit #129 (2026-07-25).
+
+**Architecture:** Aucun changement de structure DOM ni de `part` (les 2 `part` existants,
+`bubble`/`arrow`, sont inchangés). Simplification de `tooltip.styles.ts` (retrait de 5
+déclarations sur `[part='bubble']`), nouveau bloc `ar-tooltip { &::part(bubble) {...} }` créé en
+fin de `default.css` (à la suite du dernier bloc, `ar-pagination { }`), JSDoc mis à jour.
+
+**Tech Stack:** Lit 3, TypeScript, Vitest + WTR (browser), garde-fous CI
+(`validate-no-hardcoded-tokens.js`, custom-elements-manifest via `cem.config.js`).
+
+## Global Constraints
+
+- Prettier : 100 char, 4 spaces, single quotes (CLAUDE.md).
+- `--ar-*` cascade toujours via `var()` référençant `default.css`, jamais de valeur littérale
+  codée en dur dans un `.styles.ts` sans commentaire `a11y-fallback`/`functional-default`
+  justificatif (garde-fou `validate-no-hardcoded-tokens.js`) — non applicable ici, aucun token ne
+  reste avec fallback à ajouter/modifier.
+- Tout token `--ar-*` retiré doit avoir son entrée `@cssprop` retirée du JSDoc du composant
+  (feedback_cssprop_jsdoc / feedback_cssprop_requires_internal_consumption).
+- Ne jamais merger sur `dev` sans confirmation explicite de l'utilisateur
+  (feedback_merge_after_autonomous_fix).
+- `npm run dev --workspace=apps/docs` seul ne reconstruit pas le JS de `packages/core/dist` —
+  rebuild explicite (`npm run build:dev --workspace=packages/core`) requis avant toute
+  vérification Playwright d'un changement de renderer (feedback_docs_dev_stale_dist).
+
+---
+
+## Task 1: Créer la branche de travail
+
+**Files:** aucun.
+
+- [ ] **Step 1: Créer la branche depuis `dev`**
+
+```bash
+git checkout dev
+git pull origin dev
+git checkout -b fix/tooltip-token-vs-part-129
+```
+
+- [ ] **Step 2: Vérifier l'état propre**
+
+Run: `git status`
+Expected: `On branch fix/tooltip-token-vs-part-129`, `nothing to commit, working tree clean`.
+
+---
+
+## Task 2: Simplifier `tooltip.styles.ts`
+
+**Files:**
+
+- Modify: `packages/core/src/components/tooltip/tooltip.styles.ts`
+
+**Interfaces:**
+
+- Consumes: rien de nouveau.
+- Produces: `[part='bubble']` ne déclare plus `border-radius`/`font-size`/`padding`/`max-width`/
+  `line-height` — ces 5 propriétés deviennent une opinion pure du thème (Task 3). Comportement
+  visuel inchangé une fois `default.css` mis à jour (Task 3) puisque les valeurs migrées sont
+  identiques.
+
+- [ ] **Step 1: Retirer les 5 déclarations cosmétiques de `[part='bubble']`**
+
+Retirer `border-radius: var(--ar-tooltip-border-radius);`, `font-size: var(--ar-tooltip-font-size);`,
+`padding: var(--ar-tooltip-padding);`, `max-width: var(--ar-tooltip-max-width);`,
+`line-height: 1.4;`. La règle ne garde que le reset de positionnement, le box model
+(`box-sizing`/`overflow`), et `background-color`/`color`/`border: none`/`word-break`.
+
+Résultat attendu :
+
+```css
+[part='bubble'] {
+    /* Popover positioning reset */
+    position: absolute;
+    inset: 0 auto auto 0;
+    margin: 0;
+
+    /* Box model */
+    box-sizing: border-box;
+
+    /* overflow: visible requis pour que le caret (position: absolute) dépasse de la bulle */
+    overflow: visible;
+
+    /* Visual */
+    background-color: var(--ar-tooltip-bg, Canvas);
+    color: var(--ar-tooltip-color, CanvasText);
+    border: none;
+    word-break: break-word;
+}
+```
+
+`[part='bubble']:not(:popover-open)`, `[part='bubble']:popover-open`, la garde
+`prefers-reduced-motion`, et `[part='arrow']` restent inchangés.
+
+- [ ] **Step 2: Vérifier qu'aucune autre règle du fichier ne référence les 4 tokens retirés**
+
+Run: `grep -n "ar-tooltip-border-radius\|ar-tooltip-font-size\|ar-tooltip-padding\|ar-tooltip-max-width" packages/core/src/components/tooltip/tooltip.styles.ts`
+Expected: aucune occurrence.
+
+---
+
+## Task 3: Mettre à jour `default.css` (retrait des tokens + nouveau bloc `ar-tooltip { }`)
+
+**Files:**
+
+- Modify: `packages/core/src/styles/themes/default.css`
+
+**Interfaces:**
+
+- Consumes: `--ar-border-radius-sm` (token générique déjà existant, réutilisé tel quel).
+- Produces: bloc `Tooltip` du `:root` réduit à 6 tokens ; nouveau bloc `ar-tooltip { }` (parité
+  structurelle avec `ar-dropdown { }`/`ar-breadcrumb { }`).
+
+- [ ] **Step 1: Retirer les 4 tokens migrés du bloc `Tooltip` (`:root`, ~ligne 413)**
+
+Avant :
+
+```css
+--ar-tooltip-distance: 10px;
+--ar-tooltip-offset: var(--ar-anchor-offset);
+--ar-tooltip-bg: var(--ar-color-neutral-20);
+--ar-tooltip-color: var(--ar-color-white);
+--ar-tooltip-border-radius: var(--ar-border-radius-sm);
+--ar-tooltip-font-size: 0.8125rem;
+--ar-tooltip-padding: 0.375rem 0.625rem;
+--ar-tooltip-max-width: 18rem;
+--ar-tooltip-arrow-size: 6px;
+--ar-tooltip-show-duration: var(--ar-panel-show-duration);
+```
+
+Après :
+
+```css
+--ar-tooltip-distance: 10px;
+--ar-tooltip-offset: var(--ar-anchor-offset);
+--ar-tooltip-bg: var(--ar-color-neutral-20);
+--ar-tooltip-color: var(--ar-color-white);
+--ar-tooltip-arrow-size: 6px;
+--ar-tooltip-show-duration: var(--ar-panel-show-duration);
+```
+
+- [ ] **Step 2: Vérifier les 2 blocs dark-mode (~lignes 602 et 667)**
+
+Confirmer qu'ils ne redéfinissent que `--ar-tooltip-bg`/`--ar-tooltip-color` (déjà le cas) — ne
+rien changer, ces 2 tokens restent des tokens.
+
+- [ ] **Step 3: Ajouter le bloc `ar-tooltip { }` en fin de fichier, après `ar-pagination { }`**
+
+```css
+ar-tooltip {
+    &::part(bubble) {
+        border-radius: var(--ar-border-radius-sm);
+        font-size: 0.8125rem;
+        padding: 0.375rem 0.625rem;
+        max-width: 18rem;
+        line-height: 1.4;
+    }
+}
+```
+
+- [ ] **Step 4: Vérifier le format Prettier**
+
+Run: `npx prettier --check packages/core/src/styles/themes/default.css`
+Expected: pas de diff signalé (sinon `npx prettier --write` puis re-vérifier le rendu).
+
+---
+
+## Task 4: Mettre à jour le JSDoc de `tooltip.ts`
+
+**Files:**
+
+- Modify: `packages/core/src/components/tooltip/tooltip.ts`
+
+**Interfaces:**
+
+- Consumes: rien.
+- Produces: `@cssprop`/`@csspart` reflètent l'implémentation finale (garde-fou
+  `validate-cssprop-defaults.js`).
+
+- [ ] **Step 1: Retirer les 4 entrées `@cssprop` des tokens migrés**
+
+Retirer les lignes `@cssprop --ar-tooltip-border-radius`, `@cssprop --ar-tooltip-padding`,
+`@cssprop --ar-tooltip-font-size`, `@cssprop --ar-tooltip-max-width`. Les 6 entrées restantes
+(`bg`, `color`, `arrow-size`, `show-duration`, `distance`, `offset`) inchangées.
+
+- [ ] **Step 2: Enrichir `@csspart bubble`**
+
+```
+@csspart bubble - Le panel flottant (radius, padding, taille de police, largeur maximale et
+interligne pilotables via `::part(bubble)`).
+```
+
+---
+
+## Task 5: Vérifier les tests existants
+
+**Files:** aucune modification attendue — vérification uniquement.
+
+- [ ] **Step 1: Grep les 3 fichiers de test du composant pour une assertion sur les valeurs migrées**
+
+Run: `grep -n "border-radius\|font-size\|padding\|max-width\|line-height" packages/core/src/components/tooltip/tooltip*.test.ts`
+Expected: aucune occurrence (les tests ciblent comportement/attributs/ARIA, pas des valeurs
+calculées de style cosmétique) — confirmé par un premier passage lors de la préparation de ce
+plan. Si une occurrence apparaît, l'adapter pour charger `default.css` ou cibler `::part(bubble)`
+plutôt que d'asserter une valeur calculée sans thème.
+
+---
+
+## Task 6: Lancer les suites de tests et régénérer le manifeste
+
+**Files:** aucun.
+
+- [ ] **Step 1: Suite Vitest complète**
+
+Run: `npm run test --workspace=packages/core`
+Expected: tous les tests passent, y compris `tooltip.test.ts`/`tooltip.a11y.test.ts`.
+
+- [ ] **Step 2: Régénérer le manifeste (garde-fous CI)**
+
+Run: `npm run build:manifest --workspace=packages/core`
+Expected: succès — `validate-cssprop-defaults.js` confirme que les 6 `@cssprop` restants
+correspondent exactement aux 6 tokens `:root`, `validate-no-hardcoded-tokens.js` ne signale rien
+de nouveau.
+
+- [ ] **Step 3: Suite browser (WTR)**
+
+Run: `npm run test:all --workspace=packages/core` (ou la commande WTR dédiée si distincte)
+Expected: `tooltip.browser.test.ts` passe.
+
+---
+
+## Task 7: Vérification visuelle manuelle (Playwright)
+
+**Files:** aucun fichier modifié — vérification uniquement.
+
+- [ ] **Step 1: Rebuild explicite de `packages/core`**
+
+Run: `npm run build:dev --workspace=packages/core`
+Expected: build réussi.
+
+- [ ] **Step 2: Lancer le serveur de doc**
+
+Run: `npm run dev --workspace=apps/docs` (arrière-plan ou terminal dédié).
+
+- [ ] **Step 3: Capturer la page `ar-tooltip` (thème chargé)**
+
+Naviguer vers `http://localhost:<port>/components/tooltip`, capturer :
+
+- L'affichage par défaut au hover/focus d'un trigger (`placement="top"`) — comparer visuellement
+  à une capture prise avant ce lot : aucune différence attendue (radius/padding/font-size/
+  max-width/line-height reproduits à l'identique).
+- Un tooltip avec texte long (retour à la ligne, `max-width` en jeu) — vérifier `word-break`/
+  `line-height` du texte multi-lignes.
+- Un placement différent (`bottom-start` ou équivalent) — vérifier le caret (`[part='arrow']`,
+  inchangé).
+
+- [ ] **Step 4: Vérifier le rendu sans thème (fallback a11y)**
+
+Commenter temporairement l'import de `default.css`, recharger, confirmer que : le fond/texte
+restent lisibles (`Canvas`/`CanvasText`), le tooltip reste positionné correctement (`distance`/
+`offset` à 0, comportement déjà attendu sans thème), radius/padding/font-size/max-width/
+line-height retombent au rendu nu du navigateur (attendu, plus aucun repli interne). Rétablir
+l'import après vérification.
+
+- [ ] **Step 5: Diff empirique `getComputedStyle` (radius/padding/font-size/max-width/line-height)**
+
+Sur la page thémée, comparer par script Playwright les valeurs `getComputedStyle` de
+`[part='bubble']` avant/après ce lot (commit `dev` vs branche) pour ces 5 propriétés
+spécifiquement — méthode retenue sur les lots précédents pour débusquer des régressions fines
+invisibles à l'œil (cf. lot `ar-stepper`, PR #156).
+
+- [ ] **Step 6: Consigner le résultat**
+
+Si un écart est trouvé, corriger `tooltip.styles.ts`/`default.css` (Tasks 2-3) et refaire les
+Steps 3-5. Si rien trouvé, continuer.
+
+---
+
+## Task 8: Revue finale de branche
+
+**Files:** aucun — revue uniquement.
+
+- [ ] **Step 1: Dispatcher une revue de branche complète sur un agent capable**
+
+Comparer l'intégralité du diff `dev...fix/tooltip-token-vs-part-129` contre
+`docs/decisions/ADR-005-tokens-pilotes-par-attribut.md` et
+`docs/superpowers/specs/2026-08-05-tooltip-token-vs-part-129-design.md`. Points d'attention :
+
+- Les 6 tokens conservés (`bg`, `color`, `arrow-size`, `show-duration`, `distance`, `offset`)
+  correspondent exactement entre `default.css` (`:root` + 2 blocs dark), `tooltip.styles.ts`
+  (consommation `var()`) et `tooltip.ts` (`@cssprop`) — aucun écart.
+- Le nouveau bloc `ar-tooltip { &::part(bubble) {...} }` respecte la structure d'imbrication déjà
+  utilisée par `ar-dropdown { }`/`ar-breadcrumb { }`/`ar-pagination { }`.
+- `--ar-tooltip-border-radius` référence toujours `var(--ar-border-radius-sm)` dans son nouvel
+  emplacement (pas recodé en dur), cohérent avec le token générique déjà utilisé auparavant.
+- Le trade-off `!important` documenté dans l'amendement ADR-005 du 2026-08-05 (resets
+  structurels de `[part='bubble']` non verrouillés) reste hors scope de ce lot — confirmer que la
+  PR ne tente pas de le corriger accessoirement.
+- JSDoc `@cssprop`/`@csspart` cohérent avec l'implémentation finale.
+
+- [ ] **Step 2: Corriger les findings en une vague unique**
+
+Si des findings « Critical »/« Important » remontent, les corriger en un seul commit groupé, puis
+relancer Task 6 pour re-vérifier.
+
+---
+
+## Task 9: Créer la Pull Request
+
+**Files:** aucun.
+
+- [ ] **Step 1: Pousser la branche**
+
+```bash
+git push -u origin fix/tooltip-token-vs-part-129
+```
+
+- [ ] **Step 2: Créer la PR vers `dev`**
+
+```bash
+gh pr create --base dev --title "refactor(tooltip): migre token vs ::part(), dernier lot du périmètre initial (#129)" --body "$(cat <<'EOF'
+## Summary
+- Migre 4 des 10 tokens `--ar-tooltip-*` (`border-radius`, `font-size`, `padding`, `max-width`) plus une valeur jamais tokenisée (`line-height`) vers une règle littérale `ar-tooltip::part(bubble)` dans `default.css`.
+- Conserve 6 tokens : `bg`/`color` (fallback a11y + calibration dark-mode), `arrow-size` (réutilisé en interne), `show-duration` (garde `prefers-reduced-motion`), `distance`/`offset` (lus en JS par `TooltipController`).
+- Aucun changement de structure DOM ni de `part` (`bubble`/`arrow` inchangés), aucun changement visuel par défaut.
+- Dernier composant du périmètre initial de l'audit #129 (2026-07-25) — reste ensuite un lot groupé (`table-sort`/`charcounter`/`progressbar`/`tab-group`/`collapse`) puis `tab` séparément.
+- En marge : amendement ADR-005 consignant la réflexion sur `!important` comme verrou technique contre la surcharge `::part()` (non appliqué à ce lot, trade-off assumé).
+
+Spec : \`docs/superpowers/specs/2026-08-05-tooltip-token-vs-part-129-design.md\`
+Plan : \`docs/superpowers/plans/2026-08-05-tooltip-token-vs-part-129.md\`
+
+## Test plan
+- [x] \`npm run test --workspace=packages/core\`
+- [x] \`npm run build:manifest --workspace=packages/core\` (garde-fous CI verts)
+- [x] Suite browser (WTR) tooltip
+- [x] Vérification visuelle Playwright (thème chargé, sans thème, diff `getComputedStyle`)
+- [x] Revue finale de branche
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Confirmer avec l'utilisateur avant tout merge**
+
+Ne pas merger sur `dev` sans confirmation explicite — signaler la PR créée et attendre la revue
+de l'utilisateur (feedback_merge_after_autonomous_fix).
+
+---
+
+## Self-Review (déjà appliqué en rédigeant ce plan)
+
+1. **Couverture de la spec** : les 4 tokens migrés, la valeur `line-height` jamais tokenisée, les
+   6 tokens conservés et leurs justifications respectives sont tous repris dans les tasks
+   d'implémentation (2-4) — aucune section de la spec laissée de côté.
+2. **Scan placeholders** : aucun « TBD » — les 5 valeurs littérales migrées vers `::part(bubble)`
+   sont fixées explicitement (reprises telles quelles depuis les tokens actuels), pas de décision
+   reportée à l'implémentation.
+3. **Cohérence des noms** : `border-radius: var(--ar-border-radius-sm)` (Task 3) correspond à la
+   valeur exacte de l'ancien `--ar-tooltip-border-radius` (Task 3, avant/après) ; les 6 tokens
+   conservés sont nommés identiquement entre `default.css`, `tooltip.styles.ts` et `tooltip.ts`
+   dans les 3 tasks concernées.
+4. **Risque le plus élevé identifié** : contrairement aux lots précédents, ce lot ne touche ni
+   DOM ni structure de `part` — le risque principal est une régression visuelle fine
+   (radius/padding/font-size/max-width/line-height) invisible à une simple capture d'écran, d'où
+   l'ajout explicite d'un diff empirique `getComputedStyle` en Task 7 Step 5 (méthode qui a
+   débusqué 3 régressions similaires sur `ar-stepper`, PR #156) plutôt que de se reposer sur la
+   seule vérification visuelle.

--- a/docs/superpowers/specs/2026-08-05-tooltip-token-vs-part-129-design.md
+++ b/docs/superpowers/specs/2026-08-05-tooltip-token-vs-part-129-design.md
@@ -1,0 +1,154 @@
+# `ar-tooltip` — token vs `::part()` (dernier lot du périmètre initial, issue #129)
+
+**Date :** 2026-08-05
+**Statut :** Validé, prêt pour plan d'implémentation
+
+## Contexte
+
+Suite de la généralisation du critère token-vs-part (ADR-005) : lot 1 (`ar-stepper`), lot 2
+(`ar-datepicker`), lots 3a/3b (`ar-alert`/`ar-dialog`), lot 4 (`ar-breadcrumb`), lot 5
+(`ar-dropdown`), lot 6 (`ar-pagination`). `ar-tooltip` est le **dernier composant du périmètre
+initial de l'audit du 2026-07-25** (les composants restants — `table-sort`, `charcounter`,
+`progressbar`, `tab-group`, `collapse`, `tab` — suivent un séquencement séparé, cf.
+`[[project_token_vs_part_generalization_129]]`).
+
+**Particularités par rapport aux lots précédents** :
+
+- Composant le plus simple traité jusqu'ici : un seul élément stylé porteur de design
+  (`[part='bubble']`), un second `part` purement géométrique (`arrow`), aucune dépendance à
+  `button.styles.ts` ou `panel.styles.ts` (pas de bouton, pas de panel partagé — le tooltip
+  utilise l'API Popover directement).
+- Aucun CSS mort, aucune classe interne redondante, aucun `part` manquant à débloquer — le
+  composant est déjà propre (pas d'historique d'import externe comme `ar-breadcrumb`).
+- Deux tokens ont une calibration dark-mode **indépendante** (`bg`/`color`), un profil déjà
+  rencontré sur les panels partagés (`ar-dropdown`/`ar-breadcrumb`/`ar-stepper`), mais ici
+  appliqué à un composant qui ne partage pas de feuille de style.
+- `--ar-tooltip-show-duration` illustre la contrainte 6 (garde `prefers-reduced-motion`) sur un
+  cas nouveau : `animation` (pas `transition`), entièrement interne à `tooltip.styles.ts`.
+- Audit complété par une revue de valeurs jamais tokenisées (étape 0) : `line-height: 1.4` sur
+  `[part='bubble']`, jamais exposée comme token, candidate au même titre que les tokens existants.
+
+## Application du critère (10 tokens + 1 valeur jamais tokenisée)
+
+| Propriété                         | Décision                     | Raison                                                                                                                                                                                                                                                                       |
+| --------------------------------- | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--ar-tooltip-distance`           | **Reste token**              | Lu en JS (`TooltipController._readCssVar` via `getComputedStyle`) — contrainte 2                                                                                                                                                                                             |
+| `--ar-tooltip-offset`             | **Reste token**              | Idem                                                                                                                                                                                                                                                                         |
+| `--ar-tooltip-bg`                 | **Reste token**              | Calibration dark-mode indépendante (`--ar-color-neutral-80`, pas un simple alias) — contrainte 1. Fallback a11y `Canvas` (`ar-tooltip` explicitement cité dans l'amendement du 2026-07-22). Réutilisé 2× dans le composant (`bubble` + `arrow`) — branche 3 aussi satisfaite |
+| `--ar-tooltip-color`              | **Reste token**              | Calibration dark-mode indépendante (`--ar-color-neutral-10`) — contrainte 1. Fallback a11y `CanvasText`                                                                                                                                                                      |
+| `--ar-tooltip-arrow-size`         | **Reste token**              | Réutilisé 2× dans la même règle (`width`/`height` de `[part='arrow']`) — branche 3                                                                                                                                                                                           |
+| `--ar-tooltip-show-duration`      | **Reste token**              | Contrainte 6 : la propriété `animation` reste interne (`[part='bubble']:popover-open`), avec la garde `prefers-reduced-motion` juste en dessous. Externaliser casserait cette garde                                                                                          |
+| `--ar-tooltip-border-radius`      | **Migre → `::part(bubble)`** | Usage unique, hors exception a11y (border-radius explicitement exclu par l'amendement du 2026-07-22), aucune calibration dark — branche 4                                                                                                                                    |
+| `--ar-tooltip-font-size`          | **Migre → `::part(bubble)`** | Idem                                                                                                                                                                                                                                                                         |
+| `--ar-tooltip-padding`            | **Migre → `::part(bubble)`** | Idem (padding générique explicitement exclu de l'exception a11y)                                                                                                                                                                                                             |
+| `--ar-tooltip-max-width`          | **Migre → `::part(bubble)`** | Idem                                                                                                                                                                                                                                                                         |
+| `line-height: 1.4` (jamais token) | **Migre → `::part(bubble)`** | Trouvée à l'étape 0 (valeur littérale jamais externalisée), même profil que les 4 tokens ci-dessus : usage unique, purement cosmétique, aucun fallback critique                                                                                                              |
+
+Contrairement aux lots panel (`dropdown`/`breadcrumb`/`stepper`), les 5 propriétés migrées ne
+proviennent pas d'une feuille de style partagée — elles se regroupent simplement en une seule
+nouvelle règle `ar-tooltip::part(bubble)` dans le thème, sans redondance à traiter avec un
+composant voisin.
+
+## Changements
+
+### `packages/core/src/components/tooltip/tooltip.styles.ts`
+
+`[part='bubble']` perd les 5 propriétés migrées :
+
+```css
+[part='bubble'] {
+    /* Popover positioning reset */
+    position: absolute;
+    inset: 0 auto auto 0;
+    margin: 0;
+
+    /* Box model */
+    box-sizing: border-box;
+
+    /* overflow: visible requis pour que le caret (position: absolute) dépasse de la bulle */
+    overflow: visible;
+
+    /* Visual */
+    background-color: var(--ar-tooltip-bg, Canvas);
+    color: var(--ar-tooltip-color, CanvasText);
+    border: none;
+    word-break: break-word;
+}
+```
+
+`border-radius`, `font-size`, `padding`, `max-width`, `line-height` retirés. `[part='arrow']` et
+le reste du fichier (animation, garde `prefers-reduced-motion`) inchangés.
+
+### `packages/core/src/styles/themes/default.css`
+
+Bloc `Tooltip` (`:root`, lignes ~413-424) : les 4 tokens migrés retirés, seuls `distance`,
+`offset`, `bg`, `color`, `arrow-size`, `show-duration` restent :
+
+```css
+/* Tooltip */
+--ar-tooltip-distance: 10px;
+--ar-tooltip-offset: var(--ar-anchor-offset);
+--ar-tooltip-bg: var(--ar-color-neutral-20);
+--ar-tooltip-color: var(--ar-color-white);
+--ar-tooltip-arrow-size: 6px;
+--ar-tooltip-show-duration: var(--ar-panel-show-duration);
+```
+
+Nouvelle règle `::part(bubble)` ajoutée dans un bloc `ar-tooltip { }` (le fichier n'en a pas
+encore, à créer à la suite du dernier bloc de composant — même schéma que
+`ar-dropdown { &::part(panel) {...} } `) :
+
+```css
+ar-tooltip {
+    &::part(bubble) {
+        border-radius: var(--ar-border-radius-sm);
+        font-size: 0.8125rem;
+        padding: 0.375rem 0.625rem;
+        max-width: 18rem;
+        line-height: 1.4;
+    }
+}
+```
+
+`border-radius` continue de référencer le token générique déjà utilisé (`--ar-border-radius-sm`)
+plutôt que d'être recodé en dur — seul l'intermédiaire `--ar-tooltip-border-radius` disparaît. Les
+2 blocs dark-mode (`:root[data-theme='dark']` et `@media (prefers-color-scheme: dark)`, lignes
+~602-604/~667-669) sont inchangés : ils ne redéfinissent que `bg`/`color`, qui restent tokens.
+
+### `packages/core/src/components/tooltip/tooltip.ts` (JSDoc)
+
+`@cssprop` retirés pour `--ar-tooltip-border-radius`, `--ar-tooltip-padding`,
+`--ar-tooltip-font-size`, `--ar-tooltip-max-width`. Les 6 `@cssprop` restants (`bg`, `color`,
+`arrow-size`, `show-duration`, `distance`, `offset`) inchangés. `@csspart bubble` enrichi pour
+mentionner que le radius/padding/font-size/max-width/line-height sont désormais pilotables via
+`::part(bubble)`.
+
+### Tests
+
+`tooltip.test.ts`/`tooltip.browser.test.ts`/`tooltip.a11y.test.ts` : aucun changement de structure
+DOM ni de `part` (les 2 `part` existants, `bubble` et `arrow`, ne changent pas). Vérifier
+qu'aucun test n'asserte la valeur calculée de `border-radius`/`font-size`/`padding`/`max-width`/
+`line-height` directement sur le composant sans thème chargé — peu probable, ces valeurs sont
+purement cosmétiques.
+
+## Résultat attendu
+
+- 4 tokens supprimés sur 10 (`border-radius`, `font-size`, `padding`, `max-width` — migrés vers
+  `::part(bubble)`), 1 valeur littérale jamais tokenisée migrée avec eux (`line-height`). 6 tokens
+  conservés (`bg`/`color` pour fallback a11y + calibration dark, `arrow-size` réutilisé en
+  interne, `show-duration` pour la garde `prefers-reduced-motion`, `distance`/`offset` pour
+  lecture JS).
+- Aucun changement de structure DOM, aucun nouveau `part`, aucun changement visuel par défaut (le
+  thème reproduit exactement les valeurs actuelles).
+- `ar-tooltip` devient le dernier composant du périmètre initial de l'audit #129 à être traité —
+  seuls les lots groupés restants (`table-sort`/`charcounter`/`progressbar`/`tab-group`/
+  `collapse`, puis `tab` séparément) subsistent après ce lot.
+
+## Hors scope
+
+- Le trade-off `!important` documenté dans l'amendement ADR-005 du 2026-08-05 (verrouillage des
+  resets structurels `position`/`overflow`/`border` de `[part='bubble']` contre une surcharge
+  externe via `::part()`) n'est pas traité dans ce lot — aucune régression concrète ne le
+  justifie aujourd'hui, cf. amendement.
+- `table-sort`, `charcounter`, `progressbar`, `tab-group`, `collapse`, `tab` — lots suivants,
+  séquencement séparé.

--- a/packages/core/src/components/tooltip/tooltip.styles.ts
+++ b/packages/core/src/components/tooltip/tooltip.styles.ts
@@ -14,8 +14,6 @@ const tooltipStyles = css`
 
         /* Box model */
         box-sizing: border-box;
-        padding: var(--ar-tooltip-padding);
-        max-width: var(--ar-tooltip-max-width);
 
         /* overflow: visible requis pour que le caret (position: absolute) dépasse de la bulle */
         overflow: visible;
@@ -24,9 +22,6 @@ const tooltipStyles = css`
         background-color: var(--ar-tooltip-bg, Canvas);
         color: var(--ar-tooltip-color, CanvasText);
         border: none;
-        border-radius: var(--ar-tooltip-border-radius);
-        font-size: var(--ar-tooltip-font-size);
-        line-height: 1.4;
         word-break: break-word;
     }
 

--- a/packages/core/src/components/tooltip/tooltip.styles.ts
+++ b/packages/core/src/components/tooltip/tooltip.styles.ts
@@ -15,6 +15,12 @@ const tooltipStyles = css`
         /* Box model */
         box-sizing: border-box;
 
+        /* a11y-fallback: évite un débordement horizontal (WCAG 1.4.10 Reflow) sur un viewport
+           étroit si aucun thème n'est chargé — 18rem correspond à la valeur par défaut du
+           thème (max-width externe via ::part() prend le dessus une fois chargé),
+           calc(100vw - 2rem) borne la largeur sur mobile */
+        max-width: min(18rem, calc(100vw - 2rem));
+
         /* overflow: visible requis pour que le caret (position: absolute) dépasse de la bulle */
         overflow: visible;
 

--- a/packages/core/src/components/tooltip/tooltip.ts
+++ b/packages/core/src/components/tooltip/tooltip.ts
@@ -29,15 +29,11 @@ export type ArTooltipPlacement =
  *
  * @slot - Texte du tooltip.
  *
- * @csspart bubble - Le panel flottant.
+ * @csspart bubble - Le panel flottant (radius, padding, taille de police, largeur maximale et interligne pilotables via `::part(bubble)`).
  * @csspart arrow  - Le caret directionnel.
  *
  * @cssprop --ar-tooltip-bg - Fond de la bulle (repli système `Canvas` si aucun thème n'est chargé).
  * @cssprop --ar-tooltip-color - Couleur du texte (repli système `CanvasText` si aucun thème n'est chargé).
- * @cssprop --ar-tooltip-border-radius - Arrondi.
- * @cssprop --ar-tooltip-padding - Marge interne.
- * @cssprop --ar-tooltip-font-size - Taille de police.
- * @cssprop --ar-tooltip-max-width - Largeur maximale.
  * @cssprop --ar-tooltip-arrow-size - Taille du caret.
  * @cssprop --ar-tooltip-show-duration - Durée de l'animation d'apparition de la bulle (cascade vers --ar-panel-show-duration).
  * @cssprop --ar-tooltip-distance - Espacement entre le trigger et la bulle.

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -416,10 +416,6 @@
         --ar-tooltip-offset: var(--ar-anchor-offset);
         --ar-tooltip-bg: var(--ar-color-neutral-20);
         --ar-tooltip-color: var(--ar-color-white);
-        --ar-tooltip-border-radius: var(--ar-border-radius-sm);
-        --ar-tooltip-font-size: 0.8125rem;
-        --ar-tooltip-padding: 0.375rem 0.625rem;
-        --ar-tooltip-max-width: 18rem;
         --ar-tooltip-arrow-size: 6px;
         --ar-tooltip-show-duration: var(--ar-panel-show-duration);
 
@@ -1167,6 +1163,16 @@
         &::part(current),
         &::part(ellipsis) {
             padding: 0 0.75rem;
+        }
+    }
+
+    ar-tooltip {
+        &::part(bubble) {
+            border-radius: var(--ar-border-radius-sm);
+            font-size: 0.8125rem;
+            padding: 0.375rem 0.625rem;
+            max-width: 18rem;
+            line-height: 1.4;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Migre 4 des 10 tokens `--ar-tooltip-*` (`border-radius`, `font-size`, `padding`, `max-width`) plus une valeur jamais tokenisée (`line-height`) vers une règle littérale `ar-tooltip::part(bubble)` dans `default.css`.
- Conserve 6 tokens : `bg`/`color` (fallback a11y + calibration dark-mode), `arrow-size` (réutilisé en interne), `show-duration` (garde `prefers-reduced-motion`), `distance`/`offset` (lus en JS par `TooltipController`).
- Aucun changement de structure DOM ni de `part` (`bubble`/`arrow` inchangés).
- **Fix a11y additionnel** (trouvé par la revue finale de branche, confirmé empiriquement) : `max-width` migré sans aucun repli interne provoquait un débordement horizontal réel (WCAG 1.4.10 Reflow) sur un viewport étroit quand aucun thème n'est chargé — repli `max-width: min(18rem, calc(100vw - 2rem))` ajouté sur `[part='bubble']`, invisible une fois un thème chargé (la règle externe `::part(bubble)` continue de l'emporter).
- Dernier composant du périmètre initial de l'audit #129 (2026-07-25) — reste ensuite un lot groupé (`table-sort`/`charcounter`/`progressbar`/`tab-group`/`collapse`) puis `tab` séparément.
- En marge : amendement ADR-005 consignant la réflexion sur `!important` comme verrou technique contre la surcharge `::part()` (non appliqué à ce lot, trade-off assumé).

Spec : `docs/superpowers/specs/2026-08-05-tooltip-token-vs-part-129-design.md`
Plan : `docs/superpowers/plans/2026-08-05-tooltip-token-vs-part-129.md`

## Test plan
- [x] `npm run test --workspace=packages/core` (824/824)
- [x] `npm run build:manifest --workspace=packages/core` (garde-fous CI verts)
- [x] Suite browser (WTR) tooltip (10/10)
- [x] Vérification visuelle Playwright (thème chargé, sans thème, diff `getComputedStyle` avant/après via worktree jetable — 5 valeurs identiques au bit près)
- [x] Vérification empirique du fix a11y `max-width` (320px/500px/200px, avec et sans thème)
- [x] Revue finale de branche (0 Critical, 0 Important, 4 Minor parqués — non bloquants)

🤖 Generated with [Claude Code](https://claude.com/claude-code)