### PR TITLE
fix(panel): ajoute un repli a11y sur max-width partagé (WCAG 1.4.10)

### DIFF
--- a/packages/core/src/styles/shared/panel.styles.ts
+++ b/packages/core/src/styles/shared/panel.styles.ts
@@ -27,7 +27,8 @@ const panelBaseStyles = css`
         box-shadow: var(--ar-panel-shadow);
         padding: var(--ar-panel-padding);
         min-width: var(--ar-panel-min-width);
-        max-width: var(--ar-panel-max-width);
+        /* a11y-fallback: évite un débordement horizontal (WCAG 1.4.10 Reflow) sur un viewport étroit si aucun thème n'est chargé — 18rem correspond à --ar-panel-max-width par défaut, calc(100vw - 2rem) borne la largeur sur mobile */
+        max-width: var(--ar-panel-max-width, min(18rem, calc(100vw - 2rem)));
     }
 
     [part='panel']:not(:popover-open) {


### PR DESCRIPTION
## Summary
- `packages/core/src/styles/shared/panel.styles.ts` (partagé par `ar-dropdown`, `ar-breadcrumb`, `ar-stepper`, `ar-datepicker`, `ar-tab-panel`) consommait `max-width: var(--ar-panel-max-width)` sans repli — sans thème chargé, le panel flottant n'a plus aucune contrainte de largeur et peut déborder horizontalement le viewport (WCAG 1.4.10 Reflow).
- Trouvé en creusant le même bug déjà corrigé sur `ar-tooltip` (#163) — confirmé empiriquement ici aussi sur `ar-dropdown` (débordement à 320px avant fix, éliminé après) et `ar-breadcrumb`.
- Repli ajouté via le mécanisme `var(--token, repli)` déjà utilisé sur `bg`/`color`/`border` dans la même règle : `var(--ar-panel-max-width, min(18rem, calc(100vw - 2rem)))`, invisible une fois un thème chargé (toujours `288px`/18rem, inchangé).
- `min-width` non touché (pas de risque de reflow, un panel qui rétrécit au contenu n'est pas un problème d'accessibilité).

Suite de #163 (`ar-tooltip`), même cause racine (issue #129 — migration token vs `::part()`).

## Test plan
- [x] `npm run build:manifest --workspace=packages/core` (garde-fous CI verts)
- [x] `npm run test --workspace=packages/core` (824/824, suite complète — fichier partagé par 5 composants)
- [x] WTR browser `dropdown` (12/12) et `breadcrumb` (10/10)
- [x] Vérification empirique Playwright (thème chargé/non chargé, `ar-dropdown` + `ar-breadcrumb`)
- [x] Revue de branche — 0 Critical, 1 Important (lacune préexistante du garde-fou `validate-no-hardcoded-tokens.js` sur les fallbacks `var()` à double niveau d'imbrication — pas introduite par ce correctif, suivi séparé), 1 Minor (longueur de commentaire, cohérente avec le reste du code)

## Suivi
- Lacune du garde-fou CI (`VAR_FALLBACK_RE` ne détecte pas les fallbacks `min()`/`calc()` imbriqués sur 2 niveaux) — à tracker séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)