### PR TITLE
fix(tooltip): tokens pour la bulle + renvoi doc pour les composants imbriqués

### DIFF
--- a/apps/docs/src/components/ComponentApi.astro
+++ b/apps/docs/src/components/ComponentApi.astro
@@ -8,12 +8,19 @@
  */
 import { type CemDeclaration, getPublicMethods } from '../utils/cem-types.ts';
 import { isCancelableEvent, stripCancelableMarker } from '../utils/events.ts';
+import { getSlug } from '../utils/tag-name.ts';
 
-interface Props {
-    component: CemDeclaration;
+interface RelatedTokens {
+    component:   string;
+    description: string;
 }
 
-const { component } = Astro.props;
+interface Props {
+    component:      CemDeclaration;
+    relatedTokens?: RelatedTokens[];
+}
+
+const { component, relatedTokens = [] } = Astro.props;
 
 const publicMethods = getPublicMethods(component);
 
@@ -149,7 +156,7 @@ const ownProps = (component.cssProperties ?? []).filter((p) => !p.name.startsWit
     )}
 
     {/* ── CSS Custom Properties propres au composant ── */}
-    {(ownProps.length > 0 || panelProps.length > 0) && (
+    {(ownProps.length > 0 || panelProps.length > 0 || relatedTokens.length > 0) && (
         <section>
             <h4 id="api-css-props" class="subsection-title">CSS Custom Properties</h4>
             {/* ── Tokens du panel partagé (affiché en premier si présent) ── */}
@@ -201,6 +208,20 @@ const ownProps = (component.cssProperties ?? []).filter((p) => !p.name.startsWit
                             ))}
                         </tbody>
                     </table>
+                </div>
+            )}
+            {/* ── Tokens d'un composant imbriqué en interne (ex. tooltip dans table-sort) ── */}
+            {relatedTokens.length > 0 && (
+                <div class="related-tokens">
+                    {relatedTokens.map((rt) => (
+                        <p class="related-tokens-note">
+                            {rt.description}{' '}
+                            <a href={`/components/${getSlug(rt.component)}`}>
+                                Voir les tokens de <code>{rt.component}</code>
+                            </a>
+                            .
+                        </p>
+                    ))}
                 </div>
             )}
         </section>
@@ -259,6 +280,19 @@ const ownProps = (component.cssProperties ?? []).filter((p) => !p.name.startsWit
 
     .own-props-intro {
         margin-top: 1.875rem;
+    }
+
+    .related-tokens {
+        margin-top: 1.875rem;
+    }
+
+    .related-tokens-note {
+        font-size: 0.875rem;
+        color: var(--doc-text-muted);
+    }
+
+    .related-tokens-note a {
+        color: var(--doc-accent);
     }
 
     .token-example pre {

--- a/apps/docs/src/components/ComponentApi.astro
+++ b/apps/docs/src/components/ComponentApi.astro
@@ -212,17 +212,14 @@ const ownProps = (component.cssProperties ?? []).filter((p) => !p.name.startsWit
             )}
             {/* ── Tokens d'un composant imbriqué en interne (ex. tooltip dans table-sort) ── */}
             {relatedTokens.length > 0 && (
-                <div class="related-tokens">
+                <ar-alert class="related-tokens" variant="info" without-notification>
                     {relatedTokens.map((rt) => (
                         <p class="related-tokens-note">
-                            {rt.description}{' '}
-                            <a href={`/components/${getSlug(rt.component)}`}>
-                                Voir les tokens de <code>{rt.component}</code>
-                            </a>
-                            .
+                            {rt.description}{' '}<br>
+                            <a href={`/components/${getSlug(rt.component)}#api-css-props`}>Voir les tokens de <code>{rt.component}</code></a>.
                         </p>
                     ))}
-                </div>
+                </ar-alert>
             )}
         </section>
     )}
@@ -282,11 +279,18 @@ const ownProps = (component.cssProperties ?? []).filter((p) => !p.name.startsWit
         margin-top: 1.875rem;
     }
 
