### PR TITLE
fix(pagination): masquage responsive progressif piloté par la largeur du composant

### DIFF
--- a/apps/docs/src/components/Playground.astro
+++ b/apps/docs/src/components/Playground.astro
@@ -511,4 +511,15 @@ const showPlayground = displayMode === 'demo';
         border-top: 1px solid var(--ar-color-border, #e5e7eb);
         margin:     0.25rem 0;
     }
+
+    /*
+     * .preview est un flex container : sur l'axe principal (horizontal), les enfants se
+     * dimensionnent selon leur contenu par défaut, pas selon la largeur disponible. Un
+     * composant `display: block` qui mesure sa propre largeur pour adapter son rendu
+     * (ar-pagination, ResizeObserver) se retrouve donc contraint à la largeur de son
+     * contenu au lieu de la largeur réelle du preview.
+     */
+    .preview :global(ar-pagination) {
+        flex: 1 1 100%;
+    }
 </style>

--- a/apps/docs/src/content/components/ar-pagination.mdx
+++ b/apps/docs/src/content/components/ar-pagination.mdx
@@ -58,10 +58,12 @@ nombre de numéros affichés pour toujours tenir sur une ligne — aucune config
   première et la dernière page restent toujours visibles aux côtés de la page active, même à
   budget réduit — pour préserver le contexte de navigation — jusqu'au palier texte ci-dessous.
 - **Largeur extrême** : les numéros de page sont remplacés par un `<select>` de saut de page,
-  peuplé des mêmes pages que la fenêtre minimale ci-dessus (première page, dernière page, page
-  active) — les ellipses y apparaissent comme options désactivées. Sélectionner une page dans
-  cette liste a le même effet qu'un clic sur un numéro. Les boutons précédent/suivant restent
-  toujours affichés et fonctionnels.
+  peuplé du même jeu de pages qu'à largeur confortable (pas une fenêtre réduite à la largeur
+  actuelle) — le mobile n'est jamais moins capable que le desktop, seulement rendu différemment.
+  Les ellipses y apparaissent comme options désactivées. Sélectionner une page dans cette liste
+  déclenche le même changement de page qu'un clic sur un numéro (le focus reste toutefois sur le
+  `<select>`, contrairement à un clic sur un lien qui le déplace vers la page active). Les boutons
+  précédent/suivant restent toujours affichés et fonctionnels.
 
 Le composant peut être placé dans un conteneur étroit (ex. barre latérale) sur un écran large : le
 comportement suit la largeur du conteneur, pas celle de l'écran.

--- a/apps/docs/src/content/components/ar-pagination.mdx
+++ b/apps/docs/src/content/components/ar-pagination.mdx
@@ -54,8 +54,9 @@ Le composant mesure sa propre largeur (pas celle du viewport) et réduit progres
 nombre de numéros affichés pour toujours tenir sur une ligne — aucune configuration nécessaire :
 
 - **Largeur confortable** : tous les numéros de page, comme aujourd'hui.
-- **Largeur réduite** : les pages voisines de la page active diminuent progressivement (jusqu'à
-  ne plus afficher que la page active elle-même, entourée d'ellipses).
+- **Largeur réduite** : les pages voisines de la page active diminuent progressivement. La
+  première et la dernière page restent toujours visibles aux côtés de la page active, même à
+  budget réduit — pour préserver le contexte de navigation — jusqu'au palier texte ci-dessous.
 - **Largeur extrême** : les numéros de page sont remplacés par un texte "Page X sur Y". Les
   boutons précédent/suivant restent toujours affichés et fonctionnels.
 

--- a/apps/docs/src/content/components/ar-pagination.mdx
+++ b/apps/docs/src/content/components/ar-pagination.mdx
@@ -50,10 +50,17 @@ import WcagRef from '../../components/WcagRef.astro';
 
 ## Comportement responsive
 
-En dessous de **640px**, le composant réduit automatiquement le nombre de pages affichées :
+Le composant mesure sa propre largeur (pas celle du viewport) et réduit progressivement le
+nombre de numéros affichés pour toujours tenir sur une ligne — aucune configuration nécessaire :
 
-- Seules les pages **précédente**, **active**, **suivante** et les deux voisines directes restent visibles.
-- Les autres pages sont masquées — aucune configuration nécessaire.
+- **Largeur confortable** : tous les numéros de page, comme aujourd'hui.
+- **Largeur réduite** : les pages voisines de la page active diminuent progressivement (jusqu'à
+  ne plus afficher que la page active elle-même, entourée d'ellipses).
+- **Largeur extrême** : les numéros de page sont remplacés par un texte "Page X sur Y". Les
+  boutons précédent/suivant restent toujours affichés et fonctionnels.
+
+Le composant peut être placé dans un conteneur étroit (ex. barre latérale) sur un écran large : le
+comportement suit la largeur du conteneur, pas celle de l'écran.
 
 ## Utilisation
 

--- a/apps/docs/src/content/components/ar-pagination.mdx
+++ b/apps/docs/src/content/components/ar-pagination.mdx
@@ -57,8 +57,11 @@ nombre de numéros affichés pour toujours tenir sur une ligne — aucune config
 - **Largeur réduite** : les pages voisines de la page active diminuent progressivement. La
   première et la dernière page restent toujours visibles aux côtés de la page active, même à
   budget réduit — pour préserver le contexte de navigation — jusqu'au palier texte ci-dessous.
-- **Largeur extrême** : les numéros de page sont remplacés par un texte "Page X sur Y". Les
-  boutons précédent/suivant restent toujours affichés et fonctionnels.
+- **Largeur extrême** : les numéros de page sont remplacés par un `<select>` de saut de page,
+  peuplé des mêmes pages que la fenêtre minimale ci-dessus (première page, dernière page, page
+  active) — les ellipses y apparaissent comme options désactivées. Sélectionner une page dans
+  cette liste a le même effet qu'un clic sur un numéro. Les boutons précédent/suivant restent
+  toujours affichés et fonctionnels.
 
 Le composant peut être placé dans un conteneur étroit (ex. barre latérale) sur un écran large : le
 comportement suit la largeur du conteneur, pas celle de l'écran.

--- a/apps/docs/src/content/components/ar-pagination.mdx
+++ b/apps/docs/src/content/components/ar-pagination.mdx
@@ -31,13 +31,18 @@ import WcagRef from '../../components/WcagRef.astro';
 
 ### Pris en charge automatiquement
 
-- `role="navigation"` et `aria-labelledby` posés sur le conteneur — la région est annoncée
-  par les lecteurs d'écran comme zone de navigation.
+- `role="navigation"` et `aria-labelledby` posés sur le conteneur, dont le nom inclut la position
+  courante ("Pagination, page 4 sur 12") — repérable immédiatement en navigation par régions,
+  sans avoir à explorer les liens pour savoir où on en est.
 - Les boutons "précédent" et "suivant" ont `aria-disabled` synchronisé avec leur état désactivé —
     <WcagRef
         criterion="4.1.2"
         summary="Name, Role, Value : tout composant UI doit exposer son nom, rôle et valeur (états inclus) aux technologies d'assistance."
     />
+- Chaque lien de page et les boutons "précédent"/"suivant" indiquent le nombre total de pages
+  ("Page 4 sur 12") — la position dans la liste (début, milieu, fin) est compréhensible en
+  navigation clavier/lecteur d'écran, sans avoir à deviner si une page est la dernière.
+- La page active porte `aria-current="page"`.
 - Les séparateurs et points de suspension sont masqués aux lecteurs d'écran (`aria-hidden`).
 
 ### À votre charge

--- a/apps/docs/src/content/components/ar-pagination.mdx
+++ b/apps/docs/src/content/components/ar-pagination.mdx
@@ -55,23 +55,9 @@ import WcagRef from '../../components/WcagRef.astro';
 
 ## Comportement responsive
 
-Le composant mesure sa propre largeur (pas celle du viewport) et réduit progressivement le
-nombre de numéros affichés pour toujours tenir sur une ligne — aucune configuration nécessaire :
-
-- **Largeur confortable** : tous les numéros de page, comme aujourd'hui.
-- **Largeur réduite** : les pages voisines de la page active diminuent progressivement. La
-  première et la dernière page restent toujours visibles aux côtés de la page active, même à
-  budget réduit — pour préserver le contexte de navigation — jusqu'au palier texte ci-dessous.
-- **Largeur extrême** : les numéros de page sont remplacés par un `<select>` de saut de page,
-  peuplé du même jeu de pages qu'à largeur confortable (pas une fenêtre réduite à la largeur
-  actuelle) — le mobile n'est jamais moins capable que le desktop, seulement rendu différemment.
-  Les ellipses y apparaissent comme options désactivées. Sélectionner une page dans cette liste
-  déclenche le même changement de page qu'un clic sur un numéro (le focus reste toutefois sur le
-  `<select>`, contrairement à un clic sur un lien qui le déplace vers la page active). Les boutons
-  précédent/suivant restent toujours affichés et fonctionnels.
-
-Le composant peut être placé dans un conteneur étroit (ex. barre latérale) sur un écran large : le
-comportement suit la largeur du conteneur, pas celle de l'écran.
+Le composant adapte son contenu automatiquement à la largeur du conteneur dans lequel il est positionné (pas celle du viewport) :
+Lorsque l'espace disponible n'est plus jugé suffisant, les numéros de page sont remplacés par un `<select>` de saut de page,
+peuplé du même jeu de pages qu'à largeur confortable.
 
 ## Utilisation
 

