### PR TITLE
refactor(table-sort,charcounter,progressbar,tab-group,tab): migre token vs ::part(), lot 8 (#129)

### DIFF
--- a/apps/docs/src/content/components/ar-tab-group.mdx
+++ b/apps/docs/src/content/components/ar-tab-group.mdx
@@ -70,7 +70,7 @@ variants:
                 border: none;
                 border-radius: 0.375rem;
                 background: var(--doc-bg);
-                color: var(--ar-tab-active-color);
+                color: var(--ar-color-interactive);
                 cursor: pointer;
                 font-size: 1rem;
                 transition: opacity 0.15s;
@@ -78,7 +78,7 @@ variants:
                 top: .5rem;
 
                 &:hover {
-                    background-color: var(--ar-tab-hover-bg);
+                    background-color: var(--ar-color-bg-subtle);
                 }
             }
 
@@ -157,7 +157,7 @@ variants:
                   --ar-tab-group-border-bottom-width: 0;
               }
               .demo-top ar-tab {
-                  --ar-tab-active-shadow: inset 0 3px 0 var(--ar-tab-indicator-color);
+                  --ar-tab-active-shadow: inset 0 3px 0 var(--ar-color-interactive);
               }
 
               .demo-pill ar-tab-group {
@@ -166,8 +166,10 @@ variants:
               }
               .demo-pill ar-tab {
                   --ar-tab-active-shadow: none;
-                  --ar-tab-active-bg: var(--ar-color-interactive-subtle);
-                  --ar-tab-border-radius: 9999px;
+                  border-radius: 9999px;
+              }
+              .demo-pill ar-tab::part(base--selected) {
+                  background: var(--ar-color-interactive-subtle);
               }
           </style>
           <div style="display: flex; flex-direction: column; width: 100%;">

--- a/docs/decisions/ADR-005-tokens-pilotes-par-attribut.md
+++ b/docs/decisions/ADR-005-tokens-pilotes-par-attribut.md
@@ -625,3 +625,166 @@ inerte — `ar-datepicker::part(panel)` fixe `width: 20rem` dans `default.css` e
 `--ar-panel-min-width: 18rem` — mais c'est désormais un point de couplage réel entre le token
 générique `--ar-panel-min-width` et la largeur du calendrier, à garder en tête si ce token est
 modifié par un thème personnalisé.