-    .related-tokens {
+    ar-alert.related-tokens {
         margin-top: 1.875rem;
+
+        &::part(body) {
+            display: flex;
+            flex-direction: column;
+            row-gap: 0.5rem;
+        }
     }
 
     .related-tokens-note {
+        margin: 0;
         font-size: 0.875rem;
         color: var(--doc-text-muted);
     }

--- a/apps/docs/src/components/ComponentApi.astro
+++ b/apps/docs/src/components/ComponentApi.astro
@@ -292,11 +292,15 @@ const ownProps = (component.cssProperties ?? []).filter((p) => !p.name.startsWit
     .related-tokens-note {
         margin: 0;
         font-size: 0.875rem;
-        color: var(--doc-text-muted);
+        /* Pas de couleur explicite : hérite de --ar-alert-color posé par ar-alert sur
+           :host — ar-alert calcule déjà un contraste correct contre son propre fond de
+           variante (info/warning/...), un remplacement fixe ici casserait ce contrat
+           pour tout variant dont le fond diffère de la couleur muette de la doc. */
     }
 
     .related-tokens-note a {
-        color: var(--doc-accent);
+        color: inherit;
+        text-decoration: underline;
     }
 
     .token-example pre {

--- a/apps/docs/src/components/Playground.astro
+++ b/apps/docs/src/components/Playground.astro
@@ -21,6 +21,11 @@ interface Variant {
     html:         string;
 }
 
+interface RelatedTokens {
+    component:   string;
+    description: string;
+}
+
 interface Props {
     variants:       Variant[];
     tagName:        string;
@@ -29,6 +34,7 @@ interface Props {
     playgroundHtml: string;
     controls:       CemControl[];
     component:      CemDeclaration;
+    relatedTokens?: RelatedTokens[];
 }
 
 const {
@@ -39,6 +45,7 @@ const {
     playgroundHtml,
     controls,
     component,
+    relatedTokens = [],
 } = Astro.props;
 
 const showPlayground = displayMode === 'demo';
@@ -164,7 +171,7 @@ const showPlayground = displayMode === 'demo';
 {/* ── Référence API ── */}
 <section id="reference-api">
     <h3 class="section-title">Référence API</h3>
-    <ComponentApi component={component} />
+    <ComponentApi component={component} relatedTokens={relatedTokens} />
 </section>
 
 <style>

--- a/apps/docs/src/content.config.ts
+++ b/apps/docs/src/content.config.ts
@@ -18,6 +18,19 @@ const variantSchema = z.object({
 });
 
 /**
+ * Note pointant vers les CSS Custom Properties d'un autre composant, applicables à
+ * celui-ci — cas d'un composant qui en imbrique un autre themable dans son propre
+ * shadow root (ex. ar-table-sort → ar-tooltip). Affichée dans la section CSS Custom
+ * Properties de la page, sous la table des tokens propres au composant.
+ */
+const relatedTokensSchema = z.object({
+    /** Tag du composant dont les tokens s'appliquent (ex: ar-tooltip) */
+    component: z.string(),
+    /** Explique pourquoi/comment ces tokens s'appliquent ici. Le lien vers la doc du composant est ajouté automatiquement. */
+    description: z.string(),
+});
+
+/**
  * Collection "components" — un fichier MDX par composant.
  * Le frontmatter définit les métadonnées et les variantes pré-configurées.
  */
@@ -36,6 +49,8 @@ const components = defineCollection({
         // variants: z.array(variantSchema).default([]),
         // coerce : si le champ est absent ou null dans le MDX, on force un array vide
         variants: z.preprocess((val) => (Array.isArray(val) ? val : []), z.array(variantSchema)),
+        /** Tokens d'autres composants applicables ici (composant imbriqué en interne) */
+        relatedTokens: z.array(relatedTokensSchema).optional(),
     }),
 });
 

--- a/apps/docs/src/content/components/ar-table-sort.mdx
+++ b/apps/docs/src/content/components/ar-table-sort.mdx
@@ -3,6 +3,11 @@ tagName: ar-table-sort
 title: Table Sort
 description: Entête de colonne triable accessible — indicateur visuel ↑↓, aria-sort automatique et annonce aria-live contextualisée.
 playgroundTemplate: alpha
+relatedTokens:
+    - component: ar-tooltip
+      description: >-
+          Le libellé d'action affiché au survol/focus du bouton de tri utilise en
+          interne ar-tooltip, personnalisable via ses tokens --ar-tooltip-*.
 variants:
     - name: alpha
       label: Alphabétique

--- a/apps/docs/src/pages/components/[slug].astro
+++ b/apps/docs/src/pages/components/[slug].astro
@@ -40,11 +40,12 @@ const { component, mdx } = Astro.props as {
 
 const { Content, headings } = mdx ? await render(mdx) : { Content: null, headings: [] };
 
-const variants    = mdx?.data.variants ?? [];
-const pageTitle   = mdx?.data.title ?? component.name;
-const pageDesc    = mdx?.data.description ?? component.summary;
-const displayMode = component['x-display'] ?? 'demo';
-const parentTag   = component['x-parent'];
+const variants      = mdx?.data.variants ?? [];
+const pageTitle     = mdx?.data.title ?? component.name;
+const pageDesc      = mdx?.data.description ?? component.summary;
+const displayMode   = component['x-display'] ?? 'demo';
+const parentTag     = component['x-parent'];
+const relatedTokens = mdx?.data.relatedTokens ?? [];
 
 // ─── HTML initial du playground ───────────────────────────────────────────────
 
@@ -179,6 +180,7 @@ const tocEntries = [
             playgroundHtml={playgroundHtml}
             controls={controls}
             component={component}
+            relatedTokens={relatedTokens}
         />
     </div>
 

--- a/packages/core/src/components/table-sort/table-sort.browser.test.ts
+++ b/packages/core/src/components/table-sort/table-sort.browser.test.ts
@@ -124,4 +124,25 @@ describe('ar-table-sort — browser', () => {
             expect(th.getAttribute('aria-sort')).to.equal('none');
         });
     });
+
+    // ── font-weight du tooltip interne (régression #168) ────────────────────
+
+    describe('font-weight du tooltip interne', () => {
+        it("le tooltip n'hérite pas du bold par défaut d'un <th>, le libellé de colonne si", async () => {
+            const th = await fixture<HTMLTableCellElement>(
+                html`<th>
+                    <ar-table-sort><span id="label">Nom</span></ar-table-sort>
+                </th>`,
+            );
+            const el = th.querySelector<ArTableSort>('ar-table-sort')!;
+            await el.updateComplete;
+
+            const label = th.querySelector<HTMLElement>('#label')!;
+            expect(getComputedStyle(label).fontWeight).to.equal('700');
+
+            const tooltip = el.shadowRoot?.querySelector('ar-tooltip');
+            if (!tooltip) throw new Error('ar-tooltip introuvable');
+            expect(getComputedStyle(tooltip).fontWeight).to.equal('400');
+        });
+    });
 });

--- a/packages/core/src/components/table-sort/table-sort.styles.ts
+++ b/packages/core/src/components/table-sort/table-sort.styles.ts
@@ -6,6 +6,13 @@ export default css`
         align-items: center;
     }
 
+    /* Réinitialise le poids hérité du <th> (bold par défaut UA) pour le tooltip interne
+       uniquement — un reset sur :host affecterait aussi le libellé de colonne slotté
+       (même parent DOM réel que le tooltip pour l'héritage CSS, cf. #168). */
+    ar-tooltip {
+        font-weight: normal;
+    }
+
     [part~='button'] {
         display: inline-flex;
         align-items: center;

--- a/packages/core/src/components/tooltip/tooltip.styles.ts
+++ b/packages/core/src/components/tooltip/tooltip.styles.ts
@@ -14,11 +14,12 @@ const tooltipStyles = css`
 
         /* Box model */
         box-sizing: border-box;
+        padding: var(--ar-tooltip-padding);
+        border-radius: var(--ar-tooltip-radius);
 
         /* a11y-fallback: évite un débordement horizontal (WCAG 1.4.10 Reflow) sur un viewport
-           étroit si aucun thème n'est chargé — 18rem correspond à la valeur par défaut du
-           thème (max-width externe via ::part() prend le dessus une fois chargé),
-           calc(100vw - 2rem) borne la largeur sur mobile */
+           étroit, avec ou sans thème chargé — calc(100vw - 2rem) borne la largeur sur mobile.
+           Personnalisable via ::part(bubble) { max-width: ... } si besoin. */
         max-width: min(18rem, calc(100vw - 2rem));
 
         /* overflow: visible requis pour que le caret (position: absolute) dépasse de la bulle */
@@ -29,6 +30,10 @@ const tooltipStyles = css`
         color: var(--ar-tooltip-color, CanvasText);
         border: none;
         word-break: break-word;
+
+        /* Typography */
+        font-size: var(--ar-tooltip-font-size);
+        line-height: var(--ar-tooltip-line-height);
     }
 
     [part='bubble']:not(:popover-open) {

--- a/packages/core/src/components/tooltip/tooltip.ts
+++ b/packages/core/src/components/tooltip/tooltip.ts
@@ -29,11 +29,15 @@ export type ArTooltipPlacement =
  *
  * @slot - Texte du tooltip.
  *
- * @csspart bubble - Le panel flottant (radius, padding, taille de police, largeur maximale et interligne pilotables via `::part(bubble)`).
+ * @csspart bubble - Le panel flottant (largeur maximale pilotable via `::part(bubble)`).
  * @csspart arrow  - Le caret directionnel.
  *
  * @cssprop --ar-tooltip-bg - Fond de la bulle (repli système `Canvas` si aucun thème n'est chargé).
  * @cssprop --ar-tooltip-color - Couleur du texte (repli système `CanvasText` si aucun thème n'est chargé).
+ * @cssprop --ar-tooltip-radius - Rayon de bordure de la bulle.
+ * @cssprop --ar-tooltip-padding - Espacement interne de la bulle.
+ * @cssprop --ar-tooltip-font-size - Taille de police du texte de la bulle.
+ * @cssprop --ar-tooltip-line-height - Interligne du texte de la bulle.
  * @cssprop --ar-tooltip-arrow-size - Taille du caret.
  * @cssprop --ar-tooltip-show-duration - Durée de l'animation d'apparition de la bulle (cascade vers --ar-panel-show-duration).
  * @cssprop --ar-tooltip-distance - Espacement entre le trigger et la bulle.

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -418,6 +418,10 @@
         --ar-tooltip-color: var(--ar-color-white);
         --ar-tooltip-arrow-size: 6px;
         --ar-tooltip-show-duration: var(--ar-panel-show-duration);
+        --ar-tooltip-radius: var(--ar-border-radius-sm);
+        --ar-tooltip-padding: 0.375rem 0.625rem;
+        --ar-tooltip-font-size: 0.8125rem;
+        --ar-tooltip-line-height: 1.4;
 
         /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
          * Dropdown
@@ -1145,16 +1149,6 @@
         &::part(current),
         &::part(ellipsis) {
             padding: 0 0.75rem;
-        }
-    }
-
-    ar-tooltip {
-        &::part(bubble) {
-            border-radius: var(--ar-border-radius-sm);
-            font-size: 0.8125rem;
-            padding: 0.375rem 0.625rem;
-            max-width: 18rem;
-            line-height: 1.4;
         }
     }
 


### PR DESCRIPTION
Closes #168

## Résumé

`ar-tooltip` imbriqué dans le shadow root d'un autre composant (`ar-table-sort`, seul cas actuel) n'héritait ni du `border-radius`, ni du `padding`, ni du `font-size`, ni du `line-height` de sa bulle : ces propriétés n'étaient pilotées que via `::part(bubble)` dans `default.css`, un mécanisme qui ne franchit qu'une seule frontière shadow — il ne peut pas atteindre le tooltip interne de table-sort, qui en vit derrière deux.

## Correctif

- Ajout de 4 tokens consommés en interne dans `tooltip.styles.ts` : `--ar-tooltip-radius`, `--ar-tooltip-padding`, `--ar-tooltip-font-size`, `--ar-tooltip-line-height` (héritent par cascade CSS, traversent n'importe quelle profondeur de shadow root).
- `default.css` : valorise ces tokens à `:root` avec les valeurs déjà en place auparavant (aucun changement visuel pour l'usage direct non-imbriqué).
- Le `::part(bubble) { max-width: 18rem }` résiduel de `default.css` est retiré : il écrasait le clamp responsive interne (`min(18rem, calc(100vw - 2rem))`) par une valeur fixe — régression involontaire sur mobile, corrigée au passage. Le fallback interne suffit et reste personnalisable via `::part(bubble)` si besoin.
- `::part(bubble)` reste disponible comme échappatoire de personnalisation fine pour l'usage direct (non-imbriqué) — coexiste avec les tokens, ne les duplique plus.

## Doc — renvoi vers les tokens d'un composant imbriqué

Angle mort identifié en discutant #168 : même une fois les tokens ajoutés, rien sur la page de doc `ar-table-sort` n'indiquait qu'il fallait aller chercher du côté d'`ar-tooltip` pour personnaliser son tooltip interne.

- Nouveau champ frontmatter `relatedTokens` (schéma `content.config.ts`), affiché dans la section CSS Custom Properties de `ComponentApi.astro` après la table des tokens propres au composant, avec un lien vers la page du composant référencé.
- Généralise le mécanisme déjà existant pour `--ar-panel-*` (intro + table dédiée) à n'importe quel composant themable imbriqué en interne par un autre — réutilisable pour de futurs cas similaires sans nouveau développement.
- Appliqué à `ar-table-sort` → renvoi vers `ar-tooltip`.
- Affiché via `<ar-alert variant="info" without-notification>` (cohérence visuelle avec les autres encarts de la doc, pas de notification ARIA superflue pour une note statique) ; le lien pointe directement sur `#api-css-props` du composant référencé ; gap automatique si plusieurs composants liés.

## Fix — poids de texte du tooltip interne

Repéré en relisant la PR : le tooltip de `table-sort` héritait du `font-weight: bold` par défaut d'un `<th>` (aucun composant ne le réinitialisait). Un premier correctif sur `:host` réglait le tooltip mais dé-graissait aussi le libellé de colonne slotté (même parent DOM réel que le tooltip pour l'héritage CSS) — vérifié empiriquement avant d'ajuster. Correctif final scopé à `ar-tooltip` uniquement dans `table-sort.styles.ts`, avec test de régression navigateur (vérifie que le libellé reste bold et que le tooltip passe en normal).

## Test plan

- [x] `npx vitest run scripts/validate-cssprop-defaults.test.js src/components/tooltip/tooltip.test.ts` : 38/38 passent
- [x] `npx web-test-runner` tooltip + table-sort : 27/27 passent (dont le nouveau test de régression font-weight)
- [x] `npm run build:manifest` (validation `@cssprop`) : OK
- [x] `npm run test --workspace=apps/docs` : 59/59 passent
- [x] `npm run build --workspace=apps/docs` : build complet OK, 22 pages générées
- [x] Vérification visuelle doc (pages tooltip + table-sort) en dev server, note `relatedTokens` confirmée dans le HTML généré

🤖 Generated with [Claude Code](https://claude.com/claude-code)