--- a/docs/superpowers/plans/2026-08-07-pagination-responsive-masking.md
+++ b/docs/superpowers/plans/2026-08-07-pagination-responsive-masking.md
@@ -1,0 +1,800 @@
+# Pagination — Masquage Responsive Progressif (#152) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remplacer le masquage responsive CSS binaire (`@media max-width: 640px`) d'`ar-pagination`
+par un algorithme piloté par JS qui mesure la largeur réelle du composant (`ResizeObserver`) et
+réduit progressivement le nombre de pages générées, avec un palier texte "Page X sur Y" en dessous
+d'un plancher minimal.
+
+**Architecture:** `_calculatePages(current, total, budget?)` (pagination.utils.ts) devient
+paramétrable par un budget de slots numériques ; un `ResizeObserver` sur `[part="nav"]`
+(pagination.ts) mesure la largeur disponible à chaque resize et calcule ce budget ; en dessous
+d'un plancher (3 slots si `current` est en bord, 5 sinon), le composant bascule sur un rendu texte
+plutôt que d'appeler `_calculatePages`. CSS : suppression de la media query, `flex-wrap: nowrap`.
+
+**Tech Stack:** Lit 3, TypeScript, Vitest (unitaire), @web/test-runner + @open-wc/testing
+(navigateur réel, Chromium).
+
+## Global Constraints
+
+- Prettier : 100 caractères, 4 espaces, guillemets simples.
+- `import type` pour tous les imports de types.
+- Conventional Commits (validé par commitlint/Husky).
+- Composant headless : aucun fallback cosmétique `var(--token, valeur)` dans `pagination.styles.ts`
+  pour un nouveau token — seuls les fallbacks structurels (0px, `2.5rem` déjà existant pour WCAG
+  2.5.8) sont acceptables. Cette PR n'introduit pas de nouveau token CSS.
+- Tout nouveau `@csspart` doit être documenté dans le JSDoc du composant.
+- Branches `fix/<desc>` depuis `dev`, PR vers `dev`.
+
+---
+
+## Fichiers concernés
+
+- `packages/core/src/components/pagination/pagination.utils.ts` — généralisation de
+  `_calculatePages` avec paramètre `budget` optionnel.
+- `packages/core/src/components/pagination/pagination.utils.test.ts` — **nouveau**, tests
+  unitaires dédiés à `_calculatePages` (n'existait pas : la fonction n'était testée
+  qu'indirectement via le rendu DOM).
+- `packages/core/src/components/pagination/pagination.ts` — mesure `ResizeObserver`, état
+  `_budget`, palier texte, JSDoc `@csspart`.
+- `packages/core/src/components/pagination/pagination.styles.ts` — suppression de la media query,
+  `flex-wrap: nowrap`.
+- `packages/core/src/components/pagination/pagination.browser.test.ts` — tests WTR du
+  comportement responsive réel.
+- `apps/docs/src/content/components/ar-pagination.mdx` — mise à jour de la section
+  "Comportement responsive".
+
+---
+
+### Task 1 : Branche + `_calculatePages(current, total, budget?)`
+
+**Files:**
+
+- Modify: `packages/core/src/components/pagination/pagination.utils.ts`
+- Create: `packages/core/src/components/pagination/pagination.utils.test.ts`
+
+**Interfaces:**
+
+- Produces: `_calculatePages(current: number, total: number, budget?: number): number[]` — sans
+  `budget` (ou `budget` ≥ `total`), comportement identique à l'existant (liste complète si
+  `total < 10`, sinon jusqu'à 9 slots avec `siblingCount` de 2). Avec `budget` réduit, réduit
+  `siblingCount` (2 → 1 → 0) jusqu'à tenir dans le budget, puis renvoie la représentation
+  minimale (`[1, -1, current, -2, total]` ou variante bord) si aucune ne tient — c'est le
+  **plancher algorithmique** de la fonction ; le composant (Task 3) doit éviter d'appeler la
+  fonction en dessous de ce plancher et utiliser le palier texte à la place.
+- Produces (inchangé) : `_clamp(value, min, max): number`.
+
+- [ ] **Step 1 : Créer la branche de travail**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git checkout dev
+git pull origin dev
+git checkout -b fix/pagination-responsive-masking
+```
+
+- [ ] **Step 2 : Écrire les tests unitaires (doivent échouer)**
+
+Remplacer entièrement `packages/core/src/components/pagination/pagination.utils.test.ts` (nouveau
+fichier) par :
+
+```typescript
+import { describe, expect, it } from 'vitest';
+import { _calculatePages, _clamp } from './pagination.utils.js';
+
+describe('_calculatePages', () => {
+    describe('sans budget (comportement existant inchangé)', () => {
+        it('total < 10 : renvoie la liste complète', () => {
+            expect(_calculatePages(3, 5)).toEqual([1, 2, 3, 4, 5]);
+        });
+
+        it('current proche du début : boundary + ellipsis de fin', () => {
+            expect(_calculatePages(1, 15)).toEqual([1, 2, 3, 4, 5, 6, 7, -2, 15]);
+            expect(_calculatePages(5, 15)).toEqual([1, 2, 3, 4, 5, 6, 7, -2, 15]);
+        });
+
+        it('current proche de la fin : ellipsis de début + boundary', () => {
+            expect(_calculatePages(11, 15)).toEqual([1, -1, 9, 10, 11, 12, 13, 14, 15]);
+            expect(_calculatePages(15, 15)).toEqual([1, -1, 9, 10, 11, 12, 13, 14, 15]);
+        });
+
+        it('current au milieu : deux ellipsis', () => {
+            expect(_calculatePages(8, 15)).toEqual([1, -1, 6, 7, 8, 9, 10, -2, 15]);
+        });
+    });
+
+    describe('avec budget suffisant pour le total', () => {
+        it('renvoie la liste complète, comme sans budget', () => {
+            expect(_calculatePages(3, 5, 5)).toEqual([1, 2, 3, 4, 5]);
+            expect(_calculatePages(8, 15, 9)).toEqual([1, -1, 6, 7, 8, 9, 10, -2, 15]);
+        });
+    });
+
+    describe('avec budget réduit : siblingCount décroissant', () => {
+        it('budget=7 : siblingCount passe de 2 à 1', () => {
+            expect(_calculatePages(8, 15, 7)).toEqual([1, -1, 7, 8, 9, -2, 15]);
+        });
+
+        it('budget=5 : siblingCount passe à 0', () => {
+            expect(_calculatePages(8, 15, 5)).toEqual([1, -1, 8, -2, 15]);
+        });
+
+        it('budget tout juste suffisant pour siblingCount=1 (7 slots exactement)', () => {
+            expect(_calculatePages(11, 15, 7)).toEqual([1, -1, 10, 11, 12, -2, 15]);
+        });
+    });
+
+    describe('plancher : budget insuffisant même pour siblingCount=0', () => {
+        it('current au bord (page 1) : représentation minimale à 3 slots', () => {
+            expect(_calculatePages(1, 15, 3)).toEqual([1, -2, 15]);
+        });
+
+        it('current au bord (dernière page) : représentation minimale à 3 slots', () => {
+            expect(_calculatePages(15, 15, 3)).toEqual([1, -1, 15]);
+        });
+
+        it('current au milieu : représentation minimale à 5 slots (plancher réel de la fonction)', () => {
+            expect(_calculatePages(8, 15, 3)).toEqual([1, -1, 8, -2, 15]);
+        });
+    });
+
+    describe('total < 10 avec budget très restreint (troncable aussi)', () => {
+        it('current au bord : réduit à la représentation minimale', () => {
+            expect(_calculatePages(1, 5, 3)).toEqual([1, -2, 5]);
+        });
+
+        it("budget partiellement restreint : tronque avant d'atteindre le plancher", () => {
+            expect(_calculatePages(3, 5, 4)).toEqual([1, 3, 4, 5]);
+        });
+    });
+});
+
+describe('_clamp', () => {
+    it('renvoie value si dans les bornes', () => {
+        expect(_clamp(3, 1, 5)).toBe(3);
+    });
+
+    it('renvoie min si value < min', () => {
+        expect(_clamp(-1, 1, 5)).toBe(1);
+    });
+
+    it('renvoie max si value > max', () => {
+        expect(_clamp(10, 1, 5)).toBe(5);
+    });
+});
+```
+
+- [ ] **Step 3 : Lancer les tests, vérifier l'échec**
+
+Run: `cd /Users/jon/Code/Active_projects/ariane && npx vitest run packages/core/src/components/pagination/pagination.utils.test.ts`
+Expected: FAIL — `_calculatePages` n'accepte pas encore de 3ᵉ paramètre, les scénarios budgétés
+ne matchent pas les valeurs attendues (le budget est actuellement ignoré).
+
+- [ ] **Step 4 : Généraliser `_calculatePages`**
+
+Remplacer entièrement le contenu de
+`packages/core/src/components/pagination/pagination.utils.ts` par :
+
+```typescript
+/**
+ * Renvoie la liste des pages à afficher suivant la position courante.
+ *
+ * Sans `budget` (ou `budget` suffisant pour afficher `total` pages), comportement inchangé.
+ * Avec un `budget` réduit (nombre de slots numériques disponibles, ellipses incluses), réduit
+ * progressivement le nombre de pages voisines autour de `current` (`siblingCount` : 2 → 1 → 0),
+ * puis renvoie une représentation minimale (3 ou 5 slots) si aucune ne tient dans le budget —
+ * c'est le plancher algorithmique de cette fonction ; en dessous, l'appelant doit utiliser un
+ * autre mode de rendu plutôt que d'appeler cette fonction.
+ *
+ * @param current Page courante
+ * @param total Nombre total de pages
+ * @param budget Nombre maximal de slots numériques (pages + ellipses, hors prev/next).
+ *   `undefined` = comportement historique (liste complète si `total < 10`, sinon 9 slots max).
+ */
+export function _calculatePages(current: number, total: number, budget?: number): number[] {
+    // 9 = plafond historique (siblingCount 2, boundary 1 + 2 ellipses + 5 pages autour de current)
+    // utilisé quand `budget` n'est pas fourni — préserve le comportement existant à l'identique.
+    const DEFAULT_BUDGET = 9;
+    const effectiveBudget = budget ?? DEFAULT_BUDGET;
+
+    if (total <= effectiveBudget) {
+        return Array.from({ length: total }, (_, i) => i + 1);
+    }
+
+    for (const siblingCount of [2, 1, 0]) {
+        const pages = _pagesWithSiblings(current, total, siblingCount);
+        if (pages.length <= effectiveBudget) return pages;
+    }
+
+    return _minimalPages(current, total);
+}
+
+/**
+ * Construit la liste [1, ...ellipsis/siblings..., total] pour un `siblingCount` donné : jusqu'à
+ * `siblingCount` pages de chaque côté de `current`, avec ellipses (`-1`/`-2`) si la page 1 ou
+ * `total` ne sont pas directement adjacentes à la plage affichée.
+ */
+function _pagesWithSiblings(current: number, total: number, siblingCount: number): number[] {
+    // Nombre de pages affichées quand une ellipse est absorbée d'un côté (boundary incluse).
+    const windowSize = 2 * siblingCount + 3;
+
+    let left = Math.max(current - siblingCount, 2);
+    let right = Math.min(current + siblingCount, total - 1);
+
+    const showLeftEllipsis = left > 3;
+    const showRightEllipsis = right < total - 2;
+
+    if (!showLeftEllipsis) {
+        left = 2;
+        right = Math.min(windowSize, total - 1);
+    }
+    if (!showRightEllipsis) {
+        right = total - 1;
+        left = Math.max(total - windowSize + 1, 2);
+    }
+
+    const pages = [1];
+    if (showLeftEllipsis) pages.push(-1);
+    for (let p = left; p <= right; p++) pages.push(p);
+    if (showRightEllipsis) pages.push(-2);
+    pages.push(total);
+    return pages;
+}
+
+/** Plancher algorithmique : boundary(s) + current, avec ellipses si nécessaire. 3 ou 5 slots. */
+function _minimalPages(current: number, total: number): number[] {
+    if (current <= 1) return [1, -2, total];
+    if (current >= total) return [1, -1, total];
+    return [1, -1, current, -2, total];
+}
+
+/**
+ * Renvoie une valeur comprise dans un intervalle
+ *
+ * @param value Valeur retournée si comprise dans l'intervalle
+ * @param min Valeur minimale retournée
+ * @param max Valeur maximale retournée
+ */
+export function _clamp(value: number, min: number, max: number) {
+    return Math.min(Math.max(value, min), max);
+}
+```
+
+- [ ] **Step 5 : Lancer les tests, vérifier le succès**
+
+Run: `cd /Users/jon/Code/Active_projects/ariane && npx vitest run packages/core/src/components/pagination/pagination.utils.test.ts`
+Expected: PASS — tous les tests de l'étape 2.
+
+- [ ] **Step 6 : Lancer la suite complète du composant (non-régression)**
+
+Run: `cd /Users/jon/Code/Active_projects/ariane && npx vitest run packages/core/src/components/pagination/pagination.test.ts`
+Expected: PASS — `pagination.test.ts` appelle `_calculatePages` uniquement via le rendu (sans
+budget), le comportement doit être strictement identique à avant.
+
+- [ ] **Step 7 : Commit**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git add packages/core/src/components/pagination/pagination.utils.ts \
+        packages/core/src/components/pagination/pagination.utils.test.ts
+git commit -m "feat(pagination): ajoute un paramètre budget optionnel à _calculatePages"
+```
+
+---
+
+### Task 2 : Mesure `ResizeObserver` et intégration du budget dans le rendu
+
+**Files:**
+
+- Modify: `packages/core/src/components/pagination/pagination.ts`
+
+**Interfaces:**
+
+- Consumes: `_calculatePages(current: number, total: number, budget?: number): number[]` (Task 1).
+- Produces: état interne `_budget?: number` (non exposé publiquement) — consommé par Task 3 pour
+  décider du palier texte.
+
+- [ ] **Step 1 : Ajouter l'état `_budget`, la mesure et le nettoyage**
+
+Dans `packages/core/src/components/pagination/pagination.ts`, modifier l'import Lit en haut du
+fichier :
+
+```typescript
+import { LitElement, type TemplateResult, type CSSResultGroup, html } from 'lit';
+import { property, state } from 'lit/decorators.js';
+```
+
+Ajouter les champs privés et le cycle de vie juste avant `override updated(...)` (après la
+déclaration de `total`) :
+
+```typescript
+    @state() private _budget?: number;
+    private _resizeObserver?: ResizeObserver;
+    private _itemWidth = 0;
+
+    override firstUpdated(): void {
+        this._setupResizeObserver();
+    }
+
+    override disconnectedCallback(): void {
+        super.disconnectedCallback();
+        this._resizeObserver?.disconnect();
+    }
+
+    private _setupResizeObserver(): void {
+        const nav = this.shadowRoot?.querySelector<HTMLElement>('[part="nav"]');
+        if (!nav) return;
+        this._resizeObserver = new ResizeObserver(() => this._recalculateBudget());
+        this._resizeObserver.observe(nav);
+    }
+
+    private _recalculateBudget(): void {
+        const nav = this.shadowRoot?.querySelector<HTMLElement>('[part="nav"]');
+        const prev = this.shadowRoot?.querySelector<HTMLElement>('[part~="prev"]');
+        const next = this.shadowRoot?.querySelector<HTMLElement>('[part~="next"]');
+        const item = this.shadowRoot?.querySelector<HTMLElement>('[part~="link"], [part~="current"]');
+        if (!nav || !prev || !next) return;
+
+        if (!this._itemWidth && item) {
+            this._itemWidth = item.getBoundingClientRect().width;
+        }
+        if (!this._itemWidth) return;
+
+        const available =
+            nav.getBoundingClientRect().width -
+            prev.getBoundingClientRect().width -
+            next.getBoundingClientRect().width;
+        this._budget = Math.max(Math.floor(available / this._itemWidth), 0);
+    }
+```
+
+Dans `override render()`, passer le budget à `_calculatePages` :
+
+```typescript
+                ${repeat(
+                    _calculatePages(current, total, this._budget),
+                    (page) => page,
+```
+
+- [ ] **Step 2 : Vérifier que les tests existants passent toujours (happy-dom sans vrai `ResizeObserver`)**
+
+Run: `cd /Users/jon/Code/Active_projects/ariane && npx vitest run packages/core/src/components/pagination/`
+Expected: PASS. `happy-dom` (environnement Vitest de ce projet) ne calcule pas de vrai layout :
+`getBoundingClientRect().width` renvoie `0` pour tous les éléments, donc `_itemWidth` reste `0`
+et `_recalculateBudget` retourne avant d'assigner `_budget` (garde `if (!this._itemWidth) return;`).
+`_budget` reste `undefined`, donc `_calculatePages(current, total, undefined)` — comportement
+historique, tests inchangés.
+
+- [ ] **Step 3 : Commit**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git add packages/core/src/components/pagination/pagination.ts
+git commit -m "feat(pagination): mesure la largeur disponible via ResizeObserver pour piloter le budget de pages"
+```
+
+---
+
+### Task 3 : Palier texte "Page X sur Y" sous le plancher
+
+**Files:**
+
+- Modify: `packages/core/src/components/pagination/pagination.ts`
+
+**Interfaces:**
+
+- Consumes: état `_budget` (Task 2), `_calculatePages` (Task 1).
+- Produces: nouveau `@csspart page-status` sur le `<li>` du palier texte.
+
+- [ ] **Step 1 : Écrire le test (doit échouer)**
+
+Ajouter dans `packages/core/src/components/pagination/pagination.test.ts`, dans le bloc
+`describe('pages affichées', ...)` déjà existant, un nouveau `describe` juste après (avant la
+fermeture du fichier, au même niveau que les autres `describe` de haut niveau) :
+
+```typescript
+// ── Palier texte (budget très restreint) ─────────────────────────────────
+
+describe('palier texte sous le plancher', () => {
+    it('bascule sur un texte "Page X sur Y" quand _budget est sous le plancher', async () => {
+        el = await fixture('<ar-pagination current="3" total="15"></ar-pagination>');
+        // @ts-expect-error accès à un champ privé pour simuler une mesure ResizeObserver
+        el._budget = 2;
+        el.requestUpdate();
+        await waitForUpdate(el);
+
+        const shadow = el.shadowRoot as ShadowRoot;
+        const status = shadow.querySelector('[part~="page-status"]');
+        expect(status).not.toBeNull();
+        expect(status?.textContent?.trim()).toBe('Page 3 sur 15');
+        expect(shadow.querySelectorAll('[part~="link"], [part~="current"]').length).toBe(0);
+    });
+
+    it('prev/next restent affichés et fonctionnels en palier texte', async () => {
+        el = await fixture('<ar-pagination current="3" total="15"></ar-pagination>');
+        // @ts-expect-error accès à un champ privé pour simuler une mesure ResizeObserver
+        el._budget = 2;
+        el.requestUpdate();
+        await waitForUpdate(el);
+
+        expect(getPart(el, 'prev')).not.toBeNull();
+        expect(getPart(el, 'next')).not.toBeNull();
+        (requirePart(el, 'next') as HTMLElement).click();
+        await waitForUpdate(el);
+        expect(el.current).toBe(4);
+    });
+
+    it('ne bascule pas en palier texte si _budget est au-dessus du plancher', async () => {
+        el = await fixture('<ar-pagination current="8" total="15"></ar-pagination>');
+        // @ts-expect-error accès à un champ privé pour simuler une mesure ResizeObserver
+        el._budget = 5;
+        el.requestUpdate();
+        await waitForUpdate(el);
+
+        const shadow = el.shadowRoot as ShadowRoot;
+        expect(shadow.querySelector('[part~="page-status"]')).toBeNull();
+    });
+});
+```
+
+- [ ] **Step 2 : Lancer les tests, vérifier l'échec**
+
+Run: `cd /Users/jon/Code/Active_projects/ariane && npx vitest run packages/core/src/components/pagination/pagination.test.ts`
+Expected: FAIL — aucun `[part~="page-status"]` n'existe encore.
+
+- [ ] **Step 3 : Implémenter le palier texte**
+
+Dans `packages/core/src/components/pagination/pagination.ts`, modifier `override render()` :
+remplacer le bloc `${repeat(...)}` par une condition sur le plancher. Le calcul du plancher et la
+condition sont insérés juste après la déclaration de `nextPageNumber` :
+
+```typescript
+const nextPageNumber = _clamp(current + 1, 1, total);
+const isEdgeCurrent = current <= 1 || current >= total;
+const floorSlots = isEdgeCurrent ? 3 : 5;
+const useTextMode = this._budget !== undefined && this._budget < floorSlots;
+```
+
+Puis remplacer :
+
+```typescript
+                ${repeat(
+                    _calculatePages(current, total, this._budget),
+                    (page) => page,
+                    (page) => {
+                        // -1 et -2 sont des sentinelles représentant les ellipses
+                        return page === -1 || page === -2
+                            ? html` <li part="item" aria-hidden="true">
+                                  <span part="ellipsis">...</span>
+                              </li>`
+                            : this.renderPage(page, page === current);
+                    },
+                )}
+```
+
+par :
+
+```typescript
+                ${useTextMode
+                    ? html`<li part="item page-status">
+                          <span class="sr-only">Page&nbsp;</span>${current}
+                          <span aria-hidden="true">&nbsp;sur&nbsp;</span>${total}
+                      </li>`
+                    : repeat(
+                          _calculatePages(current, total, this._budget),
+                          (page) => page,
+                          (page) => {
+                              // -1 et -2 sont des sentinelles représentant les ellipses
+                              return page === -1 || page === -2
+                                  ? html` <li part="item" aria-hidden="true">
+                                        <span part="ellipsis">...</span>
+                                    </li>`
+                                  : this.renderPage(page, page === current);
+                          },
+                      )}
+```
+
+Ajouter l'entrée JSDoc `@csspart` (dans le bloc de commentaire au-dessus de `export class
+ArPagination`, à côté des autres `@csspart`) :
+
+```typescript
+ * @csspart page-status - Le `<li>` du texte "Page X sur Y" affiché à la place de la liste de
+ *   pages quand l'espace disponible ne permet plus d'afficher de numéros (palier minimal).
+```
+
+- [ ] **Step 4 : Lancer les tests, vérifier le succès**
+
+Run: `cd /Users/jon/Code/Active_projects/ariane && npx vitest run packages/core/src/components/pagination/pagination.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5 : Lancer toute la suite Vitest (non-régression globale)**
+
+Run: `cd /Users/jon/Code/Active_projects/ariane && npm run test`
+Expected: PASS.
+
+- [ ] **Step 6 : Commit**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git add packages/core/src/components/pagination/pagination.ts \
+        packages/core/src/components/pagination/pagination.test.ts
+git commit -m "feat(pagination): ajoute un palier texte 'Page X sur Y' sous le plancher de budget"
+```
+
+---
+
+### Task 4 : CSS — suppression de la media query, `flex-wrap: nowrap`
+
+**Files:**
+
+- Modify: `packages/core/src/components/pagination/pagination.styles.ts`
+
+**Interfaces:**
+
+- Consumes: rien de nouveau — s'appuie sur le fait que Task 2/3 garantissent que ce qui est rendu
+  tient toujours dans la largeur disponible.
+
+- [ ] **Step 1 : Modifier les styles**
+
+Dans `packages/core/src/components/pagination/pagination.styles.ts` :
+
+1. Remplacer `flex-wrap: wrap;` par `flex-wrap: nowrap;` dans la règle `[part='list']`.
+2. Supprimer entièrement le bloc `@media screen and (max-width: 640px) { ... }` en fin de fichier.
+
+Résultat attendu pour ces deux zones :
+
+```typescript
+    [part='list'] {
+        display: flex;
+        flex-wrap: nowrap;
+        justify-content: center;
+        padding-inline-start: 0;
+        margin-bottom: 0;
+        list-style: none;
+    }
+```
+
+```typescript
+    [part~='nav-btn--disabled'] {
+        cursor: not-allowed;
+    }
+`;
+```
+
+(le fichier se termine directement après `[part~='nav-btn--disabled']`, sans media query).
+
+- [ ] **Step 2 : Lancer la suite Vitest du composant**
+
+Run: `cd /Users/jon/Code/Active_projects/ariane && npx vitest run packages/core/src/components/pagination/`
+Expected: PASS — happy-dom n'évalue pas le CSS réel, ce changement ne casse aucun test Vitest.
+
+- [ ] **Step 3 : Commit**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git add packages/core/src/components/pagination/pagination.styles.ts
+git commit -m "fix(pagination): retire la media query de masquage, le budget JS pilote désormais le contenu"
+```
+
+---
+
+### Task 5 : Tests navigateur (WTR) du comportement responsive réel
+
+**Files:**
+
+- Modify: `packages/core/src/components/pagination/pagination.browser.test.ts`
+
+**Interfaces:**
+
+- Consumes : comportement complet de Task 2/3/4 (mesure réelle `ResizeObserver` + rendu +
+  `flex-wrap: nowrap`). Un `ResizeObserver` mocké en Vitest classique ne reflète pas le
+  comportement réel du navigateur (cf. spec) — ces scénarios sont donc exclusivement en WTR.
+
+- [ ] **Step 1 : Ajouter les tests responsive**
+
+Ajouter dans `packages/core/src/components/pagination/pagination.browser.test.ts`, un nouveau
+`describe` après celui de `'propriétés logiques (RTL)'` :
+
+```typescript
+describe('masquage responsive progressif (#152)', () => {
+    async function waitForResize(): Promise<void> {
+        // Laisse le temps au ResizeObserver de déclencher son callback et à Lit de re-render.
+        await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+        await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+
+    it('affiche la liste complète des numéros dans un conteneur large', async () => {
+        const wrapper = await fixture(
+            html`<div style="width: 900px;">
+                <ar-pagination current="8" total="15"></ar-pagination>
+            </div>`,
+        );
+        const el = wrapper.querySelector('ar-pagination') as HTMLElement;
+        await elementUpdated(el);
+        await waitForResize();
+
+        const shadow = el.shadowRoot as ShadowRoot;
+        expect(shadow.querySelectorAll('[part~="link"], [part~="current"]').length).to.equal(8);
+    });
+
+    it('réduit le nombre de pages affichées quand le conteneur est rétréci', async () => {
+        const wrapper = await fixture(
+            html`<div style="width: 900px;">
+                <ar-pagination current="8" total="15"></ar-pagination>
+            </div>`,
+        );
+        const el = wrapper.querySelector('ar-pagination') as HTMLElement;
+        await elementUpdated(el);
+        await waitForResize();
+
+        wrapper.style.width = '260px';
+        await waitForResize();
+
+        const shadow = el.shadowRoot as ShadowRoot;
+        const numericCount = shadow.querySelectorAll('[part~="link"], [part~="current"]').length;
+        expect(numericCount).to.be.greaterThan(0);
+        expect(numericCount).to.be.lessThan(8);
+    });
+
+    it('bascule sur le palier texte "Page X sur Y" à largeur extrême', async () => {
+        const wrapper = await fixture(
+            html`<div style="width: 900px;">
+                <ar-pagination current="8" total="15"></ar-pagination>
+            </div>`,
+        );
+        const el = wrapper.querySelector('ar-pagination') as HTMLElement;
+        await elementUpdated(el);
+        await waitForResize();
+
+        wrapper.style.width = '90px';
+        await waitForResize();
+
+        const shadow = el.shadowRoot as ShadowRoot;
+        const status = shadow.querySelector('[part~="page-status"]');
+        expect(status).to.not.equal(null);
+        expect(status?.textContent?.trim()).to.equal('Page 8 sur 15');
+    });
+
+    it('prev/next restent cliquables au palier texte', async () => {
+        const wrapper = await fixture(
+            html`<div style="width: 90px;">
+                <ar-pagination current="8" total="15"></ar-pagination>
+            </div>`,
+        );
+        const el = wrapper.querySelector('ar-pagination') as HTMLElement;
+        await elementUpdated(el);
+        await waitForResize();
+
+        const shadow = el.shadowRoot as ShadowRoot;
+        const next = shadow.querySelector('[part~="next"]') as HTMLElement;
+        next.click();
+        await elementUpdated(el);
+
+        expect((el as unknown as { current: number }).current).to.equal(9);
+    });
+
+    it("[part='list'] ne wrap plus (flex-wrap: nowrap)", async () => {
+        const el = await fixture(html`<ar-pagination current="1" total="5"></ar-pagination>`);
+        const list = el.shadowRoot?.querySelector<HTMLElement>('[part="list"]');
+        if (!list) throw new Error('[part="list"] introuvable');
+        expect(getComputedStyle(list).flexWrap).to.equal('nowrap');
+    });
+});
+```
+
+- [ ] **Step 2 : Lancer les tests WTR**
+
+Run: `cd /Users/jon/Code/Active_projects/ariane && npm run test:all`
+Expected: PASS pour tous les nouveaux tests. Si un seuil de largeur ne produit pas le nombre de
+pages attendu, ajuster la largeur du wrapper dans le test (la largeur exacte dépend de
+`--ar-pagination-btn-size` du thème par défaut, pas d'une valeur figée dans le composant) plutôt
+que le comportement du composant.
+
+- [ ] **Step 3 : Commit**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git add packages/core/src/components/pagination/pagination.browser.test.ts
+git commit -m "test(pagination): couvre le masquage responsive progressif en conditions réelles (WTR)"
+```
+
+---
+
+### Task 6 : Documentation (apps/docs)
+
+**Files:**
+
+- Modify: `apps/docs/src/content/components/ar-pagination.mdx`
+
+- [ ] **Step 1 : Mettre à jour la section "Comportement responsive"**
+
+Dans `apps/docs/src/content/components/ar-pagination.mdx`, remplacer la section :
+
+```markdown
+## Comportement responsive
+
+En dessous de **640px**, le composant réduit automatiquement le nombre de pages affichées :
+
+- Seules les pages **précédente**, **active**, **suivante** et les deux voisines directes restent visibles.
+- Les autres pages sont masquées — aucune configuration nécessaire.
+```
+
+par :
+
+```markdown
+## Comportement responsive
+
+Le composant mesure sa propre largeur (pas celle du viewport) et réduit progressivement le
+nombre de numéros affichés pour toujours tenir sur une ligne — aucune configuration nécessaire :
+
+- **Largeur confortable** : tous les numéros de page, comme aujourd'hui.
+- **Largeur réduite** : les pages voisines de la page active diminuent progressivement (jusqu'à
+  ne plus afficher que la page active elle-même, entourée d'ellipses).
+- **Largeur extrême** : les numéros de page sont remplacés par un texte "Page X sur Y". Les
+  boutons précédent/suivant restent toujours affichés et fonctionnels.
+
+Le composant peut être placé dans un conteneur étroit (ex. barre latérale) sur un écran large : le
+comportement suit la largeur du conteneur, pas celle de l'écran.
+```
+
+- [ ] **Step 2 : Vérifier le rendu de la doc**
+
+Run: `cd /Users/jon/Code/Active_projects/ariane && npm run build --workspace=packages/core && npm run dev --workspace=apps/docs`
+Ouvrir `http://localhost:4321/components/ar-pagination` (ou le port affiché), vérifier que la
+section "Comportement responsive" s'affiche correctement, puis arrêter le serveur (Ctrl+C).
+
+- [ ] **Step 3 : Commit**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git add apps/docs/src/content/components/ar-pagination.mdx
+git commit -m "docs(pagination): décrit le masquage responsive progressif par mesure de largeur"
+```
+
+---
+
+### Task 7 : Ouvrir la PR
+
+**Files:** aucun.
+
+- [ ] **Step 1 : Vérification finale complète**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+npm run test:all
+```
+
+Expected: PASS sur l'ensemble (Vitest + WTR).
+
+- [ ] **Step 2 : Push et création de la PR**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git push -u origin fix/pagination-responsive-masking
+gh pr create --base dev --title "fix(pagination): masquage responsive progressif piloté par la largeur du composant" --body "$(cat <<'EOF'
+## Résumé
+
+- Remplace la media query CSS binaire (`max-width: 640px`) par un algorithme JS qui mesure la
+  largeur réelle du composant (`ResizeObserver`) et réduit progressivement le nombre de pages
+  générées.
+- `_calculatePages` accepte un paramètre `budget` optionnel (réduction `siblingCount` 2 → 1 → 0).
+- En dessous d'un plancher minimal, bascule sur un texte "Page X sur Y" (prev/next toujours
+  affichés et fonctionnels).
+- `[part='list']` passe de `flex-wrap: wrap` à `nowrap`.
+
+Closes #152
+
+## Test plan
+
+- [x] Tests unitaires `_calculatePages` (tous les paliers de budget)
+- [x] Tests Vitest du palier texte
+- [x] Tests WTR du comportement responsive réel (redimensionnement de conteneur)
+- [x] `npm run test:all`
+EOF
+)"
+```
+
+- [ ] **Step 3 : Partager le lien de la PR**
+
+Communiquer l'URL renvoyée par `gh pr create` à l'utilisateur·rice.

--- a/docs/superpowers/plans/2026-08-10-pagination-a11y-labels.md
+++ b/docs/superpowers/plans/2026-08-10-pagination-a11y-labels.md
@@ -13,8 +13,7 @@ affiché (`<span aria-hidden="true">`, numéro seul) au lieu de préfixer le num
 texte sr-only partiel. Le nom du landmark (`<p id="ar-pagination">`) devient dynamique.
 
 **Tech Stack:** Lit 3 + TypeScript, Vitest (happy-dom) pour les tests unitaires, `@web/test-runner`
-
-- Playwright/Chromium pour les tests navigateur et axe-core.
+et Playwright/Chromium pour les tests navigateur et axe-core.
 
 ## Global Constraints
 

--- a/docs/superpowers/plans/2026-08-10-pagination-a11y-labels.md
+++ b/docs/superpowers/plans/2026-08-10-pagination-a11y-labels.md
@@ -1,0 +1,433 @@
+# Labels accessibles enrichis d'ar-pagination Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enrichir les labels accessibles d'`ar-pagination` (prev/next, liens de page, page active,
+nom du landmark) avec le nombre total de pages, corriger `aria-current="true"` en
+`aria-current="page"`, sans changement visuel.
+
+**Architecture:** Toutes les modifications sont dans `pagination.ts` : les méthodes de rendu
+(`renderPage`, `renderPageLink`, `renderPageLabel`) gagnent un paramètre `total` propagé depuis
+`render()` ; `renderPageLabel` sépare texte lu (`<span class="sr-only">`, complet) et texte
+affiché (`<span aria-hidden="true">`, numéro seul) au lieu de préfixer le numéro visible d'un
+texte sr-only partiel. Le nom du landmark (`<p id="ar-pagination">`) devient dynamique.
+
+**Tech Stack:** Lit 3 + TypeScript, Vitest (happy-dom) pour les tests unitaires, `@web/test-runner`
+
+- Playwright/Chromium pour les tests navigateur et axe-core.
+
+## Global Constraints
+
+- Prettier : 100 caractères, 4 espaces, guillemets simples. `import type` pour les imports de
+  types. Conventional Commits.
+- Aucun changement visuel : seul le texte accessible (sr-only, attributs ARIA) change ; le rendu
+  visible (numéros affichés, mise en page) reste identique.
+- Changement de signature des méthodes protégées (`renderPage`, `renderPageLink`,
+  `renderPageLabel`) accepté sans dépréciation — composant en alpha (cf. CLAUDE.md).
+- Tout le texte interpolé destiné à être lu par un lecteur d'écran doit rester une **seule chaîne
+  dans un seul élément** (jamais plusieurs bindings Lit adjacents au même niveau dans un conteneur
+  `display:flex`) — c'est la cause du bug historique #152 ("8sur15"), déjà documentée dans
+  `pagination.ts`.
+- `vitest` s'exécute depuis `packages/core`, jamais depuis la racine du repo.
+
+---
+
+### Task 1: Labels enrichis — prev/next, pages, aria-current, landmark dynamique
+
+**Files:**
+
+- Modify: `packages/core/src/components/pagination/pagination.ts`
+- Modify: `packages/core/src/components/pagination/pagination.test.ts`
+
+**Interfaces:**
+
+- Consumes : aucune nouvelle dépendance externe.
+- Produces : nouvelles signatures `renderPage(page: number, active: boolean, total: number)`,
+  `renderPageLink(page: number, active: boolean, total: number)`,
+  `renderPageLabel(page: number, total: number)` — Task 2 (tests navigateur) et Task 3 (docs) lisent
+  le rendu qui en résulte, aucune n'appelle directement ces méthodes.
+
+- [ ] **Step 1: Écrire les tests unitaires qui échouent (Vitest)**
+
+Dans `packages/core/src/components/pagination/pagination.test.ts`, remplacer le test existant :
+
+```ts
+it('la page active a aria-current="true"', async () => {
+    el = await fixture('<ar-pagination current="3" total="5"></ar-pagination>');
+    const shadow = el.shadowRoot as ShadowRoot;
+    const current = shadow.querySelector('[part="current"]') as Element;
+    expect(current).not.toBeNull();
+    expect(current.getAttribute('aria-current')).toBe('true');
+});
+```
+
+par :
+
+```ts
+it('la page active a aria-current="page"', async () => {
+    el = await fixture('<ar-pagination current="3" total="5"></ar-pagination>');
+    const shadow = el.shadowRoot as ShadowRoot;
+    const current = shadow.querySelector('[part="current"]') as Element;
+    expect(current).not.toBeNull();
+    expect(current.getAttribute('aria-current')).toBe('page');
+});
+```
+
+Puis ajouter un nouveau bloc `describe`, juste après la fermeture du `describe('pages affichées', ...)` (après la ligne contenant le test `'ellipses présentes si total >= 10 ...'`) :
+
+```ts
+// ── Labels accessibles enrichis ──────────────────────────────────────────
+
+describe('labels accessibles enrichis (total dans le contexte)', () => {
+    it('le sr-only d\'un lien de page inclut le total ("Page X sur Y")', async () => {
+        el = await fixture('<ar-pagination current="3" total="12"></ar-pagination>');
+        const shadow = el.shadowRoot as ShadowRoot;
+        const link = shadow.querySelector('[data-ar-pagination-page="4"]') as Element;
+        const srOnly = link.querySelector('.sr-only');
+        expect(srOnly?.textContent).toBe('Page 4 sur 12');
+    });
+
+    it("le span aria-hidden d'un lien de page ne contient que le numéro (rendu visuel inchangé)", async () => {
+        el = await fixture('<ar-pagination current="3" total="12"></ar-pagination>');
+        const shadow = el.shadowRoot as ShadowRoot;
+        const link = shadow.querySelector('[data-ar-pagination-page="4"]') as Element;
+        const visible = link.querySelector('[aria-hidden="true"]');
+        expect(visible?.textContent).toBe('4');
+    });
+
+    it('le sr-only de la page active inclut le total ("Page X sur Y")', async () => {
+        el = await fixture('<ar-pagination current="3" total="12"></ar-pagination>');
+        const shadow = el.shadowRoot as ShadowRoot;
+        const current = shadow.querySelector('[part="current"]') as Element;
+        const srOnly = current.querySelector('.sr-only');
+        expect(srOnly?.textContent).toBe('Page 3 sur 12');
+    });
+
+    it('le sr-only de "précédent" inclut le total', async () => {
+        el = await fixture('<ar-pagination current="3" total="12"></ar-pagination>');
+        const srOnly = requirePart(el, 'prev').querySelector('.sr-only');
+        expect(srOnly?.textContent).toBe('Page précédente (page 2 sur 12)');
+    });
+
+    it('le sr-only de "suivant" inclut le total', async () => {
+        el = await fixture('<ar-pagination current="3" total="12"></ar-pagination>');
+        const srOnly = requirePart(el, 'next').querySelector('.sr-only');
+        expect(srOnly?.textContent).toBe('Page suivante (page 4 sur 12)');
+    });
+
+    it('le nom du landmark (aria-labelledby) reflète current/total', async () => {
+        el = await fixture('<ar-pagination current="3" total="12"></ar-pagination>');
+        const label = (el.shadowRoot as ShadowRoot).getElementById('ar-pagination');
+        expect(label?.textContent).toBe('Pagination, page 3 sur 12');
+    });
+
+    it('le nom du landmark se met à jour après un changement de page', async () => {
+        el = await fixture('<ar-pagination current="3" total="12"></ar-pagination>');
+        el.current = 4;
+        await waitForUpdate(el);
+        const label = (el.shadowRoot as ShadowRoot).getElementById('ar-pagination');
+        expect(label?.textContent).toBe('Pagination, page 4 sur 12');
+    });
+});
+```
+
+- [ ] **Step 2: Lancer les tests pour vérifier qu'ils échouent**
+
+Run: `(cd packages/core && npx vitest run src/components/pagination/pagination.test.ts)`
+Expected: FAIL — `aria-current` vaut encore `"true"`, les `.sr-only` ne contiennent pas encore le
+total, le landmark reste statique "Pagination".
+
+- [ ] **Step 3: Modifier `pagination.ts`**
+
+Dans `packages/core/src/components/pagination/pagination.ts`, dans `render()`, remplacer le nom
+statique du landmark :
+
+```ts
+            <p id="ar-pagination" class="sr-only">Pagination</p>
+```
+
+par :
+
+```ts
+            <p id="ar-pagination" class="sr-only">Pagination, page ${current} sur ${total}</p>
+```
+
+Remplacer le label sr-only de "précédent" :
+
+```ts
+                        <span class="sr-only">Page précédente (page ${previousPageNumber})</span>
+```
+
+par :
+
+```ts
+                        <span class="sr-only"
+                            >Page précédente (page ${previousPageNumber} sur ${total})</span
+                        >
+```
+
+Remplacer le label sr-only de "suivant" :
+
+```ts
+                        <span class="sr-only">Page suivante (page ${nextPageNumber})</span>
+```
+
+par :
+
+```ts
+                        <span class="sr-only"
+                            >Page suivante (page ${nextPageNumber} sur ${total})</span
+                        >
+```
+
+Dans la branche `repeat(pages, ...)`, remplacer l'appel :
+
+```ts
+                                  : this.renderPage(page, page === current);
+```
+
+par :
+
+```ts
+                                  : this.renderPage(page, page === current, total);
+```
+
+Remplacer les trois méthodes `renderPage`, `renderPageLink`, `renderPageLabel` :
+
+```ts
+    /** Génère le `<li>` d'une page. Surcharger en sous-classe si besoin. */
+    protected renderPage(page: number, active: boolean): TemplateResult {
+        return html` <li part="item${active ? ' item--current' : ''}">
+            ${this.renderPageLink(page, active)}
+        </li>`;
+    }
+
+    /** Génère le lien ou le span (si page active) d'une page */
+    protected renderPageLink(page: number, active: boolean): TemplateResult {
+        if (active) {
+            return html` <span
+                part="current"
+                tabindex="-1"
+                aria-current="true"
+                data-ar-pagination-page="${page}"
+            >
+                ${this.renderPageLabel(page)}
+            </span>`;
+        }
+        return html` <a part="link" data-ar-pagination-page="${page}" href="javascript:;">
+            ${this.renderPageLabel(page)}
+        </a>`;
+    }
+
+    /** Génère le label d'une page avec texte sr-only pour les lecteurs d'écran */
+    protected renderPageLabel(page: number): TemplateResult {
+        return html`<span class="sr-only">Page&nbsp;</span>${page}`;
+    }
+```
+
+par :
+
+```ts
+    /** Génère le `<li>` d'une page. Surcharger en sous-classe si besoin. */
+    protected renderPage(page: number, active: boolean, total: number): TemplateResult {
+        return html` <li part="item${active ? ' item--current' : ''}">
+            ${this.renderPageLink(page, active, total)}
+        </li>`;
+    }
+
+    /** Génère le lien ou le span (si page active) d'une page */
+    protected renderPageLink(page: number, active: boolean, total: number): TemplateResult {
+        if (active) {
+            return html` <span
+                part="current"
+                tabindex="-1"
+                aria-current="page"
+                data-ar-pagination-page="${page}"
+            >
+                ${this.renderPageLabel(page, total)}
+            </span>`;
+        }
+        return html` <a part="link" data-ar-pagination-page="${page}" href="javascript:;">
+            ${this.renderPageLabel(page, total)}
+        </a>`;
+    }
+
+    /**
+     * Génère le label d'une page : texte complet ("Page X sur Y") lu par les lecteurs d'écran,
+     * numéro seul affiché — les deux `<span>` doivent rester adjacents sans texte/espace entre
+     * eux (voir garde globale sur les bindings adjacents dans un conteneur flex).
+     */
+    protected renderPageLabel(page: number, total: number): TemplateResult {
+        return html`<span class="sr-only">Page ${page} sur ${total}</span
+            ><span aria-hidden="true">${page}</span>`;
+    }
+```
+
+- [ ] **Step 4: Lancer les tests pour vérifier qu'ils passent**
+
+Run: `(cd packages/core && npx vitest run src/components/pagination/pagination.test.ts)`
+Expected: PASS — tous les tests, y compris le nouveau bloc "labels accessibles enrichis".
+
+- [ ] **Step 5: Lancer la suite Vitest complète du composant pour vérifier l'absence de régression**
+
+Run: `(cd packages/core && npx vitest run src/components/pagination/)`
+Expected: PASS — en particulier le test `'total négatif : render() reste fonctionnel...'`
+(`pagination.test.ts`, describe `'warn() — bornes numériques'`), qui vérifie que le label de
+prev/next ne contient jamais de nombre négatif — doit rester vert avec le total désormais inclus
+dans ce même label.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/components/pagination/pagination.ts \
+        packages/core/src/components/pagination/pagination.test.ts
+git commit -m "feat(pagination): enrichit les labels accessibles avec le total de pages"
+```
+
+---
+
+### Task 2: Vérification navigateur — rendu réel, focus, axe-core
+
+**Files:**
+
+- Modify: `packages/core/src/components/pagination/pagination.browser.test.ts`
+- Modify: `packages/core/src/components/pagination/pagination.a11y.test.ts`
+
+**Interfaces:**
+
+- Consumes : structure produite par Task 1 (`part="link"`/`part="current"` contenant
+  `.sr-only`/`[aria-hidden="true"]`, `aria-current="page"`, palier select via `_budget` privé déjà
+  utilisé par les tests existants du même fichier).
+- Produces : aucune nouvelle interface — tests uniquement.
+
+- [ ] **Step 1: Ajouter un test navigateur avec `innerText` (pas seulement `textContent`)**
+
+Dans `packages/core/src/components/pagination/pagination.browser.test.ts`, ajouter un nouveau
+`describe`, juste après la fermeture du `describe('masquage responsive progressif (#152)', ...)`
+(avant `describe('invariant anti-débordement ...')`) :
+
+```ts
+describe('labels accessibles enrichis (total dans le contexte)', () => {
+    it('le sr-only d\'un lien de page se lit "Page X sur Y" en layout réel (innerText)', async () => {
+        const el = await fixture(html`<ar-pagination current="3" total="12"></ar-pagination>`);
+        const link = el.shadowRoot?.querySelector('[data-ar-pagination-page="4"]') as HTMLElement;
+        const srOnly = link.querySelector('.sr-only') as HTMLElement;
+        // `innerText` (pas `textContent`) : reflète le rendu réel appliqué par le layout,
+        // seul moyen fiable de détecter une régression du bug historique #152 ("8sur15") où
+        // plusieurs bindings adjacents dans un conteneur flex perdaient leurs espaces.
+        expect(srOnly.innerText.trim()).to.equal('Page 4 sur 12');
+    });
+
+    it('la page active porte aria-current="page"', async () => {
+        const el = await fixture(html`<ar-pagination current="3" total="12"></ar-pagination>`);
+        const current = el.shadowRoot?.querySelector('[part="current"]') as HTMLElement;
+        expect(current.getAttribute('aria-current')).to.equal('page');
+    });
+});
+```
+
+- [ ] **Step 2: Lancer ce test pour vérifier qu'il échoue avant Task 1... (déjà fait, Task 1 est mergée)**
+
+Ce step est informatif seulement si Task 1 n'était pas encore appliquée ; dans l'ordre normal
+d'exécution de ce plan, Task 1 est déjà en place — passer directement au Step 3.
+
+- [ ] **Step 3: Lancer la suite de tests navigateur du composant**
+
+Run: `(cd packages/core && npx web-test-runner --files "src/components/pagination/pagination.browser.test.ts")`
+Expected: PASS — tous les tests, y compris ceux de focus existants (`'focalise le nouvel élément
+part="current"...'`) : aucune régression, la structure interne de `[part="current"]` change mais
+pas son `tabindex`/focusabilité.
+
+- [ ] **Step 4: Ajouter un scénario axe-core pour le palier select**
+
+Dans `packages/core/src/components/pagination/pagination.a11y.test.ts`, ajouter à la fin du
+`describe('ar-pagination — accessibilité', ...)`, après le test `'avec ellipses (total élevé) est
+accessible'` :
+
+```ts
+it('palier select (largeur insuffisante) est accessible', async () => {
+    const el = await fixture(html`<ar-pagination current="8" total="20"></ar-pagination>`);
+    // Force le palier select sans dépendre d'un ResizeObserver réel en test — même technique
+    // que pagination.browser.test.ts pour simuler un budget mesuré très restreint.
+    (el as unknown as { _budget: number })._budget = 2;
+    (el as unknown as { requestUpdate: () => void }).requestUpdate();
+    await (el as unknown as { updateComplete: Promise<boolean> }).updateComplete;
+    await expect(el).to.be.accessible();
+});
+```
+
+- [ ] **Step 5: Lancer la suite a11y du composant**
+
+Run: `(cd packages/core && npx web-test-runner --files "src/components/pagination/pagination.a11y.test.ts")`
+Expected: PASS — les 4 scénarios existants restent verts, le nouveau scénario select passe axe-core
+sans violation.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/components/pagination/pagination.browser.test.ts \
+        packages/core/src/components/pagination/pagination.a11y.test.ts
+git commit -m "test(pagination): couvre les labels enrichis et le palier select en tests navigateur/a11y"
+```
+
+---
+
+### Task 3: Documentation
+
+**Files:**
+
+- Modify: `apps/docs/src/content/components/ar-pagination.mdx`
+
+**Interfaces:**
+
+- Consumes : comportement final d'`ar-pagination` issu de Tasks 1-2.
+- Produces : aucune nouvelle interface — documentation uniquement.
+
+- [ ] **Step 1: Mettre à jour la section "Pris en charge automatiquement"**
+
+Dans `apps/docs/src/content/components/ar-pagination.mdx`, remplacer :
+
+```mdx
+### Pris en charge automatiquement
+
+- `role="navigation"` et `aria-labelledby` posés sur le conteneur — la région est annoncée
+  par les lecteurs d'écran comme zone de navigation.
+- Les boutons "précédent" et "suivant" ont `aria-disabled` synchronisé avec leur état désactivé —
+    <WcagRef
+        criterion="4.1.2"
+        summary="Name, Role, Value : tout composant UI doit exposer son nom, rôle et valeur (états inclus) aux technologies d'assistance."
+    />
+- Les séparateurs et points de suspension sont masqués aux lecteurs d'écran (`aria-hidden`).
+```
+
+par :
+
+```mdx
+### Pris en charge automatiquement
+
+- `role="navigation"` et `aria-labelledby` posés sur le conteneur, dont le nom inclut la position
+  courante ("Pagination, page 4 sur 12") — repérable immédiatement en navigation par régions,
+  sans avoir à explorer les liens pour savoir où on en est.
+- Les boutons "précédent" et "suivant" ont `aria-disabled` synchronisé avec leur état désactivé —
+    <WcagRef
+        criterion="4.1.2"
+        summary="Name, Role, Value : tout composant UI doit exposer son nom, rôle et valeur (états inclus) aux technologies d'assistance."
+    />
+- Chaque lien de page et les boutons "précédent"/"suivant" indiquent le nombre total de pages
+  ("Page 4 sur 12") — la position dans la liste (début, milieu, fin) est compréhensible en
+  navigation clavier/lecteur d'écran, sans avoir à deviner si une page est la dernière.
+- La page active porte `aria-current="page"`.
+- Les séparateurs et points de suspension sont masqués aux lecteurs d'écran (`aria-hidden`).
+```
+
+- [ ] **Step 2: Vérifier le rendu MDX**
+
+Run: `npx astro check --root apps/docs`
+Expected: 0 erreurs.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/docs/src/content/components/ar-pagination.mdx
+git commit -m "docs(pagination): documente les labels accessibles enrichis"
+```