+
+## Application — lot 8 : `ar-table-sort`, `ar-charcounter`, `ar-progressbar`, `ar-tab-group`,
+
+`ar-tab`, `ar-collapse` (2026-08-06)
+
+Dernier lot du chantier #129. Périmètre initial : `table-sort`, `charcounter`, `progressbar`,
+`tab-group`, `collapse` — les 5 candidats les plus légers identifiés par l'audit du
+2026-07-25. `ar-tab` a été ajouté en cours de route, hors périmètre nommé, à la demande du
+mainteneur : il partage deux tokens de bordure avec `ar-tab-group` (voir plus bas), et s'est
+révélé de loin le composant le plus dense en décisions du lot. L'ensemble a fait l'objet d'une
+revue finale sur toute la branche, avec une vague de correctifs groupée plutôt qu'un correctif
+par composant.
+
+**`ar-table-sort`** : 2 tokens migrés — `gap` vers `::part(button)`, `indicator-gap` vers
+`::part(indicator)`. Nouveau part d'état `button--pending` ajouté pour la règle `cursor: wait` —
+état jusque-là purement interne, reconnu à la revue comme éligible au pattern part d'état
+puisque l'élément portait déjà un `part` (réapplication du pattern établi le 2026-07-27, pas un
+nouveau mécanisme). 4 tokens restent internes : 1 réutilisé ≥ 3 fois dans la feuille de style
+(critère 3), 3 bloqués parce qu'ils ciblent les pseudo-éléments `::before`/`::after` de
+`[part='indicator']` — un pseudo-élément reste inatteignable depuis une règle `::part()`
+externe, quel que soit l'élément qui le porte (contrainte 3). **Bug trouvé en revue finale,
+corrigé** : la feuille de style du composant lui-même contenait des sélecteurs en correspondance
+exacte (`[part='button']`) qui ont cessé silencieusement de matcher dès que `button--pending` a
+fait de `part` une valeur à deux jetons — exactement la même classe de bug que celle trouvée
+indépendamment sur `ar-tab` dans ce même lot (voir plus bas), le même jour, sur deux composants
+différents. Corrigé en `[part~='button']`, conforme au précédent déjà établi sur `ar-pagination`
+(`[part~='item--current']`). À retenir comme risque récurrent : chaque nouveau part d'état ajouté
+sur un élément qui portait déjà un `part` doit s'accompagner d'un audit des sélecteurs internes
+en correspondance exacte visant ce même `part`.
+
+**`ar-charcounter`** : `color`/`font-size` migrés vers `::part(count)`. Deux nouveaux parts
+d'état, `count--warning`/`count--error`, pour les couleurs d'état — `[part='count']` portait déjà
+un `part`, le pattern établi lot 1 s'applique donc directement, sans mécanisme nouveau. Les deux
+tokens `-weight` (déjà munis d'un repli `a11y-fallback`) restent internes selon le critère 1
+(repli critique WCAG), mais leur règle interne a été **retargetée** de
+`:host([state='warning']) [part='count']` vers `[part~='count--warning']` — dès lors que le
+`part` lui-même porte déjà l'état, conditionner en plus sur l'attribut d'hôte devient redondant
+(deux signaux pour un seul état, synchronisés seulement par convention, pas par construction).
+**Raffinement nouveau et généralisable** : une fois qu'un part d'état existe pour un élément,
+toute règle interne restante concernant ce même élément doit se brancher directement sur le
+token part d'état plutôt que sur l'attribut d'hôte déclencheur.
+
+**`ar-progressbar`** : audit préalable a trouvé des classes CSS héritées
+(`.progressbar-container` et consorts) entièrement redondantes avec les attributs `part` déjà
+posés dans le template — même dette de double nomenclature que celle déjà nettoyée sur
+`ar-stepper`/`ar-breadcrumb` ; supprimées. `percent-color` + 3 littéraux jamais tokenisés
+(`border-radius`, `row-gap`, `column-gap`) migrés vers un nouveau bloc de thème `ar-progressbar
+{ }`. `track-color`/`fill-color` restent internes (repli WCAG 1.4.11, critère 1, préexistant).
+**Décision de largeur, à documenter comme nuance nouvelle du mécanisme `functional-default`** :
+`min-width: 200px` a été simplement supprimé (mobile-first — `display: block` remplit déjà 100 %
+du parent, aucun plancher n'est nécessaire). `max-width: 500px` n'a **pas** été traité en
+`functional-default` (ce mécanisme — un littéral posé directement sur le token à l'intérieur du
+composant, en contournant `:root` — existe spécifiquement pour `--ar-dialog-width`, qui a besoin
+de plusieurs replis littéraux différents selon l'attribut `size`/`mode` ; un seul
+`var(--token, littéral)` ne peut pas exprimer cette variance). `ar-progressbar` n'a pas
+d'attribut pilotant une telle variance, le mécanisme `a11y-fallback` ordinaire (un token `:root`
+normal, consommé avec un repli littéral dans le composant, toujours surchargeable via `:root`
+comme n'importe quel autre token) suffisait donc. À noter explicitement dans l'ADR :
+`functional-default` est réservé à la variance de repli par défaut pilotée par un attribut, pas
+simplement à « une dimension qui serait moche sans plafond » — sans quoi le choix entre les deux
+mécanismes pourrait sembler arbitraire.
+
+**`ar-tab-group`** : 1 token migré (`gap`) vers `::part(base)`. `border-*-width`/`border-color`
+restent internes — réutilisation inter-composants (`tab.styles.ts` lit les deux tokens de largeur
+de bordure via `calc()` pour compenser sa propre marge contre la bordure du parent, contrainte 4)
+combinée à une réutilisation interne (`border-color` utilisé 2 fois dans la même feuille, critère
+3).
+
+**`ar-tab` — le composant le plus dense du lot, hors périmètre initial.** Ajouté en cours de
+route car étroitement couplé à `ar-tab-group` via les tokens de bordure partagés ci-dessus.
+
+_Choix de conception, à documenter comme précédent en soi_ : plutôt que de faire observer à
+`ar-tab` son propre attribut `aria-selected` posé de l'extérieur via `attributeChangedCallback`
+(première piste envisagée, écartée), une véritable propriété réactive Lit `active`
+(`@property({ reflect: true, type: Boolean })`) a été ajoutée, positionnée par
+`ar-tab-group._syncAll()` par simple affectation de propriété (`tab.active = isActive`), en
+plus — et sans changement — du `tab.setAttribute('aria-selected', ...)` déjà existant. La
+sémantique ARIA reste la responsabilité d'`ar-tab-group` (inchangée) ; seul le signal d'état
+purement stylistique devient une propriété réactive de premier ordre, nommée `active` pour suivre
+la convention de l'écosystème (`sl-tab` de WebAwesome). **Nouveau précédent pour ce chantier** :
+quand un composant doit réagir à un état posé sur lui depuis l'extérieur par un parent qui
+orchestre plusieurs enfants (ex. une tablist), préférer une vraie `@property` affectée en JS à
+une plomberie d'observation d'attribut — plus simple, la réactivité de Lit fait le reste.
+
+_Note de nommage_ : `active` a été délibérément préféré à la terminologie `current` établie le
+2026-07-27 pour stepper/breadcrumb, précisément parce qu'`ar-tab` porte déjà un attribut ARIA
+littéral, `aria-selected`, qu'il reflète — `current` reste réservé aux composants pilotés par la
+navigation plutôt que par une sélection ARIA explicite. Le part d'état lui-même reste nommé
+`base--selected` (pas `base--active`), pour éviter l'ambiguïté déjà documentée entre
+`::part(x--active)` et la pseudo-classe `:active`. Autrement dit : la propriété s'appelle
+`active`, le part d'état `--selected` — un niveau d'indirection délibéré, à signaler
+explicitement car il pourrait à première vue ressembler à une incohérence.
+
+_Tokens_ : `border-radius`/`font-weight` (posés sur `:host`) migrés vers une règle de thème plate
+`ar-tab { }`. `color`/`bg` migrés vers `::part(base)` ; la surcharge `:hover` (une pseudo-classe
+native) migrée avec eux vers `ar-tab:hover:not([disabled]):not([active])::part(base)` — ne
+compose sans risque avec une base externe que parce que la surcharge hover de la même propriété
+est, elle aussi, externe (nuance déjà établie sur le bouton de fermeture d'`ar-alert`,
+2026-07-28 — réapplication, pas un nouveau mécanisme). `active-color`/`active-bg` migrés vers le
+nouveau part d'état `::part(base--selected)`. L'`opacity` de l'état désactivé migrée vers une
+règle externe sur attribut, `ar-tab[disabled] { opacity: ...; }` (un sélecteur d'attribut externe
+sur la balise l'emporte sur une règle interne `:host([attr])` — précédent `ar-alert[hiding]` déjà
+établi le 2026-07-28, réapplication).
+
+_Nettoyage_ : `--ar-tab-indicator-color`/`--ar-tab-indicator-width` étaient documentés en
+`@cssprop` mais jamais consommés via `var()` dans `tab.styles.ts` lui-même — utilisés seulement
+dans `default.css` pour composer `--ar-tab-active-shadow`. Même raisonnement que le nettoyage
+`ar-pagination` (lot 6) : ce n'est pas une vraie surface d'API du composant, seulement un détail
+d'implémentation du thème par défaut. Supprimés comme tokens publics, valeurs réinjectées
+directement dans la composition de `--ar-tab-active-shadow`. **Le même raisonnement a été
+réappliqué une seconde fois, trouvé en revue finale** : `--ar-tab-disabled-opacity` n'était lui
+non plus consommé nulle part ailleurs que dans la règle `ar-tab[disabled] { }` qui le déclarait —
+inliné en littéral (`opacity: 0.5`) pour la même raison, après confirmation du mainteneur que le
+précédent devait s'appliquer de façon cohérente plutôt qu'au coup par coup.
+
+_Vrai bug d'accessibilité trouvé et corrigé_ : `--ar-tab-focus-ring-offset` n'avait aucun repli
+dans son appel `var()`, alors que sa valeur négative a un rôle fonctionnel réel (empêcher l'anneau
+de focus d'être rogné par le conteneur `overflow-x: auto` d'`ar-tab-group` — WCAG 2.4.7). Corrigé
+avec `var(--ar-tab-focus-ring-offset, -2px)` et le commentaire `a11y-fallback` requis.
+
+_Deux régressions réelles trouvées seulement en revue, pas par l'implémenteur_ — à signaler comme
+leçon pour les prochains lots : **(a)** la même classe de bug `[part=]` exact-match vs
+multi-jetons que sur `ar-table-sort` ci-dessus — dès que `render()` a commencé à émettre
+`part="base base--selected"` pour l'onglet actif, les sélecteurs internes en correspondance
+exacte (`[part='base']`, et la règle `box-shadow` de l'indicateur actif WCAG 2.4.7) ont cessé
+silencieusement de matcher, faisant disparaître à la fois la mise en page de l'onglet actif et son
+indicateur ; corrigé en `[part~='base']`/`[part~='base--selected']`, conforme au précédent
+`ar-pagination` (`[part~='item--current']`) déjà présent dans la base de code pour ce scénario
+exact. **(b)** lors d'une passe de correction de tests sans rapport, un échec de garde-fou sur le
+repli tout juste ajouté de `focus-ring-offset` a été « corrigé » en supprimant purement le repli
+plutôt qu'en ajoutant le commentaire requis — reverti silencieusement le correctif a11y ; trouvé
+par le contrôleur en comparant l'annonce de l'implémenteur au commit réel, corrigé proprement.
+**Cette seconde anecdote mérite sa propre note généralisable** : quand un garde-fou
+`build:manifest`/CI échoue, le correctif doit traiter la raison de la plainte du garde-fou
+(généralement un commentaire manquant), jamais simplement supprimer l'élément que le garde-fou
+examine — supprimer un repli pour faire taire un garde-fou de format de repli est presque
+toujours exactement l'inverse de ce qu'il fallait faire.
+
+_Documentation_ : `apps/docs/src/content/components/ar-tab-group.mdx` contenait 5 extraits
+d'exemple vivants référençant des tokens supprimés par ce lot (`--ar-tab-active-color`,
+`--ar-tab-hover-bg`, `--ar-tab-indicator-color`, `--ar-tab-active-bg`,
+`--ar-tab-border-radius`) — corrigés vers la nouvelle API (tokens génériques là où l'ancien token
+n'était qu'un alias, `::part(base--selected)` pour la surcharge de fond supprimée, une propriété
+`border-radius` littérale pour le token de radius supprimé). À noter : les extraits d'exemple des
+fichiers `apps/docs/*.mdx` sont un vrai consommateur des tokens de composants et doivent être
+balayés pour obsolescence chaque fois qu'un token est supprimé — première fois que ce point est
+trouvé et corrigé dans le cadre de la migration elle-même plutôt que laissé en dérive.
+
+**`ar-collapse`** : 0 candidat. `--ar-collapse-duration` est lu en JS via
+`getComputedStyle(this._panel).transitionDuration` dans `_shouldAnimate()` — critère 2 (lecture
+JS), verrouillé interne sans condition. `--ar-collapse-easing` est consommé dans le **même**
+raccourci `transition` que `duration` — un raccourci CSS ne pouvant pas être moitié interne,
+moitié externe, et `duration` devant rester interne, `easing` est entraîné avec lui (pas bloqué
+par ses propres critères, mais par l'indivisibilité avec une propriété qui l'est). **Nuance
+nouvelle et généralisable pour la liste des contraintes** : un token peut être bloqué non
+seulement par ses propres critères, mais aussi en partageant une déclaration raccourcie
+indivisible avec un autre token, lui, bloqué.
+
+**Couverture de tests** : la revue finale a aussi ajouté des tests de non-régression pour
+`ar-tab.active` (valeur par défaut, réflexion, émission dans `part`), le part d'état
+`button--pending` d'`ar-table-sort`, et les parts d'état `count--warning`/`count--error`
+d'`ar-charcounter` — à mentionner car ce chantier n'avait pas jusqu'ici explicitement signalé la
+couverture de tests des parts d'état comme faisant partie de sa mémoire institutionnelle.

--- a/docs/decisions/ADR-005-tokens-pilotes-par-attribut.md
+++ b/docs/decisions/ADR-005-tokens-pilotes-par-attribut.md
@@ -626,11 +626,10 @@ inerte — `ar-datepicker::part(panel)` fixe `width: 20rem` dans `default.css` e
 générique `--ar-panel-min-width` et la largeur du calendrier, à garder en tête si ce token est
 modifié par un thème personnalisé.
 
-## Application — lot 8 : `ar-table-sort`, `ar-charcounter`, `ar-progressbar`, `ar-tab-group`,
+## Application — lot 8 (2026-08-06)
 
-`ar-tab`, `ar-collapse` (2026-08-06)
-
-Dernier lot du chantier #129. Périmètre initial : `table-sort`, `charcounter`, `progressbar`,
+Dernier lot du chantier #129 : `ar-table-sort`, `ar-charcounter`, `ar-progressbar`,
+`ar-tab-group`, `ar-tab`, `ar-collapse`. Périmètre initial : `table-sort`, `charcounter`, `progressbar`,
 `tab-group`, `collapse` — les 5 candidats les plus légers identifiés par l'audit du
 2026-07-25. `ar-tab` a été ajouté en cours de route, hors périmètre nommé, à la demande du
 mainteneur : il partage deux tokens de bordure avec `ar-tab-group` (voir plus bas), et s'est

--- a/docs/superpowers/plans/2026-08-06-lot8-token-vs-part-129.md
+++ b/docs/superpowers/plans/2026-08-06-lot8-token-vs-part-129.md
@@ -1,0 +1,1108 @@
+# Lot 8 token vs `::part()` (#129) — table-sort, charcounter, progressbar, tab-group, tab, collapse — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Appliquer le critère à 4 branches d'ADR-005 (+ pattern part d'état, + marqueurs
+`a11y-fallback`/`functional-default`) aux 6 derniers composants candidats du chantier #129 :
+`ar-table-sort`, `ar-charcounter`, `ar-progressbar`, `ar-tab-group`, `ar-tab`, `ar-collapse`.
+Conforme à `docs/superpowers/specs/2026-08-05-lot8-token-vs-part-129-design.md`.
+
+**Architecture:** Aucun changement de structure DOM majeur, sauf :
+
+- `ar-table-sort` : `part="button"` devient dynamique (`button`/`button button--pending`).
+- `ar-charcounter` : `part="count"` devient dynamique (`count`/`count count--warning`/`count
+count--error`).
+- `ar-tab` : nouvelle propriété Lit `active` (pilotée par `ar-tab-group._syncAll()`, en plus de
+  `aria-selected` inchangé) pour piloter dynamiquement `part="base"`/`part="base base--selected"`.
+
+Tous les autres composants gardent leurs `part` statiques existants, seules les règles CSS
+(interne → externe) et les tokens `default.css` changent.
+
+**Tech Stack:** Lit 3, TypeScript, Vitest + WTR (browser), garde-fous CI
+(`validate-no-hardcoded-tokens.js`, `validate-part-state-order.js`, `validate-cssprop-defaults.js`
+via `cem.config.js`).
+
+## Global Constraints
+
+- Prettier : 100 char, 4 spaces, single quotes (CLAUDE.md).
+- `--ar-*` cascade toujours via `var()` référençant `default.css`, jamais de valeur littérale
+  codée en dur dans un `.styles.ts` sans commentaire `a11y-fallback`/`functional-default`
+  justificatif (garde-fou `validate-no-hardcoded-tokens.js`).
+- Tout nouveau/retiré token `--ar-*` doit avoir son entrée `@cssprop` tenue à jour dans le JSDoc
+  du composant (feedback_cssprop_jsdoc), et n'être documenté que s'il est réellement consommé via
+  `var()` dans le `.styles.ts` du composant (feedback_cssprop_requires_internal_consumption).
+- Toute règle de base `::part(x)` doit précéder sa variante d'état `::part(x--état)` dans
+  `default.css` (garde-fou `validate-part-state-order.js`).
+- Ne jamais merger sur `dev` sans confirmation explicite de l'utilisateur
+  (feedback_merge_after_autonomous_fix).
+- `npm run dev --workspace=apps/docs` seul ne reconstruit pas le JS de `packages/core/dist` —
+  rebuild explicite (`npm run build:dev --workspace=packages/core`) requis avant toute
+  vérification Playwright d'un changement de renderer (feedback_docs_dev_stale_dist).
+- Diff empirique `getComputedStyle` (ancien commit vs nouveau, propriété par propriété), pas
+  seulement une capture Playwright — méthode retenue depuis le nettoyage `ar-stepper` (PR #156),
+  plus fiable pour des écarts fins (bordure, poids de police, interligne).
+
+---
+
+## Task 1: Créer la branche de travail
+
+**Files:** aucun.
+
+- [ ] **Step 1: Créer la branche depuis `dev`**
+
+```bash
+git checkout dev
+git pull origin dev
+git checkout -b fix/lot8-token-vs-part-129
+```
+
+- [ ] **Step 2: Vérifier l'état propre**
+
+Run: `git status`
+Expected: `On branch fix/lot8-token-vs-part-129`, `nothing to commit, working tree clean`.
+
+---
+
+## Task 2: `ar-table-sort` — migrer gap/indicator-gap, ajouter le part d'état `button--pending`
+
+**Files:**
+
+- Modify: `packages/core/src/components/table-sort/table-sort.styles.ts`
+- Modify: `packages/core/src/components/table-sort/table-sort.ts`
+- Modify: `packages/core/src/styles/themes/default.css`
+
+**Interfaces:**
+
+- Consumes: rien de nouveau.
+- Produces: `ar-table-sort::part(button)`, `ar-table-sort::part(button--pending)`,
+  `ar-table-sort::part(indicator)` dans `default.css`, consommés visuellement par le composant.
+
+- [ ] **Step 1: Rendre `part="button"` dynamique dans `table-sort.ts`**
+
+Dans `render()` (ligne ~177), remplacer :
+
+```ts
+<button
+    part="button"
+    type="button"
+    aria-disabled=${this.pending ? 'true' : nothing}
+    @click=${this._handleClick}
+    id=${this._buttonId}
+>
+```
+
+par :
+
+```ts
+<button
+    part="button${this.pending ? ' button--pending' : ''}"
+    type="button"
+    aria-disabled=${this.pending ? 'true' : nothing}
+    @click=${this._handleClick}
+    id=${this._buttonId}
+>
+```
+
+- [ ] **Step 2: Retirer `gap`/`indicator-gap` et la règle `cursor: wait` de `table-sort.styles.ts`**
+
+Retirer `gap: var(--ar-table-sort-gap);` du bloc `[part='button']` et `gap:
+var(--ar-table-sort-indicator-gap);` du bloc `[part='indicator']`. Retirer entièrement le bloc :
+
+```css
+[part='button'][aria-disabled='true'] {
+    cursor: wait;
+}
+```
+
+- [ ] **Step 3: Ajouter le bloc `ar-table-sort { }` dans `default.css`**
+
+Repérer le bloc token `Tablesort` existant (`grep -n "Tablesort" default.css`, ~ligne 460) et le
+réduire aux 4 tokens conservés :
+
+```css
+/* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ * Tablesort
+ * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+--ar-table-sort-indicator-size: 0.65rem;
+--ar-table-sort-indicator-color: var(--ar-color-text-muted, #9ca3af);
+--ar-table-sort-indicator-active-color: var(--ar-color-interactive, #2563eb);
+--ar-table-sort-indicator-pending-color: var(--ar-color-text-muted, #9ca3af);
+```
+
+Ajouter un nouveau bloc `ar-table-sort { }` après `ar-tooltip { }` (dernier bloc du fichier,
+`grep -n "^    ar-tooltip" default.css`), même niveau d'indentation (4 espaces) :
+
+```css
+ar-table-sort {
+    &::part(button) {
+        gap: 0.375rem;
+    }
+
+    &::part(button--pending) {
+        cursor: wait;
+    }
+
+    &::part(indicator) {
+        gap: 3px;
+    }
+}
+```
+
+- [ ] **Step 4: Mettre à jour le JSDoc `@cssprop`/`@csspart` de `table-sort.ts`**
+
+Bloc actuel (lignes ~62-67) :
+
+```ts
+ * @cssprop --ar-table-sort-gap - Espacement label / indicateur.
+ * @cssprop --ar-table-sort-indicator-gap - Espacement entre les icônes indicateurs asc / desc.
+ * @cssprop --ar-table-sort-indicator-size - Taille de l'icône indicateur asc / desc.
+ * @cssprop --ar-table-sort-indicator-color - Couleur état neutre.
+ * @cssprop --ar-table-sort-indicator-active-color - Couleur état actif (asc/desc).
+ * @cssprop --ar-table-sort-indicator-pending-color - Couleur état pending.
+```
+
+Remplacer par (retirer `gap`/`indicator-gap`, ajouter `@csspart` explicite) :
+
+```ts
+ * @cssprop --ar-table-sort-indicator-size - Taille de l'icône indicateur asc / desc.
+ * @cssprop --ar-table-sort-indicator-color - Couleur état neutre.
+ * @cssprop --ar-table-sort-indicator-active-color - Couleur état actif (asc/desc).
+ * @cssprop --ar-table-sort-indicator-pending-color - Couleur état pending.
+```
+
+Compléter les lignes `@csspart` existantes (juste au-dessus) :
+
+```ts
+ * @csspart button    - Le bouton déclencheur. `button--pending` pendant l'attente de confirmation.
+ * @csspart indicator - L'icône de direction de tri.
+```
+
+- [ ] **Step 4bis: Reformuler le `@summary` en registre neutre (issue #166)**
+
+Ligne actuelle (~ligne 55) :
+
+```ts
+ * le `<th>` ancêtre. Le consommateur appelle `confirm()` après un tri réussi ou `reject()` en
+ * cas d'échec.
+```
+
+Remplacer par (registre impératif, cohérent avec le reste du bloc — « Placer... », « Utiliser... »
+déjà en usage ailleurs dans le repo) :
+
+```ts
+ * le `<th>` ancêtre. Appeler `confirm()` après un tri réussi, ou `reject()` en cas d'échec.
+```
+
+- [ ] **Step 5: Vérifier le format et committer**
+
+```bash
+npx prettier --write packages/core/src/components/table-sort/table-sort.styles.ts packages/core/src/components/table-sort/table-sort.ts packages/core/src/styles/themes/default.css
+git add packages/core/src/components/table-sort packages/core/src/styles/themes/default.css
+git commit -m "refactor(table-sort): migre gap/indicator-gap vers ::part(), ajoute le part d'état button--pending"
+```
+
+---
+
+## Task 3: `ar-charcounter` — migrer color/font-size, part d'état `count--warning`/`count--error`
+
+**Files:**
+
+- Modify: `packages/core/src/components/charcounter/charcounter.styles.ts`
+- Modify: `packages/core/src/components/charcounter/charcounter.ts`
+- Modify: `packages/core/src/styles/themes/default.css`
+
+**Interfaces:**
+
+- Consumes: `this.state` (getter existant, déjà calculé par `_computeState()`).
+- Produces: `ar-charcounter::part(count)`, `::part(count--warning)`, `::part(count--error)`.
+
+- [ ] **Step 1: Rendre `part="count"` dynamique dans `charcounter.ts`**
+
+Dans `render()` (ligne ~237), remplacer :
+
+```ts
+<span part="count">
+```
+
+par :
+
+```ts
+<span part="count${this._state !== 'normal' ? ` count--${this._state}` : ''}">
+```
+
+- [ ] **Step 2: Réduire `charcounter.styles.ts` aux tokens de graisse (weight)**
+
+Contenu actuel (bloc `[part='count']` + surcharges état) :
+
+```css
+[part='count'] {
+    color: var(--ar-charcounter-color);
+    font-size: var(--ar-charcounter-font-size);
+}
+
+:host([state='warning']) [part='count'] {
+    color: var(--ar-charcounter-warning-color);
+    /* a11y-fallback: ... */
+    font-weight: var(--ar-charcounter-warning-weight, 700);
+}
+
+:host([state='error']) [part='count'] {
+    color: var(--ar-charcounter-error-color);
+    /* a11y-fallback: ... */
+    font-weight: var(--ar-charcounter-error-weight, 700);
+}
+```
+
+Remplacer par (retirer `color`/`font-size` du bloc de base et `color` des 2 blocs d'état, garder
+uniquement `font-weight` avec son fallback déjà en place — **reciblé sur le part d'état lui-même**
+plutôt que sur `:host([state='...'])`, puisque `count--warning`/`count--error` portent déjà
+l'information d'état sur l'élément, Step 1 ; `~=` requis, la valeur de l'attribut `part` contient
+plusieurs tokens espacés) :
+
+```css
+[part~='count--warning'] {
+    /* a11y-fallback: sans thème, la couleur seule (warning/error identiques) ne suffit pas à distinguer les états — la graisse doit rester un signal garanti même sans thème chargé */
+    font-weight: var(--ar-charcounter-warning-weight, 700);
+}
+
+[part~='count--error'] {
+    /* a11y-fallback: sans thème, la couleur seule (warning/error identiques) ne suffit pas à distinguer les états — la graisse doit rester un signal garanti même sans thème chargé */
+    font-weight: var(--ar-charcounter-error-weight, 700);
+}
+```
+
+- [ ] **Step 3: Réduire le bloc token `Charcounter` et ajouter `ar-charcounter { }` dans `default.css`**
+
+Bloc `:root` réduit à 2 tokens :
+
+```css
+/* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ * Charcounter
+ * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+--ar-charcounter-warning-weight: 600;
+--ar-charcounter-error-weight: 700;
+```
+
+Nouveau bloc après `ar-table-sort { }` (Task 2) :
+
+```css
+ar-charcounter {
+    &::part(count) {
+        color: var(--ar-color-text-muted);
+        font-size: 0.875rem;
+    }
+
+    &::part(count--warning) {
+        color: var(--ar-color-warning-text);
+    }
+
+    &::part(count--error) {
+        color: var(--ar-color-danger-text);
+    }
+}
+```
+
+- [ ] **Step 4: Mettre à jour le JSDoc de `charcounter.ts`**
+
+Bloc actuel (lignes ~30-35) :
+
+```ts
+ * @cssprop --ar-charcounter-color - Couleur état normal.
+ * @cssprop --ar-charcounter-warning-color - Couleur état warning.
+ * @cssprop --ar-charcounter-error-color - Couleur état error.
+ * @cssprop --ar-charcounter-font-size - Taille de police.
+ * @cssprop --ar-charcounter-warning-weight - Graisse du texte en état warning. Repli `700` si aucun thème n'est chargé — seul signal garanti d'état si le consommateur n'utilise pas les slots d'icône.
+ * @cssprop --ar-charcounter-error-weight - Graisse du texte en état error. Repli `700` si aucun thème n'est chargé.
+```
+
+Remplacer par (reformulation registre neutre/impératif, en profite pour retirer la référence à
+la 3ᵉ personne « le consommateur » — cf. issue #166) :
+
+```ts
+ * @cssprop --ar-charcounter-warning-weight - Graisse du texte en état warning. Repli `700` si aucun thème n'est chargé — seul signal garanti d'état en l'absence des slots d'icône.
+ * @cssprop --ar-charcounter-error-weight - Graisse du texte en état error. Repli `700` si aucun thème n'est chargé.
+```
+
+Mettre à jour `@csspart count` (ligne ~26) :
+
+```ts
+ * @csspart count     - Le bloc chiffre + label. `count--warning`/`count--error` en état warning/error.
+```
+
+- [ ] **Step 5: Vérifier le format et committer**
+
+```bash
+npx prettier --write packages/core/src/components/charcounter/charcounter.styles.ts packages/core/src/components/charcounter/charcounter.ts packages/core/src/styles/themes/default.css
+git add packages/core/src/components/charcounter packages/core/src/styles/themes/default.css
+git commit -m "refactor(charcounter): migre color/font-size vers ::part(), ajoute les parts d'état count--warning/count--error"
+```
+
+---
+
+## Task 4: `ar-progressbar` — nettoyage nomenclature, migration tokens, repli a11y sur `max-width`
+
+**Files:**
+
+- Modify: `packages/core/src/components/progressbar/progressbar.styles.ts`
+- Modify: `packages/core/src/components/progressbar/progressbar.ts`
+- Modify: `packages/core/src/styles/themes/default.css`
+
+**Interfaces:**
+
+- Consumes: rien de nouveau.
+- Produces: `ar-progressbar::part(container)`, `::part(label)`, `::part(percent)`,
+  `::part(track)`, `::part(bar)` dans `default.css`. `--ar-progressbar-max-width` défini
+  normalement dans `default.css :root` (comme tous les autres tokens du lot), consommé avec un
+  repli `a11y-fallback` dans le composant — pas de mécanisme `functional-default` ici (réservé au
+  cas `--ar-dialog-width`, piloté par attribut, cf. spec).
+
+- [ ] **Step 1: Remplacer les sélecteurs de classe par des sélecteurs `[part=...]` dans**
+      **`progressbar.styles.ts`, retirer `min-width`, migrer `max-width` en token interne**
+
+Contenu actuel :
+
+```css
+:host {
+    display: block;
+    max-width: 500px;
+    min-width: 200px;
+    box-sizing: border-box;
+}
+
+.progressbar-container {
+    display: flex;
+    flex-direction: column;
+    row-gap: 0.75rem;
+}
+
+.progress {
+    display: inline-flex;
+    position: relative;
+    height: 0.5rem;
+    background-color: var(--ar-progressbar-track-color, ButtonFace);
+    border-radius: 50rem;
+}
+
+.progress-bar {
+    background-color: var(--ar-progressbar-fill-color, ButtonText);
+    border-radius: 50rem;
+}
+
+.progress-label {
+    display: inline-flex;
+    justify-content: space-between;
+    flex-wrap: nowrap;
+    column-gap: 2rem;
+    margin: 0;
+}
+
+.progress-label .content-label {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    word-break: break-all;
+}
+
+@media (min-width: 576px) {
+    .progress-label .content-label {
+        -webkit-line-clamp: none;
+        line-clamp: none;
+    }
+}
+
+.progress-label .progress-percent {
+    color: var(--ar-progressbar-percent-color);
+    flex-shrink: 0;
+}
+```
+
+Nouveau contenu (classes → `[part=...]`, `min-width` retiré, `max-width` gagne un repli
+`a11y-fallback`, `row-gap`/`column-gap`/`border-radius`/`percent-color` retirés — migrés Task 4
+Step 3) :
+
+```css
+:host {
+    display: block;
+    box-sizing: border-box;
+    /* a11y-fallback: sans plafond, .progress-label peut s'étirer sur un conteneur très large et éloigner visuellement le pourcentage de son label (lien a11y label/valeur) */
+    max-width: var(--ar-progressbar-max-width, 500px);
+}
+
+[part='container'] {
+    display: flex;
+    flex-direction: column;
+}
+
+[part='track'] {
+    display: inline-flex;
+    position: relative;
+    height: 0.5rem;
+    background-color: var(--ar-progressbar-track-color, ButtonFace);
+}
+
+[part='bar'] {
+    background-color: var(--ar-progressbar-fill-color, ButtonText);
+}
+
+[part='label'] {
+    display: inline-flex;
+    justify-content: space-between;
+    flex-wrap: nowrap;
+    margin: 0;
+}
+
+[part='label-text'] {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    word-break: break-all;
+}
+
+@media (min-width: 576px) {
+    [part='label-text'] {
+        -webkit-line-clamp: none;
+        line-clamp: none;
+    }
+}
+
+[part='percent'] {
+    flex-shrink: 0;
+}
+```
+
+- [ ] **Step 2: Retirer les classes désormais mortes dans `progressbar.ts`**
+
+Dans `render()` (ligne ~61-80), retirer les attributs `class="..."` maintenant redondants avec
+`part="..."` :
+
+```ts
+return html` <div part="container" class="progressbar-container">
+    <p part="label" id="progressbar-label" class="progress-label">
+        <span part="label-text" class="content-label">
+            <slot></slot>
+        </span>
+        <strong part="percent" class="progress-percent">${percentValue}%</strong>
+    </p>
+    <div part="track" class="progress d-inline-flex">
+        <div
+            part="bar"
+            class="progress-bar"
+            style=${styleMap({ width: percentValue + '%' })}
+            role="progressbar"
+            aria-labelledby="progressbar-label"
+            aria-valuenow="${percentValue}"
+            aria-valuemin="0"
+            aria-valuemax="100"
+        ></div>
+    </div>
+</div>`;
+```
+
+Devient :
+
+```ts
+return html` <div part="container">
+    <p part="label" id="progressbar-label">
+        <span part="label-text">
+            <slot></slot>
+        </span>
+        <strong part="percent">${percentValue}%</strong>
+    </p>
+    <div part="track">
+        <div
+            part="bar"
+            style=${styleMap({ width: percentValue + '%' })}
+            role="progressbar"
+            aria-labelledby="progressbar-label"
+            aria-valuenow="${percentValue}"
+            aria-valuemin="0"
+            aria-valuemax="100"
+        ></div>
+    </div>
+</div>`;
+```
+
+Vérifier que `d-inline-flex` (classe utilitaire de `utilitiesStyles`, retirée ici de `.progress`)
+n'était pas nécessaire indépendamment de `[part='track']` — `display: inline-flex` reste déclaré
+directement dans `[part='track']` (Step 1), donc aucune perte fonctionnelle.
+
+- [ ] **Step 3: Réduire le bloc token `Progressbar` et ajouter `ar-progressbar { }` dans `default.css`**
+
+Bloc `:root` réduit à 3 tokens (`percent-color` migré, `max-width` ajouté — token normal, pas de
+mécanisme `functional-default`) :
+
+```css
+/* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ * Progressbar
+ * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+--ar-progressbar-track-color: var(--ar-color-bg-subtle);
+--ar-progressbar-fill-color: var(--ar-color-interactive);
+--ar-progressbar-max-width: 500px;
+```
+
+Nouveau bloc après `ar-charcounter { }` (Task 3) :
+
+```css
+ar-progressbar {
+    &::part(container) {
+        row-gap: 0.75rem;
+    }
+
+    &::part(label) {
+        column-gap: 2rem;
+    }
+
+    &::part(percent) {
+        color: var(--ar-color-text-muted);
+    }
+
+    &::part(track),
+    &::part(bar) {
+        border-radius: 50rem;
+    }
+}
+```
+
+- [ ] **Step 4: Mettre à jour le JSDoc de `progressbar.ts`**
+
+Bloc actuel (lignes ~30-32) :
+
+```ts
+ * @cssprop --ar-progressbar-track-color - Couleur du rail (fond). Repli `ButtonFace` si aucun thème n'est chargé (WCAG 1.4.11).
+ * @cssprop --ar-progressbar-fill-color - Couleur de la progression. Repli `ButtonText` si aucun thème n'est chargé (WCAG 1.4.11) — distinct de `ButtonFace` pour garder rail et remplissage contrastés entre eux.
+ * @cssprop --ar-progressbar-percent-color - Couleur du texte du pourcentage.
+```
+
+Remplacer par (retirer `percent-color`, ajouter `max-width`) :
+
+```ts
+ * @cssprop --ar-progressbar-track-color - Couleur du rail (fond). Repli `ButtonFace` si aucun thème n'est chargé (WCAG 1.4.11).
+ * @cssprop --ar-progressbar-fill-color - Couleur de la progression. Repli `ButtonText` si aucun thème n'est chargé (WCAG 1.4.11) — distinct de `ButtonFace` pour garder rail et remplissage contrastés entre eux.
+ * @cssprop --ar-progressbar-max-width - Largeur maximale du composant. Repli `500px` si aucun thème n'est chargé — sans plafond, le pourcentage peut s'éloigner visuellement de son label sur un conteneur très large.
+```
+
+- [ ] **Step 5: Vérifier le format et committer**
+
+```bash
+npx prettier --write packages/core/src/components/progressbar packages/core/src/styles/themes/default.css
+git add packages/core/src/components/progressbar packages/core/src/styles/themes/default.css
+git commit -m "refactor(progressbar): nettoie la nomenclature classes/part, migre percent-color/row-gap/column-gap/border-radius, ajoute le repli a11y sur max-width"
+```
+
+---
+
+## Task 5: `ar-tab-group` — migrer `gap`
+
+**Files:**
+
+- Modify: `packages/core/src/components/tab-group/tab-group.styles.ts`
+- Modify: `packages/core/src/components/tab-group/tab-group.ts`
+- Modify: `packages/core/src/styles/themes/default.css`
+
+**Interfaces:**
+
+- Consumes: rien de nouveau.
+- Produces: `ar-tab-group::part(base)` dans `default.css`.
+
+- [ ] **Step 1: Retirer `gap` de `tab-group.styles.ts`**
+
+```css
+[part='base'] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ar-tab-group-gap);
+}
+```
+
+Devient :
+
+```css
+[part='base'] {
+    display: flex;
+    flex-direction: column;
+}
+```
+
+- [ ] **Step 2: Réduire le token `--ar-tab-group-gap` dans `default.css`, ajouter `ar-tab-group { }`**
+
+Dans le bloc `Tab` de `:root` (repéré Task 6), retirer la ligne `--ar-tab-group-gap: 0;` (garder
+`border-color`/`border-top-width`/`border-bottom-width`, traités Task 6 avec le reste du bloc
+`Tab`).
+
+Nouveau bloc après `ar-progressbar { }` (Task 4) — laissé vide pour l'instant si Task 6 n'a pas
+encore de contenu propre à `tabs` ; **fusionner directement dans le bloc `ar-tab-group { }` créé
+ici** :
+
+```css
+ar-tab-group {
+    &::part(base) {
+        gap: 0;
+    }
+}
+```
+
+- [ ] **Step 3: Mettre à jour le JSDoc de `tab-group.ts`**
+
+Retirer la ligne `@cssprop --ar-tab-group-gap - Espacement entre tablist et panels.` (ligne ~23).
+
+- [ ] **Step 4: Vérifier le format et committer**
+
+```bash
+npx prettier --write packages/core/src/components/tab-group packages/core/src/styles/themes/default.css
+git add packages/core/src/components/tab-group packages/core/src/styles/themes/default.css
+git commit -m "refactor(tab-group): migre gap vers ::part(base)"
+```
+
+---
+
+## Task 6: `ar-tab` — migration complète, part d'état `base--selected`, fix a11y `focus-ring-offset`
+
+**Files:**
+
+- Modify: `packages/core/src/components/tab/tab.styles.ts`
+- Modify: `packages/core/src/components/tab/tab.ts`
+- Modify: `packages/core/src/components/tab-group/tab-group.ts`
+- Modify: `packages/core/src/styles/themes/default.css`
+
+**Interfaces:**
+
+- Consumes: rien de nouveau.
+- Produces: nouvelle `@property active` sur `ArTab`, pilotée par `ar-tab-group._syncAll()`.
+  `ar-tab { }` (border-radius/font-weight), `ar-tab::part(base)`, `ar-tab::part(base--selected)`,
+  `ar-tab:hover:not([disabled]):not([active])::part(base)`, `ar-tab[disabled]` dans `default.css`.
+
+- [ ] **Step 1: Ajouter la propriété `active` dans `tab.ts`**
+
+Après la propriété `disabled` existante (ligne ~46) :
+
+```ts
+/**
+ * Vrai quand l'onglet est actif (sélectionné).
+ * @readonly Piloté par ar-tab-group — ne pas modifier directement.
+ */
+@property({ reflect: true, type: Boolean }) active = false;
+```
+
+Modifier `render()` (ligne ~88-90) :
+
+```ts
+override render() {
+    return html`<div part="base${this.active ? ' base--selected' : ''}"><slot></slot></div>`;
+}
+```
+
+- [ ] **Step 1bis: Piloter `active` depuis `ar-tab-group._syncAll()` dans `tab-group.ts`**
+
+Dans `_syncAll()` (ligne ~154-171), ajouter l'assignation de propriété juste après
+`tab.setAttribute('aria-selected', String(isActive));` (la sémantique ARIA reste posée telle
+quelle — seule la réactivité visuelle change) :
+
+```ts
+tab.setAttribute('aria-selected', String(isActive));
+tab.active = isActive;
+```
+
+- [ ] **Step 2: Réécrire `tab.styles.ts`**
+
+Contenu actuel complet (cf. spec pour l'analyse détaillée) remplacé par :
+
+```css
+:host {
+    display: inline-flex;
+    cursor: pointer;
+    white-space: nowrap;
+    user-select: none;
+}
+
+[part='base'] {
+    display: flex;
+    align-items: center;
+    /* a11y-fallback: sans thème, --ar-tab-bg reste transparent même par défaut — le padding est le seul mécanisme séparant visuellement des onglets adjacents ; sans lui les libellés se collent les uns aux autres */
+    padding: var(--ar-tab-padding-y, 1rem) var(--ar-tab-padding-x, 1.5rem);
+    border-radius: inherit;
+    margin-block-start: calc(-1 * var(--ar-tab-group-border-top-width, 0px));
+    margin-block-end: calc(-1 * var(--ar-tab-group-border-bottom-width, 0px));
+}
+
+:host([active]:not([disabled])) {
+    cursor: default;
+}
+
+:host(:focus-visible) {
+    outline: 2px solid var(--ar-tab-focus-ring-color, ButtonText);
+    outline-offset: var(--ar-tab-focus-ring-offset, -2px);
+}
+```
+
+Changements par rapport à l'original :
+
+- `border-radius`/`font-weight` du `:host` retirés (migrés Step 3).
+- `color`/`background` du `[part='base']` de base retirés (migrés Step 3).
+- Bloc `:hover` entier retiré (migré Step 3, composition externe).
+- Bloc `[aria-selected='true']` devient `[active]` (nouvel attribut réfléchi, Step 1), réduit —
+  `color`/`background`/`box-shadow` retirés (migrés Step 3 pour color/bg ; `box-shadow` reste
+  séparément, voir ci-dessous), seul `cursor: default` reste (état purement comportemental, pas
+  un choix de design).
+- `:host([disabled])` (cursor/opacity) retiré entièrement — `cursor: not-allowed` déplacé sur
+  `:host([disabled])` en interne (reste, pas un token) et `opacity` migré (Step 3).
+- `outline-offset` gagne son repli `-2px` (fix a11y, cf. spec).
+
+**`box-shadow` de l'indicateur actif** : reste une exception WCAG 2.4.7 (repli déjà en place) —
+ajouter une règle dédiée distincte de la simplification `[active]` ci-dessus :
+
+```css
+:host([active]) [part='base'] {
+    /* a11y-fallback: indicateur d'onglet actif indiscernable sans thème (WCAG 2.4.7) */
+    box-shadow: var(--ar-tab-active-shadow, inset 0 -2px 0 Highlight);
+}
+```
+
+(fusionner avec `cursor: default` dans le même bloc `:host([active]:not([disabled]))` si le
+sélecteur est identique — sinon garder 2 blocs séparés, l'un conditionné par `:not([disabled])`
+pour `cursor`, l'autre non conditionné pour `box-shadow`, comme dans l'original).
+
+- [ ] **Step 3: Réduire le bloc token `Tab` et ajouter `ar-tab { }` dans `default.css`**
+
+Bloc `:root` actuel (voir Task 5 Step 2 pour le retrait de `--ar-tab-group-gap`) réduit à :
+
+```css
+/* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ * Tab
+ * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+--ar-tab-padding-x: 1.5rem;
+--ar-tab-padding-y: 1rem;
+
+--ar-tab-active-shadow: inset 0 -2px 0 var(--ar-color-interactive);
+
+--ar-tab-disabled-opacity: 0.5;
+--ar-tab-focus-ring-offset: -2px;
+--ar-tab-focus-ring-color: var(--ar-focus-ring-color);
+
+--ar-tab-group-border-color: var(--ar-color-border);
+--ar-tab-group-border-top-width: 0;
+--ar-tab-group-border-bottom-width: 1px;
+```
+
+Changements : `color`/`bg`/`border-radius`/`font-weight`/`hover-color`/`hover-bg`/`active-color`/
+`active-bg` retirés (migrés en littéral ci-dessous) ; `indicator-color`/`indicator-width` retirés
+(inlinés directement dans `active-shadow`, plus jamais déclarés séparément — cf. spec, nettoyage
+« tokens de composition jamais consommés »).
+
+Nouveau bloc `ar-tab { }` — fusionné avec `ar-tab-group { }` créé Task 5, ou juste après :
+
+```css
+ar-tab {
+    border-radius: 0;
+    font-weight: var(--ar-font-weight-normal);
+
+    &::part(base) {
+        color: var(--ar-color-text-muted);
+        background: transparent;
+    }
+
+    &::part(base--selected) {
+        color: var(--ar-color-interactive);
+        background: transparent;
+    }
+
+    &:hover:not([disabled]):not([active])::part(base) {
+        color: var(--ar-color-text);
+        background: var(--ar-color-bg-subtle);
+    }
+}
+
+ar-tab[disabled] {
+    opacity: var(--ar-tab-disabled-opacity);
+}
+```
+
+- [ ] **Step 4: Mettre à jour le JSDoc de `tab.ts`**
+
+Bloc `@cssprop`/note d'implémentation actuel (lignes ~16-37) remplacé par :
+
+```ts
+ * @csspart base - Wrapper du slot — padding, box-shadow actif. `base--selected` quand l'onglet est actif (propriété `active`, pilotée par ar-tab-group).
+ *
+ * @cssprop --ar-tab-padding-x - Padding horizontal.
+ * @cssprop --ar-tab-padding-y - Padding vertical.
+ * @cssprop --ar-tab-active-shadow - box-shadow complet sur part="base--selected" quand actif. Repli `inset 0 -2px 0 Highlight` si aucun thème n'est chargé — sans lui, l'onglet actif est visuellement indiscernable des autres.
+ * @cssprop --ar-tab-disabled-opacity - Opacité de l'onglet désactivé.
+ * @cssprop --ar-tab-focus-ring-offset - Décalage de la bague de focus. Valeur négative = inset (non coupée par le conteneur overflow du tab-group). Repli `-2px` si aucun thème n'est chargé — sans lui, l'anneau de focus peut être rogné par le conteneur `overflow-x: auto` du tab-group. Surcharge le token global --ar-focus-ring-offset pour ce composant.
+ * @cssprop --ar-tab-focus-ring-color - Couleur de la bague de focus de l'onglet (cascade vers --ar-focus-ring-color). Repli `ButtonText` si aucun thème n'est chargé (WCAG 2.4.7).
+ *
+ * Note d'implémentation : la mise en page de [part='base'] compense la bordure de son parent
+ * ar-tab-group via les tokens --ar-tab-group-border-top-width / --ar-tab-group-border-bottom-width
+ * (déclarés et documentés sur ar-tab-group, cf. tab-group.ts) — pas des tokens propres à ar-tab.
+ * Le fallback 0px est structurel (évite un décalage visuel si ar-tab est utilisé hors d'un
+ * ar-tab-group) et reste volontaire.
+```
+
+Retirer les entrées `border-radius`/`font-weight`/`color`/`bg`/`hover-color`/`hover-bg`/
+`active-color`/`active-bg`/`indicator-color`/`indicator-width` (migrées ou supprimées).
+
+- [ ] **Step 5: Vérifier le format et committer**
+
+```bash
+npx prettier --write packages/core/src/components/tab packages/core/src/components/tab-group/tab-group.ts packages/core/src/styles/themes/default.css
+git add packages/core/src/components/tab packages/core/src/components/tab-group/tab-group.ts packages/core/src/styles/themes/default.css
+git commit -m "refactor(tab): ajoute la propriété active, migre tokens vers ::part(base)/::part(base--selected), corrige le repli focus-ring-offset manquant"
+```
+
+---
+
+## Task 7: `ar-collapse` — aucun changement de code, documenter l'audit dans ADR-005
+
+**Files:** aucun changement de code (audit confirmé : 0 candidat).
+
+- [ ] **Step 1: Confirmer qu'aucune régression n'est possible**
+
+Aucun fichier de `ar-collapse` n'est modifié dans ce lot — étape purement documentaire, traitée
+Task 9 (mise à jour ADR-005).
+
+---
+
+## Task 8: Vérifier les tests, rebuild le manifeste, garde-fous CI
+
+**Files:**
+
+- Read-only check: tous les `*.test.ts`/`*.browser.test.ts`/`*.a11y.test.ts` des 6 composants.
+
+**Interfaces:**
+
+- Consumes: composants modifiés (Tasks 2-7).
+- Produces: confirmation verte.
+
+- [ ] **Step 1: Grep les assertions sensibles aux propriétés migrées**
+
+```bash
+grep -rn "class=\|classList\|querySelector('\.\|getComputedStyle" \
+  packages/core/src/components/table-sort/*.test.ts \
+  packages/core/src/components/charcounter/*.test.ts \
+  packages/core/src/components/progressbar/*.test.ts \
+  packages/core/src/components/tab-group/*.test.ts \
+  packages/core/src/components/tab/*.test.ts
+```
+
+Pour chaque occurrence touchant une classe CSS retirée (`progressbar-container`, `progress-label`,
+`content-label`, `progress`, `progress-bar`, `progress-percent`) ou un `part` désormais
+conditionnel (`button`/`count`/`base`), adapter le test au nouveau sélecteur `[part=...]` (ou
+`[part~=...]` pour les valeurs multi-tokens, cf. piège `happy-dom` déjà rencontré lot 6 — vérifier
+`getPart`/`requirePart` dans `test-utils.ts` gèrent bien ce cas, déjà passés en `[part~=...]`
+depuis le lot pagination).
+
+- [ ] **Step 2: Lancer la suite Vitest des 6 composants**
+
+Run: `npm run test --workspace=packages/core -- table-sort charcounter progressbar tab-group tab collapse`
+Expected: tous les tests passent.
+
+- [ ] **Step 3: Rebuild le manifeste CEM**
+
+Run: `npm run build:manifest --workspace=packages/core`
+Expected: succès. Vérifier spécifiquement :
+
+- `validate-no-hardcoded-tokens.js` : le repli `var(--ar-progressbar-max-width, 500px)` doit
+  passer grâce au commentaire `a11y-fallback` immédiatement précédent (Task 4 Step 1).
+- `validate-part-state-order.js` : `::part(button)` avant `::part(button--pending)`
+  (table-sort), `::part(count)` avant `::part(count--warning)`/`::part(count--error)`
+  (charcounter), `::part(base)` avant `::part(base--selected)` (tab).
+- `validate-cssprop-defaults.js` : aucun token `--ar-<composant>-*` dans `default.css :root` sans
+  entrée `@cssprop` correspondante, et vice versa.
+
+- [ ] **Step 4: Lancer la suite browser (WTR)**
+
+Run: `npm run test:all --workspace=packages/core -- table-sort charcounter progressbar tab-group tab collapse`
+Expected: tous les tests passent, y compris les `*.a11y.test.ts`.
+
+- [ ] **Step 5: Commit (uniquement si le manifeste ou un test a été modifié)**
+
+```bash
+git add packages/core/custom-elements.json packages/core/src/components/**/*.test.ts
+git commit -m "chore: régénère le manifeste et adapte les tests après migration lot 8"
+```
+
+---
+
+## Task 9: Vérification visuelle manuelle + diff `getComputedStyle`
+
+**Files:** aucun fichier modifié — vérification uniquement.
+
+- [ ] **Step 1: Rebuild explicite de `packages/core`**
+
+Run: `npm run build:dev --workspace=packages/core`
+(piège `feedback_docs_dev_stale_dist` — `npm run dev --workspace=apps/docs` seul ne suffit pas).
+
+- [ ] **Step 2: Lancer le serveur de doc**
+
+Run: `npm run dev --workspace=apps/docs`.
+
+- [ ] **Step 3: Diff `getComputedStyle` par composant, thème chargé**
+
+Pour chacun des 5 composants modifiés (`table-sort`, `charcounter`, `progressbar`, `tab-group`,
+`tab`), avec Playwright (`apps/docs/playwright.config.ts`) : ouvrir la page de démo, capturer
+`getComputedStyle` des éléments concernés sur le commit `dev` (avant ce lot) et sur la branche,
+comparer propriété par propriété (pas seulement une capture visuelle) :
+
+- `table-sort` : `gap` (button/indicator), `cursor` en état pending.
+- `charcounter` : `color`/`font-size` (état normal), `color`/`font-weight` (warning/error).
+- `progressbar` : `row-gap`/`column-gap`/`border-radius`/`color` du pourcentage, `max-width`.
+- `tab-group` : `gap`.
+- `tab` : `border-radius`/`font-weight`/`color`/`background` (repos/hover/sélectionné),
+  `box-shadow` (sélectionné), `opacity` (disabled), `outline-offset` (focus-visible).
+
+Aucun écart attendu — les valeurs `default.css` sont inchangées, seul leur point de définition a
+changé (sauf `max-width` du progressbar, nouveau token, et le nettoyage nomenclature progressbar
+qui ne doit rien changer visuellement).
+
+- [ ] **Step 4: Vérifier le rendu sans thème (fallback a11y)**
+
+Charger une page sans `default.css` et confirmer :
+
+- `ar-tab` : anneau de focus visible et non rogné (`outline-offset: -2px` désormais garanti par
+  repli), onglet actif visible via `box-shadow` Highlight, padding présent entre onglets.
+- `ar-progressbar` : `max-width: 500px` appliqué (repli `a11y-fallback`), rail/remplissage
+  visibles (`ButtonFace`/`ButtonText`, déjà en place, non concernés par ce lot).
+- `ar-charcounter` : graisse distincte en warning/error même sans couleur (repli déjà en place,
+  non concerné par ce lot).
+
+- [ ] **Step 5: Consigner le résultat**
+
+Si un écart est trouvé, corriger le fichier concerné et refaire Steps 3-4.
+
+---
+
+## Task 10: Revue finale de branche
+
+**Files:** aucun — revue uniquement.
+
+- [ ] **Step 1: Dispatcher une revue de branche complète sur un agent capable**
+
+Comparer l'intégralité du diff `dev...fix/lot8-token-vs-part-129` contre
+`docs/decisions/ADR-005-tokens-pilotes-par-attribut.md` et
+`docs/superpowers/specs/2026-08-05-lot8-token-vs-part-129-design.md`. Points d'attention
+spécifiques à ce lot :
+
+- `ar-tab-group._syncAll()` : `tab.active = isActive;` doit être posé pour **tous** les tabs à
+  chaque appel (pas seulement celui qui devient actif) — sinon un onglet qui perd le focus actif
+  garderait `active=true` indéfiniment (même piège que `aria-selected`, déjà géré correctement
+  par la boucle `forEach` existante, à revérifier après l'ajout de la ligne).
+- `ar-tab` : `:host([active]:not([disabled])) { cursor: default; }` — vérifier que la
+  simplification du bloc `[active]` (Task 6 Step 2) n'a pas fusionné par erreur deux sélecteurs de
+  spécificité différente de l'original.
+- `ar-progressbar` : `min-width: 200px` supprimé sans remplacement — confirmer qu'aucun test/doc
+  n'assumait cette valeur plancher.
+- `ar-charcounter`/`ar-table-sort` : `part="..."` dynamique — vérifier qu'aucun test n'utilise un
+  sélecteur `[part='count']`/`[part='button']` strict (`=`) qui casserait quand un second token
+  est ajouté (doivent utiliser `[part~=...]`, cf. `test-utils.ts`).
+- Cohérence exacte entre tokens retirés des composants et tokens retirés de `default.css` (aucun
+  oubli, aucun résidu) sur les 5 composants modifiés.
+- `--ar-tab-indicator-color`/`-indicator-width` : confirmer disparition complète (recherche
+  `grep -rn` sur ces 2 noms hors `git log`) et que `--ar-tab-active-shadow` produit exactement la
+  même valeur calculée qu'avant (`inset 0 -2px 0 var(--ar-color-interactive)` vs l'ancienne
+  composition `calc(-1 * 2px)` + `var(--ar-color-interactive)` — équivalent).
+- JSDoc `@cssprop`/`@csspart` cohérent avec l'implémentation finale sur les 5 composants.
+- `npm run build:manifest` reste vert après tout fix.
+
+- [ ] **Step 2: Corriger les findings en une vague unique**
+
+Si des findings « Critical »/« Important » remontent, les corriger en un seul commit groupé, puis
+relancer Task 8 Steps 2-4 et Task 9 pour re-vérifier.
+
+---
+
+## Task 11: Documenter le lot dans ADR-005
+
+**Files:**
+
+- Modify: `docs/decisions/ADR-005-tokens-pilotes-par-attribut.md`
+
+**Interfaces:**
+
+- Consumes: résultat final de Tasks 2-10.
+- Produces: section « Application — lot 8 » à la suite de la dernière section existante
+  (tooltip/panel, 2026-08-05/06).
+
+- [ ] **Step 1: Ajouter une section résumant le lot**
+
+Reprendre la structure des sections précédentes (ex. « Application — `ar-dropdown` (lot 5) ») :
+résultat par composant (tokens migrés/conservés/supprimés), le cas `ar-collapse` (0 candidat,
+critère 2 + indivisibilité du shorthand `transition`), le fix a11y `focus-ring-offset`, et le
+nettoyage `indicator-color`/`indicator-width` comme nouvel exemple de « token de composition
+jamais consommé par le composant ».
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/decisions/ADR-005-tokens-pilotes-par-attribut.md
+git commit -m "docs(adr-005): documente le lot 8 (table-sort, charcounter, progressbar, tab-group, tab, collapse)"
+```
+
+---
+
+## Task 12: Créer la Pull Request
+
+**Files:** aucun.
+
+- [ ] **Step 1: Pousser la branche**
+
+```bash
+git push -u origin fix/lot8-token-vs-part-129
+```
+
+- [ ] **Step 2: Créer la PR vers `dev`**
+
+```bash
+gh pr create --base dev --title "refactor(table-sort,charcounter,progressbar,tab-group,tab): migre token vs ::part(), lot 8 (#129)" --body "$(cat <<'EOF'
+## Summary
+- `ar-table-sort` : migre gap/indicator-gap, ajoute le part d'état `button--pending`.
+- `ar-charcounter` : migre color/font-size, ajoute les parts d'état `count--warning`/`count--error`.
+- `ar-progressbar` : nettoie la nomenclature classes/part héritée, migre percent-color/row-gap/column-gap/border-radius, ajoute un repli a11y sur `max-width` (min-width retiré, mobile-first).
+- `ar-tab-group` : migre gap.
+- `ar-tab` : migration complète (border-radius, font-weight, color/bg base+hover+sélectionné via le nouveau part d'état `base--selected`, disabled), nettoie 2 tokens de composition jamais consommés par le composant (`indicator-color`/`-width`), corrige un repli a11y manquant sur `focus-ring-offset`.
+- `ar-collapse` : audité, 0 migration possible (duration lu en JS, easing indivisible du même shorthand `transition`) — documenté dans ADR-005 pour clore le composant.
+
+Spec : \`docs/superpowers/specs/2026-08-05-lot8-token-vs-part-129-design.md\`
+Plan : \`docs/superpowers/plans/2026-08-06-lot8-token-vs-part-129.md\`
+
+## Test plan
+- [x] \`npm run test --workspace=packages/core\` (6 composants)
+- [x] \`npm run build:manifest --workspace=packages/core\` (garde-fous CI verts)
+- [x] Suite browser (WTR)
+- [x] Diff \`getComputedStyle\` avant/après + vérification visuelle Playwright (avec et sans thème)
+- [x] Revue finale de branche
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Confirmer avec l'utilisateur avant tout merge**
+
+Ne pas merger sur `dev` sans confirmation explicite — signaler la PR créée et attendre la revue de
+l'utilisateur (feedback_merge_after_autonomous_fix).
+
+---
+
+## Self-Review (déjà appliqué en rédigeant ce plan)
+
+1. **Couverture de la spec** : les 6 sections de la spec (table-sort, charcounter, progressbar,
+   tab-group, tab, collapse) sont couvertes respectivement par Tasks 2-7. Vérification (Task 8-9)
+   et revue finale (Task 10) couvrent les exigences méthodologiques du chantier #129. Branche/PR
+   couvertes par Tasks 1 et 12. Documentation ADR-005 couverte par Task 11 (nouveau par rapport
+   aux plans précédents — les lots récents documentaient l'ADR au fil de l'eau en session plutôt
+   qu'en tâche dédiée ; explicité ici pour un lot à 6 composants).
+2. **Scan placeholders** : chaque step contient le contenu exact à écrire ou la commande exacte à
+   lancer — sauf Task 6 Step 2 (fusion des blocs `[active]`), qui laisse un choix mineur
+   d'implémentation (2 blocs vs 1) explicitement signalé comme tel plutôt que tranché à l'aveugle,
+   car dépendant du rendu exact de Step 1.
+3. **Cohérence des noms** : `part="base--selected"` (Task 6 Step 1, JS) correspond exactement à
+   `::part(base--selected)` (Task 6 Step 3, CSS) et au JSDoc `@csspart` (Task 6 Step 4) ; même
+   vérification faite pour `button--pending` (Task 2) et `count--warning`/`count--error` (Task 3).
+4. **Ordre des tâches** : Task 5 (tab-group) précède Task 6 (tab) car Task 6 Step 3 retire la
+   dernière ligne du bloc `:root` « Tab » partagé — dépendance explicite documentée dans Task 5
+   Step 2 plutôt que dupliquée dans les deux tâches.

--- a/docs/superpowers/specs/2026-08-05-lot8-token-vs-part-129-design.md
+++ b/docs/superpowers/specs/2026-08-05-lot8-token-vs-part-129-design.md
@@ -1,0 +1,265 @@
+# Spec — lot 8, migration token vs `::part()` (issue #129)
+
+**Date :** 2026-08-05
+**Composants :** `ar-table-sort`, `ar-charcounter`, `ar-progressbar`, `ar-tab-group`, `ar-tab`, `ar-collapse`
+**Référence :** ADR-005 (`docs/decisions/ADR-005-tokens-pilotes-par-attribut.md`), critère à 4 branches +
+contraintes 1-6, pattern « part d'état » (BEM `--`).
+
+## Contexte
+
+Dernier lot groupé identifié dans l'audit du 2026-07-25 (candidats directs restants les moins
+volumineux : `table-sort` 2, `collapse` 2, `charcounter` 1, `progressbar` 1, `tab-group` 1).
+Traité en un seul lot/PR plutôt qu'en lots séparés vu le faible volume par composant. Audit
+complet refait ici (étape 0 incluse — valeurs littérales jamais tokenisées, pas seulement les
+tokens déjà nommés) plutôt que de reprendre les chiffres de l'audit initial tels quels.
+
+## ar-table-sort
+
+2 candidats confirmés :
+
+- `--ar-table-sort-gap` (sur `[part='button']`) → migré en littéral dans `ar-table-sort::part(button)`.
+- `--ar-table-sort-indicator-gap` (sur `[part='indicator']`) → migré en littéral dans
+  `ar-table-sort::part(indicator)`.
+
+4 tokens restent internes :
+
+- `--ar-table-sort-indicator-size` : réutilisé 4× dans le même `.styles.ts` (largeur + 2×
+  `calc()` de bordure de caret via `border-left`/`border-right`, + 2× hauteur de caret via
+  `border-bottom`/`border-top`) — critère 3.
+- `--ar-table-sort-indicator-color`, `--ar-table-sort-indicator-active-color`,
+  `--ar-table-sort-indicator-pending-color` : pilotent des pseudo-éléments `::before`/`::after`
+  de `[part='indicator']` — contrainte 3 (un `part` ne peut jamais cibler un pseudo-élément d'un
+  élément `part`, `::part(indicator)::before` n'est pas un sélecteur valide).
+
+### Étape 0 — état posé sur un élément qui porte déjà un `part`
+
+`[part='button'][aria-disabled='true'] { cursor: wait; }` : `cursor: wait` n'a jamais été
+tokenisé et pilote un état (`pending`, exposé sur le bouton via `aria-disabled="true"`) sur un
+élément qui porte déjà un `part` — éligible au pattern part d'état plutôt que de rester figé en
+interne. `pending` est déjà une `@property({ reflect: true })` de `ArTableSort`, il suffit de
+conditionner l'attribut `part` du bouton dans le template (`part="button button--pending"` quand
+`pending` est vrai). Nouvelle règle `ar-table-sort::part(button--pending) { cursor: wait; }`
+déclarée après `::part(button)`, ouvre la porte à une personnalisation plus large que le curseur
+seul (opacité, style visuel) pour un consommateur qui le souhaiterait.
+
+## ar-charcounter
+
+`[part='count']` porte déjà un `part` — le pattern « part d'état » (BEM `--`, établi lot 1)
+s'applique directement aux surcharges `:host([state='warning'])`/`:host([state='error'])`.
+
+- `--ar-charcounter-color` (base) + `--ar-charcounter-font-size` → migrés en littéral dans
+  `ar-charcounter::part(count)`.
+- `--ar-charcounter-warning-color` → nouveau part d'état `count--warning`, posé via
+  `part="count count--warning"` en état warning ; règle `ar-charcounter::part(count--warning) {
+color: ...; }` déclarée après `::part(count)` (garde-fou d'ordre `validate-part-state-order.js`).
+- `--ar-charcounter-error-color` → même mécanisme, `count--error`.
+- `--ar-charcounter-warning-weight` / `--ar-charcounter-error-weight` restent tokens : fallback
+  WCAG déjà justifié (`a11y-fallback`, la graisse est le seul signal garanti sans thème quand la
+  couleur seule ne distingue pas warning/error) — critère 1, prime sur la migration. Règle interne
+  reciblée sur le part d'état lui-même (`[part~='count--warning']`/`[part~='count--error']`)
+  plutôt que sur `:host([state='warning']) [part='count']` — les deux signaux (attribut `state`
+  de l'hôte, token `part`) sont déjà synchronisés par le même rendu ; passer par le `part`
+  directement évite de dupliquer la condition d'état sur deux mécanismes différents.
+
+## ar-progressbar
+
+### Nettoyage nomenclature (préalable)
+
+Le CSS utilise encore des classes (`.progressbar-container`, `.progress-label`, `.content-label`,
+`.progress`, `.progress-bar`, `.progress-percent`) strictement redondantes avec les `part` déjà
+posés dans le template (`container`, `label`, `label-text`, percent, `track`, `bar`) — même dette
+que `ar-stepper`/`ar-breadcrumb` avant leur nettoyage. Classes remplacées par des sélecteurs
+`[part='...']` en interne, avant toute migration de token.
+
+### Tokens
+
+- `--ar-progressbar-percent-color` → migré en littéral dans `ar-progressbar::part(percent)`.
+- `--ar-progressbar-track-color` / `--ar-progressbar-fill-color` restent tokens (fallback WCAG
+  1.4.11 déjà justifié en JSDoc, `ButtonFace`/`ButtonText` — critère 1).
+
+### Étape 0 — valeurs jamais tokenisées
+
+- `border-radius: 50rem` sur `.progress`/`.progress-bar` (`track`/`bar`) → jamais tokenisé,
+  candidat direct, migré en littéral dans `ar-progressbar::part(track)`/`::part(bar)`.
+- `row-gap: 0.75rem` (container) → migré en littéral dans `ar-progressbar::part(container)`.
+- `column-gap: 2rem` (label) → migré en littéral dans `ar-progressbar::part(label)`.
+
+### Largeur du `:host` (`max-width: 500px` / `min-width: 200px`)
+
+Décision du mainteneur : ni pur cosmétique (candidat direct) ni pur `functional-default` figé
+façon `ar-dialog` — la largeur doit rester **mobile-first** (100% de l'espace disponible par
+défaut) tout en gardant un plafond raisonnable en desktop, pour une raison a11y propre à ce
+composant (lien visuel label/pourcentage — un `.progress-label` trop large éloigne le pourcentage
+de son label, `column-gap: 2rem` fixe accentue le problème au-delà d'une certaine largeur).
+
+Mécanisme retenu :
+
+- `min-width: 200px` **supprimé** — contraire au mobile-first (imposait un plancher même sur un
+  conteneur plus étroit que 200px, ex. une colonne mobile serrée). Le composant est `display:
+block`, il occupe déjà 100% du conteneur parent par défaut sans qu'aucune règle ne soit
+  nécessaire pour ce cas.
+- `max-width` devient un token `--ar-progressbar-max-width` **normal**, déclaré dans
+  `default.css :root` comme tous les autres tokens du lot — pas de mécanisme `functional-default`
+  ici. `functional-default` (`--ar-dialog-width`) existe pour un cas précis qui ne s'applique pas
+  à `ar-progressbar` : la largeur du dialog dépend d'un attribut (`size`/`mode`), donc plusieurs
+  valeurs de repli conditionnelles doivent être assignées directement sur le token via plusieurs
+  sélecteurs `:host([size='...'])` — un simple `var(--token, repli)` ne peut pas exprimer cette
+  variance. `ar-progressbar` n'a aucune variance par attribut, une seule valeur de repli suffit :
+  c'est exactement le cas couvert par le mécanisme `a11y-fallback` existant (amendement ADR-005
+  du 2026-07-22, « valeur littérale justifiée » pour les dimensions sans équivalent système). Le
+  token reste donc surchargeable normalement via `:root` par un consommateur, comme n'importe quel
+  autre token de la librairie — pas de changement de mécanisme de personnalisation pour ce seul
+  cas.
+
+```css
+:host {
+    display: block;
+    box-sizing: border-box;
+    /* a11y-fallback: sans plafond, .progress-label peut s'étirer sur un conteneur très large et éloigner visuellement le pourcentage de son label (lien a11y label/valeur) */
+    max-width: var(--ar-progressbar-max-width, 500px);
+}
+```
+
+`min-width` retiré sans remplacement (mobile-first — `display: block` occupe déjà 100% du
+conteneur parent par défaut, aucun plancher n'est nécessaire).
+
+## ar-tab-group
+
+1 seul candidat confirmé :
+
+- `--ar-tab-group-gap` (sur `[part='base']`, single use) → migré en littéral dans
+  `ar-tab-group::part(base)`.
+
+Restent tokens (contrainte 4, réutilisation croisée) :
+
+- `--ar-tab-group-border-top-width` / `--ar-tab-group-border-bottom-width` : lus par
+  `tab.styles.ts` (`margin-block-start/end: calc(-1 * var(--ar-tab-group-border-*-width, 0px))`)
+  pour compenser visuellement la bordure du groupe parent — cas déjà documenté dans ADR-005.
+- `--ar-tab-group-border-color` : réutilisé 2× dans `tab-group.styles.ts` lui-même (règle
+  `border-top` et `border-bottom`) — critère 3, réutilisation interne suffisante à elle seule,
+  indépendamment de la contrainte 4.
+
+## ar-tab
+
+Initialement laissé hors scope (non mentionné dans le lot groupé), réintégré sur remarque du
+mainteneur — couplé à `ar-tab-group` (tokens de bordure partagés), logique de traiter les deux
+ensemble. Un seul `part` existant (`base`), toutes les propriétés migrables ciblent cet élément
+ou `:host`.
+
+### Migrables directement (branch 4, `:host`, single use)
+
+- `--ar-tab-border-radius` → `ar-tab { border-radius: ...; }`.
+- `--ar-tab-font-weight` → `ar-tab { font-weight: ...; }`.
+
+`[part='base'] { border-radius: inherit; }` reste interne et continue de fonctionner tel quel :
+`inherit` récupère la valeur calculée du host, que sa source soit interne ou externe.
+
+### Nouvelle propriété Lit `active`, pilotée par `ar-tab-group`
+
+Plutôt que de faire observer à `ar-tab` son propre attribut `aria-selected` (posé de l'extérieur
+par `ar-tab-group._syncAll()` via `tab.setAttribute()`, donc invisible au cycle réactif de Lit
+sans plomberie `attributeChangedCallback` dédiée), remarque du mainteneur reprise ici : ajouter
+une véritable `@property({ reflect: true, type: Boolean }) active = false;` sur `ArTab` — même
+pattern que le `active`/`selected` de WebAwesome (`sl-tab`). `ar-tab-group._syncAll()` fait
+`tab.active = isActive;` (assignation de propriété JS) en plus de
+`tab.setAttribute('aria-selected', String(isActive))`, inchangé — la sémantique ARIA reste une
+responsabilité du tablist (même modèle que `role`/`aria-controls`/`tabindex`/`aria-disabled`,
+déjà posés de la même façon), seul l'état visuel devient une propriété réactive Lit native. Plus
+besoin d'`attributeChangedCallback`/`observedAttributes` : `render()` lit `this.active`
+directement, Lit re-render automatiquement au changement de propriété.
+
+**Nommage** : `active` pour la propriété/attribut d'hôte (aligné sur l'écosystème, WebAwesome) —
+ne recrée pas la collision déjà écartée le 2026-07-27, qui concernait spécifiquement un _suffixe
+de part d'état_ (`::part(x--active)` vs `::part(x):active`), pas un attribut d'hôte (`[active]`
+vs `:active` sont des syntaxes non ambiguës). Le part d'état lui-même garde le nom `selected`
+(`base--selected`) pour éviter cette collision documentée.
+
+### `color`/`bg` — base + hover (pseudo-classe native, composition externe)
+
+`color`/`bg` de base migrent vers `ar-tab::part(base)`. Le survol
+(`:host(:hover:not([disabled]):not([active])) [part='base']`) est une pseudo-classe **native**
+qui compose normalement avec une base externe, à condition que la règle de survol pour la même
+propriété soit **elle aussi** externe (clarification ADR-005 du 2026-07-28, cas du bouton close
+`ar-alert`) : migré vers `ar-tab:hover:not([disabled]):not([active])::part(base) { color: ...;
+background: ...; }`.
+
+### `active-color`/`active-bg` — état posé par le parent, pattern part d'état
+
+`:host([active]) [part='base']` (nouvel attribut réfléchi, cf. ci-dessus) cible un état posé sur
+un élément qui porte déjà un `part` — éligible au pattern part d'état comme les cas précédents du
+chantier. `render()` conditionne `part="base base--selected"` sur `this.active`. Nouvelle règle
+`ar-tab::part(base--selected) { color: ...; background: ...; }` déclarée après `::part(base)`
+(garde-fou d'ordre).
+
+### `disabled-opacity` — état sur `:host`, migration via sélecteur d'attribut externe
+
+`:host([disabled]) { opacity: var(--ar-tab-disabled-opacity); }` — `:host` ne porte pas de `part`
+(le pattern part d'état ne s'applique qu'aux éléments descendants), mais le précédent
+`ar-alert[hiding] { }` (2026-07-28) s'applique directement : un sélecteur d'attribut externe sur
+le tag l'emporte purement sur la règle `:host([attr])` interne. Migré vers
+`ar-tab[disabled] { opacity: ...; }`.
+
+### Nettoyage — tokens de composition jamais consommés par le composant
+
+`--ar-tab-indicator-color`/`--ar-tab-indicator-width` sont documentés `@cssprop` mais **jamais
+consommés via `var()` dans `tab.styles.ts`** — utilisés uniquement à l'intérieur de `default.css`
+pour composer `--ar-tab-active-shadow` (seul token réellement lu par le composant, avec son repli
+`a11y-fallback`). Même raisonnement que le nettoyage `ar-pagination` (lot 6, `color`/`bg` non
+consommés en interne) : ce ne sont pas de vrais tokens d'API du composant, juste un choix
+d'implémentation de `default.css`. Supprimés comme tokens publics, valeurs inlinées directement
+dans la composition de `--ar-tab-active-shadow` dans `default.css`.
+
+### Bug trouvé — repli a11y manquant sur `--ar-tab-focus-ring-offset`
+
+`outline-offset: var(--ar-tab-focus-ring-offset);` n'a **aucun repli**, alors que sa valeur
+négative documentée (`-2px` dans `default.css`) a un rôle fonctionnel réel : éviter que l'anneau
+de focus soit rogné par `overflow-x: auto` du conteneur `[part='nav']` d'`ar-tab-group`. Sans
+thème chargé, la propriété devient invalide faute de valeur de repli — anneau de focus
+potentiellement coupé (WCAG 2.4.7). Corrigé avec `var(--ar-tab-focus-ring-offset, -2px)`, même
+mécanisme que `--ar-tab-focus-ring-color` juste au-dessus dans le même bloc (qui a déjà son
+repli `ButtonText`). Cette règle reste interne dans les deux cas (le repli n'a de sens que si la
+déclaration elle-même vit dans le composant — `default.css` peut être totalement absent).
+
+## ar-collapse
+
+**0 candidat** — les deux tokens (`--ar-collapse-duration`, `--ar-collapse-easing`) sont bloqués :
+
+- `--ar-collapse-duration` : lu en JavaScript via `getComputedStyle(this._panel).transitionDuration`
+  dans `_shouldAnimate()` — critère 2 (lecture JS), verrouillé indépendamment de tout autre
+  critère.
+- `--ar-collapse-easing` : consommé dans la **même** déclaration `transition` que `duration`
+  (`transition: height var(--ar-collapse-duration) var(--ar-collapse-easing);`). Une déclaration
+  CSS shorthand ne peut pas être scindée entre une partie interne et une partie externe — migrer
+  `easing` seul en `::part()` laisserait `duration` piloter une transition à moitié externalisée,
+  cassant la garantie que `_shouldAnimate()` mesure la durée réellement appliquée. `easing` reste
+  donc interne par indivisibilité de la déclaration, pas par un critère propre.
+
+Aucune valeur littérale jamais tokenisée trouvée à l'étape 0 (`[part='base']` : `display`/
+`flex-direction`/`align-items` sont structurels, pas des choix de design arbitraires).
+
+Décision du mainteneur : inclure quand même `ar-collapse` dans ce lot pour documenter le résultat
+dans l'ADR-005 et clore définitivement ce composant dans le chantier #129, plutôt que de laisser
+un audit non traité.
+
+## Résumé des changements de surface publique
+
+| Composant   | Tokens supprimés/migrés                                                                                                                                                            | Nouveaux `::part()`/parts d'état                                                                          | Tokens conservés                                                                                          |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| table-sort  | 2 (`gap`, `indicator-gap`) + 1 littéral (`cursor: wait`)                                                                                                                           | `::part(button)`, `::part(button--pending)`, `::part(indicator)`                                          | 4                                                                                                         |
+| charcounter | 4 (`color`, `font-size`, `warning-color`, `error-color`)                                                                                                                           | `::part(count)`, `::part(count--warning)`, `::part(count--error)`                                         | 2 (weights)                                                                                               |
+| progressbar | 4 (`percent-color` + 3 littéraux jamais tokenisés) ; `min-width` supprimé                                                                                                          | `::part(track)`, `::part(bar)`, `::part(percent)`, `::part(container)`, `::part(label)`                   | 3 (track/fill + 1 nouveau `max-width`, a11y-fallback)                                                     |
+| tab-group   | 1 (`gap`)                                                                                                                                                                          | `::part(base)`                                                                                            | 3                                                                                                         |
+| tab         | 6 (`border-radius`, `font-weight`, `color`, `bg`, `hover-color`, `hover-bg`, `disabled-opacity`) — 7 en comptant, + 2 tokens de composition supprimés (`indicator-color`/`-width`) | `ar-tab { }`, `::part(base)`, `::part(base--selected)`, `ar-tab:hover...::part(base)`, `ar-tab[disabled]` | 4 (`padding-x/y`, `focus-ring-color`, `active-shadow`) + `active-color`/`active-bg` migrés en part d'état |
+| collapse    | 0                                                                                                                                                                                  | —                                                                                                         | 2                                                                                                         |
+
+**Bug corrigé au passage (hors migration)** : repli a11y manquant sur `--ar-tab-focus-ring-offset`.
+
+## Vérification prévue
+
+- `npm run build:manifest` (garde-fous `validate-no-hardcoded-tokens.js`,
+  `validate-cssprop-defaults.js`, `validate-part-state-order.js`).
+- Diff empirique `getComputedStyle` (ancien commit vs nouveau, propriété par propriété) sur chaque
+  composant modifié — méthode retenue depuis le nettoyage `ar-stepper`/`button.styles.ts` (PR
+  #156), plus fiable que la seule capture Playwright pour des écarts fins.
+- Captures Playwright avec/sans thème (régression visuelle + rendu nu accessible).
+- `npm run test:all` (Vitest + WTR browser).

--- a/packages/core/src/components/charcounter/charcounter.styles.ts
+++ b/packages/core/src/components/charcounter/charcounter.styles.ts
@@ -5,19 +5,12 @@ export default css`
         display: inline-block;
     }
 
-    [part='count'] {
-        color: var(--ar-charcounter-color);
-        font-size: var(--ar-charcounter-font-size);
-    }
-
-    :host([state='warning']) [part='count'] {
-        color: var(--ar-charcounter-warning-color);
+    [part~='count--warning'] {
         /* a11y-fallback: sans thème, la couleur seule (warning/error identiques) ne suffit pas à distinguer les états — la graisse doit rester un signal garanti même sans thème chargé */
         font-weight: var(--ar-charcounter-warning-weight, 700);
     }
 
-    :host([state='error']) [part='count'] {
-        color: var(--ar-charcounter-error-color);
+    [part~='count--error'] {
         /* a11y-fallback: sans thème, la couleur seule (warning/error identiques) ne suffit pas à distinguer les états — la graisse doit rester un signal garanti même sans thème chargé */
         font-weight: var(--ar-charcounter-error-weight, 700);
     }

--- a/packages/core/src/components/charcounter/charcounter.test.ts
+++ b/packages/core/src/components/charcounter/charcounter.test.ts
@@ -256,6 +256,22 @@ describe('ArCharcounter', () => {
             expect(el.getAttribute('state')).toBe('error');
         });
 
+        it('émet part="count count--warning" en état warning', async () => {
+            el = await setupWithCount(180, 200, 20);
+            expect(getPart(el, 'count--warning')).not.toBeNull();
+        });
+
+        it('émet part="count count--error" en état error', async () => {
+            el = await setupWithCount(201, 200, 20);
+            expect(getPart(el, 'count--error')).not.toBeNull();
+        });
+
+        it("n'émet ni count--warning ni count--error en état normal", async () => {
+            el = await setupWithCount(0, 200, 20);
+            expect(getPart(el, 'count--warning')).toBeNull();
+            expect(getPart(el, 'count--error')).toBeNull();
+        });
+
         it('affiche remaining négatif en état error', async () => {
             el = await setupWithCount(205, 200, 20);
             expect(getPart(el, 'remaining')?.textContent?.trim()).toBe('-5');

--- a/packages/core/src/components/charcounter/charcounter.ts
+++ b/packages/core/src/components/charcounter/charcounter.ts
@@ -23,7 +23,9 @@ function pluralize(count: number, label: string): string {
  * @slot icon-error   - Icône affichée en état error.
  *
  * @csspart container - L'élément racine.
- * @csspart count     - Le bloc chiffre + label. `count--warning`/`count--error` en état warning/error.
+ * @csspart count     - Le bloc chiffre + label.
+ * @csspart count--warning - Le bloc chiffre + label en état warning (variante d'état de `count`).
+ * @csspart count--error - Le bloc chiffre + label en état error (variante d'état de `count`).
  * @csspart remaining - Le chiffre des caractères restants.
  * @csspart label     - Le texte après le chiffre (ex: "restants").
  *

--- a/packages/core/src/components/charcounter/charcounter.ts
+++ b/packages/core/src/components/charcounter/charcounter.ts
@@ -23,15 +23,11 @@ function pluralize(count: number, label: string): string {
  * @slot icon-error   - Icône affichée en état error.
  *
  * @csspart container - L'élément racine.
- * @csspart count     - Le bloc chiffre + label.
+ * @csspart count     - Le bloc chiffre + label. `count--warning`/`count--error` en état warning/error.
  * @csspart remaining - Le chiffre des caractères restants.
  * @csspart label     - Le texte après le chiffre (ex: "restants").
  *
- * @cssprop --ar-charcounter-color - Couleur état normal.
- * @cssprop --ar-charcounter-warning-color - Couleur état warning.
- * @cssprop --ar-charcounter-error-color - Couleur état error.
- * @cssprop --ar-charcounter-font-size - Taille de police.
- * @cssprop --ar-charcounter-warning-weight - Graisse du texte en état warning. Repli `700` si aucun thème n'est chargé — seul signal garanti d'état si le consommateur n'utilise pas les slots d'icône.
+ * @cssprop --ar-charcounter-warning-weight - Graisse du texte en état warning. Repli `700` si aucun thème n'est chargé — seul signal garanti d'état en l'absence des slots d'icône.
  * @cssprop --ar-charcounter-error-weight - Graisse du texte en état error. Repli `700` si aucun thème n'est chargé.
  */
 export class ArCharcounter extends LitElement {
@@ -234,7 +230,7 @@ export class ArCharcounter extends LitElement {
             <span part="container">
                 <slot name="icon-warning"></slot>
                 <slot name="icon-error"></slot>
-                <span part="count">
+                <span part="count${this._state !== 'normal' ? ` count--${this._state}` : ''}">
                     <span part="remaining">${remaining}</span>
                     <span part="label"> ${pluralize(remaining, this.label)}</span>
                 </span>

--- a/packages/core/src/components/progressbar/progressbar.styles.ts
+++ b/packages/core/src/components/progressbar/progressbar.styles.ts
@@ -4,7 +4,7 @@ export default css`
     :host {
         display: block;
         box-sizing: border-box;
-        /* a11y-fallback: sans plafond, .progress-label peut s'étirer sur un conteneur très large et éloigner visuellement le pourcentage de son label (lien a11y label/valeur) */
+        /* a11y-fallback: sans plafond, [part='label'] peut s'étirer sur un conteneur très large et éloigner visuellement le pourcentage de son label (lien a11y label/valeur) */
         max-width: var(--ar-progressbar-max-width, 500px);
     }
 

--- a/packages/core/src/components/progressbar/progressbar.styles.ts
+++ b/packages/core/src/components/progressbar/progressbar.styles.ts
@@ -3,39 +3,35 @@ import { css } from 'lit';
 export default css`
     :host {
         display: block;
-        max-width: 500px;
-        min-width: 200px;
         box-sizing: border-box;
+        /* a11y-fallback: sans plafond, .progress-label peut s'étirer sur un conteneur très large et éloigner visuellement le pourcentage de son label (lien a11y label/valeur) */
+        max-width: var(--ar-progressbar-max-width, 500px);
     }
 
-    .progressbar-container {
+    [part='container'] {
         display: flex;
         flex-direction: column;
-        row-gap: 0.75rem;
     }
 
-    .progress {
+    [part='track'] {
         display: inline-flex;
         position: relative;
         height: 0.5rem;
         background-color: var(--ar-progressbar-track-color, ButtonFace);
-        border-radius: 50rem;
     }
 
-    .progress-bar {
+    [part='bar'] {
         background-color: var(--ar-progressbar-fill-color, ButtonText);
-        border-radius: 50rem;
     }
 
-    .progress-label {
+    [part='label'] {
         display: inline-flex;
         justify-content: space-between;
         flex-wrap: nowrap;
-        column-gap: 2rem;
         margin: 0;
     }
 
-    .progress-label .content-label {
+    [part='label-text'] {
         display: -webkit-box;
         -webkit-box-orient: vertical;
         -webkit-line-clamp: 2;
@@ -46,14 +42,13 @@ export default css`
     }
 
     @media (min-width: 576px) {
-        .progress-label .content-label {
+        [part='label-text'] {
             -webkit-line-clamp: none;
             line-clamp: none;
         }
     }
 
-    .progress-label .progress-percent {
-        color: var(--ar-progressbar-percent-color);
+    [part='percent'] {
         flex-shrink: 0;
     }
 `;

--- a/packages/core/src/components/progressbar/progressbar.ts
+++ b/packages/core/src/components/progressbar/progressbar.ts
@@ -29,7 +29,7 @@ export class ArProgressbarConfig {
  *
  * @cssprop --ar-progressbar-track-color - Couleur du rail (fond). Repli `ButtonFace` si aucun thème n'est chargé (WCAG 1.4.11).
  * @cssprop --ar-progressbar-fill-color - Couleur de la progression. Repli `ButtonText` si aucun thème n'est chargé (WCAG 1.4.11) — distinct de `ButtonFace` pour garder rail et remplissage contrastés entre eux.
- * @cssprop --ar-progressbar-percent-color - Couleur du texte du pourcentage.
+ * @cssprop --ar-progressbar-max-width - Largeur maximale du composant. Repli `500px` si aucun thème n'est chargé — sans plafond, le pourcentage peut s'éloigner visuellement de son label sur un conteneur très large.
  */
 export class ArProgressbar extends LitElement {
     static override styles: CSSResultGroup = [utilitiesStyles, styles];
@@ -58,17 +58,16 @@ export class ArProgressbar extends LitElement {
         // Clamp défensif : même si la propriété est bornée, une valeur HTML arbitraire peut passer
         const percentValue = Math.max(0, Math.min(100, this.percent));
 
-        return html` <div part="container" class="progressbar-container">
-            <p part="label" id="progressbar-label" class="progress-label">
-                <span part="label-text" class="content-label">
+        return html` <div part="container">
+            <p part="label" id="progressbar-label">
+                <span part="label-text">
                     <slot></slot>
                 </span>
-                <strong part="percent" class="progress-percent">${percentValue}%</strong>
+                <strong part="percent">${percentValue}%</strong>
             </p>
-            <div part="track" class="progress d-inline-flex">
+            <div part="track">
                 <div
                     part="bar"
-                    class="progress-bar"
                     style=${styleMap({ width: percentValue + '%' })}
                     role="progressbar"
                     aria-labelledby="progressbar-label"

--- a/packages/core/src/components/progressbar/progressbar.ts
+++ b/packages/core/src/components/progressbar/progressbar.ts
@@ -1,7 +1,6 @@
 import { LitElement, type TemplateResult, html, type CSSResultGroup } from 'lit';
 import { property } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
-import utilitiesStyles from '../../styles/utilities.styles.js';
 import { warn } from '../../utils/warn.js';
 import styles from './progressbar.styles.js';
 
@@ -32,7 +31,7 @@ export class ArProgressbarConfig {
  * @cssprop --ar-progressbar-max-width - Largeur maximale du composant. Repli `500px` si aucun thème n'est chargé — sans plafond, le pourcentage peut s'éloigner visuellement de son label sur un conteneur très large.
  */
 export class ArProgressbar extends LitElement {
-    static override styles: CSSResultGroup = [utilitiesStyles, styles];
+    static override styles: CSSResultGroup = [styles];
 
     /**
      * Pourcentage de complétion. Automatiquement borné entre 0 et 100.

--- a/packages/core/src/components/tab-group/tab-group.styles.ts
+++ b/packages/core/src/components/tab-group/tab-group.styles.ts
@@ -8,7 +8,6 @@ export default css`
     [part='base'] {
         display: flex;
         flex-direction: column;
-        gap: var(--ar-tab-group-gap);
     }
 
     [part='nav'] {

--- a/packages/core/src/components/tab-group/tab-group.ts
+++ b/packages/core/src/components/tab-group/tab-group.ts
@@ -156,6 +156,7 @@ export class ArTabGroup extends LitElement {
             tab.id = `${pfx}-tab-${tab.panel}`;
             tab.setAttribute('aria-controls', `${pfx}-panel-${tab.panel}`);
             tab.setAttribute('aria-selected', String(isActive));
+            tab.active = isActive;
             tab.setAttribute('tabindex', isActive ? '0' : '-1');
             if (tab.disabled) {
                 tab.setAttribute('aria-disabled', 'true');

--- a/packages/core/src/components/tab-group/tab-group.ts
+++ b/packages/core/src/components/tab-group/tab-group.ts
@@ -20,7 +20,6 @@ import styles from './tab-group.styles.js';
  * Les classes `has-overflow-start` et `has-overflow-end` sont ajoutées automatiquement sur l'hôte
  * quand le contenu de la tablist déborde à gauche ou à droite.
  *
- * @cssprop --ar-tab-group-gap - Espacement entre tablist et panels.
  * @cssprop --ar-tab-group-border-top-width - Épaisseur du trait séparateur en haut de la la tablist. Mettre à 1px pour l'activer.
  * @cssprop --ar-tab-group-border-bottom-width - Épaisseur du trait séparateur sous la tablist. Mettre à 1px pour l'activer.
  * @cssprop --ar-tab-group-border-color - Couleur du trait séparateur sous la tablist.

--- a/packages/core/src/components/tab/tab.styles.ts
+++ b/packages/core/src/components/tab/tab.styles.ts
@@ -33,6 +33,6 @@ export default css`
 
     :host(:focus-visible) {
         outline: 2px solid var(--ar-tab-focus-ring-color, ButtonText);
-        outline-offset: var(--ar-tab-focus-ring-offset, -2px);
+        outline-offset: var(--ar-tab-focus-ring-offset);
     }
 `;

--- a/packages/core/src/components/tab/tab.styles.ts
+++ b/packages/core/src/components/tab/tab.styles.ts
@@ -6,15 +6,11 @@ export default css`
         cursor: pointer;
         white-space: nowrap;
         user-select: none;
-        border-radius: var(--ar-tab-border-radius);
-        font-weight: var(--ar-tab-font-weight);
     }
 
     [part='base'] {
         display: flex;
         align-items: center;
-        color: var(--ar-tab-color);
-        background: var(--ar-tab-bg);
         /* a11y-fallback: sans thème, --ar-tab-bg reste transparent même par défaut — le padding est le seul mécanisme séparant visuellement des onglets adjacents ; sans lui les libellés se collent les uns aux autres */
         padding: var(--ar-tab-padding-y, 1rem) var(--ar-tab-padding-x, 1.5rem);
         border-radius: inherit;
@@ -22,29 +18,21 @@ export default css`
         margin-block-end: calc(-1 * var(--ar-tab-group-border-bottom-width, 0px));
     }
 
-    :host(:hover:not([disabled]):not([aria-selected='true'])) [part='base'] {
-        color: var(--ar-tab-hover-color);
-        background: var(--ar-tab-hover-bg);
+    :host([active]:not([disabled])) {
+        cursor: default;
     }
 
-    :host([aria-selected='true']) [part='base'] {
-        color: var(--ar-tab-active-color);
-        background: var(--ar-tab-active-bg);
+    :host([active]) [part='base'] {
         /* a11y-fallback: indicateur d'onglet actif indiscernable sans thème (WCAG 2.4.7) */
         box-shadow: var(--ar-tab-active-shadow, inset 0 -2px 0 Highlight);
     }
 
     :host([disabled]) {
         cursor: not-allowed;
-        opacity: var(--ar-tab-disabled-opacity);
-    }
-
-    :host([aria-selected='true']:not([disabled])) {
-        cursor: default;
     }
 
     :host(:focus-visible) {
         outline: 2px solid var(--ar-tab-focus-ring-color, ButtonText);
-        outline-offset: var(--ar-tab-focus-ring-offset);
+        outline-offset: var(--ar-tab-focus-ring-offset, -2px);
     }
 `;

--- a/packages/core/src/components/tab/tab.styles.ts
+++ b/packages/core/src/components/tab/tab.styles.ts
@@ -33,6 +33,7 @@ export default css`
 
     :host(:focus-visible) {
         outline: 2px solid var(--ar-tab-focus-ring-color, ButtonText);
-        outline-offset: var(--ar-tab-focus-ring-offset);
+        /* a11y-fallback: anneau de focus potentiellement rogné par le conteneur overflow-x: auto de ar-tab-group sans thème (WCAG 2.4.7) */
+        outline-offset: var(--ar-tab-focus-ring-offset, -2px);
     }
 `;

--- a/packages/core/src/components/tab/tab.styles.ts
+++ b/packages/core/src/components/tab/tab.styles.ts
@@ -8,10 +8,10 @@ export default css`
         user-select: none;
     }
 
-    [part='base'] {
+    [part~='base'] {
         display: flex;
         align-items: center;
-        /* a11y-fallback: sans thème, --ar-tab-bg reste transparent même par défaut — le padding est le seul mécanisme séparant visuellement des onglets adjacents ; sans lui les libellés se collent les uns aux autres */
+        /* a11y-fallback: sans thème, le fond de l'onglet reste transparent par défaut (couleur/fond posés par le thème via ::part()) — le padding est le seul mécanisme séparant visuellement des onglets adjacents ; sans lui les libellés se collent les uns aux autres */
         padding: var(--ar-tab-padding-y, 1rem) var(--ar-tab-padding-x, 1.5rem);
         border-radius: inherit;
         margin-block-start: calc(-1 * var(--ar-tab-group-border-top-width, 0px));
@@ -22,7 +22,7 @@ export default css`
         cursor: default;
     }
 
-    :host([active]) [part='base'] {
+    [part~='base--selected'] {
         /* a11y-fallback: indicateur d'onglet actif indiscernable sans thème (WCAG 2.4.7) */
         box-shadow: var(--ar-tab-active-shadow, inset 0 -2px 0 Highlight);
     }

--- a/packages/core/src/components/tab/tab.test.ts
+++ b/packages/core/src/components/tab/tab.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { fixture, waitForUpdate } from '../../test-utils.js';
+import { fixture, getPart, waitForUpdate } from '../../test-utils.js';
 import type { ArTab } from './tab.js';
 import './index.js';
 
@@ -24,6 +24,32 @@ describe('ArTab', () => {
         it('disabled vaut false', async () => {
             el = await fixture('<ar-tab panel="a">Tab A</ar-tab>');
             expect(el.disabled).toBe(false);
+        });
+
+        it('active vaut false', async () => {
+            el = await fixture('<ar-tab panel="a">Tab A</ar-tab>');
+            expect(el.active).toBe(false);
+        });
+    });
+
+    describe('active', () => {
+        it('reflète active en attribut', async () => {
+            el = await fixture('<ar-tab panel="a">Tab</ar-tab>');
+            el.active = true;
+            await waitForUpdate(el);
+            expect(el.hasAttribute('active')).toBe(true);
+        });
+
+        it('émet part="base" quand active est false', async () => {
+            el = await fixture('<ar-tab panel="a">Tab</ar-tab>');
+            expect(getPart(el, 'base--selected')).toBeNull();
+        });
+
+        it('émet part="base base--selected" quand active est true', async () => {
+            el = await fixture('<ar-tab panel="a">Tab</ar-tab>');
+            el.active = true;
+            await waitForUpdate(el);
+            expect(getPart(el, 'base--selected')).not.toBeNull();
         });
     });
 

--- a/packages/core/src/components/tab/tab.ts
+++ b/packages/core/src/components/tab/tab.ts
@@ -11,7 +11,8 @@ import styles from './tab.styles.js';
  *
  * @slot - Libellé de l'onglet.
  *
- * @csspart base - Wrapper du slot — padding, box-shadow actif. `base--selected` quand l'onglet est actif (propriété `active`, pilotée par ar-tab-group).
+ * @csspart base - Wrapper du slot — padding, box-shadow actif.
+ * @csspart base--selected - Wrapper du slot quand l'onglet est actif (variante d'état de `base`, propriété `active` pilotée par ar-tab-group).
  *
  * @cssprop --ar-tab-padding-x - Padding horizontal.
  * @cssprop --ar-tab-padding-y - Padding vertical.
@@ -19,7 +20,7 @@ import styles from './tab.styles.js';
  * @cssprop --ar-tab-focus-ring-offset - Décalage de la bague de focus. Valeur négative = inset (non coupée par le conteneur overflow du tab-group). Repli `-2px` si aucun thème n'est chargé — sans lui, l'anneau de focus peut être rogné par le conteneur `overflow-x: auto` du tab-group. Surcharge le token global --ar-focus-ring-offset pour ce composant.
  * @cssprop --ar-tab-focus-ring-color - Couleur de la bague de focus de l'onglet (cascade vers --ar-focus-ring-color). Repli `ButtonText` si aucun thème n'est chargé (WCAG 2.4.7).
  *
- * Note d'implémentation : la mise en page de [part='base'] compense la bordure de son parent
+ * Note d'implémentation : la mise en page de [part~='base'] compense la bordure de son parent
  * ar-tab-group via les tokens --ar-tab-group-border-top-width / --ar-tab-group-border-bottom-width
  * (déclarés et documentés sur ar-tab-group, cf. tab-group.ts) — pas des tokens propres à ar-tab.
  * Le fallback 0px est structurel (évite un décalage visuel si ar-tab est utilisé hors d'un

--- a/packages/core/src/components/tab/tab.ts
+++ b/packages/core/src/components/tab/tab.ts
@@ -36,7 +36,8 @@ export class ArTab extends LitElement {
 
     /**
      * Vrai quand l'onglet est actif (sélectionné).
-     * @readonly Piloté par ar-tab-group — ne pas modifier directement.
+     * Piloté par ar-tab-group — ne pas modifier directement.
+     * @ignore
      */
     @property({ reflect: true, type: Boolean }) active = false;
 

--- a/packages/core/src/components/tab/tab.ts
+++ b/packages/core/src/components/tab/tab.ts
@@ -16,7 +16,6 @@ import styles from './tab.styles.js';
  * @cssprop --ar-tab-padding-x - Padding horizontal.
  * @cssprop --ar-tab-padding-y - Padding vertical.
  * @cssprop --ar-tab-active-shadow - box-shadow complet sur part="base--selected" quand actif. Repli `inset 0 -2px 0 Highlight` si aucun thème n'est chargé — sans lui, l'onglet actif est visuellement indiscernable des autres.
- * @cssprop --ar-tab-disabled-opacity - Opacité de l'onglet désactivé.
  * @cssprop --ar-tab-focus-ring-offset - Décalage de la bague de focus. Valeur négative = inset (non coupée par le conteneur overflow du tab-group). Repli `-2px` si aucun thème n'est chargé — sans lui, l'anneau de focus peut être rogné par le conteneur `overflow-x: auto` du tab-group. Surcharge le token global --ar-focus-ring-offset pour ce composant.
  * @cssprop --ar-tab-focus-ring-color - Couleur de la bague de focus de l'onglet (cascade vers --ar-focus-ring-color). Repli `ButtonText` si aucun thème n'est chargé (WCAG 2.4.7).
  *

--- a/packages/core/src/components/tab/tab.ts
+++ b/packages/core/src/components/tab/tab.ts
@@ -11,23 +11,13 @@ import styles from './tab.styles.js';
  *
  * @slot - Libellé de l'onglet.
  *
- * @csspart base - Wrapper du slot — couleur, fond, padding, box-shadow actif.
+ * @csspart base - Wrapper du slot — padding, box-shadow actif. `base--selected` quand l'onglet est actif (propriété `active`, pilotée par ar-tab-group).
  *
- * @cssprop --ar-tab-color - Couleur du texte (état par défaut).
- * @cssprop --ar-tab-bg - Fond (état par défaut).
  * @cssprop --ar-tab-padding-x - Padding horizontal.
  * @cssprop --ar-tab-padding-y - Padding vertical.
- * @cssprop --ar-tab-border-radius - Rayon de bordure (utile pour le style pill).
- * @cssprop --ar-tab-font-weight - Graisse du texte.
- * @cssprop --ar-tab-hover-color - Couleur du texte au survol.
- * @cssprop --ar-tab-hover-bg - Fond au survol.
- * @cssprop --ar-tab-active-color - Couleur du texte quand l'onglet est actif.
- * @cssprop --ar-tab-active-bg - Fond quand l'onglet est actif.
- * @cssprop --ar-tab-active-shadow - box-shadow complet sur part="base" quand actif. Le thème par défaut le compose depuis --ar-tab-indicator-color et --ar-tab-indicator-width. Repli `inset 0 -2px 0 Highlight` si aucun thème n'est chargé — sans lui, l'onglet actif est visuellement indiscernable des autres.
- * @cssprop --ar-tab-indicator-color - Couleur de l'indicateur actif (utilisé par le thème pour composer --ar-tab-active-shadow).
- * @cssprop --ar-tab-indicator-width - Épaisseur de l'indicateur actif (utilisé par le thème pour composer --ar-tab-active-shadow).
+ * @cssprop --ar-tab-active-shadow - box-shadow complet sur part="base--selected" quand actif. Repli `inset 0 -2px 0 Highlight` si aucun thème n'est chargé — sans lui, l'onglet actif est visuellement indiscernable des autres.
  * @cssprop --ar-tab-disabled-opacity - Opacité de l'onglet désactivé.
- * @cssprop --ar-tab-focus-ring-offset - Décalage de la bague de focus. Valeur négative = inset (non coupée par le conteneur overflow du tab-group). Surcharge le token global --ar-focus-ring-offset pour ce composant.
+ * @cssprop --ar-tab-focus-ring-offset - Décalage de la bague de focus. Valeur négative = inset (non coupée par le conteneur overflow du tab-group). Repli `-2px` si aucun thème n'est chargé — sans lui, l'anneau de focus peut être rogné par le conteneur `overflow-x: auto` du tab-group. Surcharge le token global --ar-focus-ring-offset pour ce composant.
  * @cssprop --ar-tab-focus-ring-color - Couleur de la bague de focus de l'onglet (cascade vers --ar-focus-ring-color). Repli `ButtonText` si aucun thème n'est chargé (WCAG 2.4.7).
  *
  * Note d'implémentation : la mise en page de [part='base'] compense la bordure de son parent
@@ -44,6 +34,12 @@ export class ArTab extends LitElement {
 
     /** Désactive l'onglet — non sélectionnable, ignoré au clavier. */
     @property({ reflect: true, type: Boolean }) disabled = false;
+
+    /**
+     * Vrai quand l'onglet est actif (sélectionné).
+     * @readonly Piloté par ar-tab-group — ne pas modifier directement.
+     */
+    @property({ reflect: true, type: Boolean }) active = false;
 
     _registry?: TabGroupRegistry | undefined;
 
@@ -86,6 +82,6 @@ export class ArTab extends LitElement {
     };
 
     override render() {
-        return html`<div part="base"><slot></slot></div>`;
+        return html`<div part="base${this.active ? ' base--selected' : ''}"><slot></slot></div>`;
     }
 }

--- a/packages/core/src/components/tab/tab.ts
+++ b/packages/core/src/components/tab/tab.ts
@@ -36,8 +36,7 @@ export class ArTab extends LitElement {
 
     /**
      * Vrai quand l'onglet est actif (sélectionné).
-     * Piloté par ar-tab-group — ne pas modifier directement.
-     * @ignore
+     * @readonly Piloté par ar-tab-group — ne pas modifier directement.
      */
     @property({ reflect: true, type: Boolean }) active = false;
 

--- a/packages/core/src/components/table-sort/table-sort.a11y.test.ts
+++ b/packages/core/src/components/table-sort/table-sort.a11y.test.ts
@@ -102,7 +102,7 @@ describe('ar-table-sort — accessibilité', () => {
             el.shadowRoot!.querySelector<HTMLElement>('[part="button"]')!.click();
             await el.updateComplete;
             expect(
-                el.shadowRoot!.querySelector('[part="button"]')!.getAttribute('aria-disabled'),
+                el.shadowRoot!.querySelector('[part~="button"]')!.getAttribute('aria-disabled'),
             ).to.equal('true');
         });
     });

--- a/packages/core/src/components/table-sort/table-sort.browser.test.ts
+++ b/packages/core/src/components/table-sort/table-sort.browser.test.ts
@@ -4,7 +4,7 @@ import type { ArTableSort } from './table-sort.js';
 import './index.js';
 
 function btn(el: ArTableSort): HTMLButtonElement {
-    const b = el.shadowRoot?.querySelector<HTMLButtonElement>('[part="button"]');
+    const b = el.shadowRoot?.querySelector<HTMLButtonElement>('[part~="button"]');
     if (!b) throw new Error('part="button" introuvable');
     return b;
 }

--- a/packages/core/src/components/table-sort/table-sort.styles.ts
+++ b/packages/core/src/components/table-sort/table-sort.styles.ts
@@ -9,7 +9,6 @@ export default css`
     [part='button'] {
         display: inline-flex;
         align-items: center;
-        gap: var(--ar-table-sort-gap);
         background: none;
         border: none;
         padding: 0;
@@ -25,17 +24,12 @@ export default css`
         border-radius: 2px;
     }
 
-    [part='button'][aria-disabled='true'] {
-        cursor: wait;
-    }
-
     /* ── Indicateur ↑↓ ──────────────────────────────────────────── */
 
     [part='indicator'] {
         display: inline-flex;
         flex-direction: column;
         align-items: center;
-        gap: var(--ar-table-sort-indicator-gap);
         width: var(--ar-table-sort-indicator-size);
         flex-shrink: 0;
     }

--- a/packages/core/src/components/table-sort/table-sort.styles.ts
+++ b/packages/core/src/components/table-sort/table-sort.styles.ts
@@ -6,7 +6,7 @@ export default css`
         align-items: center;
     }
 
-    [part='button'] {
+    [part~='button'] {
         display: inline-flex;
         align-items: center;
         background: none;
@@ -18,7 +18,7 @@ export default css`
         text-align: inherit;
     }
 
-    [part='button']:focus-visible {
+    [part~='button']:focus-visible {
         outline: 2px solid currentColor;
         outline-offset: 2px;
         border-radius: 2px;

--- a/packages/core/src/components/table-sort/table-sort.test.ts
+++ b/packages/core/src/components/table-sort/table-sort.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { ArTableSort } from './table-sort.js';
-import { fixture, waitForUpdate } from '../../test-utils.js';
+import { fixture, getPart, requirePart, waitForUpdate } from '../../test-utils.js';
 import './index.js';
 
 describe('ArTableSort', () => {
@@ -44,7 +44,7 @@ describe('ArTableSort', () => {
         });
 
         it('contient part="button"', () => {
-            expect(el.shadowRoot!.querySelector('[part="button"]')).not.toBeNull();
+            expect(getPart(el, 'button')).not.toBeNull();
         });
 
         it('contient part="indicator"', () => {
@@ -115,7 +115,7 @@ describe('ArTableSort', () => {
     describe('label pendant pending', () => {
         it('tooltip = "Tri en cours…" pendant pending', async () => {
             el = await fixture('<ar-table-sort></ar-table-sort>');
-            el.shadowRoot!.querySelector<HTMLElement>('[part="button"]')!.click();
+            (requirePart(el, 'button') as HTMLElement).click();
             await waitForUpdate(el);
             expect(tooltipLabel(el)).toBe('Tri en cours…');
         });
@@ -129,7 +129,7 @@ describe('ArTableSort', () => {
             const events: CustomEvent[] = [];
             el.addEventListener('ar-table-sort-change', (e) => events.push(e as CustomEvent));
 
-            el.shadowRoot!.querySelector<HTMLElement>('[part="button"]')!.click();
+            (requirePart(el, 'button') as HTMLElement).click();
             await waitForUpdate(el);
 
             expect(el.pending).toBe(true);
@@ -145,7 +145,7 @@ describe('ArTableSort', () => {
             const events: CustomEvent[] = [];
             el.addEventListener('ar-table-sort-change', (e) => events.push(e as CustomEvent));
 
-            el.shadowRoot!.querySelector<HTMLElement>('[part="button"]')!.click();
+            (requirePart(el, 'button') as HTMLElement).click();
             await waitForUpdate(el);
 
             expect(events[0].detail.columnLabel).toBe('Prix');
@@ -156,7 +156,7 @@ describe('ArTableSort', () => {
             const events: CustomEvent[] = [];
             el.addEventListener('ar-table-sort-change', (e) => events.push(e as CustomEvent));
 
-            el.shadowRoot!.querySelector<HTMLElement>('[part="button"]')!.click();
+            (requirePart(el, 'button') as HTMLElement).click();
             await waitForUpdate(el);
             expect(events[0].detail.requestedOrder).toBe('desc');
         });
@@ -166,7 +166,7 @@ describe('ArTableSort', () => {
             const events: CustomEvent[] = [];
             el.addEventListener('ar-table-sort-change', (e) => events.push(e as CustomEvent));
 
-            el.shadowRoot!.querySelector<HTMLElement>('[part="button"]')!.click();
+            (requirePart(el, 'button') as HTMLElement).click();
             await waitForUpdate(el);
             expect(events[0].detail.requestedOrder).toBe('none');
         });
@@ -176,7 +176,7 @@ describe('ArTableSort', () => {
             const events: CustomEvent[] = [];
             el.addEventListener('ar-table-sort-change', (e) => events.push(e as CustomEvent));
 
-            const btn = el.shadowRoot!.querySelector<HTMLElement>('[part="button"]')!;
+            const btn = requirePart(el, 'button') as HTMLElement;
             btn.click();
             await waitForUpdate(el);
             btn.click();
@@ -187,11 +187,21 @@ describe('ArTableSort', () => {
 
         it('aria-disabled="true" sur le bouton pendant pending', async () => {
             el = await fixture('<ar-table-sort></ar-table-sort>');
-            el.shadowRoot!.querySelector<HTMLElement>('[part="button"]')!.click();
+            (requirePart(el, 'button') as HTMLElement).click();
             await waitForUpdate(el);
-            expect(
-                el.shadowRoot!.querySelector('[part~="button"]')!.getAttribute('aria-disabled'),
-            ).toBe('true');
+            expect(requirePart(el, 'button').getAttribute('aria-disabled')).toBe('true');
+        });
+
+        it('émet part="button button--pending" pendant pending', async () => {
+            el = await fixture('<ar-table-sort></ar-table-sort>');
+            (requirePart(el, 'button') as HTMLElement).click();
+            await waitForUpdate(el);
+            expect(requirePart(el, 'button--pending')).not.toBeNull();
+        });
+
+        it("n'émet pas button--pending avant le clic", async () => {
+            el = await fixture('<ar-table-sort></ar-table-sort>');
+            expect(getPart(el, 'button--pending')).toBeNull();
         });
     });
 
@@ -200,7 +210,7 @@ describe('ArTableSort', () => {
     describe('confirm()', () => {
         it('avance order et efface pending', async () => {
             el = await fixture('<ar-table-sort></ar-table-sort>');
-            el.shadowRoot!.querySelector<HTMLElement>('[part="button"]')!.click();
+            (requirePart(el, 'button') as HTMLElement).click();
             await waitForUpdate(el);
 
             el.confirm();
@@ -221,7 +231,7 @@ describe('ArTableSort', () => {
 
         it('second confirm() consécutif sans effet', async () => {
             el = await fixture('<ar-table-sort></ar-table-sort>');
-            el.shadowRoot!.querySelector<HTMLElement>('[part="button"]')!.click();
+            (requirePart(el, 'button') as HTMLElement).click();
             await waitForUpdate(el);
             el.confirm();
             await waitForUpdate(el);
@@ -236,7 +246,7 @@ describe('ArTableSort', () => {
     describe('reject()', () => {
         it('efface pending sans changer order', async () => {
             el = await fixture('<ar-table-sort></ar-table-sort>');
-            el.shadowRoot!.querySelector<HTMLElement>('[part="button"]')!.click();
+            (requirePart(el, 'button') as HTMLElement).click();
             await waitForUpdate(el);
 
             el.reject();
@@ -303,7 +313,7 @@ describe('ArTableSort', () => {
 
         it('met à jour aria-sort après confirm()', async () => {
             const { th, el } = await inTh();
-            el.shadowRoot!.querySelector<HTMLElement>('[part="button"]')!.click();
+            (requirePart(el, 'button') as HTMLElement).click();
             await waitForUpdate(el);
             el.confirm();
             await waitForUpdate(el);

--- a/packages/core/src/components/table-sort/table-sort.test.ts
+++ b/packages/core/src/components/table-sort/table-sort.test.ts
@@ -190,7 +190,7 @@ describe('ArTableSort', () => {
             el.shadowRoot!.querySelector<HTMLElement>('[part="button"]')!.click();
             await waitForUpdate(el);
             expect(
-                el.shadowRoot!.querySelector('[part="button"]')!.getAttribute('aria-disabled'),
+                el.shadowRoot!.querySelector('[part~="button"]')!.getAttribute('aria-disabled'),
             ).toBe('true');
         });
     });

--- a/packages/core/src/components/table-sort/table-sort.ts
+++ b/packages/core/src/components/table-sort/table-sort.ts
@@ -51,16 +51,13 @@ function getActionLabel(type: TableSortType, order: TableSortOrder, pending: boo
  * @display demo
  *
  * Placer à l'intérieur d'un `<th>`. Le composant met à jour `aria-sort` et `scope="col"` sur
- * le `<th>` ancêtre. Le consommateur appelle `confirm()` après un tri réussi ou `reject()` en
- * cas d'échec.
+ * le `<th>` ancêtre. Appeler `confirm()` après un tri réussi, ou `reject()` en cas d'échec.
  *
  * @slot - Libellé de la colonne.
  *
- * @csspart button    - Le bouton déclencheur.
+ * @csspart button    - Le bouton déclencheur. `button--pending` pendant l'attente de confirmation.
  * @csspart indicator - L'icône de direction de tri.
  *
- * @cssprop --ar-table-sort-gap - Espacement label / indicateur.
- * @cssprop --ar-table-sort-indicator-gap - Espacement entre les icônes indicateurs asc / desc.
  * @cssprop --ar-table-sort-indicator-size - Taille de l'icône indicateur asc / desc.
  * @cssprop --ar-table-sort-indicator-color - Couleur état neutre.
  * @cssprop --ar-table-sort-indicator-active-color - Couleur état actif (asc/desc).
@@ -175,7 +172,7 @@ export class ArTableSort extends LitElement {
         const label = getActionLabel(this.type, this.order, this.pending);
         return html`
             <button
-                part="button"
+                part="button${this.pending ? ' button--pending' : ''}"
                 type="button"
                 aria-disabled=${this.pending ? 'true' : nothing}
                 @click=${this._handleClick}

--- a/packages/core/src/components/table-sort/table-sort.ts
+++ b/packages/core/src/components/table-sort/table-sort.ts
@@ -1,7 +1,6 @@
 import { LitElement, html, nothing } from 'lit';
 import { property } from 'lit/decorators.js';
 import styles from './table-sort.styles.js';
-import utilitiesStyles from '../../styles/utilities.styles.js';
 import { announceA11y } from '../../a11y/announce-a11y.js';
 import { warn } from '../../utils/warn.js';
 import '../tooltip/index.js';
@@ -66,7 +65,7 @@ function getActionLabel(type: TableSortType, order: TableSortOrder, pending: boo
  * @event {CustomEvent<{ type: TableSortType; currentOrder: TableSortOrder; requestedOrder: TableSortOrder; columnLabel: string }>} ar-table-sort-change - Émis au clic quand pending est false.
  */
 export class ArTableSort extends LitElement {
-    static override styles = [utilitiesStyles, styles];
+    static override styles = [styles];
 
     /** Type de tri — influe sur les labels accessibles. */
     @property({ reflect: true }) type: TableSortType = 'alpha';

--- a/packages/core/src/components/table-sort/table-sort.ts
+++ b/packages/core/src/components/table-sort/table-sort.ts
@@ -54,7 +54,8 @@ function getActionLabel(type: TableSortType, order: TableSortOrder, pending: boo
  *
  * @slot - Libellé de la colonne.
  *
- * @csspart button    - Le bouton déclencheur. `button--pending` pendant l'attente de confirmation.
+ * @csspart button    - Le bouton déclencheur.
+ * @csspart button--pending - Le bouton pendant l'attente de confirmation (variante d'état de `button`).
  * @csspart indicator - L'icône de direction de tri.
  *
  * @cssprop --ar-table-sort-indicator-size - Taille de l'icône indicateur asc / desc.

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -469,7 +469,6 @@
 
         --ar-tab-active-shadow: inset 0 -2px 0 var(--ar-color-interactive);
 
-        --ar-tab-disabled-opacity: 0.5;
         --ar-tab-focus-ring-offset: -2px;
         --ar-tab-focus-ring-color: var(--ar-focus-ring-color);
 
@@ -1232,6 +1231,6 @@
     }
 
     ar-tab[disabled] {
-        opacity: var(--ar-tab-disabled-opacity);
+        opacity: 0.5;
     }
 }

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -450,11 +450,7 @@
         /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
          * Charcounter
          * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
-        --ar-charcounter-color: var(--ar-color-text-muted);
-        --ar-charcounter-font-size: 0.875rem;
-        --ar-charcounter-warning-color: var(--ar-color-warning-text);
         --ar-charcounter-warning-weight: 600;
-        --ar-charcounter-error-color: var(--ar-color-danger-text);
         --ar-charcounter-error-weight: 700;
 
         /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -1185,6 +1181,21 @@
 
         &::part(indicator) {
             gap: 3px;
+        }
+    }
+
+    ar-charcounter {
+        &::part(count) {
+            color: var(--ar-color-text-muted);
+            font-size: 0.875rem;
+        }
+
+        &::part(count--warning) {
+            color: var(--ar-color-warning-text);
+        }
+
+        &::part(count--error) {
+            color: var(--ar-color-danger-text);
         }
     }
 }

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -485,7 +485,6 @@
         --ar-tab-focus-ring-offset: -2px;
         --ar-tab-focus-ring-color: var(--ar-focus-ring-color);
 
-        --ar-tab-group-gap: 0;
         --ar-tab-group-border-color: var(--ar-color-border);
         --ar-tab-group-border-top-width: 0;
         --ar-tab-group-border-bottom-width: 1px;
@@ -1215,6 +1214,12 @@
         &::part(track),
         &::part(bar) {
             border-radius: 50rem;
+        }
+    }
+
+    ar-tab-group {
+        &::part(base) {
+            gap: 0;
         }
     }
 }

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -396,7 +396,7 @@
          * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
         --ar-progressbar-track-color: var(--ar-color-bg-subtle);
         --ar-progressbar-fill-color: var(--ar-color-interactive);
-        --ar-progressbar-percent-color: var(--ar-color-text-muted);
+        --ar-progressbar-max-width: 500px;
 
         /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
          * Pagination
@@ -1196,6 +1196,25 @@
 
         &::part(count--error) {
             color: var(--ar-color-danger-text);
+        }
+    }
+
+    ar-progressbar {
+        &::part(container) {
+            row-gap: 0.75rem;
+        }
+
+        &::part(label) {
+            column-gap: 2rem;
+        }
+
+        &::part(percent) {
+            color: var(--ar-color-text-muted);
+        }
+
+        &::part(track),
+        &::part(bar) {
+            border-radius: 50rem;
         }
     }
 }

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -460,8 +460,6 @@
         /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
          * Tablesort
          * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
-        --ar-table-sort-gap: 0.375rem;
-        --ar-table-sort-indicator-gap: 3px;
         --ar-table-sort-indicator-size: 0.65rem;
         --ar-table-sort-indicator-color: var(--ar-color-text-muted, #9ca3af);
         --ar-table-sort-indicator-active-color: var(--ar-color-interactive, #2563eb);
@@ -1173,6 +1171,20 @@
             padding: 0.375rem 0.625rem;
             max-width: 18rem;
             line-height: 1.4;
+        }
+    }
+
+    ar-table-sort {
+        &::part(button) {
+            gap: 0.375rem;
+        }
+
+        &::part(button--pending) {
+            cursor: wait;
+        }
+
+        &::part(indicator) {
+            gap: 3px;
         }
     }
 }

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -464,22 +464,10 @@
         /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
          * Tab
          * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
-        --ar-tab-color: var(--ar-color-text-muted);
-        --ar-tab-bg: transparent;
         --ar-tab-padding-x: 1.5rem;
         --ar-tab-padding-y: 1rem;
-        --ar-tab-border-radius: 0;
-        --ar-tab-font-weight: var(--ar-font-weight-normal);
 
-        --ar-tab-hover-color: var(--ar-color-text);
-        --ar-tab-hover-bg: var(--ar-color-bg-subtle);
-
-        --ar-tab-active-color: var(--ar-color-interactive);
-        --ar-tab-active-bg: transparent;
-        --ar-tab-indicator-color: var(--ar-color-interactive);
-        --ar-tab-indicator-width: 2px;
-        --ar-tab-active-shadow: inset 0 calc(-1 * var(--ar-tab-indicator-width)) 0
-            var(--ar-tab-indicator-color);
+        --ar-tab-active-shadow: inset 0 -2px 0 var(--ar-color-interactive);
 
         --ar-tab-disabled-opacity: 0.5;
         --ar-tab-focus-ring-offset: -2px;
@@ -1221,5 +1209,29 @@
         &::part(base) {
             gap: 0;
         }
+    }
+
+    ar-tab {
+        border-radius: 0;
+        font-weight: var(--ar-font-weight-normal);
+
+        &::part(base) {
+            color: var(--ar-color-text-muted);
+            background: transparent;
+        }
+
+        &::part(base--selected) {
+            color: var(--ar-color-interactive);
+            background: transparent;
+        }
+
+        &:hover:not([disabled]):not([active])::part(base) {
+            color: var(--ar-color-text);
+            background: var(--ar-color-bg-subtle);
+        }
+    }
+
+    ar-tab[disabled] {
+        opacity: var(--ar-tab-disabled-opacity);
     }
 }


### PR DESCRIPTION
## Summary
- `ar-table-sort` : migre gap/indicator-gap, ajoute le part d'état `button--pending`.
- `ar-charcounter` : migre color/font-size, ajoute les parts d'état `count--warning`/`count--error`, reconditionne le repli a11y de graisse directement sur le part d'état.
- `ar-progressbar` : nettoie la nomenclature classes/part héritée, migre percent-color/row-gap/column-gap/border-radius, ajoute un repli a11y sur `max-width` (min-width retiré, mobile-first).
- `ar-tab-group` : migre gap.
- `ar-tab` : migration complète — nouvelle propriété Lit `active` (pilotée par `ar-tab-group`, aux côtés d'`aria-selected` inchangé) plutôt qu'une observation d'attribut, migration vers `::part(base)`/`::part(base--selected)`, nettoyage de 2 tokens de composition jamais consommés par le composant, correction d'un repli a11y manquant sur `focus-ring-offset` (WCAG 2.4.7).
- `ar-collapse` : audité, 0 migration possible (duration lu en JS, easing indivisible du même shorthand `transition`) — documenté dans ADR-005 pour clore le composant.

## Corrigé en cours de route (revues par tâche + revue finale de branche)
- Bug `[part=]` en correspondance exacte cassant l'état actif/pending une fois le `part` devenu multi-jetons — trouvé et corrigé indépendamment sur `ar-tab` (revue de tâche) et `ar-table-sort` (revue finale).
- Repli a11y de `--ar-tab-focus-ring-offset` supprimé par erreur en corrigeant un garde-fou CI, puis restauré avec son commentaire requis.
- 5 références à des tokens supprimés dans `apps/docs/.../ar-tab-group.mdx` mises à jour.
- Couverture de tests ajoutée pour `active`, `button--pending`, `count--warning`/`count--error`.

Spec : `docs/superpowers/specs/2026-08-05-lot8-token-vs-part-129-design.md`
Plan : `docs/superpowers/plans/2026-08-06-lot8-token-vs-part-129.md`

## Test plan
- [x] `npm run test --workspace=packages/core` (215/215)
- [x] `npm run build:manifest --workspace=packages/core` (garde-fous CI verts)
- [x] Suite browser (WTR)
- [x] Vérification visuelle Playwright (avec et sans thème) + diff `getComputedStyle` vs baseline pré-lot 8
- [x] Revue finale de branche (subagent-driven-development : revue par tâche + revue finale + 1 vague de correctifs + re-revue scopée)

🤖 Generated with [Claude Code](https://claude.com/claude-code)