--- a/docs/superpowers/plans/2026-08-10-pagination-select-fallback.md
+++ b/docs/superpowers/plans/2026-08-10-pagination-select-fallback.md
@@ -16,8 +16,7 @@ un débordement du déclencheur fermé à 320-375px, Task 3 (conditionnelle) bas
 d'option courts + un `aria-label` dynamique combinant nom et valeur.
 
 **Tech Stack:** Lit 3 + TypeScript, Vitest (happy-dom) pour les tests unitaires, `@web/test-runner`
-
-- Playwright/Chromium pour les tests navigateur.
+et Playwright/Chromium pour les tests navigateur.
 
 ## Global Constraints
 

--- a/docs/superpowers/plans/2026-08-10-pagination-select-fallback.md
+++ b/docs/superpowers/plans/2026-08-10-pagination-select-fallback.md
@@ -524,7 +524,7 @@ it('le select porte un aria-label dynamique combinant nom et valeur courante', a
     await waitForUpdate(el);
 
     const select = getPart(el, 'select') as HTMLSelectElement;
-    expect(select.getAttribute('aria-label')).toBe('Aller à la page, page 3 sur 15');
+    expect(select.getAttribute('aria-label')).toBe('Aller à la page 3 sur 15');
     expect(select.hasAttribute('aria-labelledby')).toBe(false);
 });
 ```
@@ -551,7 +551,7 @@ Dans `packages/core/src/components/pagination/pagination.ts`, remplacer `renderP
         return html`<li part="item page-select">
             <select
                 part="select"
-                aria-label="Aller à la page, page ${current} sur ${total}"
+                aria-label="Aller à la page ${current} sur ${total}"
                 .value=${String(current)}
                 @change=${this._onSelectChange}
             >
@@ -584,7 +584,7 @@ par :
 
 ```ts
 expect(options[2]?.textContent?.trim()).to.equal('8');
-expect(select.getAttribute('aria-label')).to.equal('Aller à la page, page 8 sur 15');
+expect(select.getAttribute('aria-label')).to.equal('Aller à la page 8 sur 15');
 ```
 
 - [ ] **Step 6: Relancer la vérification empirique (Task 2 Step 5) pour confirmer le repli**

--- a/docs/superpowers/plans/2026-08-10-pagination-select-fallback.md
+++ b/docs/superpowers/plans/2026-08-10-pagination-select-fallback.md
@@ -1,0 +1,649 @@
+# Select de saut de page au palier minimal d'ar-pagination — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remplacer le palier texte non interactif ("Page X sur Y") d'`ar-pagination` par un
+`<select>` natif de saut de page, peuplé des mêmes options que produirait `_calculatePages` au
+plancher (première/dernière page, fenêtre minimale, ellipses en `<option disabled>`).
+
+**Architecture:** Un seul point de bascule change dans `pagination.ts` : la branche qui rendait un
+texte statique rend désormais un `<li part="item page-select">` contenant un `<select part="select">`
+peuplé via `_calculatePages(current, total, this._budget)` (aucune modification de l'algorithme).
+Le `change` sur le select suit le même chemin que les clics sur les liens de page existants
+(`current` mis à jour, événement émis, annonce a11y). Le nom accessible utilise `aria-labelledby`
+vers un `<span class="sr-only">` statique par défaut ; si la vérification empirique en Task 2 montre
+un débordement du déclencheur fermé à 320-375px, Task 3 (conditionnelle) bascule vers des labels
+d'option courts + un `aria-label` dynamique combinant nom et valeur.
+
+**Tech Stack:** Lit 3 + TypeScript, Vitest (happy-dom) pour les tests unitaires, `@web/test-runner`
+
+- Playwright/Chromium pour les tests navigateur.
+
+## Global Constraints
+
+- Prettier : 100 caractères, 4 espaces, guillemets simples.
+- Toujours `import type` pour les imports de types.
+- Conventional Commits (commitlint + Husky) sur chaque commit.
+- Composant headless : aucune couleur/fond en dur dans `pagination.styles.ts` — seules les valeurs
+  structurelles (tailles, `appearance: none`) y vont ; l'apparence visuelle va dans
+  `themes/default.css` (hors périmètre de ce plan, aucune modification requise ici — le sélecteur
+  `ar-pagination::part(select)` n'existe pas encore dans le thème, ce qui est acceptable : un
+  `<select>` non thémé reste fonctionnel avec l'apparence native du navigateur).
+- `--ar-pagination-btn-size` (déjà déclaré, repli interne `2.5rem`) doit être réutilisé pour la
+  taille minimale du `<select>`, pas une nouvelle variable — cohérence WCAG 2.5.8 avec prev/next/link.
+- Toute nouvelle entrée `@csspart` doit être documentée dans le JSDoc du composant
+  (`pagination.ts`), toute entrée obsolète retirée.
+- `vitest` s'exécute depuis `packages/core`, jamais depuis la racine du repo.
+
+---
+
+### Task 1: Rendu `<select>` au palier minimal (remplace le palier texte)
+
+**Files:**
+
+- Modify: `packages/core/src/components/pagination/pagination.ts`
+- Modify: `packages/core/src/components/pagination/pagination.styles.ts`
+- Modify: `packages/core/src/components/pagination/pagination.test.ts`
+
+**Interfaces:**
+
+- Consumes: `_calculatePages(current: number, total: number, budget?: number): number[]` (déjà
+  exporté par `pagination.utils.ts`, aucune modification) ; `announceA11y(message: string, politeness?: 'polite' | 'assertive'): void`.
+- Produces: nouvelle méthode privée `_onSelectChange(event: Event): void` sur `ArPagination` ;
+  nouvelle méthode protégée `renderPageSelect(current: number, total: number): TemplateResult` ;
+  nouveaux parts shadow DOM `select` et `page-select`. Tasks 2 et 3 s'appuient sur ces noms.
+
+- [ ] **Step 1: Écrire les tests unitaires qui échouent (Vitest)**
+
+Dans `packages/core/src/components/pagination/pagination.test.ts`, remplacer entièrement le bloc
+`describe('palier texte sous le plancher', ...)` (lignes 219-258 actuelles) par :
+
+```ts
+// ── Palier select (budget très restreint) ────────────────────────────────
+
+describe('palier select sous le plancher', () => {
+    it('bascule sur un <select> de saut de page quand _budget est sous le plancher', async () => {
+        el = await fixture('<ar-pagination current="3" total="15"></ar-pagination>');
+        // @ts-expect-error accès à un champ privé pour simuler une mesure ResizeObserver
+        el._budget = 2;
+        el.requestUpdate();
+        await waitForUpdate(el);
+
+        const shadow = el.shadowRoot as ShadowRoot;
+        const select = shadow.querySelector('[part~="select"]');
+        expect(select).not.toBeNull();
+        expect(select?.tagName.toLowerCase()).toBe('select');
+        expect(shadow.querySelectorAll('[part~="link"], [part~="current"]').length).toBe(0);
+    });
+
+    it('peuple le select avec les mêmes pages que _calculatePages au plancher (première/dernière page, fenêtre minimale, ellipses en disabled)', async () => {
+        el = await fixture('<ar-pagination current="3" total="15"></ar-pagination>');
+        // @ts-expect-error accès à un champ privé pour simuler une mesure ResizeObserver
+        el._budget = 2;
+        el.requestUpdate();
+        await waitForUpdate(el);
+
+        const select = getPart(el, 'select') as HTMLSelectElement;
+        const options = Array.from(select.querySelectorAll('option'));
+        // _calculatePages(3, 15, 2) retombe sur _minimalPages(3, 15) = [1, -1, 3, -2, 15]
+        expect(options).toHaveLength(5);
+        expect(options.map((o) => o.disabled)).toEqual([false, true, false, true, false]);
+        expect(options.map((o) => o.value)).toEqual(['1', '', '3', '', '15']);
+        expect(options[2]?.selected).toBe(true);
+    });
+
+    it('le label de chaque option contient "Page X sur Y"', async () => {
+        el = await fixture('<ar-pagination current="3" total="15"></ar-pagination>');
+        // @ts-expect-error accès à un champ privé pour simuler une mesure ResizeObserver
+        el._budget = 2;
+        el.requestUpdate();
+        await waitForUpdate(el);
+
+        const select = getPart(el, 'select') as HTMLSelectElement;
+        const options = Array.from(select.querySelectorAll('option'));
+        expect(options[0]?.textContent?.trim()).toBe('Page 1 sur 15');
+        expect(options[2]?.textContent?.trim()).toBe('Page 3 sur 15');
+        expect(options[4]?.textContent?.trim()).toBe('Page 15 sur 15');
+    });
+
+    it('changer la valeur du select émet ar-pagination-page-change et met à jour current', async () => {
+        el = await fixture('<ar-pagination current="3" total="15"></ar-pagination>');
+        // @ts-expect-error accès à un champ privé pour simuler une mesure ResizeObserver
+        el._budget = 2;
+        el.requestUpdate();
+        await waitForUpdate(el);
+
+        const handler = vi.fn();
+        el.addEventListener('ar-pagination-page-change', handler);
+        const select = getPart(el, 'select') as HTMLSelectElement;
+        select.value = '15';
+        select.dispatchEvent(new Event('change'));
+        await waitForUpdate(el);
+
+        expect(el.current).toBe(15);
+        expect(handler).toHaveBeenCalledOnce();
+        const detail = (handler.mock.calls[0][0] as CustomEvent<ArPaginationPageChangeDetail>)
+            .detail;
+        expect(detail).toEqual({ from: 3, to: 15 });
+    });
+
+    it('prev/next restent affichés et fonctionnels au palier select', async () => {
+        el = await fixture('<ar-pagination current="3" total="15"></ar-pagination>');
+        // @ts-expect-error accès à un champ privé pour simuler une mesure ResizeObserver
+        el._budget = 2;
+        el.requestUpdate();
+        await waitForUpdate(el);
+
+        expect(getPart(el, 'prev')).not.toBeNull();
+        expect(getPart(el, 'next')).not.toBeNull();
+        (requirePart(el, 'next') as HTMLElement).click();
+        await waitForUpdate(el);
+        expect(el.current).toBe(4);
+    });
+
+    it('ne bascule pas en palier select si _budget est au-dessus du plancher', async () => {
+        el = await fixture('<ar-pagination current="8" total="15"></ar-pagination>');
+        // @ts-expect-error accès à un champ privé pour simuler une mesure ResizeObserver
+        el._budget = 5;
+        el.requestUpdate();
+        await waitForUpdate(el);
+
+        const shadow = el.shadowRoot as ShadowRoot;
+        expect(shadow.querySelector('[part~="select"]')).toBeNull();
+    });
+});
+```
+
+- [ ] **Step 2: Lancer les tests pour vérifier qu'ils échouent**
+
+Run: `(cd packages/core && npx vitest run src/components/pagination/pagination.test.ts)`
+Expected: FAIL — `[part~="select"]` introuvable (le composant rend encore l'ancien
+`[part~="page-status"]`).
+
+- [ ] **Step 3: Modifier `pagination.ts` — rendu du select**
+
+Dans `packages/core/src/components/pagination/pagination.ts` :
+
+1. Renommer la variable locale `useTextMode` en `useSelectMode` dans `render()` (même condition
+   `this._budget !== undefined && this._budget < floorSlots`, seul le nom change).
+
+2. Remplacer le bloc conditionnel de rendu (actuellement) :
+
+```ts
+                ${useTextMode
+                    ? html`<li part="item page-status">Page ${current} sur ${total}</li>`
+                    : repeat(
+```
+
+par :
+
+```ts
+                ${useSelectMode
+                    ? this.renderPageSelect(current, total)
+                    : repeat(
+```
+
+(la branche `repeat(...)` existante et sa fermeture ne changent pas).
+
+3. Ajouter les deux nouvelles méthodes, juste après `renderPageLabel` (avant `_onPreviousPage`) :
+
+```ts
+    /**
+     * Génère le `<li>` du select de saut de page, affiché à la place de la liste de pages au
+     * palier minimal (largeur insuffisante pour la fenêtre de boutons la plus réduite).
+     */
+    protected renderPageSelect(current: number, total: number): TemplateResult {
+        return html`<li part="item page-select">
+            <span class="sr-only" id="ar-pagination-select-label">Aller à la page</span>
+            <select
+                part="select"
+                aria-labelledby="ar-pagination-select-label"
+                .value=${String(current)}
+                @change=${this._onSelectChange}
+            >
+                ${_calculatePages(current, total, this._budget).map((page) =>
+                    page === -1 || page === -2
+                        ? html`<option disabled value="">…</option>`
+                        : html`<option value=${page} ?selected=${page === current}>
+                              Page ${page} sur ${total}
+                          </option>`,
+                )}
+            </select>
+        </li>`;
+    }
+```
+
+```ts
+    private _onSelectChange(event: Event): void {
+        const select = event.target as HTMLSelectElement;
+        const page = parseInt(select.value, 10);
+        if (Number.isNaN(page) || page === this.current) return;
+        const from = this.current;
+        this.current = page;
+        this._emit({ from, to: this.current });
+        this._announcePageChange();
+    }
+```
+
+4. Mettre à jour le JSDoc du composant : remplacer
+
+```ts
+ * @csspart page-status - Le `<li>` du texte "Page X sur Y" affiché à la place de la liste de
+ *   pages quand l'espace disponible ne permet plus d'afficher de numéros (palier minimal).
+```
+
+par :
+
+```ts
+ * @csspart page-select - Le `<li>` englobant le `<select>` de saut de page, affiché à la place
+ *   de la liste de pages quand l'espace disponible ne permet plus d'afficher de numéros (palier
+ *   minimal).
+ * @csspart select - L'élément `<select>` de saut de page. Personnalisable via `::part(select)`
+ *   (apparence, flèche custom via `appearance: none` posé en structurel).
+```
+
+- [ ] **Step 4: Modifier `pagination.styles.ts` — styles structurels du select**
+
+Dans `packages/core/src/components/pagination/pagination.styles.ts` :
+
+1. Ajouter `[part~='select']` au groupe de sélecteurs qui pose la taille de cible tactile minimale :
+
+```css
+[part~='prev'],
+[part~='next'],
+[part~='link'],
+[part~='current'],
+[part~='select'],
+[part~='ellipsis'] {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    /* a11y-fallback: WCAG 2.5.8 taille de cible minimale */
+    min-height: var(--ar-pagination-btn-size, 2.5rem);
+    /* a11y-fallback: WCAG 2.5.8 taille de cible minimale */
+    min-width: var(--ar-pagination-btn-size, 2.5rem);
+}
+```
+
+2. Ajouter `[part~='select']` au groupe qui pose l'outline `:focus-visible` :
+
+```css
+[part~='prev'],
+[part~='next'],
+[part~='link'],
+[part~='current'],
+[part~='select'] {
+    &:focus-visible {
+        outline: 2px solid currentColor;
+        outline-offset: 2px;
+    }
+}
+```
+
+3. Remplacer la règle `[part~='page-status'] { white-space: nowrap; }` (en fin de fichier) par :
+
+```css
+[part~='select'] {
+    appearance: none;
+}
+```
+
+- [ ] **Step 5: Lancer les tests pour vérifier qu'ils passent**
+
+Run: `(cd packages/core && npx vitest run src/components/pagination/pagination.test.ts)`
+Expected: PASS — tous les tests, y compris le nouveau bloc "palier select sous le plancher".
+
+- [ ] **Step 6: Lancer la suite Vitest complète du composant pour vérifier l'absence de régression**
+
+Run: `(cd packages/core && npx vitest run src/components/pagination/)`
+Expected: PASS — aucun test existant (rendu, navigation, événements, annonces a11y, warn) cassé
+par le renommage `useTextMode` → `useSelectMode` ou l'ajout du select.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/src/components/pagination/pagination.ts \
+        packages/core/src/components/pagination/pagination.styles.ts \
+        packages/core/src/components/pagination/pagination.test.ts
+git commit -m "feat(pagination): remplace le palier texte par un select de saut de page"
+```
+
+---
+
+### Task 2: Tests navigateur (WTR) et vérification empirique du débordement
+
+**Files:**
+
+- Modify: `packages/core/src/components/pagination/pagination.browser.test.ts`
+
+**Interfaces:**
+
+- Consumes: parts `select`, `page-select` produits par Task 1 ; propriété `.current`, événement
+  `ar-pagination-page-change` (inchangés).
+- Produces: verdict GO/NO-GO qui détermine si Task 3 (repli) doit être exécutée.
+
+- [ ] **Step 1: Remplacer le test du palier texte par son équivalent select**
+
+Dans `packages/core/src/components/pagination/pagination.browser.test.ts`, remplacer le test
+`it('bascule sur le palier texte "Page X sur Y" à largeur extrême', ...)` (lignes 117-143
+actuelles) par :
+
+```ts
+it('bascule sur un <select> de saut de page à largeur extrême', async () => {
+    const wrapper = await fixture(
+        html`<div style="width: 900px;">
+            <ar-pagination current="8" total="15"></ar-pagination>
+        </div>`,
+    );
+    const el = wrapper.querySelector('ar-pagination') as HTMLElement;
+    await elementUpdated(el);
+    await waitForResize();
+
+    wrapper.style.width = '90px';
+    await waitForResize();
+
+    const shadow = el.shadowRoot as ShadowRoot;
+    const select = shadow.querySelector('[part~="select"]') as HTMLSelectElement;
+    expect(select).to.not.equal(null);
+    expect(select.tagName.toLowerCase()).to.equal('select');
+    expect(shadow.querySelectorAll('[part~="link"], [part~="current"]').length).to.equal(0);
+
+    // _calculatePages(8, 15, budget-plancher) → _minimalPages(8, 15) = [1, -1, 8, -2, 15]
+    const options = Array.from(select.querySelectorAll('option'));
+    expect(options).to.have.lengthOf(5);
+    expect(options[2]?.selected).to.equal(true);
+    expect(options[2]?.textContent?.trim()).to.equal('Page 8 sur 15');
+    expect(options[1]?.disabled).to.equal(true);
+    expect(options[3]?.disabled).to.equal(true);
+});
+
+it('sélectionner une option du select change la page', async () => {
+    const wrapper = await fixture(
+        html`<div style="width: 90px;">
+            <ar-pagination current="8" total="15"></ar-pagination>
+        </div>`,
+    );
+    const el = wrapper.querySelector('ar-pagination') as HTMLElement;
+    await elementUpdated(el);
+    await waitForResize();
+
+    const shadow = el.shadowRoot as ShadowRoot;
+    const select = shadow.querySelector('[part~="select"]') as HTMLSelectElement;
+    select.value = '15';
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+    await elementUpdated(el);
+
+    expect((el as unknown as { current: number }).current).to.equal(15);
+});
+```
+
+- [ ] **Step 2: Mettre à jour le test "prev/next restent cliquables"**
+
+Le test `it('prev/next restent cliquables au palier texte', ...)` (lignes 145-161 actuelles) ne
+référence aucun sélecteur `page-status` — aucune modification nécessaire, seul son nom peut être
+clarifié :
+
+```ts
+        it('prev/next restent cliquables au palier select', async () => {
+```
+
+(remplacer uniquement le titre du test, le corps reste identique).
+
+- [ ] **Step 3: Mettre à jour le test de régression "ne reste pas bloqué"**
+
+Dans le test `it("ne reste pas bloqué au palier texte après un changement d'ordre de grandeur de total suivi d'un réélargissement", ...)` (lignes 170-216 actuelles), remplacer toutes les occurrences de
+`[part~="page-status"]` par `[part~="select"]`, et le titre du test :
+
+```ts
+it("ne reste pas bloqué au palier select après un changement d'ordre de grandeur de total suivi d'un réélargissement", async () => {
+    // Régression : `total` qui change d'ordre de grandeur (9 → 10, 99 → 100, ...)
+    // pendant que le composant est déjà au palier select marquait `_itemWidth` comme à
+    // remesurer, mais aucun item numérique n'est rendu à ce palier — sans item à
+    // mesurer, `_recalculateBudget` ne recalculait plus jamais `_budget`, bloquant le
+    // composant sur le select même après un réélargissement massif du conteneur.
+    const wrapper = await fixture(
+        html`<div style="width: 700px;">
+            <ar-pagination current="100" total="200"></ar-pagination>
+        </div>`,
+    );
+    const el = wrapper.querySelector('ar-pagination') as HTMLElement;
+    await elementUpdated(el);
+    await waitForResize();
+
+    const shadow = el.shadowRoot as ShadowRoot;
+
+    // 1. Conteneur large → numéros affichés, `_itemWidth` mesuré normalement.
+    expect(shadow.querySelectorAll('[part~="link"], [part~="current"]').length).to.be.greaterThan(
+        0,
+    );
+
+    // 2. Rétrécir jusqu'au palier select.
+    wrapper.style.width = '90px';
+    await waitForResize();
+    expect(shadow.querySelector('[part~="select"]')).to.not.equal(null);
+    expect(shadow.querySelectorAll('[part~="link"], [part~="current"]').length).to.equal(0);
+
+    // 3. Changer `total` (et `current`, pour rester valide) d'ordre de grandeur pendant
+    //    que le composant est au palier select (déclenche l'invalidation de
+    //    `_itemWidth`) — toujours aucun item numérique disponible pour remesurer
+    //    immédiatement.
+    (el as unknown as { total: number; current: number }).total = 15;
+    (el as unknown as { total: number; current: number }).current = 8;
+    await elementUpdated(el);
+    await waitForResize();
+
+    // 4. Réélargir le conteneur → les numéros doivent réapparaître normalement, pas
+    //    rester bloqués sur le select.
+    wrapper.style.width = '700px';
+    await waitForResize();
+
+    expect(shadow.querySelector('[part~="select"]')).to.equal(null);
+    expect(shadow.querySelectorAll('[part~="link"], [part~="current"]').length).to.be.greaterThan(
+        0,
+    );
+});
+```
+
+- [ ] **Step 4: Lancer la suite de tests navigateur du composant**
+
+Run: `(cd packages/core && npx web-test-runner --files "src/components/pagination/pagination.browser.test.ts")`
+Expected: PASS — tous les tests, y compris ceux de la section
+`describe('invariant anti-débordement avec le thème par défaut ...')` (non modifiée par ce plan).
+
+- [ ] **Step 5: Vérification empirique du débordement (décision GO/NO-GO pour Task 3)**
+
+Le test `it('list.scrollWidth ne dépasse jamais list.clientWidth avec un total à 3 chiffres (total=999)', ...)`
+(section "invariant anti-débordement", déjà présent, non modifié) balaie les largeurs
+`[280, 360, 440, 480, 700]` avec `current="500" total="999"` — le cas le plus défavorable pour la
+longueur du label (`"Page 500 sur 999"`, 3 chiffres × 2), avec les règles CSS du thème par défaut
+(`column-gap`, `padding`) simulées. C'est la vérification empirique demandée par le spec (§ Tests,
+"Vérification manuelle (Playwright)") : elle couvre directement le cas limite en conditions
+proches du thème réel, sans script Playwright séparé.
+
+- Si ce test **passe** (Step 4 déjà vert) : le label complet tient à toutes les largeurs testées,
+  y compris 280px. **Ne pas exécuter Task 3** — noter dans le message de commit de Task 4 que le
+  repli n'a pas été nécessaire.
+- Si ce test **échoue** (débordement détecté à une largeur ≥ 320px) : passer à Task 3 avant de
+  continuer.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/components/pagination/pagination.browser.test.ts
+git commit -m "test(pagination): couvre le select de saut de page en tests navigateur"
+```
+
+---
+
+### Task 3 (conditionnelle — seulement si Task 2 Step 5 a détecté un débordement) : Repli labels courts + aria-label dynamique
+
+**Ne pas exécuter cette task si Task 2 Step 5 est passée sans débordement.** Si elle est ignorée,
+le documenter explicitement dans Task 4.
+
+**Files:**
+
+- Modify: `packages/core/src/components/pagination/pagination.ts`
+- Modify: `packages/core/src/components/pagination/pagination.test.ts`
+- Modify: `packages/core/src/components/pagination/pagination.browser.test.ts`
+
+**Interfaces:**
+
+- Consumes: `renderPageSelect`, `_onSelectChange` produits par Task 1 (modifiés sur place, aucun
+  renommage).
+- Produces: aucun nouveau symbole — le contrat public (`part="select"`, événement
+  `ar-pagination-page-change`) ne change pas, seul le contenu du DOM interne change.
+
+- [ ] **Step 1: Modifier les tests unitaires (Vitest) pour le label court + aria-label**
+
+Dans `packages/core/src/components/pagination/pagination.test.ts`, remplacer les deux tests
+"peuple le select..." et "le label de chaque option..." du bloc `describe('palier select sous le
+plancher', ...)` (ajoutés en Task 1) par :
+
+```ts
+it('peuple le select avec des labels courts et les mêmes pages que _calculatePages au plancher', async () => {
+    el = await fixture('<ar-pagination current="3" total="15"></ar-pagination>');
+    // @ts-expect-error accès à un champ privé pour simuler une mesure ResizeObserver
+    el._budget = 2;
+    el.requestUpdate();
+    await waitForUpdate(el);
+
+    const select = getPart(el, 'select') as HTMLSelectElement;
+    const options = Array.from(select.querySelectorAll('option'));
+    // _calculatePages(3, 15, 2) retombe sur _minimalPages(3, 15) = [1, -1, 3, -2, 15]
+    expect(options).toHaveLength(5);
+    expect(options.map((o) => o.disabled)).toEqual([false, true, false, true, false]);
+    expect(options.map((o) => o.value)).toEqual(['1', '', '3', '', '15']);
+    expect(options.map((o) => o.textContent?.trim())).toEqual(['1', '…', '3', '…', '15']);
+    expect(options[2]?.selected).toBe(true);
+});
+
+it('le select porte un aria-label dynamique combinant nom et valeur courante', async () => {
+    el = await fixture('<ar-pagination current="3" total="15"></ar-pagination>');
+    // @ts-expect-error accès à un champ privé pour simuler une mesure ResizeObserver
+    el._budget = 2;
+    el.requestUpdate();
+    await waitForUpdate(el);
+
+    const select = getPart(el, 'select') as HTMLSelectElement;
+    expect(select.getAttribute('aria-label')).toBe('Aller à la page, page 3 sur 15');
+    expect(select.hasAttribute('aria-labelledby')).toBe(false);
+});
+```
+
+- [ ] **Step 2: Lancer les tests pour vérifier qu'ils échouent**
+
+Run: `(cd packages/core && npx vitest run src/components/pagination/pagination.test.ts)`
+Expected: FAIL — le select porte encore `aria-labelledby` et des labels complets.
+
+- [ ] **Step 3: Modifier `renderPageSelect` — labels courts + aria-label dynamique**
+
+Dans `packages/core/src/components/pagination/pagination.ts`, remplacer `renderPageSelect` par :
+
+```ts
+    /**
+     * Génère le `<li>` du select de saut de page, affiché à la place de la liste de pages au
+     * palier minimal (largeur insuffisante pour la fenêtre de boutons la plus réduite).
+     *
+     * Labels d'option courts (numéro seul) + `aria-label` dynamique portant le nom et la valeur
+     * courante : le label complet ("Page X sur Y") dans les options faisait déborder le
+     * déclencheur fermé à largeur réduite (vérifié empiriquement, cf. plan d'implémentation).
+     */
+    protected renderPageSelect(current: number, total: number): TemplateResult {
+        return html`<li part="item page-select">
+            <select
+                part="select"
+                aria-label="Aller à la page, page ${current} sur ${total}"
+                .value=${String(current)}
+                @change=${this._onSelectChange}
+            >
+                ${_calculatePages(current, total, this._budget).map((page) =>
+                    page === -1 || page === -2
+                        ? html`<option disabled value="">…</option>`
+                        : html`<option value=${page} ?selected=${page === current}>${page}</option>`,
+                )}
+            </select>
+        </li>`;
+    }
+```
+
+- [ ] **Step 4: Lancer les tests pour vérifier qu'ils passent**
+
+Run: `(cd packages/core && npx vitest run src/components/pagination/pagination.test.ts)`
+Expected: PASS.
+
+- [ ] **Step 5: Mettre à jour les tests navigateur (WTR) pour le label court**
+
+Dans `packages/core/src/components/pagination/pagination.browser.test.ts`, dans le test
+`it('bascule sur un <select> de saut de page à largeur extrême', ...)` (ajouté en Task 2),
+remplacer :
+
+```ts
+expect(options[2]?.textContent?.trim()).to.equal('Page 8 sur 15');
+```
+
+par :
+
+```ts
+expect(options[2]?.textContent?.trim()).to.equal('8');
+expect(select.getAttribute('aria-label')).to.equal('Aller à la page, page 8 sur 15');
+```
+
+- [ ] **Step 6: Relancer la vérification empirique (Task 2 Step 5) pour confirmer le repli**
+
+Run: `(cd packages/core && npx web-test-runner --files "src/components/pagination/pagination.browser.test.ts")`
+Expected: PASS, y compris `list.scrollWidth ne dépasse jamais list.clientWidth avec un total à 3
+chiffres (total=999)` — confirme que le repli résout le débordement détecté en Task 2.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/src/components/pagination/pagination.ts \
+        packages/core/src/components/pagination/pagination.test.ts \
+        packages/core/src/components/pagination/pagination.browser.test.ts
+git commit -m "fix(pagination): repli labels courts + aria-label dynamique (débordement à largeur réduite)"
+```
+
+---
+
+### Task 4: Documentation
+
+**Files:**
+
+- Modify: `apps/docs/src/content/components/ar-pagination.mdx`
+
+**Interfaces:**
+
+- Consumes: comportement final d'`ar-pagination` issu de Task 1 (+ Task 3 si exécutée).
+- Produces: aucune nouvelle interface — documentation uniquement.
+
+- [ ] **Step 1: Réécrire la section "Comportement responsive"**
+
+Dans `apps/docs/src/content/components/ar-pagination.mdx`, remplacer le troisième point de la
+liste (actuellement) :
+
+```
+- **Largeur extrême** : les numéros de page sont remplacés par un texte "Page X sur Y". Les
+  boutons précédent/suivant restent toujours affichés et fonctionnels.
+```
+
+par :
+
+```
+- **Largeur extrême** : les numéros de page sont remplacés par un `<select>` de saut de page,
+  peuplé des mêmes pages que la fenêtre minimale ci-dessus (première page, dernière page, page
+  active) — les ellipses y apparaissent comme options désactivées. Sélectionner une page dans
+  cette liste a le même effet qu'un clic sur un numéro. Les boutons précédent/suivant restent
+  toujours affichés et fonctionnels.
+```
+
+- [ ] **Step 2: Vérifier le rendu MDX**
+
+Run: `npx astro check --root apps/docs`
+Expected: 0 erreurs.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/docs/src/content/components/ar-pagination.mdx
+git commit -m "docs(pagination): documente le select de saut de page au palier minimal"
+```

--- a/docs/superpowers/specs/2026-08-07-pagination-responsive-masking-design.md
+++ b/docs/superpowers/specs/2026-08-07-pagination-responsive-masking-design.md
@@ -1,0 +1,102 @@
+# Design — Masquage responsive progressif d'ar-pagination (#152)
+
+**Statut :** Validé (en attente de plan d'implémentation)
+**Date :** 2026-08-07
+**Issue :** [#152](https://github.com/jogo-labs/ariane/issues/152) — `ar-pagination` : repenser le
+masquage responsive
+
+## Contexte
+
+`ar-pagination` masque actuellement ses numéros de page intermédiaires via une media query CSS
+unique (`max-width: 640px`) qui ne tient compte ni du nombre de pages réellement rendues par
+`_calculatePages` (jusqu'à 9 numéros + prev/next), ni de la largeur réelle du composant. Deux
+problèmes en découlent : un seuil binaire non progressif, et un référentiel viewport plutôt que
+composant — inadapté à un composant qui peut être placé dans un conteneur étroit (sidebar) sur un
+écran large, ou en pleine largeur sur mobile.
+
+Trouvé lors de l'audit token-vs-part #129 (lot 6), hors scope de cette migration, traité ici
+séparément.
+
+## Décisions issues du brainstorming
+
+- **Référentiel de largeur** : la largeur propre du composant (son conteneur), pas le viewport.
+  Le composant peut être intégré dans des contextes de largeur variable indépendants de l'écran.
+- **Mécanisme** : JavaScript (`ResizeObserver`) plutôt que CSS pur (`@container`). Les seuils de
+  container queries en dur seraient désynchronisés dès qu'un thème personnalise
+  `--ar-pagination-btn-size` ou la typographie (`var()` n'est pas utilisable dans une condition
+  `@container`) — incohérent avec la philosophie headless du projet (ADR-004).
+- **Plancher minimal à largeur extrême** : prev/next + page courante + un texte visible en
+  permanence `Page X / Y` (pas un nouveau widget interactif type `<select>`/combobox — hors scope,
+  élargirait significativement le périmètre de cette issue vers un nouveau pattern d'interaction).
+
+## Architecture
+
+### 1. Mesure
+
+Un `ResizeObserver` observe l'élément `<nav part="nav">` et déclenche, à chaque changement de
+largeur, le recalcul d'un **budget** : le nombre de slots numériques (pages + ellipses, hors
+prev/next) que l'espace disponible peut contenir.
+
+- Largeur disponible pour les numéros = largeur du `nav` − largeur mesurée de `prev` − largeur
+  mesurée de `next`.
+- Largeur d'un item numérique : mesurée sur un item réellement rendu (ex. premier `<li>`
+  numérique) après le premier rendu complet. Une valeur unique est utilisée pour tous les items
+  (ils partagent un `min-width` commun via `--ar-pagination-btn-size`) — un composant avec des
+  tailles d'item hétérogènes n'est pas dans le périmètre de cette issue.
+- Pas de debounce/throttle sur le callback : le volume d'événements de resize pour ce composant
+  est faible (pas un cas de scroll/drag continu).
+
+Avant la première mesure (`firstUpdated`), le composant utilise un budget par défaut généreux
+(comportement actuel, aucune troncature) pour éviter un rendu vide. Un léger réajustement visuel
+au tout premier paint est accepté comme compromis assumé, sans mécanisme de masquage préventif
+(pas de sur-ingénierie pour un flash d'une frame).
+
+### 2. Algorithme de pagination généralisé
+
+`_calculatePages(current, total, budget?)` est étendu avec un paramètre `budget` optionnel :
+
+- **Sans `budget`** (ou budget suffisant pour le total) : comportement actuel inchangé — jusqu'à 9
+  slots (boundary 1 + 2 ellipses + 5 pages autour de la courante) ou liste complète si
+  `total < 10`.
+- **Avec `budget` réduit** : réduction progressive du nombre de pages voisines affichées autour de
+  la page courante (`siblingCount` décroissant : 2 → 1 → 0), puis abandon de first/last si le
+  budget est encore insuffisant.
+- **Sous le plancher** (budget ne permet même plus prev/next + courante + first/last) : ce cas
+  n'est plus traité par `_calculatePages` mais par un mode de rendu distinct (voir §3).
+
+Le budget pilote directement ce qui est **généré**, pas ce qui est **masqué en CSS** après coup —
+contrairement à l'implémentation actuelle qui masque via `display: none` des `<a>` déjà présents
+dans le DOM. Bénéfice secondaire : l'ordre de tabulation reflète naturellement ce qui est visible,
+sans dépendre d'un `display:none` sur des liens qui restent focusables par défaut.
+
+### 3. Palier texte
+
+En dessous du budget plancher, la liste de numéros est remplacée par un texte visible en
+permanence "Page X / Y" (réutilise l'infrastructure existante de `renderPageLabel`/annonce
+a11y). prev/next restent affichés et fonctionnels dans tous les cas.
+
+### 4. CSS
+
+- Suppression de la media query `@media screen and (max-width: 640px)` (`pagination.styles.ts`).
+- `[part='list']` passe de `flex-wrap: wrap` à `flex-wrap: nowrap` — le budget calculé par JS
+  garantit que ce qui est rendu tient toujours sur une ligne, le wrap n'est plus un filet de
+  sécurité nécessaire.
+
+## Tests
+
+- **Unitaires (Vitest)** : `_calculatePages(current, total, budget)` sur chaque palier de budget
+  (large/inchangé, réduit avec siblingCount décroissant, minimal sans first/last). Le cas
+  `total < 10` (déjà sans ellipse aujourd'hui) doit aussi pouvoir être tronqué si le budget est
+  très restreint.
+- **Browser (WTR)** : comportement responsive réel — redimensionner le conteneur et vérifier
+  quels `part` sont présents à différentes largeurs, y compris le palier texte. Un `ResizeObserver`
+  mocké en Vitest classique ne reflète pas le comportement réel du navigateur, donc pas de test
+  unitaire sur ce point.
+
+## Hors scope
+
+- Un widget de saut de page (`<select>`/combobox) sur les très petites largeurs — pattern
+  d'interaction différent, non demandé par l'issue.
+- Support de tailles d'item hétérogènes entre les numéros de page.
+- Débounce/throttle du `ResizeObserver` — à reconsidérer seulement si un cas d'usage réel montre
+  un problème de performance.

--- a/docs/superpowers/specs/2026-08-10-pagination-a11y-labels-design.md
+++ b/docs/superpowers/specs/2026-08-10-pagination-a11y-labels-design.md
@@ -1,0 +1,131 @@
+# Design — Labels accessibles enrichis d'ar-pagination
+
+**Statut :** Validé (en attente de plan d'implémentation)
+**Date :** 2026-08-10
+**Contexte :** suite du select de saut de page ([spec](2026-08-10-pagination-select-fallback-design.md),
+PR #172)
+
+## Contexte
+
+Audit des labels et attributs ARIA actuels d'`ar-pagination` (`packages/core/src/components/pagination/pagination.ts`), à la demande explicite d'un retour terrain : en explorant la pagination au clavier/lecteur d'écran, rien n'indique le nombre total de pages ni la position de la page active dans l'ensemble — impossible de savoir si "page 5" est la dernière ou si on est en début/fin de liste.
+
+**Déjà en place, non modifié par ce spec :**
+
+- `role="navigation"` + `aria-labelledby` (landmark repérable).
+- `aria-disabled` synchronisé sur prev/next.
+- Ellipses masquées (`aria-hidden`).
+- `announceA11y` après changement de page — annonce déjà "Page X sur Y" en entier, mais
+  uniquement de façon réactive (après une action), jamais pendant l'exploration.
+- Le `<select>` mobile (livré juste avant) a déjà des labels complets "Page X sur Y" par option.
+
+**Piste explorée et écartée** : `aria-setsize`/`aria-posinset` (mécanisme ARIA natif prévu pour
+une liste tronquée) — support réel vérifié partiel : VoiceOver ne respecte ces attributs que sur
+`role="option"`, pas sur `role="listitem"`/liens (notre structure). Sources :
+[aria-posinset — Accessibility Support](https://a11ysupport.io/tech/aria/aria-posinset_attribute),
+[Issue #93 — a11ysupport.io](https://github.com/accessibilitysupported/a11ysupport.io/issues/93).
+Écarté au profit d'un texte sr-only enrichi, fiable sur tous les lecteurs d'écran.
+
+## Décisions issues du brainstorming
+
+1. **Prev/next** : ajouter le total au label déjà présent.
+2. **Liens de page + page active** : enrichir avec le total, sans changement visuel — nécessite de
+   séparer texte lu (sr-only, complet) et texte affiché (`aria-hidden`, juste le numéro).
+3. **`aria-current="true"` → `aria-current="page"`** : correction sémantique indépendante, trouvée
+   en auditant l'existant. `"page"` est le token ARIA spécifiquement prévu pour "page courante
+   dans un ensemble de pages" (vs `"true"`, générique) — certains lecteurs d'écran distinguent les
+   deux à l'annonce.
+4. **Nom du landmark dynamique** : `"Pagination"` (statique) devient `"Pagination, page X sur Y"`
+   — donne le contexte immédiatement à qui saute directement dans la région via un raccourci
+   lecteur d'écran (ex. navigation par régions NVDA/JAWS), sans avoir à explorer les liens.
+
+Hors scope : nommage distinct pour plusieurs instances du composant sur une même page (landmark
+"Pagination" partagé) — problème réel mais distinct, non soulevé par la demande initiale.
+
+## Architecture
+
+### 1. Prev/next (`pagination.ts`, `render()`)
+
+```html
+<span class="sr-only">Page précédente (page ${previousPageNumber} sur ${total})</span>
+<span class="sr-only">Page suivante (page ${nextPageNumber} sur ${total})</span>
+```
+
+Simple ajout de texte — ces labels sont déjà entièrement sr-only (l'icône est séparément
+`aria-hidden`), aucun risque de duplication visuelle.
+
+### 2. Liens de page + page active
+
+Structure actuelle (`renderPageLabel`) :
+
+```html
+<span class="sr-only">Page&nbsp;</span>${page}
+```
+
+Le numéro est affiché ET lu tel quel après le préfixe sr-only. Nouvelle structure — texte complet
+lu, numéro seul affiché :
+
+```html
+<span class="sr-only">Page ${page} sur ${total}</span> <span aria-hidden="true">${page}</span>
+```
+
+`renderPageLabel(page, total)` gagne le paramètre `total` ; `renderPage`/`renderPageLink` (qui
+l'appellent) le propagent depuis `render()`. Changement de signature accepté sans dépréciation
+(composant en alpha, cf. CLAUDE.md).
+
+**Sécurité vis-à-vis du bug historique (#152, "8sur15")** : ce bug venait de plusieurs bindings
+Lit interpolés séparément à même niveau dans un conteneur `display:flex`, chacun devenant un
+flex-item anonyme distinct (whitespace inter-item perdu). Ici, tout le texte lu est **une seule
+chaîne interpolée dans un seul `<span>`** (`Page ${page} sur ${total}`) — même schéma déjà utilisé
+sans problème pour les options du select et pour `_announcePageChange`. Le `<span class="sr-only">`
+est de toute façon retiré du flux flex par `position: absolute` (propriété CSS des éléments
+positionnés en absolu : ils ne participent pas au layout flex de leur parent), donc aucune
+interaction avec le flex du conteneur `[part~='link']`/`[part~='current']`.
+
+`aria-current` continue de porter l'information "page active" séparément — pas de texte
+"page actuelle" dupliqué dans le label (déjà porté par `aria-current`, cf. point 3).
+
+### 3. `aria-current="page"`
+
+Dans `renderPageLink` :
+
+```html
+<span part="current" tabindex="-1" aria-current="page" data-ar-pagination-page="${page}"></span>
+```
+
+Remplace `aria-current="true"`. Seul ce point change dans `renderPageLink` ; le reste (structure,
+`tabindex="-1"`, `data-ar-pagination-page`) est inchangé.
+
+### 4. Nom du landmark dynamique
+
+```html
+<p id="ar-pagination" class="sr-only">Pagination, page ${current} sur ${total}</p>
+```
+
+Remplace le texte statique `"Pagination"`. `aria-labelledby="ar-pagination"` sur le `<nav>` reste
+inchangé — seul le contenu du `<p>` référencé devient dynamique. Réactif à chaque changement de
+`current`/`total` comme le reste du template.
+
+## Tests
+
+- **Unitaires (Vitest)** :
+    - `aria-current` vaut `"page"` (pas `"true"`) sur `[part="current"]` — met à jour le test
+      existant `'la page active a aria-current="true"'` (`pagination.test.ts:161`).
+    - Contenu du `<span class="sr-only">` de chaque lien/page active = `"Page X sur Y"`.
+    - Contenu du `<span aria-hidden="true">` = le numéro seul (comportement visuel inchangé).
+    - Labels sr-only de prev/next incluent `"sur {total}"`.
+    - Nom du landmark (`<p id="ar-pagination">`) reflète `current`/`total` courants, y compris après
+      un changement de page.
+- **Browser (WTR)** : aucune régression sur les tests de focus existants
+  (`pagination.browser.test.ts`, focus sur `[part~="current"]` après activation) — la structure du
+  `<span part="current">` change de contenu interne, pas de tabindex/focusabilité.
+- **Accessibilité (axe-core, `pagination.a11y.test.ts`)** : suite existante (première/milieu/
+  dernière page, avec ellipses) doit rester verte. Ajouter un scénario au palier select
+  (`_budget` forcé sous le plancher) pour couvrir ce mode dans le passage axe-core, non couvert
+  aujourd'hui.
+
+## Hors scope
+
+- `aria-setsize`/`aria-posinset` (support VoiceOver insuffisant sur notre structure, cf. ci-dessus).
+- Nommage distinct du landmark pour plusieurs instances du composant sur une même page.
+- Modification du contenu ou du comportement du `<select>` mobile (déjà conforme, labels complets
+  livrés dans la PR précédente).

--- a/docs/superpowers/specs/2026-08-10-pagination-select-fallback-design.md
+++ b/docs/superpowers/specs/2026-08-10-pagination-select-fallback-design.md
@@ -180,3 +180,21 @@ au budget **actuel** (§2 ci-dessus, décision initiale) produisait deux effets 
   budget de 3-4 slots, recréant le bug de débordement corrigé lors de la review finale du
   2026-08-07). Conséquence acceptée : les pages en bord basculent en select légèrement plus tôt
   qu'avant (à une largeur où 3 boutons tiendraient encore).
+
+### Amendement 2 (2026-08-10, second retour terrain) : bascule anticipée si la fenêtre a 2 ellipses
+
+Constat complémentaire : même avec `floorSlots = 5`, une position `current` loin des deux bords
+(ex. `current = 8, total = 15`) peut faire retomber `_calculatePages` sur sa fenêtre minimale
+`[1, -1, current, -2, total]` dès que le budget touche exactement 5 — 5 slots dont 2 ellipses
+purement décoratives, pour seulement **3 pages réellement cliquables**. Le budget brut suffit
+techniquement à afficher cette fenêtre, mais le select (une fois fermé, plus étroit que n'importe
+quelle fenêtre de boutons, et peuplé de la richesse desktop depuis l'amendement précédent) offre
+alors nettement plus de valeur pour le même espace.
+
+**Décision** : en plus du critère `_budget < floorSlots`, on bascule aussi en mode select dès que
+la fenêtre obtenue via `_calculatePages(current, total, this._budget)` contient exactement 5
+éléments avec les deux sentinelles d'ellipse (`-1` et `-2`) présentes — indépendamment du budget
+brut. Repli strictement plus sûr que les boutons qu'il remplace (un `<select>` fermé est plus
+étroit que la fenêtre à 5 slots qu'il aurait fallu rendre), donc aucun nouveau risque de
+débordement. `pages` est calculé une seule fois dans `render()` et réutilisé à la fois pour cette
+détection et pour le rendu des boutons numérotés (`repeat`) quand on reste en mode boutons.

--- a/docs/superpowers/specs/2026-08-10-pagination-select-fallback-design.md
+++ b/docs/superpowers/specs/2026-08-10-pagination-select-fallback-design.md
@@ -146,8 +146,37 @@ troisième point ("Largeur extrême : … remplacés par un texte") est réécri
 
 - Peupler le `<select>` avec la liste complète 1..total (redondant avec l'objectif de réduction
   visuelle ; le picker natif deviendrait long sans bénéfice par rapport à la fenêtre réduite).
+  Toujours hors scope après l'amendement ci-dessous : le jeu à largeur confortable reste
+  lui-même une fenêtre réduite par `_calculatePages` (jusqu'à 9 slots), pas la liste 1..total.
 - Mesure dédiée de la largeur du `<select>` pour un repli prev/next-seul en dessous — cas non
   observé aux largeurs réelles ciblées, à reconsidérer seulement si un usage réel le montre
   nécessaire.
 - Support de tailles d'item hétérogènes entre les numéros de page (hérité de la spec du
   2026-08-07, toujours hors scope ici).
+
+## Amendement (2026-08-10, post-implémentation)
+
+Constaté en testant localement la version livrée : peupler le `<select>` avec la fenêtre réduite
+au budget **actuel** (§2 ci-dessus, décision initiale) produisait deux effets non désirés :
+
+1. **Le mobile restait moins capable que le desktop** à largeur extrême — seule la fenêtre
+   minimale (première/dernière page, page active) était accessible, alors que le `<select>`, une
+   fois fermé, reste compact quel que soit son nombre d'options.
+2. **Le seuil de bascule dépendait de la position de `current`** — `floorSlots` valait 3 en bord
+   de liste (`current` = 1 ou `total`) et 5 sinon (hérité du plancher algorithmique naturel de
+   `_calculatePages`/`_minimalPages`, cf. spec du 2026-08-07). À largeur égale, une page en bord
+   restait donc plus longtemps en boutons numérotés qu'une page intermédiaire — un changement de
+   mode visible en changeant seulement de page active, sans changement de largeur.
+
+**Décisions révisées :**
+
+- Le `<select>` est peuplé via `_calculatePages(current, total)` **sans** `this._budget` (donc
+  avec le budget par défaut de la fonction, jusqu'à 9 slots) plutôt qu'avec la fenêtre réduite à
+  la largeur réelle. Le contenu du select ne varie donc plus avec `_budget` — seul le
+  déclenchement du palier select en dépend toujours.
+- `floorSlots` est fixé uniformément à **5** (au lieu de 3 en bord / 5 sinon). Sûr par
+  construction : 5 est déjà le plancher réel en position non-bord, donc aucun risque de
+  débordement (contrairement à uniformiser vers 3, qui ferait tenter un rendu à 5 items dans un
+  budget de 3-4 slots, recréant le bug de débordement corrigé lors de la review finale du
+  2026-08-07). Conséquence acceptée : les pages en bord basculent en select légèrement plus tôt
+  qu'avant (à une largeur où 3 boutons tiendraient encore).

--- a/docs/superpowers/specs/2026-08-10-pagination-select-fallback-design.md
+++ b/docs/superpowers/specs/2026-08-10-pagination-select-fallback-design.md
@@ -82,7 +82,7 @@ ailleurs dans le composant, sur des éléments DOM normaux).
 Si la vérification empirique montre un débordement, le repli se fait sans ajouter d'élément
 sibling — le `<select>` reste seul : les options passent à un label court (`${n}`), et le
 `<select>` porte un `aria-label` dynamique combinant nom et valeur courante
-(ex. `"Aller à la page, page 2 sur 20"`, recalculé à chaque changement de `current`), à la place du
+(ex. `"Aller à la page 2 sur 20"`, recalculé à chaque changement de `current`), à la place du
 `aria-labelledby` statique décrit en §3. Le texte visuel affiché dans le déclencheur fermé reste
 court (`"2"`), seul le nom accessible porte l'information complète.
 

--- a/docs/superpowers/specs/2026-08-10-pagination-select-fallback-design.md
+++ b/docs/superpowers/specs/2026-08-10-pagination-select-fallback-design.md
@@ -79,11 +79,12 @@ accessible d'une option sont donc nécessairement identiques ; aucune compressio
 possible à l'intérieur des `<option>` (contrairement aux `<span class="sr-only">` déjà utilisés
 ailleurs dans le composant, sur des éléments DOM normaux).
 
-Si la vérification empirique montre un débordement, le repli se fait donc directement vers un
-label d'option court (`${n}`) accompagné d'un total en texte statique **sibling** du `<select>`
-(élément DOM normal, hors du contrôle) — c'est à ce niveau, et uniquement à ce niveau, qu'une
-compression visuel/SR différenciée est possible si l'espace reste serré : `/` visible
-(`aria-hidden`) + "sur" en `sr-only`, et en dernier recours "Page" également en `sr-only`.
+Si la vérification empirique montre un débordement, le repli se fait sans ajouter d'élément
+sibling — le `<select>` reste seul : les options passent à un label court (`${n}`), et le
+`<select>` porte un `aria-label` dynamique combinant nom et valeur courante
+(ex. `"Aller à la page, page 2 sur 20"`, recalculé à chaque changement de `current`), à la place du
+`aria-labelledby` statique décrit en §3. Le texte visuel affiché dans le déclencheur fermé reste
+court (`"2"`), seul le nom accessible porte l'information complète.
 
 Exemple à `total=20, current=10` (fenêtre minimale, non-bord) : options "Page 1 sur 20" ·
 … · "Page 10 sur 20" · … · "Page 20 sur 20" — le jeu de pages est identique à ce que produirait un
@@ -96,9 +97,13 @@ desktop très réduit avec le même budget, seul le label change.
   (`{ from, to }`), `announceA11y`. Pas de gestion de focus additionnelle : le focus natif reste
   sur le `<select>` après sélection (contrairement au clic sur un lien, qui déplace le focus vers
   `[part~="current"]` via `focusAfterUpdate`).
-- Nom accessible : `<span class="sr-only">` + `aria-labelledby`, cohérent avec le pattern déjà
-  utilisé pour prev/next (`<span class="sr-only">Page précédente…</span>`), plutôt qu'un
-  `aria-label` en dur.
+- Nom accessible (cas par défaut, label complet dans les options) : `<span class="sr-only">` +
+  `aria-labelledby`, cohérent avec le pattern déjà utilisé pour prev/next
+  (`<span class="sr-only">Page précédente…</span>`) — la valeur (page courante) est déjà portée
+  par le texte de l'option sélectionnée, pas besoin de la dupliquer dans le nom.
+- Nom accessible (repli, labels d'option courts) : `aria-label` dynamique sur le `<select>`
+  combinant nom et valeur (§2), remplace le `aria-labelledby` ci-dessus dans ce cas — un élément
+  ne peut porter les deux sans que `aria-labelledby` ne l'emporte silencieusement.
 - Les `<option disabled>` (ellipses) sont nativement ignorées par la navigation clavier et les
   lecteurs d'écran — comportement natif du `<select>`, aucun code custom requis.
 
@@ -134,8 +139,8 @@ troisième point ("Largeur extrême : … remplacés par un texte") est réécri
   budget réel mesuré (pas seulement en test headless/jsdom), et que le style natif + custom du
   `<select>` se comporte correctement dans un vrai rendu navigateur. Vérifier en particulier que le
   déclencheur fermé avec label complet ("Page 20 sur 20", le cas le plus large) ne déborde pas à
-  320-375px à côté de prev/next — sinon appliquer le repli décrit en §2 (label court + total en
-  texte sibling) avant de figer le plan d'implémentation.
+  320-375px à côté de prev/next — sinon appliquer le repli décrit en §2 (label court + `aria-label`
+  dynamique, sans élément sibling) avant de figer le plan d'implémentation.
 
 ## Hors scope
 

--- a/docs/superpowers/specs/2026-08-10-pagination-select-fallback-design.md
+++ b/docs/superpowers/specs/2026-08-10-pagination-select-fallback-design.md
@@ -82,9 +82,8 @@ ailleurs dans le composant, sur des éléments DOM normaux).
 Si la vérification empirique montre un débordement, le repli se fait donc directement vers un
 label d'option court (`${n}`) accompagné d'un total en texte statique **sibling** du `<select>`
 (élément DOM normal, hors du contrôle) — c'est à ce niveau, et uniquement à ce niveau, qu'une
-compression visuel/SR différenciée est possible si l'espace reste serré : `/` visible (`aria-hidden`)
-
-- "sur" en `sr-only`, et en dernier recours "Page" également en `sr-only`.
+compression visuel/SR différenciée est possible si l'espace reste serré : `/` visible
+(`aria-hidden`) + "sur" en `sr-only`, et en dernier recours "Page" également en `sr-only`.
 
 Exemple à `total=20, current=10` (fenêtre minimale, non-bord) : options "Page 1 sur 20" ·
 … · "Page 10 sur 20" · … · "Page 20 sur 20" — le jeu de pages est identique à ce que produirait un

--- a/docs/superpowers/specs/2026-08-10-pagination-select-fallback-design.md
+++ b/docs/superpowers/specs/2026-08-10-pagination-select-fallback-design.md
@@ -1,0 +1,125 @@
+# Design — `<select>` de saut de page au palier minimal d'ar-pagination
+
+**Statut :** Validé (en attente de plan d'implémentation)
+**Date :** 2026-08-10
+**Contexte :** suite du masquage responsive progressif (#152, [spec du
+2026-08-07](2026-08-07-pagination-responsive-masking-design.md), PR #172)
+
+## Contexte
+
+Le masquage responsive livré en PR #172 introduit un palier texte ("Page X sur Y", non
+interactif) quand la largeur disponible ne permet plus d'afficher la fenêtre minimale de boutons
+numérotés (`floorSlots` : 3 en position de bord, 5 sinon). Ce palier dégrade significativement
+l'expérience par rapport au desktop : plus aucun moyen d'atteindre directement une page qui n'est
+ni la précédente ni la suivante, alors que ce plancher se déclenche dès ~375px de large — une
+largeur d'écran mobile courante, pas un cas extrême.
+
+La spec du 2026-08-07 excluait explicitement un widget de saut de page ("hors scope : pattern
+d'interaction différent, non demandé par l'issue"). Ce document révise cette décision : un
+`<select>` natif remplace le palier texte, sans élargir le périmètre visuel ni casser le contrat
+headless.
+
+## Décisions issues du brainstorming
+
+- **Portée de la bascule** : uniquement le palier le plus étroit (ex-mode texte). Les réductions
+  intermédiaires (fenêtre à ellipses avec boutons cliquables, budget entre le plancher et le total)
+  restent inchangées.
+- **Contenu du `<select>`** : les mêmes options que produirait `_calculatePages` au plancher —
+  première page, dernière page, fenêtre minimale autour de la page courante — pas la liste
+  complète 1..total. Les ellipses deviennent des `<option disabled>`. Aucune modification de
+  l'algorithme `_calculatePages` : son plancher naturel (`_minimalPages`) est déjà exactement ce
+  qu'il faut peupler.
+- **Style** : le `<select>` reste headless (`appearance: none` structurel dans les styles du
+  composant, apparence visuelle dans `themes/default.css`) — le déclencheur est stylable, la liste
+  d'options natives (rendue par l'OS) ne l'est pas, ce qui est un compromis accepté et déjà
+  pratiqué sur d'autres projets par l'équipe.
+- **Repli sous le `<select>`** : pas de mécanisme dédié. Un `<select>` (contrôle unique) est bien
+  plus étroit que la rangée de boutons qu'il remplace ; le cas où même lui ne tiendrait pas à côté
+  de prev/next (largeur extrême, <150px) n'est pas traité séparément — pas de sur-ingénierie pour
+  un cas non observé aux largeurs réelles ciblées (320px+).
+
+## Architecture
+
+### 1. Rendu — un seul point de bascule modifié
+
+Dans `pagination.ts`, la condition `useTextMode` (actuellement `this._budget < floorSlots`)
+déclenche désormais le rendu d'un `<select>` au lieu du texte statique :
+
+```html
+<li part="item page-select">
+    <span class="sr-only" id="ar-pagination-select-label">Aller à la page</span>
+    <select part="select" aria-labelledby="ar-pagination-select-label" @change="${...}">
+        <!-- options générées depuis _calculatePages(current, total, this._budget) -->
+    </select>
+</li>
+```
+
+Rien d'autre ne change : la réduction progressive par `siblingCount` décroissant (largeurs
+intermédiaires) continue de rendre des `<li>` numérotés cliquables comme aujourd'hui ; prev/next
+restent affichés et fonctionnels dans tous les cas, y compris au palier `<select>`.
+
+### 2. Génération des options
+
+Réutilisation directe de `_calculatePages(current, total, this._budget)` — aucune modification de
+`pagination.utils.ts`. Le mapping des éléments retournés :
+
+- page numérique `n` → `<option value="${n}" ?selected=${n === current}>${n}</option>`
+- sentinelle d'ellipse (`-1`/`-2`) → `<option disabled>…</option>`
+
+Exemple à `total=20, current=10` (fenêtre minimale, non-bord) : options `1 · … · 10 · … · 20` —
+identique à ce que produirait un desktop très réduit avec le même budget, pas une liste 1..20.
+
+### 3. Interaction et accessibilité
+
+- Événement `change` sur le `<select>` → même chemin que `_onPageChange` aujourd'hui : lecture de
+  la valeur sélectionnée, `this.current = ...`, émission de `ar-pagination-page-change`
+  (`{ from, to }`), `announceA11y`. Pas de gestion de focus additionnelle : le focus natif reste
+  sur le `<select>` après sélection (contrairement au clic sur un lien, qui déplace le focus vers
+  `[part~="current"]` via `focusAfterUpdate`).
+- Nom accessible : `<span class="sr-only">` + `aria-labelledby`, cohérent avec le pattern déjà
+  utilisé pour prev/next (`<span class="sr-only">Page précédente…</span>`), plutôt qu'un
+  `aria-label` en dur.
+- Les `<option disabled>` (ellipses) sont nativement ignorées par la navigation clavier et les
+  lecteurs d'écran — comportement natif du `<select>`, aucun code custom requis.
+
+### 4. Style
+
+- Nouveaux parts : `select` (sur l'élément `<select>`) et `page-select` (sur le `<li>` englobant,
+  symétrique à `page-status` qu'il remplace).
+- `pagination.styles.ts` : `appearance: none` structurel + réutilisation de
+  `--ar-pagination-btn-size` pour la hauteur minimale (cohérence WCAG 2.5.8 avec les autres
+  contrôles). Aucune couleur/fond en dur — va dans `themes/default.css` (flèche custom, apparence
+  visuelle du déclencheur), conformément à la philosophie headless du projet.
+- `[part~='page-status']` et sa règle `white-space: nowrap` sont supprimés (le mode texte
+  disparaît).
+- JSDoc du composant : entrée `@csspart page-status` retirée, `@csspart select` et
+  `@csspart page-select` ajoutées.
+
+### 5. Documentation
+
+`apps/docs/src/content/components/ar-pagination.mdx`, section "Comportement responsive" : le
+troisième point ("Largeur extrême : … remplacés par un texte") est réécrit pour décrire le
+`<select>` de saut de page à la place du texte statique.
+
+## Tests
+
+- **Unitaires (Vitest)** : génération des options du `<select>` à partir de
+  `_calculatePages` (mapping page → `<option>`, ellipse → `<option disabled>`, `selected` sur la
+  page courante) ; émission de `ar-pagination-page-change` au `change`.
+- **Browser (WTR)** : comportement responsive réel au palier minimal — présence du `part="select"`
+  à largeur réduite (remplaçant l'actuel test du palier texte), absence des anciens
+  `part="page-status"`, sélection d'une option qui déclenche bien le changement de page.
+- **Vérification manuelle (Playwright)** : avant de considérer le spec figé, vérifier
+  empiriquement que la bascule vers le `<select>` se produit bien autour de 320-375px selon le
+  budget réel mesuré (pas seulement en test headless/jsdom), et que le style natif + custom du
+  `<select>` se comporte correctement dans un vrai rendu navigateur.
+
+## Hors scope
+
+- Peupler le `<select>` avec la liste complète 1..total (redondant avec l'objectif de réduction
+  visuelle ; le picker natif deviendrait long sans bénéfice par rapport à la fenêtre réduite).
+- Mesure dédiée de la largeur du `<select>` pour un repli prev/next-seul en dessous — cas non
+  observé aux largeurs réelles ciblées, à reconsidérer seulement si un usage réel le montre
+  nécessaire.
+- Support de tailles d'item hétérogènes entre les numéros de page (hérité de la spec du
+  2026-08-07, toujours hors scope ici).

--- a/docs/superpowers/specs/2026-08-10-pagination-select-fallback-design.md
+++ b/docs/superpowers/specs/2026-08-10-pagination-select-fallback-design.md
@@ -63,11 +63,19 @@ restent affichés et fonctionnels dans tous les cas, y compris au palier `<selec
 Réutilisation directe de `_calculatePages(current, total, this._budget)` — aucune modification de
 `pagination.utils.ts`. Le mapping des éléments retournés :
 
-- page numérique `n` → `<option value="${n}" ?selected=${n === current}>${n}</option>`
+- page numérique `n` → `<option value="${n}" ?selected=${n === current}>Page ${n} sur ${total}</option>`
 - sentinelle d'ellipse (`-1`/`-2`) → `<option disabled>…</option>`
 
-Exemple à `total=20, current=10` (fenêtre minimale, non-bord) : options `1 · … · 10 · … · 20` —
-identique à ce que produirait un desktop très réduit avec le même budget, pas une liste 1..20.
+Le label complet ("Page 2 sur 20", cohérent avec le texte déjà utilisé par `announceA11y`) plutôt
+qu'un simple numéro : un `<select>` fermé affiche le texte de l'option sélectionnée, donc ce choix
+expose le total sans avoir à ouvrir le picker. Contrepartie assumée : le déclencheur fermé est plus
+large qu'un simple numéro — **à confirmer empiriquement** (§5) qu'il tient toujours à 320-375px à
+côté de prev/next. Si la vérification échoue, repli vers un label court (`${n}`) avec le total
+affiché en texte statique sibling du `<select>` (hors du contrôle, toujours visible).
+
+Exemple à `total=20, current=10` (fenêtre minimale, non-bord) : options "Page 1 sur 20" ·
+… · "Page 10 sur 20" · … · "Page 20 sur 20" — le jeu de pages est identique à ce que produirait un
+desktop très réduit avec le même budget, seul le label change.
 
 ### 3. Interaction et accessibilité
 
@@ -112,7 +120,10 @@ troisième point ("Largeur extrême : … remplacés par un texte") est réécri
 - **Vérification manuelle (Playwright)** : avant de considérer le spec figé, vérifier
   empiriquement que la bascule vers le `<select>` se produit bien autour de 320-375px selon le
   budget réel mesuré (pas seulement en test headless/jsdom), et que le style natif + custom du
-  `<select>` se comporte correctement dans un vrai rendu navigateur.
+  `<select>` se comporte correctement dans un vrai rendu navigateur. Vérifier en particulier que le
+  déclencheur fermé avec label complet ("Page 20 sur 20", le cas le plus large) ne déborde pas à
+  320-375px à côté de prev/next — sinon appliquer le repli décrit en §2 (label court + total en
+  texte sibling) avant de figer le plan d'implémentation.
 
 ## Hors scope
 

--- a/docs/superpowers/specs/2026-08-10-pagination-select-fallback-design.md
+++ b/docs/superpowers/specs/2026-08-10-pagination-select-fallback-design.md
@@ -70,8 +70,21 @@ Le label complet ("Page 2 sur 20", cohérent avec le texte déjà utilisé par `
 qu'un simple numéro : un `<select>` fermé affiche le texte de l'option sélectionnée, donc ce choix
 expose le total sans avoir à ouvrir le picker. Contrepartie assumée : le déclencheur fermé est plus
 large qu'un simple numéro — **à confirmer empiriquement** (§5) qu'il tient toujours à 320-375px à
-côté de prev/next. Si la vérification échoue, repli vers un label court (`${n}`) avec le total
-affiché en texte statique sibling du `<select>` (hors du contrôle, toujours visible).
+côté de prev/next.
+
+**Contrainte technique** : le contenu d'un `<option>` est du texte brut — toute balise imbriquée
+(`<span aria-hidden>`, `sr-only`, etc.) est ignorée par le navigateur, aussi bien à l'affichage
+(y compris le picker natif OS) qu'à l'annonce lecteur d'écran. Le texte visuel et le texte
+accessible d'une option sont donc nécessairement identiques ; aucune compression différenciée n'est
+possible à l'intérieur des `<option>` (contrairement aux `<span class="sr-only">` déjà utilisés
+ailleurs dans le composant, sur des éléments DOM normaux).
+
+Si la vérification empirique montre un débordement, le repli se fait donc directement vers un
+label d'option court (`${n}`) accompagné d'un total en texte statique **sibling** du `<select>`
+(élément DOM normal, hors du contrôle) — c'est à ce niveau, et uniquement à ce niveau, qu'une
+compression visuel/SR différenciée est possible si l'espace reste serré : `/` visible (`aria-hidden`)
+
+- "sur" en `sr-only`, et en dernier recours "Page" également en `sr-only`.
 
 Exemple à `total=20, current=10` (fenêtre minimale, non-bord) : options "Page 1 sur 20" ·
 … · "Page 10 sur 20" · … · "Page 20 sur 20" — le jeu de pages est identique à ce que produirait un

--- a/packages/core/src/components/pagination/pagination.a11y.test.ts
+++ b/packages/core/src/components/pagination/pagination.a11y.test.ts
@@ -27,4 +27,14 @@ describe('ar-pagination — accessibilité', () => {
         const el = await fixture(html`<ar-pagination current="8" total="20"></ar-pagination>`);
         await expect(el).to.be.accessible();
     });
+
+    it('palier select (largeur insuffisante) est accessible', async () => {
+        const el = await fixture(html`<ar-pagination current="8" total="20"></ar-pagination>`);
+        // Force le palier select sans dépendre d'un ResizeObserver réel en test — même technique
+        // que pagination.browser.test.ts pour simuler un budget mesuré très restreint.
+        (el as unknown as { _budget: number })._budget = 2;
+        (el as unknown as { requestUpdate: () => void }).requestUpdate();
+        await (el as unknown as { updateComplete: Promise<boolean> }).updateComplete;
+        await expect(el).to.be.accessible();
+    });
 });

--- a/packages/core/src/components/pagination/pagination.browser.test.ts
+++ b/packages/core/src/components/pagination/pagination.browser.test.ts
@@ -159,6 +159,10 @@ describe('ar-pagination — browser', () => {
             await elementUpdated(el);
 
             expect((el as unknown as { current: number }).current).to.equal(15);
+            expect(select.selectedIndex).to.not.equal(-1);
+            expect(select.options[select.selectedIndex]?.textContent?.trim()).to.equal(
+                'Page 15 sur 15',
+            );
         });
 
         it('prev/next restent cliquables au palier select', async () => {
@@ -177,6 +181,12 @@ describe('ar-pagination — browser', () => {
             await elementUpdated(el);
 
             expect((el as unknown as { current: number }).current).to.equal(9);
+
+            const select = shadow.querySelector('[part~="select"]') as HTMLSelectElement;
+            expect(select.selectedIndex).to.not.equal(-1);
+            expect(select.options[select.selectedIndex]?.textContent?.trim()).to.equal(
+                'Page 9 sur 15',
+            );
         });
 
         it("[part='list'] ne wrap plus (flex-wrap: nowrap)", async () => {

--- a/packages/core/src/components/pagination/pagination.browser.test.ts
+++ b/packages/core/src/components/pagination/pagination.browser.test.ts
@@ -247,6 +247,26 @@ describe('ar-pagination — browser', () => {
         });
     });
 
+    describe('labels accessibles enrichis (total dans le contexte)', () => {
+        it('le sr-only d\'un lien de page se lit "Page X sur Y" en layout réel (innerText)', async () => {
+            const el = await fixture(html`<ar-pagination current="3" total="12"></ar-pagination>`);
+            const link = el.shadowRoot?.querySelector(
+                '[data-ar-pagination-page="4"]',
+            ) as HTMLElement;
+            const srOnly = link.querySelector('.sr-only') as HTMLElement;
+            // `innerText` (pas `textContent`) : reflète le rendu réel appliqué par le layout,
+            // seul moyen fiable de détecter une régression du bug historique #152 ("8sur15") où
+            // plusieurs bindings adjacents dans un conteneur flex perdaient leurs espaces.
+            expect(srOnly.innerText.trim()).to.equal('Page 4 sur 12');
+        });
+
+        it('la page active porte aria-current="page"', async () => {
+            const el = await fixture(html`<ar-pagination current="3" total="12"></ar-pagination>`);
+            const current = el.shadowRoot?.querySelector('[part="current"]') as HTMLElement;
+            expect(current.getAttribute('aria-current')).to.equal('page');
+        });
+    });
+
     describe('invariant anti-débordement avec le thème par défaut (#152, Finding Critical #1/#3)', () => {
         async function waitForResize(): Promise<void> {
             await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));

--- a/packages/core/src/components/pagination/pagination.browser.test.ts
+++ b/packages/core/src/components/pagination/pagination.browser.test.ts
@@ -133,13 +133,15 @@ describe('ar-pagination — browser', () => {
             expect(select.tagName.toLowerCase()).to.equal('select');
             expect(shadow.querySelectorAll('[part~="link"], [part~="current"]').length).to.equal(0);
 
-            // _calculatePages(8, 15, budget-plancher) → _minimalPages(8, 15) = [1, -1, 8, -2, 15]
+            // _calculatePages(8, 15) SANS budget (donc budget par défaut 9, pas la fenêtre
+            // réduite au budget réel de la largeur actuelle) = [1, -1, 6, 7, 8, 9, 10, -2, 15] —
+            // le select doit rester aussi riche qu'à largeur confortable.
             const options = Array.from(select.querySelectorAll('option'));
-            expect(options).to.have.lengthOf(5);
-            expect(options[2]?.selected).to.equal(true);
-            expect(options[2]?.textContent?.trim()).to.equal('Page 8 sur 15');
+            expect(options).to.have.lengthOf(9);
+            expect(options[4]?.selected).to.equal(true);
+            expect(options[4]?.textContent?.trim()).to.equal('Page 8 sur 15');
             expect(options[1]?.disabled).to.equal(true);
-            expect(options[3]?.disabled).to.equal(true);
+            expect(options[7]?.disabled).to.equal(true);
         });
 
         it('sélectionner une option du select change la page', async () => {

--- a/packages/core/src/components/pagination/pagination.browser.test.ts
+++ b/packages/core/src/components/pagination/pagination.browser.test.ts
@@ -114,7 +114,7 @@ describe('ar-pagination — browser', () => {
             expect(numericCount).to.equal(5);
         });
 
-        it('bascule sur le palier texte "Page X sur Y" à largeur extrême', async () => {
+        it('bascule sur un <select> de saut de page à largeur extrême', async () => {
             const wrapper = await fixture(
                 html`<div style="width: 900px;">
                     <ar-pagination current="8" total="15"></ar-pagination>
@@ -128,21 +128,40 @@ describe('ar-pagination — browser', () => {
             await waitForResize();
 
             const shadow = el.shadowRoot as ShadowRoot;
-            const status = shadow.querySelector('[part~="page-status"]') as HTMLElement;
-            expect(status).to.not.equal(null);
-            expect(status?.textContent?.trim()).to.equal('Page 8 sur 15');
+            const select = shadow.querySelector('[part~="select"]') as HTMLSelectElement;
+            expect(select).to.not.equal(null);
+            expect(select.tagName.toLowerCase()).to.equal('select');
+            expect(shadow.querySelectorAll('[part~="link"], [part~="current"]').length).to.equal(0);
 
-            // `textContent` seul ne détecterait pas une régression où les espaces entre les
-            // mots disparaissent visuellement (chaque run devenant un flex item anonyme
-            // distinct sous [part~='item'] { display: flex }) : `innerText` reflète le rendu
-            // réel (layout appliqué), contrairement à `textContent` qui lit l'arbre DOM brut.
-            // Égalité stricte (pas une regex `\s+`) : `\s` matche aussi les retours à la ligne
-            // qu'`innerText` insère entre flex items séparés, ce qui laisserait passer un
-            // ancien balisage buggé (ex. "Page\n8\nsur\n15") sans jamais échouer.
-            expect(status.innerText.trim()).to.equal('Page 8 sur 15');
+            // _calculatePages(8, 15, budget-plancher) → _minimalPages(8, 15) = [1, -1, 8, -2, 15]
+            const options = Array.from(select.querySelectorAll('option'));
+            expect(options).to.have.lengthOf(5);
+            expect(options[2]?.selected).to.equal(true);
+            expect(options[2]?.textContent?.trim()).to.equal('Page 8 sur 15');
+            expect(options[1]?.disabled).to.equal(true);
+            expect(options[3]?.disabled).to.equal(true);
         });
 
-        it('prev/next restent cliquables au palier texte', async () => {
+        it('sélectionner une option du select change la page', async () => {
+            const wrapper = await fixture(
+                html`<div style="width: 90px;">
+                    <ar-pagination current="8" total="15"></ar-pagination>
+                </div>`,
+            );
+            const el = wrapper.querySelector('ar-pagination') as HTMLElement;
+            await elementUpdated(el);
+            await waitForResize();
+
+            const shadow = el.shadowRoot as ShadowRoot;
+            const select = shadow.querySelector('[part~="select"]') as HTMLSelectElement;
+            select.value = '15';
+            select.dispatchEvent(new Event('change', { bubbles: true }));
+            await elementUpdated(el);
+
+            expect((el as unknown as { current: number }).current).to.equal(15);
+        });
+
+        it('prev/next restent cliquables au palier select', async () => {
             const wrapper = await fixture(
                 html`<div style="width: 90px;">
                     <ar-pagination current="8" total="15"></ar-pagination>
@@ -167,12 +186,12 @@ describe('ar-pagination — browser', () => {
             expect(getComputedStyle(list).flexWrap).to.equal('nowrap');
         });
 
-        it("ne reste pas bloqué au palier texte après un changement d'ordre de grandeur de total suivi d'un réélargissement", async () => {
+        it("ne reste pas bloqué au palier select après un changement d'ordre de grandeur de total suivi d'un réélargissement", async () => {
             // Régression : `total` qui change d'ordre de grandeur (9 → 10, 99 → 100, ...)
-            // pendant que le composant est déjà au palier texte marquait `_itemWidth` comme à
+            // pendant que le composant est déjà au palier select marquait `_itemWidth` comme à
             // remesurer, mais aucun item numérique n'est rendu à ce palier — sans item à
             // mesurer, `_recalculateBudget` ne recalculait plus jamais `_budget`, bloquant le
-            // composant sur "Page X sur Y" même après un réélargissement massif du conteneur.
+            // composant sur le select même après un réélargissement massif du conteneur.
             const wrapper = await fixture(
                 html`<div style="width: 700px;">
                     <ar-pagination current="100" total="200"></ar-pagination>
@@ -189,14 +208,14 @@ describe('ar-pagination — browser', () => {
                 shadow.querySelectorAll('[part~="link"], [part~="current"]').length,
             ).to.be.greaterThan(0);
 
-            // 2. Rétrécir jusqu'au palier texte.
+            // 2. Rétrécir jusqu'au palier select.
             wrapper.style.width = '90px';
             await waitForResize();
-            expect(shadow.querySelector('[part~="page-status"]')).to.not.equal(null);
+            expect(shadow.querySelector('[part~="select"]')).to.not.equal(null);
             expect(shadow.querySelectorAll('[part~="link"], [part~="current"]').length).to.equal(0);
 
             // 3. Changer `total` (et `current`, pour rester valide) d'ordre de grandeur pendant
-            //    que le composant est au palier texte (déclenche l'invalidation de
+            //    que le composant est au palier select (déclenche l'invalidation de
             //    `_itemWidth`) — toujours aucun item numérique disponible pour remesurer
             //    immédiatement.
             (el as unknown as { total: number; current: number }).total = 15;
@@ -205,11 +224,11 @@ describe('ar-pagination — browser', () => {
             await waitForResize();
 
             // 4. Réélargir le conteneur → les numéros doivent réapparaître normalement, pas
-            //    rester bloqués sur "Page X sur Y".
+            //    rester bloqués sur le select.
             wrapper.style.width = '700px';
             await waitForResize();
 
-            expect(shadow.querySelector('[part~="page-status"]')).to.equal(null);
+            expect(shadow.querySelector('[part~="select"]')).to.equal(null);
             expect(
                 shadow.querySelectorAll('[part~="link"], [part~="current"]').length,
             ).to.be.greaterThan(0);

--- a/packages/core/src/components/pagination/pagination.browser.test.ts
+++ b/packages/core/src/components/pagination/pagination.browser.test.ts
@@ -128,9 +128,15 @@ describe('ar-pagination — browser', () => {
             await waitForResize();
 
             const shadow = el.shadowRoot as ShadowRoot;
-            const status = shadow.querySelector('[part~="page-status"]');
+            const status = shadow.querySelector('[part~="page-status"]') as HTMLElement;
             expect(status).to.not.equal(null);
             expect(status?.textContent?.trim()).to.equal('Page 8 sur 15');
+
+            // `textContent` seul ne détecterait pas une régression où les espaces entre les
+            // mots disparaissent visuellement (chaque run devenant un flex item anonyme
+            // distinct sous [part~='item'] { display: flex }) : `innerText` reflète le rendu
+            // réel (layout appliqué), contrairement à `textContent` qui lit l'arbre DOM brut.
+            expect(status.innerText.trim()).to.match(/^Page\s+8\s+sur\s+15$/);
         });
 
         it('prev/next restent cliquables au palier texte', async () => {
@@ -156,6 +162,82 @@ describe('ar-pagination — browser', () => {
             const list = el.shadowRoot?.querySelector<HTMLElement>('[part="list"]');
             if (!list) throw new Error('[part="list"] introuvable');
             expect(getComputedStyle(list).flexWrap).to.equal('nowrap');
+        });
+    });
+
+    describe('invariant anti-débordement avec le thème par défaut (#152, Finding Critical #1/#3)', () => {
+        async function waitForResize(): Promise<void> {
+            await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+            await new Promise((resolve) => setTimeout(resolve, 50));
+        }
+
+        // Reproduit les règles pertinentes de packages/core/src/styles/themes/default.css pour
+        // ar-pagination (column-gap sur [part='list'], padding sur link/current/ellipsis) sans
+        // charger le thème complet : ce sont précisément les règles non budgétées par
+        // `_recalculateBudget` avant le fix (Finding Critical #1), à l'origine d'un débordement
+        // horizontal mesuré jusqu'à 61px. `--ar-pagination-btn-size` n'a pas besoin d'être
+        // redéclaré ici : le composant a déjà un repli interne à 2.5rem, valeur identique à
+        // celle du thème par défaut.
+        let themeStyle: HTMLStyleElement;
+
+        beforeEach(() => {
+            themeStyle = document.createElement('style');
+            themeStyle.textContent = `
+                ar-pagination::part(list) { column-gap: 0.25rem; }
+                ar-pagination::part(link),
+                ar-pagination::part(current),
+                ar-pagination::part(ellipsis) { padding: 0 0.75rem; }
+            `;
+            document.head.appendChild(themeStyle);
+        });
+
+        afterEach(() => {
+            themeStyle.remove();
+        });
+
+        it('list.scrollWidth ne dépasse jamais list.clientWidth sur un balayage de largeurs (total=15)', async () => {
+            const wrapper = await fixture(
+                html`<div style="width: 700px;">
+                    <ar-pagination current="8" total="15"></ar-pagination>
+                </div>`,
+            );
+            const el = wrapper.querySelector('ar-pagination') as HTMLElement;
+            await elementUpdated(el);
+            await waitForResize();
+
+            for (const width of [280, 360, 440, 480, 700]) {
+                wrapper.style.width = `${width}px`;
+                await waitForResize();
+
+                const list = el.shadowRoot?.querySelector<HTMLElement>('[part="list"]');
+                if (!list) throw new Error('[part="list"] introuvable');
+                // Tolérance de 1px pour les arrondis sous-pixel de layout.
+                expect(list.scrollWidth, `débordement à ${width}px`).to.be.at.most(
+                    list.clientWidth + 1,
+                );
+            }
+        });
+
+        it('list.scrollWidth ne dépasse jamais list.clientWidth avec un total à 3 chiffres (total=999)', async () => {
+            const wrapper = await fixture(
+                html`<div style="width: 700px;">
+                    <ar-pagination current="500" total="999"></ar-pagination>
+                </div>`,
+            );
+            const el = wrapper.querySelector('ar-pagination') as HTMLElement;
+            await elementUpdated(el);
+            await waitForResize();
+
+            for (const width of [280, 360, 440, 480, 700]) {
+                wrapper.style.width = `${width}px`;
+                await waitForResize();
+
+                const list = el.shadowRoot?.querySelector<HTMLElement>('[part="list"]');
+                if (!list) throw new Error('[part="list"] introuvable');
+                expect(list.scrollWidth, `débordement à ${width}px`).to.be.at.most(
+                    list.clientWidth + 1,
+                );
+            }
         });
     });
 });

--- a/packages/core/src/components/pagination/pagination.browser.test.ts
+++ b/packages/core/src/components/pagination/pagination.browser.test.ts
@@ -57,4 +57,101 @@ describe('ar-pagination — browser', () => {
             expect(listRule).to.not.include('padding-left');
         });
     });
+
+    describe('masquage responsive progressif (#152)', () => {
+        async function waitForResize(): Promise<void> {
+            // Laisse le temps au ResizeObserver de déclencher son callback et à Lit de re-render.
+            await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+            await new Promise((resolve) => setTimeout(resolve, 50));
+        }
+
+        it('affiche la liste complète des numéros dans un conteneur large', async () => {
+            const wrapper = await fixture(
+                html`<div style="width: 900px;">
+                    <ar-pagination current="8" total="15"></ar-pagination>
+                </div>`,
+            );
+            const el = wrapper.querySelector('ar-pagination') as HTMLElement;
+            await elementUpdated(el);
+            await waitForResize();
+
+            // 900px mesuré en Chromium (btn-size fallback headless 2.5rem = 40px, aucun thème
+            // chargé dans ce test) suffit à afficher les 15 pages sans troncature : le budget
+            // calculé par le ResizeObserver dépasse `total`, donc `_calculatePages` renvoie la
+            // liste complète (cf. `_calculatePages`, branche `total <= effectiveBudget`).
+            const shadow = el.shadowRoot as ShadowRoot;
+            expect(shadow.querySelectorAll('[part~="link"], [part~="current"]').length).to.equal(
+                15,
+            );
+        });
+
+        it('réduit le nombre de pages affichées quand le conteneur est rétréci', async () => {
+            const wrapper = await fixture(
+                html`<div style="width: 900px;">
+                    <ar-pagination current="8" total="15"></ar-pagination>
+                </div>`,
+            );
+            const el = wrapper.querySelector('ar-pagination') as HTMLElement;
+            await elementUpdated(el);
+            await waitForResize();
+
+            // 400px mesuré empiriquement : budget suffisant pour rester au-dessus du plancher
+            // texte (5 slots, `current` non en bord) mais insuffisant pour les 15 pages —
+            // produit une liste tronquée avec ellipses, contrairement à 260px (cf. test
+            // suivant) qui passe déjà sous le plancher.
+            wrapper.style.width = '400px';
+            await waitForResize();
+
+            const shadow = el.shadowRoot as ShadowRoot;
+            const numericCount = shadow.querySelectorAll(
+                '[part~="link"], [part~="current"]',
+            ).length;
+            expect(numericCount).to.be.greaterThan(0);
+            expect(numericCount).to.be.lessThan(15);
+        });
+
+        it('bascule sur le palier texte "Page X sur Y" à largeur extrême', async () => {
+            const wrapper = await fixture(
+                html`<div style="width: 900px;">
+                    <ar-pagination current="8" total="15"></ar-pagination>
+                </div>`,
+            );
+            const el = wrapper.querySelector('ar-pagination') as HTMLElement;
+            await elementUpdated(el);
+            await waitForResize();
+
+            wrapper.style.width = '90px';
+            await waitForResize();
+
+            const shadow = el.shadowRoot as ShadowRoot;
+            const status = shadow.querySelector('[part~="page-status"]');
+            expect(status).to.not.equal(null);
+            expect(status?.textContent?.trim()).to.equal('Page 8 sur 15');
+        });
+
+        it('prev/next restent cliquables au palier texte', async () => {
+            const wrapper = await fixture(
+                html`<div style="width: 90px;">
+                    <ar-pagination current="8" total="15"></ar-pagination>
+                </div>`,
+            );
+            const el = wrapper.querySelector('ar-pagination') as HTMLElement;
+            await elementUpdated(el);
+            await waitForResize();
+
+            const shadow = el.shadowRoot as ShadowRoot;
+            const next = shadow.querySelector('[part~="next"]') as HTMLElement;
+            next.click();
+            await elementUpdated(el);
+
+            expect((el as unknown as { current: number }).current).to.equal(9);
+        });
+
+        it("[part='list'] ne wrap plus (flex-wrap: nowrap)", async () => {
+            const el = await fixture(html`<ar-pagination current="1" total="5"></ar-pagination>`);
+            const list = el.shadowRoot?.querySelector<HTMLElement>('[part="list"]');
+            if (!list) throw new Error('[part="list"] introuvable');
+            expect(getComputedStyle(list).flexWrap).to.equal('nowrap');
+        });
+    });
 });

--- a/packages/core/src/components/pagination/pagination.browser.test.ts
+++ b/packages/core/src/components/pagination/pagination.browser.test.ts
@@ -106,8 +106,12 @@ describe('ar-pagination — browser', () => {
             const numericCount = shadow.querySelectorAll(
                 '[part~="link"], [part~="current"]',
             ).length;
-            expect(numericCount).to.be.greaterThan(0);
-            expect(numericCount).to.be.lessThan(15);
+            // Valeur exacte mesurée empiriquement à 400px avec le repli headless figé
+            // (`--ar-pagination-btn-size` = 2.5rem = 40px, aucune police variable dans WTR) :
+            // déterministe. Une régression dans `_pagesWithSiblings` (ex. `siblingCount` qui ne
+            // retire qu'une page, 14 au lieu de 5) passerait inaperçue avec une simple borne
+            // `lessThan(15)` — l'égalité stricte est nécessaire pour couvrir ce cas.
+            expect(numericCount).to.equal(5);
         });
 
         it('bascule sur le palier texte "Page X sur Y" à largeur extrême', async () => {

--- a/packages/core/src/components/pagination/pagination.browser.test.ts
+++ b/packages/core/src/components/pagination/pagination.browser.test.ts
@@ -136,7 +136,10 @@ describe('ar-pagination — browser', () => {
             // mots disparaissent visuellement (chaque run devenant un flex item anonyme
             // distinct sous [part~='item'] { display: flex }) : `innerText` reflète le rendu
             // réel (layout appliqué), contrairement à `textContent` qui lit l'arbre DOM brut.
-            expect(status.innerText.trim()).to.match(/^Page\s+8\s+sur\s+15$/);
+            // Égalité stricte (pas une regex `\s+`) : `\s` matche aussi les retours à la ligne
+            // qu'`innerText` insère entre flex items séparés, ce qui laisserait passer un
+            // ancien balisage buggé (ex. "Page\n8\nsur\n15") sans jamais échouer.
+            expect(status.innerText.trim()).to.equal('Page 8 sur 15');
         });
 
         it('prev/next restent cliquables au palier texte', async () => {
@@ -162,6 +165,54 @@ describe('ar-pagination — browser', () => {
             const list = el.shadowRoot?.querySelector<HTMLElement>('[part="list"]');
             if (!list) throw new Error('[part="list"] introuvable');
             expect(getComputedStyle(list).flexWrap).to.equal('nowrap');
+        });
+
+        it("ne reste pas bloqué au palier texte après un changement d'ordre de grandeur de total suivi d'un réélargissement", async () => {
+            // Régression : `total` qui change d'ordre de grandeur (9 → 10, 99 → 100, ...)
+            // pendant que le composant est déjà au palier texte marquait `_itemWidth` comme à
+            // remesurer, mais aucun item numérique n'est rendu à ce palier — sans item à
+            // mesurer, `_recalculateBudget` ne recalculait plus jamais `_budget`, bloquant le
+            // composant sur "Page X sur Y" même après un réélargissement massif du conteneur.
+            const wrapper = await fixture(
+                html`<div style="width: 700px;">
+                    <ar-pagination current="100" total="200"></ar-pagination>
+                </div>`,
+            );
+            const el = wrapper.querySelector('ar-pagination') as HTMLElement;
+            await elementUpdated(el);
+            await waitForResize();
+
+            const shadow = el.shadowRoot as ShadowRoot;
+
+            // 1. Conteneur large → numéros affichés, `_itemWidth` mesuré normalement.
+            expect(
+                shadow.querySelectorAll('[part~="link"], [part~="current"]').length,
+            ).to.be.greaterThan(0);
+
+            // 2. Rétrécir jusqu'au palier texte.
+            wrapper.style.width = '90px';
+            await waitForResize();
+            expect(shadow.querySelector('[part~="page-status"]')).to.not.equal(null);
+            expect(shadow.querySelectorAll('[part~="link"], [part~="current"]').length).to.equal(0);
+
+            // 3. Changer `total` (et `current`, pour rester valide) d'ordre de grandeur pendant
+            //    que le composant est au palier texte (déclenche l'invalidation de
+            //    `_itemWidth`) — toujours aucun item numérique disponible pour remesurer
+            //    immédiatement.
+            (el as unknown as { total: number; current: number }).total = 15;
+            (el as unknown as { total: number; current: number }).current = 8;
+            await elementUpdated(el);
+            await waitForResize();
+
+            // 4. Réélargir le conteneur → les numéros doivent réapparaître normalement, pas
+            //    rester bloqués sur "Page X sur Y".
+            wrapper.style.width = '700px';
+            await waitForResize();
+
+            expect(shadow.querySelector('[part~="page-status"]')).to.equal(null);
+            expect(
+                shadow.querySelectorAll('[part~="link"], [part~="current"]').length,
+            ).to.be.greaterThan(0);
         });
     });
 

--- a/packages/core/src/components/pagination/pagination.browser.test.ts
+++ b/packages/core/src/components/pagination/pagination.browser.test.ts
@@ -34,6 +34,26 @@ describe('ar-pagination — browser', () => {
         });
     });
 
+    describe('clic sur le contenu imbriqué du lien (régression)', () => {
+        // `renderPageLabel` enveloppe le numéro visible dans un `<span aria-hidden="true">`
+        // (structure : `<a part="link">` > `<span aria-hidden>`). Un clic utilisateur réel sur
+        // le chiffre affiché a pour `event.target` ce `<span>` imbriqué, pas le `<a>` lui-même —
+        // contrairement aux autres tests de ce fichier/suite qui appellent `.click()`
+        // directement sur le `<a>`. Vérifie que `_onPageChange` résout bien l'ancre via
+        // `closest()` et change effectivement la page dans ce cas.
+        it('un clic sur le numéro visible (span aria-hidden imbriqué) change la page', async () => {
+            const el = await fixture(html`<ar-pagination current="1" total="5"></ar-pagination>`);
+            const shadow = el.shadowRoot as ShadowRoot;
+            const link = shadow.querySelector('[data-ar-pagination-page="3"]') as HTMLElement;
+            const visibleNumber = link.querySelector('[aria-hidden="true"]') as HTMLElement;
+
+            visibleNumber.click();
+            await elementUpdated(el);
+
+            expect((el as unknown as { current: number }).current).to.equal(3);
+        });
+    });
+
     describe('propriétés logiques (RTL)', () => {
         it('[part="list"] utilise padding-inline-start plutôt que padding-left', async () => {
             const el = await fixture(html`<ar-pagination current="1" total="5"></ar-pagination>`);

--- a/packages/core/src/components/pagination/pagination.styles.ts
+++ b/packages/core/src/components/pagination/pagination.styles.ts
@@ -8,7 +8,7 @@ export default css`
 
     [part='list'] {
         display: flex;
-        flex-wrap: wrap;
+        flex-wrap: nowrap;
         justify-content: center;
         padding-inline-start: 0;
         margin-bottom: 0;
@@ -71,11 +71,7 @@ export default css`
         cursor: not-allowed;
     }
 
-    @media screen and (max-width: 640px) {
-        [part~='item']:nth-child(n + 3):nth-last-child(n + 3):not([part~='item--current']):not(
-                [aria-hidden='true']
-            ) {
-            display: none;
-        }
+    [part~='page-status'] {
+        white-space: nowrap;
     }
 `;

--- a/packages/core/src/components/pagination/pagination.styles.ts
+++ b/packages/core/src/components/pagination/pagination.styles.ts
@@ -39,9 +39,21 @@ export default css`
     [part~='next'],
     [part~='link'] {
         text-decoration: none;
+    }
+
+    [part~='prev'],
+    [part~='next'],
+    [part~='link'],
+    [part~='select'] {
         transition:
             background-color var(--ar-pagination-transition-duration),
             color var(--ar-pagination-transition-duration);
+    }
+
+    [part~='select'] {
+        appearance: none;
+        border: none;
+        cursor: pointer;
     }
 
     [part~='prev'],
@@ -58,7 +70,8 @@ export default css`
     @media (prefers-reduced-motion: reduce) {
         [part~='prev'],
         [part~='next'],
-        [part~='link'] {
+        [part~='link'],
+        [part~='select'] {
             transition: none;
         }
     }

--- a/packages/core/src/components/pagination/pagination.styles.ts
+++ b/packages/core/src/components/pagination/pagination.styles.ts
@@ -72,8 +72,4 @@ export default css`
     [part~='nav-btn--disabled'] {
         cursor: not-allowed;
     }
-
-    [part~='select'] {
-        appearance: none;
-    }
 `;

--- a/packages/core/src/components/pagination/pagination.styles.ts
+++ b/packages/core/src/components/pagination/pagination.styles.ts
@@ -24,6 +24,7 @@ export default css`
     [part~='next'],
     [part~='link'],
     [part~='current'],
+    [part~='select'],
     [part~='ellipsis'] {
         display: inline-flex;
         align-items: center;
@@ -46,7 +47,8 @@ export default css`
     [part~='prev'],
     [part~='next'],
     [part~='link'],
-    [part~='current'] {
+    [part~='current'],
+    [part~='select'] {
         &:focus-visible {
             outline: 2px solid currentColor;
             outline-offset: 2px;
@@ -71,7 +73,7 @@ export default css`
         cursor: not-allowed;
     }
 
-    [part~='page-status'] {
-        white-space: nowrap;
+    [part~='select'] {
+        appearance: none;
     }
 `;

--- a/packages/core/src/components/pagination/pagination.test.ts
+++ b/packages/core/src/components/pagination/pagination.test.ts
@@ -548,6 +548,20 @@ describe('ArPagination', () => {
             expect(el.current).toBe(3);
         });
 
+        it("un clic sur le span imbriqué (numéro visible) à l'intérieur du lien met à jour current", async () => {
+            // Régression : `renderPageLabel` enveloppe le numéro visible dans un
+            // `<span aria-hidden="true">` nichée dans le `<a part="link">`. `_onPageChange`
+            // doit résoudre l'ancre via `closest()` même quand `event.target` est ce span
+            // imbriqué plutôt que l'ancre elle-même.
+            el = await fixture('<ar-pagination current="1" total="5"></ar-pagination>');
+            const shadow = el.shadowRoot as ShadowRoot;
+            const pageLink = shadow.querySelector('[data-ar-pagination-page="3"]') as HTMLElement;
+            const visibleNumber = pageLink.querySelector('[aria-hidden="true"]') as HTMLElement;
+            visibleNumber.click();
+            await waitForUpdate(el);
+            expect(el.current).toBe(3);
+        });
+
         it('un clic sur un lien de page focalise le nouvel élément part="current"', async () => {
             el = await fixture('<ar-pagination current="1" total="5"></ar-pagination>');
             const shadow = el.shadowRoot as ShadowRoot;

--- a/packages/core/src/components/pagination/pagination.test.ts
+++ b/packages/core/src/components/pagination/pagination.test.ts
@@ -365,8 +365,11 @@ describe('ArPagination', () => {
             expect(el.current).toBe(4);
         });
 
-        it('ne bascule pas en palier select si _budget est au-dessus du plancher', async () => {
-            el = await fixture('<ar-pagination current="8" total="15"></ar-pagination>');
+        it('ne bascule pas en palier select si _budget est au-dessus du plancher et que la fenêtre a une seule ellipse', async () => {
+            // current=3 est assez proche du bord pour que la fenêtre à budget=5 n'ait besoin
+            // que d'une seule ellipse ([1, 2, 3, -2, 15]) — 4 pages réelles, pas le cas
+            // problématique des 2 ellipses ci-dessous.
+            el = await fixture('<ar-pagination current="3" total="15"></ar-pagination>');
             // @ts-expect-error accès à un champ privé pour simuler une mesure ResizeObserver
             el._budget = 5;
             el.requestUpdate();
@@ -374,6 +377,22 @@ describe('ArPagination', () => {
 
             const shadow = el.shadowRoot as ShadowRoot;
             expect(shadow.querySelector('[part~="select"]')).toBeNull();
+        });
+
+        it('bascule en palier select si le budget suffirait techniquement mais la fenêtre obtenue a 2 ellipses (seulement 3 pages réelles)', async () => {
+            // current=8, total=15, loin des deux bords : à budget=5, _calculatePages retombe sur
+            // sa fenêtre minimale [1, -1, 8, -2, 15] — 2 ellipses pour seulement 3 pages
+            // cliquables. Le select devient préférable même si les 5 slots tiendraient.
+            el = await fixture('<ar-pagination current="8" total="15"></ar-pagination>');
+            // @ts-expect-error accès à un champ privé pour simuler une mesure ResizeObserver
+            el._budget = 5;
+            el.requestUpdate();
+            await waitForUpdate(el);
+
+            const shadow = el.shadowRoot as ShadowRoot;
+            // Match exact, cf. mise en garde `~=`/happy-dom plus haut dans ce describe.
+            expect(shadow.querySelector('[part="select"]')).not.toBeNull();
+            expect(shadow.querySelectorAll('[part~="link"], [part~="current"]').length).toBe(0);
         });
 
         it('le plancher est identique en bord de liste et en position intermédiaire (pas de dépendance à la position de current)', async () => {

--- a/packages/core/src/components/pagination/pagination.test.ts
+++ b/packages/core/src/components/pagination/pagination.test.ts
@@ -214,10 +214,10 @@ describe('ArPagination', () => {
         });
     });
 
-    // ── Palier texte (budget très restreint) ─────────────────────────────────
+    // ── Palier select (budget très restreint) ────────────────────────────────
 
-    describe('palier texte sous le plancher', () => {
-        it('bascule sur un texte "Page X sur Y" quand _budget est sous le plancher', async () => {
+    describe('palier select sous le plancher', () => {
+        it('bascule sur un <select> de saut de page quand _budget est sous le plancher', async () => {
             el = await fixture('<ar-pagination current="3" total="15"></ar-pagination>');
             // @ts-expect-error accès à un champ privé pour simuler une mesure ResizeObserver
             el._budget = 2;
@@ -225,13 +225,84 @@ describe('ArPagination', () => {
             await waitForUpdate(el);
 
             const shadow = el.shadowRoot as ShadowRoot;
-            const status = shadow.querySelector('[part~="page-status"]');
-            expect(status).not.toBeNull();
-            expect(status?.textContent?.trim()).toBe('Page 3 sur 15');
+            // Match exact (`=`, pas `~=`) : happy-dom scinde aussi sur les tirets dans son
+            // implémentation de `~=`, donc `[part~="select"]` matcherait à tort le `<li
+            // part="item page-select">` (voir mise en garde dans test-utils.ts) avant même
+            // d'atteindre le `<select part="select">` imbriqué.
+            const select = shadow.querySelector('[part="select"]');
+            expect(select).not.toBeNull();
+            expect(select?.tagName.toLowerCase()).toBe('select');
             expect(shadow.querySelectorAll('[part~="link"], [part~="current"]').length).toBe(0);
         });
 
-        it('prev/next restent affichés et fonctionnels en palier texte', async () => {
+        it('peuple le select avec les mêmes pages que _calculatePages au plancher (première/dernière page, fenêtre minimale, ellipses en disabled)', async () => {
+            el = await fixture('<ar-pagination current="3" total="15"></ar-pagination>');
+            // @ts-expect-error accès à un champ privé pour simuler une mesure ResizeObserver
+            el._budget = 2;
+            el.requestUpdate();
+            await waitForUpdate(el);
+
+            // Match exact, cf. mise en garde `~=`/happy-dom ci-dessus.
+            const select = (el.shadowRoot as ShadowRoot).querySelector(
+                '[part="select"]',
+            ) as HTMLSelectElement;
+            const options = Array.from(select.querySelectorAll('option'));
+            // _calculatePages(3, 15, 2) retombe sur _minimalPages(3, 15) = [1, -1, 3, -2, 15]
+            expect(options).toHaveLength(5);
+            expect(options.map((o) => o.disabled)).toEqual([false, true, false, true, false]);
+            expect(options.map((o) => o.value)).toEqual(['1', '', '3', '', '15']);
+            // Attribut `selected` (pas la propriété IDL `.selected`) : happy-dom ne recalcule pas
+            // correctement la "selectedness" d'un <select> au fil de l'insertion incrémentale de
+            // ses <option> (bug reproduit indépendamment de ce composant, y compris sans binding
+            // `.value` sur le <select>, avec un simple `render()` Lit) — `.selected` y retombe sur
+            // un index arbitraire. L'attribut HTML reflète fidèlement ce que le template pose via
+            // `?selected`, ce qu'un vrai navigateur traduirait correctement en `.selected === true`.
+            expect(options[2]?.hasAttribute('selected')).toBe(true);
+            expect(options.filter((o) => o.hasAttribute('selected'))).toHaveLength(1);
+        });
+
+        it('le label de chaque option contient "Page X sur Y"', async () => {
+            el = await fixture('<ar-pagination current="3" total="15"></ar-pagination>');
+            // @ts-expect-error accès à un champ privé pour simuler une mesure ResizeObserver
+            el._budget = 2;
+            el.requestUpdate();
+            await waitForUpdate(el);
+
+            // Match exact, cf. mise en garde `~=`/happy-dom plus haut dans ce describe.
+            const select = (el.shadowRoot as ShadowRoot).querySelector(
+                '[part="select"]',
+            ) as HTMLSelectElement;
+            const options = Array.from(select.querySelectorAll('option'));
+            expect(options[0]?.textContent?.trim()).toBe('Page 1 sur 15');
+            expect(options[2]?.textContent?.trim()).toBe('Page 3 sur 15');
+            expect(options[4]?.textContent?.trim()).toBe('Page 15 sur 15');
+        });
+
+        it('changer la valeur du select émet ar-pagination-page-change et met à jour current', async () => {
+            el = await fixture('<ar-pagination current="3" total="15"></ar-pagination>');
+            // @ts-expect-error accès à un champ privé pour simuler une mesure ResizeObserver
+            el._budget = 2;
+            el.requestUpdate();
+            await waitForUpdate(el);
+
+            const handler = vi.fn();
+            el.addEventListener('ar-pagination-page-change', handler);
+            // Match exact, cf. mise en garde `~=`/happy-dom plus haut dans ce describe.
+            const select = (el.shadowRoot as ShadowRoot).querySelector(
+                '[part="select"]',
+            ) as HTMLSelectElement;
+            select.value = '15';
+            select.dispatchEvent(new Event('change'));
+            await waitForUpdate(el);
+
+            expect(el.current).toBe(15);
+            expect(handler).toHaveBeenCalledOnce();
+            const detail = (handler.mock.calls[0][0] as CustomEvent<ArPaginationPageChangeDetail>)
+                .detail;
+            expect(detail).toEqual({ from: 3, to: 15 });
+        });
+
+        it('prev/next restent affichés et fonctionnels au palier select', async () => {
             el = await fixture('<ar-pagination current="3" total="15"></ar-pagination>');
             // @ts-expect-error accès à un champ privé pour simuler une mesure ResizeObserver
             el._budget = 2;
@@ -245,7 +316,7 @@ describe('ArPagination', () => {
             expect(el.current).toBe(4);
         });
 
-        it('ne bascule pas en palier texte si _budget est au-dessus du plancher', async () => {
+        it('ne bascule pas en palier select si _budget est au-dessus du plancher', async () => {
             el = await fixture('<ar-pagination current="8" total="15"></ar-pagination>');
             // @ts-expect-error accès à un champ privé pour simuler une mesure ResizeObserver
             el._budget = 5;
@@ -253,7 +324,7 @@ describe('ArPagination', () => {
             await waitForUpdate(el);
 
             const shadow = el.shadowRoot as ShadowRoot;
-            expect(shadow.querySelector('[part~="page-status"]')).toBeNull();
+            expect(shadow.querySelector('[part~="select"]')).toBeNull();
         });
     });
 

--- a/packages/core/src/components/pagination/pagination.test.ts
+++ b/packages/core/src/components/pagination/pagination.test.ts
@@ -214,6 +214,49 @@ describe('ArPagination', () => {
         });
     });
 
+    // ── Palier texte (budget très restreint) ─────────────────────────────────
+
+    describe('palier texte sous le plancher', () => {
+        it('bascule sur un texte "Page X sur Y" quand _budget est sous le plancher', async () => {
+            el = await fixture('<ar-pagination current="3" total="15"></ar-pagination>');
+            // @ts-expect-error accès à un champ privé pour simuler une mesure ResizeObserver
+            el._budget = 2;
+            el.requestUpdate();
+            await waitForUpdate(el);
+
+            const shadow = el.shadowRoot as ShadowRoot;
+            const status = shadow.querySelector('[part~="page-status"]');
+            expect(status).not.toBeNull();
+            expect(status?.textContent?.trim()).toBe('Page 3 sur 15');
+            expect(shadow.querySelectorAll('[part~="link"], [part~="current"]').length).toBe(0);
+        });
+
+        it('prev/next restent affichés et fonctionnels en palier texte', async () => {
+            el = await fixture('<ar-pagination current="3" total="15"></ar-pagination>');
+            // @ts-expect-error accès à un champ privé pour simuler une mesure ResizeObserver
+            el._budget = 2;
+            el.requestUpdate();
+            await waitForUpdate(el);
+
+            expect(getPart(el, 'prev')).not.toBeNull();
+            expect(getPart(el, 'next')).not.toBeNull();
+            (requirePart(el, 'next') as HTMLElement).click();
+            await waitForUpdate(el);
+            expect(el.current).toBe(4);
+        });
+
+        it('ne bascule pas en palier texte si _budget est au-dessus du plancher', async () => {
+            el = await fixture('<ar-pagination current="8" total="15"></ar-pagination>');
+            // @ts-expect-error accès à un champ privé pour simuler une mesure ResizeObserver
+            el._budget = 5;
+            el.requestUpdate();
+            await waitForUpdate(el);
+
+            const shadow = el.shadowRoot as ShadowRoot;
+            expect(shadow.querySelector('[part~="page-status"]')).toBeNull();
+        });
+    });
+
     describe("part d'état item--current", () => {
         it('le <li> de la page active porte part="item item--current"', async () => {
             el = await fixture('<ar-pagination current="3" total="5"></ar-pagination>');

--- a/packages/core/src/components/pagination/pagination.test.ts
+++ b/packages/core/src/components/pagination/pagination.test.ts
@@ -158,12 +158,12 @@ describe('ArPagination', () => {
             expect(requirePart(el, 'next').getAttribute('aria-disabled')).toBe('false');
         });
 
-        it('la page active a aria-current="true"', async () => {
+        it('la page active a aria-current="page"', async () => {
             el = await fixture('<ar-pagination current="3" total="5"></ar-pagination>');
             const shadow = el.shadowRoot as ShadowRoot;
             const current = shadow.querySelector('[part="current"]') as Element;
             expect(current).not.toBeNull();
-            expect(current.getAttribute('aria-current')).toBe('true');
+            expect(current.getAttribute('aria-current')).toBe('page');
         });
     });
 
@@ -211,6 +211,60 @@ describe('ArPagination', () => {
             const shadow = el.shadowRoot as ShadowRoot;
             const ellipses = shadow.querySelectorAll('[part="ellipsis"]');
             expect(ellipses.length).toBeGreaterThanOrEqual(2);
+        });
+    });
+
+    // ── Labels accessibles enrichis ──────────────────────────────────────────
+
+    describe('labels accessibles enrichis (total dans le contexte)', () => {
+        it('le sr-only d\'un lien de page inclut le total ("Page X sur Y")', async () => {
+            el = await fixture('<ar-pagination current="3" total="12"></ar-pagination>');
+            const shadow = el.shadowRoot as ShadowRoot;
+            const link = shadow.querySelector('[data-ar-pagination-page="4"]') as Element;
+            const srOnly = link.querySelector('.sr-only');
+            expect(srOnly?.textContent).toBe('Page 4 sur 12');
+        });
+
+        it("le span aria-hidden d'un lien de page ne contient que le numéro (rendu visuel inchangé)", async () => {
+            el = await fixture('<ar-pagination current="3" total="12"></ar-pagination>');
+            const shadow = el.shadowRoot as ShadowRoot;
+            const link = shadow.querySelector('[data-ar-pagination-page="4"]') as Element;
+            const visible = link.querySelector('[aria-hidden="true"]');
+            expect(visible?.textContent).toBe('4');
+        });
+
+        it('le sr-only de la page active inclut le total ("Page X sur Y")', async () => {
+            el = await fixture('<ar-pagination current="3" total="12"></ar-pagination>');
+            const shadow = el.shadowRoot as ShadowRoot;
+            const current = shadow.querySelector('[part="current"]') as Element;
+            const srOnly = current.querySelector('.sr-only');
+            expect(srOnly?.textContent).toBe('Page 3 sur 12');
+        });
+
+        it('le sr-only de "précédent" inclut le total', async () => {
+            el = await fixture('<ar-pagination current="3" total="12"></ar-pagination>');
+            const srOnly = requirePart(el, 'prev').querySelector('.sr-only');
+            expect(srOnly?.textContent).toBe('Page précédente (page 2 sur 12)');
+        });
+
+        it('le sr-only de "suivant" inclut le total', async () => {
+            el = await fixture('<ar-pagination current="3" total="12"></ar-pagination>');
+            const srOnly = requirePart(el, 'next').querySelector('.sr-only');
+            expect(srOnly?.textContent).toBe('Page suivante (page 4 sur 12)');
+        });
+
+        it('le nom du landmark (aria-labelledby) reflète current/total', async () => {
+            el = await fixture('<ar-pagination current="3" total="12"></ar-pagination>');
+            const label = (el.shadowRoot as ShadowRoot).getElementById('ar-pagination');
+            expect(label?.textContent).toBe('Pagination, page 3 sur 12');
+        });
+
+        it('le nom du landmark se met à jour après un changement de page', async () => {
+            el = await fixture('<ar-pagination current="3" total="12"></ar-pagination>');
+            el.current = 4;
+            await waitForUpdate(el);
+            const label = (el.shadowRoot as ShadowRoot).getElementById('ar-pagination');
+            expect(label?.textContent).toBe('Pagination, page 4 sur 12');
         });
     });
 

--- a/packages/core/src/components/pagination/pagination.test.ts
+++ b/packages/core/src/components/pagination/pagination.test.ts
@@ -235,7 +235,7 @@ describe('ArPagination', () => {
             expect(shadow.querySelectorAll('[part~="link"], [part~="current"]').length).toBe(0);
         });
 
-        it('peuple le select avec les mêmes pages que _calculatePages au plancher (première/dernière page, fenêtre minimale, ellipses en disabled)', async () => {
+        it("peuple le select avec le même jeu de pages qu'à largeur confortable, pas la fenêtre réduite au budget actuel", async () => {
             el = await fixture('<ar-pagination current="3" total="15"></ar-pagination>');
             // @ts-expect-error accès à un champ privé pour simuler une mesure ResizeObserver
             el._budget = 2;
@@ -247,10 +247,32 @@ describe('ArPagination', () => {
                 '[part="select"]',
             ) as HTMLSelectElement;
             const options = Array.from(select.querySelectorAll('option'));
-            // _calculatePages(3, 15, 2) retombe sur _minimalPages(3, 15) = [1, -1, 3, -2, 15]
-            expect(options).toHaveLength(5);
-            expect(options.map((o) => o.disabled)).toEqual([false, true, false, true, false]);
-            expect(options.map((o) => o.value)).toEqual(['1', '', '3', '', '15']);
+            // _calculatePages(3, 15) SANS budget (donc budget par défaut 9) = [1, 2, 3, 4, 5, 6, 7, -2, 15]
+            // — pas _minimalPages(3, 15) : le select ne doit pas être moins capable que le
+            // desktop à largeur confortable, même si le conteneur réel est très étroit.
+            expect(options).toHaveLength(9);
+            expect(options.map((o) => o.disabled)).toEqual([
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                true,
+                false,
+            ]);
+            expect(options.map((o) => o.value)).toEqual([
+                '1',
+                '2',
+                '3',
+                '4',
+                '5',
+                '6',
+                '7',
+                '',
+                '15',
+            ]);
             // Attribut `selected` (pas la propriété IDL `.selected`) : happy-dom ne recalcule pas
             // correctement la "selectedness" d'un <select> au fil de l'insertion incrémentale de
             // ses <option> (bug reproduit indépendamment de ce composant, y compris sans binding
@@ -259,6 +281,33 @@ describe('ArPagination', () => {
             // `?selected`, ce qu'un vrai navigateur traduirait correctement en `.selected === true`.
             expect(options[2]?.hasAttribute('selected')).toBe(true);
             expect(options.filter((o) => o.hasAttribute('selected'))).toHaveLength(1);
+        });
+
+        it('le contenu du select ne dépend pas de _budget (toujours le jeu à largeur confortable)', async () => {
+            el = await fixture('<ar-pagination current="3" total="15"></ar-pagination>');
+            // @ts-expect-error accès à un champ privé pour simuler une mesure ResizeObserver
+            el._budget = 0;
+            el.requestUpdate();
+            await waitForUpdate(el);
+
+            const select = (el.shadowRoot as ShadowRoot).querySelector(
+                '[part="select"]',
+            ) as HTMLSelectElement;
+            const options = Array.from(select.querySelectorAll('option'));
+            // Même jeu de 9 options qu'avec _budget = 2 ci-dessus : le contenu du select ne varie
+            // pas avec la largeur réelle, seul le déclenchement du palier select en dépend.
+            expect(options).toHaveLength(9);
+            expect(options.map((o) => o.value)).toEqual([
+                '1',
+                '2',
+                '3',
+                '4',
+                '5',
+                '6',
+                '7',
+                '',
+                '15',
+            ]);
         });
 
         it('le label de chaque option contient "Page X sur Y"', async () => {
@@ -275,7 +324,7 @@ describe('ArPagination', () => {
             const options = Array.from(select.querySelectorAll('option'));
             expect(options[0]?.textContent?.trim()).toBe('Page 1 sur 15');
             expect(options[2]?.textContent?.trim()).toBe('Page 3 sur 15');
-            expect(options[4]?.textContent?.trim()).toBe('Page 15 sur 15');
+            expect(options[8]?.textContent?.trim()).toBe('Page 15 sur 15');
         });
 
         it('changer la valeur du select émet ar-pagination-page-change et met à jour current', async () => {
@@ -325,6 +374,21 @@ describe('ArPagination', () => {
 
             const shadow = el.shadowRoot as ShadowRoot;
             expect(shadow.querySelector('[part~="select"]')).toBeNull();
+        });
+
+        it('le plancher est identique en bord de liste et en position intermédiaire (pas de dépendance à la position de current)', async () => {
+            // Avant uniformisation, current en bord (1 ou total) avait un plancher de 3, contre
+            // 5 en position intermédiaire — à budget égal (4 ici), une page en bord restait donc
+            // en boutons pendant qu'une page intermédiaire basculait déjà en select. Le plancher
+            // uniforme (5) élimine cette dépendance à la position.
+            el = await fixture('<ar-pagination current="1" total="15"></ar-pagination>');
+            // @ts-expect-error accès à un champ privé pour simuler une mesure ResizeObserver
+            el._budget = 4;
+            el.requestUpdate();
+            await waitForUpdate(el);
+
+            // Match exact, cf. mise en garde `~=`/happy-dom plus haut dans ce describe.
+            expect((el.shadowRoot as ShadowRoot).querySelector('[part="select"]')).not.toBeNull();
         });
     });
 

--- a/packages/core/src/components/pagination/pagination.ts
+++ b/packages/core/src/components/pagination/pagination.ts
@@ -75,9 +75,10 @@ export class ArPagination extends LitElement {
     total: number = ArPagination.DEFAULT_TOTAL;
 
     @state() private _budget?: number;
-    private _resizeObserver?: ResizeObserver;
+    private _resizeObserver?: ResizeObserver | undefined;
     private _itemWidth = 0;
     private _initialized = false;
+    private _prevTotalDigits = 0;
 
     override connectedCallback(): void {
         super.connectedCallback();
@@ -87,6 +88,16 @@ export class ArPagination extends LitElement {
     override firstUpdated(): void {
         this._initialized = true;
         this._setupResizeObserver();
+        // Une police web chargée après le premier paint peut changer la largeur mesurée des
+        // items (ex. police variable, chargement asynchrone) : force une remesure une fois
+        // les polices prêtes. `document.fonts` est absent de certains environnements de test
+        // (happy-dom) — garde défensive.
+        if (document.fonts) {
+            void document.fonts.ready.then(() => {
+                this._itemWidth = 0;
+                this._recalculateBudget();
+            });
+        }
     }
 
     override disconnectedCallback(): void {
@@ -104,23 +115,38 @@ export class ArPagination extends LitElement {
 
     private _recalculateBudget(): void {
         const nav = this.shadowRoot?.querySelector<HTMLElement>('[part="nav"]');
+        const list = this.shadowRoot?.querySelector<HTMLElement>('[part="list"]');
         const prev = this.shadowRoot?.querySelector<HTMLElement>('[part~="prev"]');
         const next = this.shadowRoot?.querySelector<HTMLElement>('[part~="next"]');
-        const item = this.shadowRoot?.querySelector<HTMLElement>(
+        const items = this.shadowRoot?.querySelectorAll<HTMLElement>(
             '[part~="link"], [part~="current"]',
         );
-        if (!nav || !prev || !next) return;
+        if (!nav || !list || !prev || !next) return;
 
-        if (!this._itemWidth && item) {
-            this._itemWidth = item.getBoundingClientRect().width;
+        if (!this._itemWidth && items && items.length > 0) {
+            // Le plus large des items actuellement rendus, pas le premier : un item à 2-3
+            // chiffres est plus large qu'un item à 1 chiffre, et figer la mesure sur le
+            // premier item rendu sous-estime systématiquement la largeur réelle.
+            this._itemWidth = Math.max(
+                ...Array.from(items).map((el) => el.getBoundingClientRect().width),
+            );
         }
         if (!this._itemWidth) return;
 
+        // `column-gap` posé par le thème sur [part='list'] n'est pas inclus dans la largeur
+        // des items ni de nav/prev/next : chaque slot numérique coûte `itemWidth + gap`, et un
+        // gap de marge est retranché pour la jonction avec prev/next.
+        const gap = parseFloat(getComputedStyle(list).columnGap) || 0;
         const available =
             nav.getBoundingClientRect().width -
             prev.getBoundingClientRect().width -
-            next.getBoundingClientRect().width;
-        this._budget = Math.max(Math.floor(available / this._itemWidth), 0);
+            next.getBoundingClientRect().width -
+            gap;
+        const budget = Math.floor(available / (this._itemWidth + gap));
+        // Marge de sécurité d'un slot pour absorber les imprécisions de mesure résiduelles
+        // (arrondis sous-pixel, variations de police) — filet de sécurité peu coûteux contre
+        // un débordement horizontal.
+        this._budget = Math.max(budget - 1, 0);
     }
 
     override updated(changed: Map<string, unknown>): void {
@@ -136,6 +162,17 @@ export class ArPagination extends LitElement {
                     `current (${this.current}) est supérieur à total (${this.total}).`,
                 );
             }
+        }
+        if (changed.has('total')) {
+            const digits = String(Math.max(this.total, 1)).length;
+            if (this._prevTotalDigits && digits !== this._prevTotalDigits) {
+                // Le nombre de chiffres du total a changé (ex. 9 → 10, 99 → 100) : la largeur
+                // d'item mesurée précédemment (figée sur l'ancien total) n'est plus fiable —
+                // force une remesure avant le prochain calcul de budget.
+                this._itemWidth = 0;
+                this._recalculateBudget();
+            }
+            this._prevTotalDigits = digits;
         }
     }
 
@@ -195,11 +232,7 @@ export class ArPagination extends LitElement {
                 </li>
 
                 ${useTextMode
-                    ? html`<li part="item page-status">
-                          <span class="sr-only">Page </span>${current}<span aria-hidden="true"
-                              >&#32;sur&#32;</span
-                          >${total}
-                      </li>`
+                    ? html`<li part="item page-status">Page ${current} sur ${total}</li>`
                     : repeat(
                           _calculatePages(current, total, this._budget),
                           (page) => page,

--- a/packages/core/src/components/pagination/pagination.ts
+++ b/packages/core/src/components/pagination/pagination.ts
@@ -45,7 +45,7 @@ export interface ArPaginationPageChangeDetail {
  *   de la liste de pages quand l'espace disponible ne permet plus d'afficher de numéros (palier
  *   minimal).
  * @csspart select - L'élément `<select>` de saut de page. Personnalisable via `::part(select)`
- *   (apparence, flèche custom via `appearance: none` posé en structurel).
+ *   (apparence). Conserve l'apparence native du navigateur (flèche incluse) par défaut.
  *
  * @slot prev-icon - Icône du bouton "Page précédente". Remplace le chevron SVG par défaut.
  * @slot next-icon - Icône du bouton "Page suivante". Remplace le chevron SVG par défaut.
@@ -191,6 +191,11 @@ export class ArPagination extends LitElement {
             }
             this._prevTotalDigits = digits;
         }
+        const select = this.shadowRoot?.querySelector<HTMLSelectElement>('[part~="select"]');
+        if (select) {
+            const value = String(_clamp(this.current, 1, Math.max(this.total, 1)));
+            if (select.value !== value) select.value = value;
+        }
     }
 
     private _defaultPrevIcon(): TemplateResult {
@@ -317,7 +322,6 @@ export class ArPagination extends LitElement {
             <select
                 part="select"
                 aria-labelledby="ar-pagination-select-label"
-                .value=${String(current)}
                 @change=${this._onSelectChange}
             >
                 ${_calculatePages(current, total, this._budget).map((page) =>

--- a/packages/core/src/components/pagination/pagination.ts
+++ b/packages/core/src/components/pagination/pagination.ts
@@ -261,7 +261,7 @@ export class ArPagination extends LitElement {
             (this._budget < floorSlots || isMinimalWindowWithDoubleEllipsis);
 
         return html` <nav part="nav" role="navigation" aria-labelledby="ar-pagination">
-            <p id="ar-pagination" class="sr-only">Pagination</p>
+            <p id="ar-pagination" class="sr-only">Pagination, page ${current} sur ${total}</p>
             <ul part="list" @click=${this._onPageChange}>
                 <li part="item">
                     <a
@@ -271,7 +271,9 @@ export class ArPagination extends LitElement {
                         @click=${this._onPreviousPage}
                     >
                         <slot name="prev-icon">${this._defaultPrevIcon()}</slot>
-                        <span class="sr-only">Page précédente (page ${previousPageNumber})</span>
+                        <span class="sr-only"
+                            >Page précédente (page ${previousPageNumber} sur ${total})</span
+                        >
                     </a>
                 </li>
 
@@ -286,7 +288,7 @@ export class ArPagination extends LitElement {
                                   ? html` <li part="item" aria-hidden="true">
                                         <span part="ellipsis">...</span>
                                     </li>`
-                                  : this.renderPage(page, page === current);
+                                  : this.renderPage(page, page === current, total);
                           },
                       )}
 
@@ -298,7 +300,9 @@ export class ArPagination extends LitElement {
                         @click=${this._onNextPage}
                     >
                         <slot name="next-icon">${this._defaultNextIcon()}</slot>
-                        <span class="sr-only">Page suivante (page ${nextPageNumber})</span>
+                        <span class="sr-only"
+                            >Page suivante (page ${nextPageNumber} sur ${total})</span
+                        >
                     </a>
                 </li>
             </ul>
@@ -306,32 +310,37 @@ export class ArPagination extends LitElement {
     }
 
     /** Génère le `<li>` d'une page. Surcharger en sous-classe si besoin. */
-    protected renderPage(page: number, active: boolean): TemplateResult {
+    protected renderPage(page: number, active: boolean, total: number): TemplateResult {
         return html` <li part="item${active ? ' item--current' : ''}">
-            ${this.renderPageLink(page, active)}
+            ${this.renderPageLink(page, active, total)}
         </li>`;
     }
 
     /** Génère le lien ou le span (si page active) d'une page */
-    protected renderPageLink(page: number, active: boolean): TemplateResult {
+    protected renderPageLink(page: number, active: boolean, total: number): TemplateResult {
         if (active) {
             return html` <span
                 part="current"
                 tabindex="-1"
-                aria-current="true"
+                aria-current="page"
                 data-ar-pagination-page="${page}"
             >
-                ${this.renderPageLabel(page)}
+                ${this.renderPageLabel(page, total)}
             </span>`;
         }
         return html` <a part="link" data-ar-pagination-page="${page}" href="javascript:;">
-            ${this.renderPageLabel(page)}
+            ${this.renderPageLabel(page, total)}
         </a>`;
     }
 
-    /** Génère le label d'une page avec texte sr-only pour les lecteurs d'écran */
-    protected renderPageLabel(page: number): TemplateResult {
-        return html`<span class="sr-only">Page&nbsp;</span>${page}`;
+    /**
+     * Génère le label d'une page : texte complet ("Page X sur Y") lu par les lecteurs d'écran,
+     * numéro seul affiché — les deux `<span>` doivent rester adjacents sans texte/espace entre
+     * eux (voir garde globale sur les bindings adjacents dans un conteneur flex).
+     */
+    protected renderPageLabel(page: number, total: number): TemplateResult {
+        return html`<span class="sr-only">Page ${page} sur ${total}</span
+            ><span aria-hidden="true">${page}</span>`;
     }
 
     /**

--- a/packages/core/src/components/pagination/pagination.ts
+++ b/packages/core/src/components/pagination/pagination.ts
@@ -400,9 +400,11 @@ export class ArPagination extends LitElement {
     }
 
     private _onPageChange(event: MouseEvent): void {
-        const target = event.target as HTMLElement;
-        const page = target.dataset['arPaginationPage'];
-        if (target.tagName !== 'A' || !page) return;
+        const link = (event.target as HTMLElement).closest<HTMLAnchorElement>(
+            'a[data-ar-pagination-page]',
+        );
+        const page = link?.dataset['arPaginationPage'];
+        if (!link || !page) return;
         const from = this.current;
         this.current = parseInt(page);
         this._emit({ from, to: this.current });

--- a/packages/core/src/components/pagination/pagination.ts
+++ b/packages/core/src/components/pagination/pagination.ts
@@ -243,7 +243,22 @@ export class ArPagination extends LitElement {
         // donc aucun risque de débordement (contrairement à forcer 3, qui ferait tenter un rendu
         // à 5 items dans un budget de 3-4 slots).
         const floorSlots = 5;
-        const useSelectMode = this._budget !== undefined && this._budget < floorSlots;
+        // Calculé une seule fois : réutilisé pour la décision de mode ci-dessous ET pour le
+        // rendu des boutons numérotés (repeat) si on reste en mode boutons.
+        const pages = _calculatePages(current, total, this._budget);
+        // Cas particulier : à budget=5 exactement (position non-bord, loin des deux extrémités),
+        // `_calculatePages` retombe sur sa fenêtre minimale [1, -1, current, -2, total] — 5 slots
+        // dont 2 ellipses purement décoratives, pour seulement 3 pages réellement cliquables.
+        // Le select offre alors plus de valeur pour le même espace (jusqu'à 9 pages réelles,
+        // cf. `renderPageSelect`) : basculer vers lui même si le budget brut suffirait
+        // techniquement à afficher cette fenêtre. Repli strictement plus sûr que les boutons
+        // qu'il remplace (un `<select>` fermé est plus étroit que la fenêtre à 5 slots qu'il
+        // aurait fallu rendre), donc aucun risque de débordement supplémentaire.
+        const isMinimalWindowWithDoubleEllipsis =
+            pages.length === 5 && pages.includes(-1) && pages.includes(-2);
+        const useSelectMode =
+            this._budget !== undefined &&
+            (this._budget < floorSlots || isMinimalWindowWithDoubleEllipsis);
 
         return html` <nav part="nav" role="navigation" aria-labelledby="ar-pagination">
             <p id="ar-pagination" class="sr-only">Pagination</p>
@@ -263,7 +278,7 @@ export class ArPagination extends LitElement {
                 ${useSelectMode
                     ? this.renderPageSelect(current, total)
                     : repeat(
-                          _calculatePages(current, total, this._budget),
+                          pages,
                           (page) => page,
                           (page) => {
                               // -1 et -2 sont des sentinelles représentant les ellipses

--- a/packages/core/src/components/pagination/pagination.ts
+++ b/packages/core/src/components/pagination/pagination.ts
@@ -234,8 +234,15 @@ export class ArPagination extends LitElement {
         const isPreviousDisabled = current <= 1;
         const previousPageNumber = _clamp(current - 1, 1, total > 1 ? total - 1 : 1);
         const nextPageNumber = _clamp(current + 1, 1, total);
-        const isEdgeCurrent = current <= 1 || current >= total;
-        const floorSlots = isEdgeCurrent ? 3 : 5;
+        // Plancher uniforme (5, le plus grand des deux planchers algorithmiques de
+        // `_calculatePages`) plutôt que 3 en bord de liste / 5 sinon : sinon, à largeur égale,
+        // la bascule vers le select dépendrait de la position de `current` (une page en bord
+        // resterait en boutons plus longtemps qu'une page intermédiaire) — incohérent du point
+        // de vue de l'utilisateur, qui ne doit pas voir un mode différent selon la page active
+        // sans changement de largeur. 5 est sûr : c'est déjà le plancher réel en position non-bord,
+        // donc aucun risque de débordement (contrairement à forcer 3, qui ferait tenter un rendu
+        // à 5 items dans un budget de 3-4 slots).
+        const floorSlots = 5;
         const useSelectMode = this._budget !== undefined && this._budget < floorSlots;
 
         return html` <nav part="nav" role="navigation" aria-labelledby="ar-pagination">
@@ -315,6 +322,13 @@ export class ArPagination extends LitElement {
     /**
      * Génère le `<li>` du select de saut de page, affiché à la place de la liste de pages au
      * palier minimal (largeur insuffisante pour la fenêtre de boutons la plus réduite).
+     *
+     * Peuplé sans le `_budget` courant (donc avec le plancher de largeur confortable de
+     * `_calculatePages`, jusqu'à 9 slots) plutôt qu'avec la fenêtre déjà réduite par la largeur
+     * réelle : contrairement aux boutons, le `<select>` reste compact quel que soit le nombre
+     * d'options qu'il contient une fois fermé — rien n'empêche de lui donner accès au même choix
+     * de pages qu'à largeur confortable. Le mobile n'est ainsi jamais moins capable que le
+     * desktop, seulement rendu différemment.
      */
     protected renderPageSelect(current: number, total: number): TemplateResult {
         return html`<li part="item page-select">
@@ -324,7 +338,7 @@ export class ArPagination extends LitElement {
                 aria-labelledby="ar-pagination-select-label"
                 @change=${this._onSelectChange}
             >
-                ${_calculatePages(current, total, this._budget).map((page) =>
+                ${_calculatePages(current, total).map((page) =>
                     page === -1 || page === -2
                         ? html`<option disabled value="">…</option>`
                         : html`<option value=${page} ?selected=${page === current}>

--- a/packages/core/src/components/pagination/pagination.ts
+++ b/packages/core/src/components/pagination/pagination.ts
@@ -41,6 +41,8 @@ export interface ArPaginationPageChangeDetail {
  * @csspart nav-btn  - Part combiné sur `prev`/`next`, pour cibler les deux boutons de navigation ensemble (ex. `::part(nav-btn)` pour un style commun distinct des numéros de page).
  * @csspart nav-btn--disabled - Variante d'état de `nav-btn` posée sur `prev`/`next` quand désactivé (page 1 ou dernière page).
  * @csspart ellipsis - Le `<span>` d'ellipse (`...`) entre deux groupes de pages, non interactif.
+ * @csspart page-status - Le `<li>` du texte "Page X sur Y" affiché à la place de la liste de
+ *   pages quand l'espace disponible ne permet plus d'afficher de numéros (palier minimal).
  *
  * @slot prev-icon - Icône du bouton "Page précédente". Remplace le chevron SVG par défaut.
  * @slot next-icon - Icône du bouton "Page suivante". Remplace le chevron SVG par défaut.
@@ -173,6 +175,9 @@ export class ArPagination extends LitElement {
         const isPreviousDisabled = current <= 1;
         const previousPageNumber = _clamp(current - 1, 1, total > 1 ? total - 1 : 1);
         const nextPageNumber = _clamp(current + 1, 1, total);
+        const isEdgeCurrent = current <= 1 || current >= total;
+        const floorSlots = isEdgeCurrent ? 3 : 5;
+        const useTextMode = this._budget !== undefined && this._budget < floorSlots;
 
         return html` <nav part="nav" role="navigation" aria-labelledby="ar-pagination">
             <p id="ar-pagination" class="sr-only">Pagination</p>
@@ -189,18 +194,24 @@ export class ArPagination extends LitElement {
                     </a>
                 </li>
 
-                ${repeat(
-                    _calculatePages(current, total, this._budget),
-                    (page) => page,
-                    (page) => {
-                        // -1 et -2 sont des sentinelles représentant les ellipses
-                        return page === -1 || page === -2
-                            ? html` <li part="item" aria-hidden="true">
-                                  <span part="ellipsis">...</span>
-                              </li>`
-                            : this.renderPage(page, page === current);
-                    },
-                )}
+                ${useTextMode
+                    ? html`<li part="item page-status">
+                          <span class="sr-only">Page </span>${current}<span aria-hidden="true"
+                              >&#32;sur&#32;</span
+                          >${total}
+                      </li>`
+                    : repeat(
+                          _calculatePages(current, total, this._budget),
+                          (page) => page,
+                          (page) => {
+                              // -1 et -2 sont des sentinelles représentant les ellipses
+                              return page === -1 || page === -2
+                                  ? html` <li part="item" aria-hidden="true">
+                                        <span part="ellipsis">...</span>
+                                    </li>`
+                                  : this.renderPage(page, page === current);
+                          },
+                      )}
 
                 <li part="item">
                     <a

--- a/packages/core/src/components/pagination/pagination.ts
+++ b/packages/core/src/components/pagination/pagination.ts
@@ -41,8 +41,11 @@ export interface ArPaginationPageChangeDetail {
  * @csspart nav-btn  - Part combiné sur `prev`/`next`, pour cibler les deux boutons de navigation ensemble (ex. `::part(nav-btn)` pour un style commun distinct des numéros de page).
  * @csspart nav-btn--disabled - Variante d'état de `nav-btn` posée sur `prev`/`next` quand désactivé (page 1 ou dernière page).
  * @csspart ellipsis - Le `<span>` d'ellipse (`...`) entre deux groupes de pages, non interactif.
- * @csspart page-status - Le `<li>` du texte "Page X sur Y" affiché à la place de la liste de
- *   pages quand l'espace disponible ne permet plus d'afficher de numéros (palier minimal).
+ * @csspart page-select - Le `<li>` englobant le `<select>` de saut de page, affiché à la place
+ *   de la liste de pages quand l'espace disponible ne permet plus d'afficher de numéros (palier
+ *   minimal).
+ * @csspart select - L'élément `<select>` de saut de page. Personnalisable via `::part(select)`
+ *   (apparence, flèche custom via `appearance: none` posé en structurel).
  *
  * @slot prev-icon - Icône du bouton "Page précédente". Remplace le chevron SVG par défaut.
  * @slot next-icon - Icône du bouton "Page suivante". Remplace le chevron SVG par défaut.
@@ -228,7 +231,7 @@ export class ArPagination extends LitElement {
         const nextPageNumber = _clamp(current + 1, 1, total);
         const isEdgeCurrent = current <= 1 || current >= total;
         const floorSlots = isEdgeCurrent ? 3 : 5;
-        const useTextMode = this._budget !== undefined && this._budget < floorSlots;
+        const useSelectMode = this._budget !== undefined && this._budget < floorSlots;
 
         return html` <nav part="nav" role="navigation" aria-labelledby="ar-pagination">
             <p id="ar-pagination" class="sr-only">Pagination</p>
@@ -245,8 +248,8 @@ export class ArPagination extends LitElement {
                     </a>
                 </li>
 
-                ${useTextMode
-                    ? html`<li part="item page-status">Page ${current} sur ${total}</li>`
+                ${useSelectMode
+                    ? this.renderPageSelect(current, total)
                     : repeat(
                           _calculatePages(current, total, this._budget),
                           (page) => page,
@@ -302,6 +305,40 @@ export class ArPagination extends LitElement {
     /** Génère le label d'une page avec texte sr-only pour les lecteurs d'écran */
     protected renderPageLabel(page: number): TemplateResult {
         return html`<span class="sr-only">Page&nbsp;</span>${page}`;
+    }
+
+    /**
+     * Génère le `<li>` du select de saut de page, affiché à la place de la liste de pages au
+     * palier minimal (largeur insuffisante pour la fenêtre de boutons la plus réduite).
+     */
+    protected renderPageSelect(current: number, total: number): TemplateResult {
+        return html`<li part="item page-select">
+            <span class="sr-only" id="ar-pagination-select-label">Aller à la page</span>
+            <select
+                part="select"
+                aria-labelledby="ar-pagination-select-label"
+                .value=${String(current)}
+                @change=${this._onSelectChange}
+            >
+                ${_calculatePages(current, total, this._budget).map((page) =>
+                    page === -1 || page === -2
+                        ? html`<option disabled value="">…</option>`
+                        : html`<option value=${page} ?selected=${page === current}>
+                              Page ${page} sur ${total}
+                          </option>`,
+                )}
+            </select>
+        </li>`;
+    }
+
+    private _onSelectChange(event: Event): void {
+        const select = event.target as HTMLSelectElement;
+        const page = parseInt(select.value, 10);
+        if (Number.isNaN(page) || page === this.current) return;
+        const from = this.current;
+        this.current = page;
+        this._emit({ from, to: this.current });
+        this._announcePageChange();
     }
 
     private _onPreviousPage(): void {

--- a/packages/core/src/components/pagination/pagination.ts
+++ b/packages/core/src/components/pagination/pagination.ts
@@ -75,8 +75,15 @@ export class ArPagination extends LitElement {
     @state() private _budget?: number;
     private _resizeObserver?: ResizeObserver;
     private _itemWidth = 0;
+    private _initialized = false;
+
+    override connectedCallback(): void {
+        super.connectedCallback();
+        if (this._initialized) this._setupResizeObserver();
+    }
 
     override firstUpdated(): void {
+        this._initialized = true;
         this._setupResizeObserver();
     }
 
@@ -86,6 +93,7 @@ export class ArPagination extends LitElement {
     }
 
     private _setupResizeObserver(): void {
+        this._resizeObserver?.disconnect();
         const nav = this.shadowRoot?.querySelector<HTMLElement>('[part="nav"]');
         if (!nav) return;
         this._resizeObserver = new ResizeObserver(() => this._recalculateBudget());

--- a/packages/core/src/components/pagination/pagination.ts
+++ b/packages/core/src/components/pagination/pagination.ts
@@ -79,6 +79,12 @@ export class ArPagination extends LitElement {
     private _itemWidth = 0;
     private _initialized = false;
     private _prevTotalDigits = 0;
+    // Une remesure est due (changement d'ordre de grandeur de `total`, `fonts.ready`) mais ne
+    // peut être effectuée que si au moins un item numérique est actuellement rendu. Au palier
+    // texte, aucun item n'est disponible : `_itemWidth` doit alors être conservé tel quel (voir
+    // `_recalculateBudget`) plutôt que d'être remis à 0, sous peine de bloquer définitivement le
+    // composant en palier texte (plus aucune mesure exploitable pour recalculer `_budget`).
+    private _needsRemeasure = false;
 
     override connectedCallback(): void {
         super.connectedCallback();
@@ -94,7 +100,7 @@ export class ArPagination extends LitElement {
         // (happy-dom) — garde défensive.
         if (document.fonts) {
             void document.fonts.ready.then(() => {
-                this._itemWidth = 0;
+                this._needsRemeasure = true;
                 this._recalculateBudget();
             });
         }
@@ -123,14 +129,19 @@ export class ArPagination extends LitElement {
         );
         if (!nav || !list || !prev || !next) return;
 
-        if (!this._itemWidth && items && items.length > 0) {
+        if ((this._needsRemeasure || !this._itemWidth) && items && items.length > 0) {
             // Le plus large des items actuellement rendus, pas le premier : un item à 2-3
             // chiffres est plus large qu'un item à 1 chiffre, et figer la mesure sur le
             // premier item rendu sous-estime systématiquement la largeur réelle.
             this._itemWidth = Math.max(
                 ...Array.from(items).map((el) => el.getBoundingClientRect().width),
             );
+            this._needsRemeasure = false;
         }
+        // Si une remesure est due mais qu'aucun item numérique n'est actuellement rendu (palier
+        // texte), on continue avec la dernière valeur connue de `_itemWidth` plutôt que de
+        // bloquer : le composant doit rester réactif au resize, la remesure aura lieu dès qu'un
+        // item numérique redevient disponible (voir commentaire sur `_needsRemeasure`).
         if (!this._itemWidth) return;
 
         // `column-gap` posé par le thème sur [part='list'] n'est pas inclus dans la largeur
@@ -168,8 +179,11 @@ export class ArPagination extends LitElement {
             if (this._prevTotalDigits && digits !== this._prevTotalDigits) {
                 // Le nombre de chiffres du total a changé (ex. 9 → 10, 99 → 100) : la largeur
                 // d'item mesurée précédemment (figée sur l'ancien total) n'est plus fiable —
-                // force une remesure avant le prochain calcul de budget.
-                this._itemWidth = 0;
+                // marque une remesure comme due avant le prochain calcul de budget. La remesure
+                // effective n'a lieu que si un item numérique est rendu (cf. `_needsRemeasure`) ;
+                // sinon la dernière valeur connue de `_itemWidth` reste utilisée pour ne pas
+                // bloquer le composant au palier texte.
+                this._needsRemeasure = true;
                 this._recalculateBudget();
             }
             this._prevTotalDigits = digits;

--- a/packages/core/src/components/pagination/pagination.ts
+++ b/packages/core/src/components/pagination/pagination.ts
@@ -1,5 +1,5 @@
 import { LitElement, type TemplateResult, type CSSResultGroup, html } from 'lit';
-import { property } from 'lit/decorators.js';
+import { property, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import utilitiesStyles from '../../styles/utilities.styles.js';
 import resetStyles from '../../styles/components/reset.styles.js';
@@ -72,6 +72,47 @@ export class ArPagination extends LitElement {
     @property({ reflect: true, type: Number, useDefault: true })
     total: number = ArPagination.DEFAULT_TOTAL;
 
+    @state() private _budget?: number;
+    private _resizeObserver?: ResizeObserver;
+    private _itemWidth = 0;
+
+    override firstUpdated(): void {
+        this._setupResizeObserver();
+    }
+
+    override disconnectedCallback(): void {
+        super.disconnectedCallback();
+        this._resizeObserver?.disconnect();
+    }
+
+    private _setupResizeObserver(): void {
+        const nav = this.shadowRoot?.querySelector<HTMLElement>('[part="nav"]');
+        if (!nav) return;
+        this._resizeObserver = new ResizeObserver(() => this._recalculateBudget());
+        this._resizeObserver.observe(nav);
+    }
+
+    private _recalculateBudget(): void {
+        const nav = this.shadowRoot?.querySelector<HTMLElement>('[part="nav"]');
+        const prev = this.shadowRoot?.querySelector<HTMLElement>('[part~="prev"]');
+        const next = this.shadowRoot?.querySelector<HTMLElement>('[part~="next"]');
+        const item = this.shadowRoot?.querySelector<HTMLElement>(
+            '[part~="link"], [part~="current"]',
+        );
+        if (!nav || !prev || !next) return;
+
+        if (!this._itemWidth && item) {
+            this._itemWidth = item.getBoundingClientRect().width;
+        }
+        if (!this._itemWidth) return;
+
+        const available =
+            nav.getBoundingClientRect().width -
+            prev.getBoundingClientRect().width -
+            next.getBoundingClientRect().width;
+        this._budget = Math.max(Math.floor(available / this._itemWidth), 0);
+    }
+
     override updated(changed: Map<string, unknown>): void {
         if (changed.has('total') && this.total < 1) {
             warn('ar-pagination', `total doit être ≥ 1. Valeur reçue : ${this.total}.`);
@@ -141,7 +182,7 @@ export class ArPagination extends LitElement {
                 </li>
 
                 ${repeat(
-                    _calculatePages(current, total),
+                    _calculatePages(current, total, this._budget),
                     (page) => page,
                     (page) => {
                         // -1 et -2 sont des sentinelles représentant les ellipses

--- a/packages/core/src/components/pagination/pagination.utils.test.ts
+++ b/packages/core/src/components/pagination/pagination.utils.test.ts
@@ -62,8 +62,26 @@ describe('_calculatePages', () => {
             expect(_calculatePages(1, 5, 3)).toEqual([1, -2, 5]);
         });
 
-        it("budget partiellement restreint : tronque avant d'atteindre le plancher", () => {
-            expect(_calculatePages(3, 5, 4)).toEqual([1, 3, 4, 5]);
+        it('budget insuffisant pour couvrir [2, total-1] sans ellipse : retombe au plancher (régression, ex-bug de trou invisible)', () => {
+            // Avant le correctif de _pagesWithSiblings, cette assertion attendait [1, 3, 4, 5] :
+            // la page 2 disparaissait silencieusement, sans marqueur d'ellipse. C'était la même
+            // classe de bug que la régression `_calculatePages(5, 9, 8)` ci-dessous — ce test
+            // encodait le bug plutôt que le documenter comme plancher légitime.
+            expect(_calculatePages(3, 5, 4)).toEqual([1, -1, 3, -2, 5]);
+        });
+    });
+
+    describe('régression : les deux fenêtres (gauche/droite) se rejoignent sans ellipse', () => {
+        it('ni ellipse ni page manquante quand showLeftEllipsis et showRightEllipsis sont tous deux faux', () => {
+            const result = _calculatePages(5, 9, 8);
+            // Aucune page entre 1 et total ne doit être absente sans marqueur d'ellipse (-1/-2).
+            const numbered = result.filter((p) => p > 0);
+            for (let p = 1; p <= 9; p++) {
+                expect(numbered.includes(p) || result.includes(-1) || result.includes(-2)).toBe(
+                    true,
+                );
+            }
+            expect(result).toEqual([1, -1, 4, 5, 6, -2, 9]);
         });
     });
 });

--- a/packages/core/src/components/pagination/pagination.utils.test.ts
+++ b/packages/core/src/components/pagination/pagination.utils.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { _calculatePages, _clamp } from './pagination.utils.js';
+
+describe('_calculatePages', () => {
+    describe('sans budget (comportement existant inchangé)', () => {
+        it('total < 10 : renvoie la liste complète', () => {
+            expect(_calculatePages(3, 5)).toEqual([1, 2, 3, 4, 5]);
+        });
+
+        it('current proche du début : boundary + ellipsis de fin', () => {
+            expect(_calculatePages(1, 15)).toEqual([1, 2, 3, 4, 5, 6, 7, -2, 15]);
+            expect(_calculatePages(5, 15)).toEqual([1, 2, 3, 4, 5, 6, 7, -2, 15]);
+        });
+
+        it('current proche de la fin : ellipsis de début + boundary', () => {
+            expect(_calculatePages(11, 15)).toEqual([1, -1, 9, 10, 11, 12, 13, 14, 15]);
+            expect(_calculatePages(15, 15)).toEqual([1, -1, 9, 10, 11, 12, 13, 14, 15]);
+        });
+
+        it('current au milieu : deux ellipsis', () => {
+            expect(_calculatePages(8, 15)).toEqual([1, -1, 6, 7, 8, 9, 10, -2, 15]);
+        });
+    });
+
+    describe('avec budget suffisant pour le total', () => {
+        it('renvoie la liste complète, comme sans budget', () => {
+            expect(_calculatePages(3, 5, 5)).toEqual([1, 2, 3, 4, 5]);
+            expect(_calculatePages(8, 15, 9)).toEqual([1, -1, 6, 7, 8, 9, 10, -2, 15]);
+        });
+    });
+
+    describe('avec budget réduit : siblingCount décroissant', () => {
+        it('budget=7 : siblingCount passe de 2 à 1', () => {
+            expect(_calculatePages(8, 15, 7)).toEqual([1, -1, 7, 8, 9, -2, 15]);
+        });
+
+        it('budget=5 : siblingCount passe à 0', () => {
+            expect(_calculatePages(8, 15, 5)).toEqual([1, -1, 8, -2, 15]);
+        });
+
+        it('budget tout juste suffisant pour siblingCount=1 (7 slots exactement)', () => {
+            expect(_calculatePages(11, 15, 7)).toEqual([1, -1, 10, 11, 12, -2, 15]);
+        });
+    });
+
+    describe('plancher : budget insuffisant même pour siblingCount=0', () => {
+        it('current au bord (page 1) : représentation minimale à 3 slots', () => {
+            expect(_calculatePages(1, 15, 3)).toEqual([1, -2, 15]);
+        });
+
+        it('current au bord (dernière page) : représentation minimale à 3 slots', () => {
+            expect(_calculatePages(15, 15, 3)).toEqual([1, -1, 15]);
+        });
+
+        it('current au milieu : représentation minimale à 5 slots (plancher réel de la fonction)', () => {
+            expect(_calculatePages(8, 15, 3)).toEqual([1, -1, 8, -2, 15]);
+        });
+    });
+
+    describe('total < 10 avec budget très restreint (troncable aussi)', () => {
+        it('current au bord : réduit à la représentation minimale', () => {
+            expect(_calculatePages(1, 5, 3)).toEqual([1, -2, 5]);
+        });
+
+        it("budget partiellement restreint : tronque avant d'atteindre le plancher", () => {
+            expect(_calculatePages(3, 5, 4)).toEqual([1, 3, 4, 5]);
+        });
+    });
+});
+
+describe('_clamp', () => {
+    it('renvoie value si dans les bornes', () => {
+        expect(_clamp(3, 1, 5)).toBe(3);
+    });
+
+    it('renvoie min si value < min', () => {
+        expect(_clamp(-1, 1, 5)).toBe(1);
+    });
+
+    it('renvoie max si value > max', () => {
+        expect(_clamp(10, 1, 5)).toBe(5);
+    });
+});

--- a/packages/core/src/components/pagination/pagination.utils.ts
+++ b/packages/core/src/components/pagination/pagination.utils.ts
@@ -46,11 +46,16 @@ function _pagesWithSiblings(current: number, total: number, siblingCount: number
     const showLeftEllipsis = left > 3;
     const showRightEllipsis = right < total - 2;
 
-    if (!showLeftEllipsis) {
+    if (!showLeftEllipsis && !showRightEllipsis) {
+        // Les deux fenêtres se rejoignent : la plage couvre tout [2, total-1] sans troncature,
+        // sinon les deux `if` s'écrasent silencieusement l'un l'autre et une page disparaît
+        // sans marqueur d'ellipse pour signaler la troncature.
+        left = 2;
+        right = total - 1;
+    } else if (!showLeftEllipsis) {
         left = 2;
         right = Math.min(windowSize, total - 1);
-    }
-    if (!showRightEllipsis) {
+    } else if (!showRightEllipsis) {
         right = total - 1;
         left = Math.max(total - windowSize + 1, 2);
     }

--- a/packages/core/src/components/pagination/pagination.utils.ts
+++ b/packages/core/src/components/pagination/pagination.utils.ts
@@ -1,27 +1,73 @@
 /**
- * Renvoie la liste des pages à afficher suivant la position courante
+ * Renvoie la liste des pages à afficher suivant la position courante.
+ *
+ * Sans `budget` (ou `budget` suffisant pour afficher `total` pages), comportement inchangé.
+ * Avec un `budget` réduit (nombre de slots numériques disponibles, ellipses incluses), réduit
+ * progressivement le nombre de pages voisines autour de `current` (`siblingCount` : 2 → 1 → 0),
+ * puis renvoie une représentation minimale (3 ou 5 slots) si aucune ne tient dans le budget —
+ * c'est le plancher algorithmique de cette fonction ; en dessous, l'appelant doit utiliser un
+ * autre mode de rendu plutôt que d'appeler cette fonction.
  *
  * @param current Page courante
  * @param total Nombre total de pages
+ * @param budget Nombre maximal de slots numériques (pages + ellipses, hors prev/next).
+ *   `undefined` = comportement historique (liste complète si `total < 10`, sinon 9 slots max).
  */
-export function _calculatePages(current: number, total: number) {
-    // => 1, 2, 3, 4, (5), 6, 7, 8, 9
-    if (total < 10) {
+export function _calculatePages(current: number, total: number, budget?: number): number[] {
+    // 9 = plafond historique (siblingCount 2, boundary 1 + 2 ellipses + 5 pages autour de current)
+    // utilisé quand `budget` n'est pas fourni — préserve le comportement existant à l'identique.
+    const DEFAULT_BUDGET = 9;
+    const effectiveBudget = budget ?? DEFAULT_BUDGET;
+
+    if (total <= effectiveBudget) {
         return Array.from({ length: total }, (_, i) => i + 1);
     }
 
-    // => 1, 2, 3, 4, (5), 6, 7, ..., 10
-    if (current <= 5) {
-        return [1, 2, 3, 4, 5, 6, 7, -2, total];
+    for (const siblingCount of [2, 1, 0]) {
+        const pages = _pagesWithSiblings(current, total, siblingCount);
+        if (pages.length <= effectiveBudget) return pages;
     }
 
-    // => 1, ..., 4, 5, (6), 7, 8, 9, 10
-    if (current >= total - 4) {
-        return [1, -1, total - 6, total - 5, total - 4, total - 3, total - 2, total - 1, total];
+    return _minimalPages(current, total);
+}
+
+/**
+ * Construit la liste [1, ...ellipsis/siblings..., total] pour un `siblingCount` donné : jusqu'à
+ * `siblingCount` pages de chaque côté de `current`, avec ellipses (`-1`/`-2`) si la page 1 ou
+ * `total` ne sont pas directement adjacentes à la plage affichée.
+ */
+function _pagesWithSiblings(current: number, total: number, siblingCount: number): number[] {
+    // Nombre de pages affichées quand une ellipse est absorbée d'un côté (boundary incluse).
+    const windowSize = 2 * siblingCount + 3;
+
+    let left = Math.max(current - siblingCount, 2);
+    let right = Math.min(current + siblingCount, total - 1);
+
+    const showLeftEllipsis = left > 3;
+    const showRightEllipsis = right < total - 2;
+
+    if (!showLeftEllipsis) {
+        left = 2;
+        right = Math.min(windowSize, total - 1);
+    }
+    if (!showRightEllipsis) {
+        right = total - 1;
+        left = Math.max(total - windowSize + 1, 2);
     }
 
-    // => 1, ..., 4, 5, (6), 7, 8, ..., 12
-    return [1, -1, current - 2, current - 1, current, current + 1, current + 2, -2, total];
+    const pages = [1];
+    if (showLeftEllipsis) pages.push(-1);
+    for (let p = left; p <= right; p++) pages.push(p);
+    if (showRightEllipsis) pages.push(-2);
+    pages.push(total);
+    return pages;
+}
+
+/** Plancher algorithmique : boundary(s) + current, avec ellipses si nécessaire. 3 ou 5 slots. */
+function _minimalPages(current: number, total: number): number[] {
+    if (current <= 1) return [1, -2, total];
+    if (current >= total) return [1, -1, total];
+    return [1, -1, current, -2, total];
 }
 
 /**

--- a/packages/core/src/components/pagination/pagination.utils.ts
+++ b/packages/core/src/components/pagination/pagination.utils.ts
@@ -68,7 +68,13 @@ function _pagesWithSiblings(current: number, total: number, siblingCount: number
     return pages;
 }
 
-/** Plancher algorithmique : boundary(s) + current, avec ellipses si nécessaire. 3 ou 5 slots. */
+/**
+ * Plancher algorithmique : boundary(s) + current, avec ellipses si nécessaire. 3 ou 5 slots.
+ *
+ * Précondition implicite non vérifiée : `total >= 3`. En dessous, le résultat n'est pas
+ * garanti — actuellement inatteignable en pratique car `_calculatePages` retourne toujours
+ * plus tôt (`total <= effectiveBudget`) pour `total <= 2`.
+ */
 function _minimalPages(current: number, total: number): number[] {
     if (current <= 1) return [1, -2, total];
     if (current >= total) return [1, -1, total];

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -1155,7 +1155,7 @@
         &::part(select) {
             background-color: var(--ar-button-tertiary-bg);
             color: var(--ar-color-text);
-            padding: 0 1.75rem 0 0.75rem;
+            padding: 0 2rem 0 0.75rem;
             background-image:
                 linear-gradient(45deg, transparent 50%, currentColor 50%),
                 linear-gradient(135deg, currentColor 50%, transparent 50%);
@@ -1164,6 +1164,23 @@
                 calc(100% - 0.75rem) center;
             background-size: 0.35rem 0.35rem;
             background-repeat: no-repeat;
+        }
+
+        /* `:open` — état exposé par le <select> natif quand son picker est affiché (Baseline
+           2026, "newly available" depuis mai 2026 : Chrome, Firefox et Safari 26.5+ le
+           supportent tous désormais). Amélioration progressive pure : un navigateur qui ne
+           reconnaît pas `:open` ignore silencieusement cette règle et garde la flèche vers le
+           bas dans tous les cas, sans casse. Inverse la flèche vers le haut — angles +180°
+           (45°→225°, 135°→315°) ET positions permutées : les deux sont nécessaires pour un
+           vrai miroir vertical du chevron (vérifié empiriquement au rendu ; +180° seul sur les
+           angles sans permuter les positions produit deux coins disjoints, pas un chevron). */
+        &::part(select):open {
+            background-image:
+                linear-gradient(225deg, transparent 50%, currentColor 50%),
+                linear-gradient(315deg, currentColor 50%, transparent 50%);
+            background-position:
+                calc(100% - 0.75rem) center,
+                calc(100% - 1.1rem) center;
         }
 
         &::part(current) {

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -1097,40 +1097,73 @@
         &::part(link),
         &::part(current),
         &::part(prev),
-        &::part(next) {
+        &::part(next),
+        &::part(select) {
             border-radius: var(--ar-border-radius-xl);
+        }
+
+        /* Ordre volontaire : :focus-visible avant :hover avant :active, à spécificité égale, pour
+           qu'un état combiné (ex. clic — hover + focus simultanés) retienne toujours le fond de
+           l'état le plus fort visuellement plutôt qu'un fond issu d'une autre origine de valeur
+           qui pourrait entrer en collision avec la couleur pilotée par :hover — même schéma que
+           le correctif ar-breadcrumb (#157, `:focus` déclaré après `:hover` y avait produit une
+           icône blanche sur fond quasi blanc). `:focus-visible` (pas `:focus`) évite en plus que
+           ce fond s'applique sur un simple clic souris, réservé au cas clavier/programmatique. */
+        &::part(link):focus-visible,
+        &::part(prev):focus-visible,
+        &::part(next):focus-visible,
+        &::part(select):focus-visible {
+            background-color: var(--ar-button-tertiary-bg-focus);
         }
 
         &::part(link):hover,
         &::part(prev):hover,
-        &::part(next):hover {
+        &::part(next):hover,
+        &::part(select):hover {
             background-color: var(--ar-button-tertiary-bg-hover);
             color: var(--ar-color-white);
         }
 
         &::part(link):active,
         &::part(prev):active,
-        &::part(next):active {
+        &::part(next):active,
+        &::part(select):active {
             background-color: var(--ar-button-tertiary-bg-active);
             color: var(--ar-color-white);
         }
 
-        &::part(link):focus,
-        &::part(prev):focus,
-        &::part(next):focus {
-            background-color: var(--ar-button-tertiary-bg-focus);
-        }
-
-        /* Spécificité égale aux variantes :hover/:active/:focus ci-dessus (pseudo-élément +
-           pseudo-classe) requise pour gagner la cascade : ::part(nav-btn--disabled) seul
+        /* Spécificité égale aux variantes :focus-visible/:hover/:active ci-dessus (pseudo-élément
+           + pseudo-classe) requise pour gagner la cascade : ::part(nav-btn--disabled) seul
            (spécificité pseudo-élément uniquement) perdrait face à ::part(prev):hover malgré
            un ordre de déclaration ultérieur. */
         &::part(nav-btn--disabled),
         &::part(nav-btn--disabled):hover,
         &::part(nav-btn--disabled):active,
-        &::part(nav-btn--disabled):focus {
+        &::part(nav-btn--disabled):focus-visible {
             background-color: var(--ar-button-disabled-bg);
             color: var(--ar-button-disabled-color);
+        }
+
+        /* Flèche custom en `currentColor` (gradients, pas une image figée) : s'adapte
+           automatiquement à chaque état (couleur de texte blanche au survol/pressé ci-dessus)
+           sans dupliquer une image par état, et fonctionne à l'identique sur tous les
+           navigateurs — contrairement à `::before`/`::after` sur `<select>`, peu fiable
+           cross-browser (Safari/Firefox ne les rendent pas systématiquement sur les contrôles de
+           formulaire). `appearance: none` est posé en structurel dans `pagination.styles.ts`.
+           Positionnement en propriétés physiques (`right`), pas logiques : limite connue et
+           acceptée pour un premier jet, à revisiter si un besoin RTL réel émerge. */
+        &::part(select) {
+            background-color: var(--ar-button-tertiary-bg);
+            color: var(--ar-color-text);
+            padding: 0 1.75rem 0 0.75rem;
+            background-image:
+                linear-gradient(45deg, transparent 50%, currentColor 50%),
+                linear-gradient(135deg, currentColor 50%, transparent 50%);
+            background-position:
+                calc(100% - 1.1rem) center,
+                calc(100% - 0.75rem) center;
+            background-size: 0.35rem 0.35rem;
+            background-repeat: no-repeat;
         }
 
         &::part(current) {


### PR DESCRIPTION
## Résumé

- Remplace la media query CSS binaire (`max-width: 640px`) par un algorithme JS qui mesure la largeur réelle du composant (`ResizeObserver`) et réduit progressivement le nombre de pages générées, au lieu de masquer en CSS des liens déjà présents dans le DOM (gain a11y : l'ordre de tabulation reflète enfin ce qui est visible).
- `_calculatePages` accepte un paramètre `budget` optionnel (réduction `siblingCount` 2 → 1 → 0), rétrocompatible à l'identique sans `budget`.
- En dessous d'un plancher minimal (3 slots si `current` est en bord, 5 sinon), bascule sur un texte "Page X sur Y" (prev/next toujours affichés et fonctionnels).
- `[part='list']` passe de `flex-wrap: wrap` à `nowrap` — le budget JS garantit que ce qui est rendu tient sur une ligne, en tenant compte du `column-gap` et de la largeur réelle des items du thème.
- Doc mise à jour (`ar-pagination.mdx`).

Closes #152

## Notes de revue

Exécuté avec superpowers:subagent-driven-development (7 tâches, chacune revue individuellement) puis une revue finale de branche complète qui a débusqué 2 bugs Critical échappés aux revues scopées par tâche (débordement horizontal ignorant `column-gap`/largeur réelle des items du thème par défaut ; palier texte cassé visuellement + en a11y). Corrigés, puis une régression introduite par le premier correctif (blocage permanent au palier texte) a été détectée en re-revue et corrigée dans un second tour ciblé, validé par une revue finale complète. Ledger détaillé de toutes les revues et findings : `docs/superpowers/plans/2026-08-07-pagination-responsive-masking.md` (plan) — le ledger d'exécution lui-même n'est pas committé (scratch gitignored).

Deux points résiduels non bloquants, notés pour suivi :
- Une fenêtre de resize avec `_itemWidth` légèrement obsolète en sortie de palier texte (auto-corrigé au resize suivant, aucun débordement mesuré).
- Bug préexistant latent (hors scope de cette PR) : quand `total` initial vaut la valeur par défaut (5) et que l'app le change ensuite, la détection de changement d'ordre de grandeur peut manquer sa première occurrence — aucun débordement mesuré aujourd'hui, à surveiller.

## Test plan

- [x] Tests unitaires `_calculatePages` (tous les paliers de budget)
- [x] Tests Vitest du palier texte
- [x] Tests WTR du comportement responsive réel (redimensionnement de conteneur, avec et sans CSS du thème par défaut simulé)
- [x] `npm run test:all` (912 tests Vitest, 252 tests navigateur)