### PR TITLE
fix(stepper): step-change annulable, ajoute step-changed avec detail {from,to} (#174)

### DIFF
--- a/apps/docs/src/content/components/ar-stepper.mdx
+++ b/apps/docs/src/content/components/ar-stepper.mdx
@@ -65,6 +65,13 @@ variants:
             <!-- Étape 3 -->
             <ar-stepper-item path="etape-3" label="Récapitulatif"></ar-stepper-item>
           </ar-stepper>
+pageScript: |
+    <script>
+        document.addEventListener('ar-stepper-step-change', (e) => {
+            /* Mettez à jour le contenu de l'étape, puis l'étape active du composant */
+            e.target.currentPath = e.detail.to;
+        });
+    </script>
 ---
 
 import WcagRef from '../../components/WcagRef.astro';
@@ -115,11 +122,13 @@ se déplace dans l'élément ciblé sur desktop, et revient à sa position d'ori
 
 ### Écouter le changement d'étape
 
-`ar-stepper` émet `ar-stepper-step-change` au clic sur une étape, avec l'attribut `path` de l'étape sélectionnée dans `detail` :
+Lorsque l'utilisateur souhaite changer d'étape, un événement `ar-stepper-step-change` est émis avec `{ from, to }` dans `event.detail`.
+Mettez à jour la propriété `currentPath` du composant avec `event.detail.to` une fois le nouveau contenu chargé pour synchroniser l'étape active du stepper.
 
 ```js
-document.querySelector('ar-stepper').addEventListener('ar-stepper-step-change', (e) => {
-    console.log('Étape sélectionnée :', e.detail.path);
+document.addEventListener('ar-stepper-step-change', (e) => {
+    /* Mettez à jour le contenu de l'étape, puis l'étape active du composant */
+    e.target.currentPath = e.detail.to;
 });
 ```
 

--- a/docs/superpowers/plans/2026-08-11-stepper-controlled-current-events-plan.md
+++ b/docs/superpowers/plans/2026-08-11-stepper-controlled-current-events-plan.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** `ar-stepper-step-change` devient annulable et n'annonce plus rien immédiatement au clic ; un nouvel event `ar-stepper-step-changed` (non-cancelable) et l'annonce aria-live ne se déclenchent que quand `currentPath` a réellement transitionné — le mécanisme de focus existant (`_pendingFocusPath`) est conservé tel quel mais regroupé dans le même point d'entrée.
+**Goal:** `ar-stepper-step-change` devient annulable et n'annonce plus rien immédiatement au clic ; un nouvel event `ar-stepper-step-changed` (non-cancelable) et l'annonce aria-live ne se déclenchent que quand `currentPath` a réellement transitionné — le mécanisme de focus existant (`_pendingFocusPath`) est conservé tel quel mais regroupé dans le même point d'entrée. Le détail des deux events passe de `{ path }` à `{ from, to }`, aligné sur `ar-pagination`.
 
 **Architecture:** Miroir du pattern livré sur `ar-pagination` (#161, PR #173), adapté à un composant déjà partiellement contrôlé : `currentPath` ne bougeait déjà jamais tout seul (sauf `follow-scroll`), et le focus était déjà gardé par confirmation. Seule l'annonce a11y était prématurée — elle rejoint le focus dans un unique bloc `updated()` guardé par confirmation réelle (`this.hasUpdated` natif de Lit + `changed.has('currentPath')` + `from !== to`).
 
@@ -19,6 +19,8 @@
 - Le marqueur `@cancelable` dans le JSDoc `@event` doit être le tout dernier token de la
   description (regex end-anchored côté doc, `apps/docs/src/utils/events.ts`) — piège déjà
   rencontré et corrigé sur #161, à ne pas reproduire.
+- Détail des deux events : `{ from: string; to: string }` (pas `{ path }`) — décision revue en
+  cours de brainstorming, alignée sur `ar-pagination`.
 
 ---
 
@@ -37,18 +39,20 @@ git checkout -b fix/174-stepper-step-events
 
 ---
 
-### Task 2: `ar-stepper-step-change` cancelable, `ar-stepper-step-changed`, annonce/focus regroupés
+### Task 2: `ar-stepper-step-change` cancelable, `ar-stepper-step-changed`, détail `{ from, to }`, annonce/focus regroupés
 
 **Files:**
 
-- Modify: `packages/core/src/components/stepper/stepper.ts:84` (JSDoc `@event`), `:240-264`
-  (`updated()`), `:458-491` (`onClickLink`)
+- Modify: `packages/core/src/components/stepper/stepper.ts:26-29` (interface
+  `ArStepperStepChangeDetail`), `:84` (JSDoc `@event`), `:240-264` (`updated()`), `:458-491`
+  (`onClickLink`)
 - Test: `packages/core/src/components/stepper/stepper.test.ts` (describes `événements`,
   `annonces a11y`, nouveau describe `événement ar-stepper-step-changed`)
 
 **Interfaces:**
 
-- Consumes: `ArStepperStepChangeDetail` (déjà défini, `stepper.ts:26-29`, `{ path: string }`).
+- Consumes/Produces (redéfini dans cette task) : `ArStepperStepChangeDetail` devient
+  `{ from: string; to: string }` (au lieu de `{ path: string }`).
 - Produces: `private _emitChanged(detail: ArStepperStepChangeDetail): void` — dispatch
   `ar-stepper-step-changed` (non-cancelable). Rien d'autre dans ce plan n'en dépend.
 
@@ -59,10 +63,31 @@ Dans `packages/core/src/components/stepper/stepper.test.ts` :
 1. Ajouter `import type { ArStepperStepChangeDetail } from './stepper.js';` en haut du fichier,
    à côté de `import type { ArStepper } from './stepper.js';`.
 
-2. Dans le describe `événements` (lignes 243-285), ajouter ces deux tests à la fin, avant
-   l'accolade fermante du describe :
+2. Dans le describe `événements` (lignes 243-285), remplacer le premier test (`'émet
+ar-stepper-step-change au clic sur un lien'`, lignes 244-264) par :
 
 ```typescript
+it('émet ar-stepper-step-change au clic sur un lien, avec { from, to }', async () => {
+    const el = await fixtureWithItems(`
+                <ar-stepper current-path="/b" mode="edit">
+                    <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
+                    <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
+                </ar-stepper>
+            `);
+
+    const handler = vi.fn();
+    el.addEventListener('ar-stepper-step-change', handler);
+
+    const link = requireQuery<HTMLAnchorElement>(shadow(el), 'a[data-path="/a"]');
+    link.click();
+
+    expect(handler).toHaveBeenCalledOnce();
+    const event = handler.mock.calls[0][0] as CustomEvent<ArStepperStepChangeDetail>;
+    expect(event.detail).toEqual({ from: '/b', to: '/a' });
+
+    el.removeEventListener('ar-stepper-step-change', handler);
+});
+
 it('ar-stepper-step-change est cancelable', async () => {
     const el = await fixtureWithItems(`
                 <ar-stepper current-path="/b" mode="edit">
@@ -103,6 +128,9 @@ it('preventDefault() sur ar-stepper-step-change bloque toute suite : currentPath
 });
 ```
 
+Le second test du describe (`"n'émet plus step-changed (nom court) au clic"`, lignes 266-284)
+reste inchangé.
+
 3. Ajouter un nouveau describe juste après le describe `événements` (avant le describe
    `navigation — preventDefault sur les liens sans href réel`) :
 
@@ -125,7 +153,7 @@ describe('événement ar-stepper-step-changed', () => {
         expect(handler).not.toHaveBeenCalled();
     });
 
-    it('est émis avec { path }, non cancelable, quand currentPath change (réassignation externe)', async () => {
+    it('est émis avec { from, to }, non cancelable, quand currentPath change (réassignation externe)', async () => {
         const el = await fixtureWithItems(`
                 <ar-stepper current-path="/b" mode="edit">
                     <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
@@ -141,7 +169,7 @@ describe('événement ar-stepper-step-changed', () => {
         expect(handler).toHaveBeenCalledOnce();
         const event = handler.mock.calls[0][0] as CustomEvent<ArStepperStepChangeDetail>;
         expect(event.cancelable).toBe(false);
-        expect(event.detail).toEqual({ path: '/a' });
+        expect(event.detail).toEqual({ from: '/b', to: '/a' });
     });
 
     it("n'est pas émis au premier rendu", async () => {
@@ -204,7 +232,7 @@ describe('annonces a11y', () => {
                 </ar-stepper>
             `);
         el.addEventListener('ar-stepper-step-change', (e) => {
-            el.currentPath = (e as CustomEvent<ArStepperStepChangeDetail>).detail.path;
+            el.currentPath = (e as CustomEvent<ArStepperStepChangeDetail>).detail.to;
         });
 
         const link = shadow(el).querySelector<HTMLAnchorElement>('a[data-path="/a"]');
@@ -233,7 +261,7 @@ describe('annonces a11y', () => {
                 </ar-stepper>
             `);
         el.addEventListener('ar-stepper-step-change', (e) => {
-            el.currentPath = (e as CustomEvent<ArStepperStepChangeDetail>).detail.path;
+            el.currentPath = (e as CustomEvent<ArStepperStepChangeDetail>).detail.to;
         });
 
         const link = shadow(el).querySelector<HTMLAnchorElement>('a[data-path="/a/2"]');
@@ -249,8 +277,8 @@ describe('annonces a11y', () => {
 
 Ne pas toucher au describe `focus après activation d'un lien` (lignes 367-474) : ses 5 tests
 confirment déjà `currentPath` explicitement avant d'asserter le focus (pattern déjà aligné sur le
-nouveau modèle) — ils doivent continuer à passer sans modification une fois l'implémentation
-faite (Step 4 vérifie ça).
+nouveau modèle), et aucun n'inspecte la forme du `detail` — ils doivent continuer à passer sans
+modification une fois l'implémentation faite (Step 4 vérifie ça).
 
 - [ ] **Step 2: Lancer les tests, vérifier qu'ils échouent contre le code actuel**
 
@@ -259,13 +287,36 @@ cd /Users/jon/Code/Active_projects/ariane
 npx vitest run packages/core/src/components/stepper/stepper.test.ts
 ```
 
-Expected : échecs sur `event.cancelable` (event actuel non cancelable), sur `preventDefault()`
-sans effet, sur `ar-stepper-step-changed` jamais émis, sur les annonces qui se déclenchent
-encore immédiatement au clic au lieu d'attendre confirmation.
+Expected : échecs sur la forme du `detail` (`{ path }` au lieu de `{ from, to }`), sur
+`event.cancelable` (event actuel non cancelable), sur `preventDefault()` sans effet, sur
+`ar-stepper-step-changed` jamais émis, sur les annonces qui se déclenchent encore immédiatement
+au clic au lieu d'attendre confirmation.
 
 - [ ] **Step 3: Implémenter dans `stepper.ts`**
 
-3a. Remplacer le bloc de fin de `updated()` (lignes 258-263) :
+3a. Remplacer l'interface (lignes 25-29) :
+
+```typescript
+/** Détail de l'événement émis lors d'un changement d'étape */
+export interface ArStepperStepChangeDetail {
+    /** Chemin (`href`) de l'étape sélectionnée */
+    path: string;
+}
+```
+
+par :
+
+```typescript
+/** Détail de l'événement émis lors d'une demande ou d'une confirmation de changement d'étape */
+export interface ArStepperStepChangeDetail {
+    /** Chemin de l'étape courante avant la transition */
+    from: string;
+    /** Chemin de l'étape cible (demandée sur `-change`, confirmée sur `-changed`) */
+    to: string;
+}
+```
+
+3b. Remplacer le bloc de fin de `updated()` (lignes 258-263) :
 
 ```typescript
 if (changed.has('currentPath') && this.currentPath === this._pendingFocusPath) {
@@ -285,7 +336,7 @@ if (this.hasUpdated && changed.has('currentPath')) {
     const from = changed.get('currentPath') as string;
     const to = this.currentPath;
     if (from !== to) {
-        this._emitChanged({ path: to });
+        this._emitChanged({ from, to });
         announceA11y(this.navigation.currentNode?.label ?? to, 'polite');
         if (to === this._pendingFocusPath) {
             this.shadowRoot?.querySelector<HTMLElement>(`[data-path="${to}"]`)?.focus();
@@ -299,7 +350,7 @@ Note : `this.hasUpdated` est déjà `false` pendant l'exécution de ce tout prem
 (Lit ne le passe à `true` qu'après ce cycle) — le guard fonctionne donc correctement dès le
 montage, sans champ privé supplémentaire à déclarer ni à réinitialiser.
 
-3b. Ajouter la méthode privée, par exemple juste après `getScrollTargets()` (avant la section
+3c. Ajouter la méthode privée, par exemple juste après `getScrollTargets()` (avant la section
 `// ── Events ──`, ligne 456) :
 
 ```typescript
@@ -314,7 +365,7 @@ montage, sans champ privé supplémentaire à déclarer ni à réinitialiser.
     }
 ```
 
-3c. Dans `onClickLink` (lignes 458-491), remplacer :
+3d. Dans `onClickLink` (lignes 458-491), remplacer :
 
 ```typescript
         const detail: ArStepperStepChangeDetail = { path };
@@ -337,7 +388,7 @@ montage, sans champ privé supplémentaire à déclarer ni à réinitialiser.
 par :
 
 ```typescript
-        const detail: ArStepperStepChangeDetail = { path };
+        const detail: ArStepperStepChangeDetail = { from: this.currentPath, to: path };
 
         const proceed = this.dispatchEvent(
             new CustomEvent('ar-stepper-step-change', {
@@ -360,7 +411,11 @@ par :
     };
 ```
 
-3d. Mettre à jour le JSDoc `@event` (ligne 84) — remplacer :
+Remarque : `from: this.currentPath` est lu **avant** le dispatch, donc reflète bien la valeur
+courante au moment du clic (pas altérée par le dispatch lui-même, puisque le composant ne mute
+jamais `currentPath` en interne).
+
+3e. Mettre à jour le JSDoc `@event` (ligne 84) — remplacer :
 
 ```typescript
  * @event {CustomEvent<{ path: string }>} ar-stepper-step-change - Émis au clic sur une étape.
@@ -369,12 +424,12 @@ par :
 par :
 
 ```typescript
- * @event {CustomEvent<{ path: string }>} ar-stepper-step-change - Émis avant le changement
- *   d'étape, au clic. Annulable via `preventDefault()` : bloque la navigation, `currentPath`
- *   ne change pas. Contient `path`. @cancelable
- * @event {CustomEvent<{ path: string }>} ar-stepper-step-changed - Émis quand `currentPath` a
- *   réellement changé (réassignation externe suite à la confirmation du consommateur, ou via
- *   `follow-scroll`). Non annulable. Contient `path`.
+ * @event {CustomEvent<{ from: string, to: string }>} ar-stepper-step-change - Émis avant le
+ *   changement d'étape, au clic. Annulable via `preventDefault()` : bloque la navigation,
+ *   `currentPath` ne change pas. Contient `from` et `to`. @cancelable
+ * @event {CustomEvent<{ from: string, to: string }>} ar-stepper-step-changed - Émis quand
+ *   `currentPath` a réellement changé (réassignation externe suite à la confirmation du
+ *   consommateur, ou via `follow-scroll`). Non annulable. Contient `from` et `to`.
 ```
 
 - [ ] **Step 4: Lancer les tests, vérifier qu'ils passent**
@@ -400,15 +455,30 @@ Expected: PASS.
 npm run test:browser --workspace=packages/core
 ```
 
-Expected: PASS — `stepper.browser.test.ts` écoute déjà `ar-stepper-step-change` et confirme
-`currentPath` avant d'asserter le focus (`stepper.browser.test.ts:128`), aucune modification de
-ce fichier n'est nécessaire.
+Expected: PASS. `stepper.browser.test.ts` écoute déjà `ar-stepper-step-change` et confirme
+`currentPath` avant d'asserter le focus, mais lit le detail via
+`(event as CustomEvent<{ path: string }>).detail.path` (ligne 126) — ce champ n'existe plus
+après ce changement. **Avant de lancer ce Step**, corriger
+`packages/core/src/components/stepper/stepper.browser.test.ts:126` : remplacer
+
+```typescript
+el.currentPath = (event as CustomEvent<{ path: string }>).detail.path;
+```
+
+par
+
+```typescript
+el.currentPath = (event as CustomEvent<{ from: string; to: string }>).detail.to;
+```
+
+Seule ligne de ce fichier à toucher, le reste de la logique (écoute + réassignation de
+`currentPath`) reste identique. Ajouter cette correction au commit de cette task.
 
 - [ ] **Step 7: Commit**
 
 ```bash
-git add packages/core/src/components/stepper/stepper.ts packages/core/src/components/stepper/stepper.test.ts
-git commit -m "fix(stepper): step-change annulable, ajoute step-changed, annonce apres confirmation (#174)"
+git add packages/core/src/components/stepper/stepper.ts packages/core/src/components/stepper/stepper.test.ts packages/core/src/components/stepper/stepper.browser.test.ts
+git commit -m "fix(stepper): step-change annulable, ajoute step-changed avec detail {from,to} (#174)"
 ```
 
 ---
@@ -426,17 +496,15 @@ Remplacer les lignes 116-124 par :
 ````mdx
 ### Écouter le changement d'étape
 
-Lorsque l'utilisateur souhaite changer d'étape, un événement `ar-stepper-step-change` est émis avec `{ path }` dans `event.detail`.
-Mettez à jour la propriété `currentPath` du composant avec `event.detail.path` une fois le nouveau contenu chargé pour synchroniser l'étape active du stepper.
+Lorsque l'utilisateur souhaite changer d'étape, un événement `ar-stepper-step-change` est émis avec `{ from, to }` dans `event.detail`.
+Mettez à jour la propriété `currentPath` du composant avec `event.detail.to` une fois le nouveau contenu chargé pour synchroniser l'étape active du stepper.
 
 ```js
 document.addEventListener('ar-stepper-step-change', (e) => {
     /* Mettez à jour le contenu de l'étape, puis l'étape active du composant */
-    e.target.currentPath = e.detail.path;
+    e.target.currentPath = e.detail.to;
 });
 ```
-````
-
 ````
 
 Les sous-sections suivantes ("Mode `create` vs `edit`", `follow-scroll`, "Navigation
@@ -452,10 +520,10 @@ pageScript: |
     <script>
         document.addEventListener('ar-stepper-step-change', (e) => {
             /* Mettez à jour le contenu de l'étape, puis l'étape active du composant */
-            e.target.currentPath = e.detail.path;
+            e.target.currentPath = e.detail.to;
         });
     </script>
-````
+```
 
 Aucune modification de schema/template nécessaire — le champ `pageScript` existe déjà
 (`apps/docs/src/content.config.ts`, `apps/docs/src/pages/components/[slug].astro`), livré avec
@@ -489,7 +557,7 @@ un redémarrage complet, pas seulement un rafraîchissement navigateur).
 
 ```bash
 git add apps/docs/src/content/components/ar-stepper.mdx
-git commit -m "docs(stepper): documente step-changed, aligne le style Utilisation, ajoute pageScript (#174)"
+git commit -m "docs(stepper): documente step-changed {from,to}, aligne le style Utilisation, ajoute pageScript (#174)"
 ```
 
 ---
@@ -529,12 +597,13 @@ Expected: PASS.
 
 ```bash
 git push -u origin fix/174-stepper-step-events
-gh pr create --base dev --title "fix(stepper): step-change annulable, ajoute step-changed (#174)" --body "$(cat <<'EOF'
+gh pr create --base dev --title "fix(stepper): step-change annulable, ajoute step-changed avec detail {from,to} (#174)" --body "$(cat <<'EOF'
 ## Résumé
 
 - `ar-stepper-step-change` devient annulable (`preventDefault()` bloque la navigation).
 - Nouvel event `ar-stepper-step-changed` (non-cancelable), émis quand `currentPath` a réellement transitionné (confirmation externe ou `follow-scroll`).
-- L'annonce aria-live est déplacée du clic vers cette confirmation réelle — le stepper ne "ment" plus sur l'état affiché pendant un chargement async qui échouerait.
+- Le détail des deux events passe de `{ path }` à `{ from, to }`, aligné sur `ar-pagination` — `ar-stepper` est fondamentalement un système de navigation comme `ar-pagination`, avec des pages nommées plutôt que numérotées.
+- L'annonce aria-live est déplacée du clic vers la confirmation réelle — le stepper ne "ment" plus sur l'état affiché pendant un chargement async qui échouerait.
 - Le mécanisme de focus (`_pendingFocusPath`) est inchangé fonctionnellement, juste regroupé au même point d'entrée.
 - Doc alignée sur le style adopté pour `ar-pagination` ; démos live câblées via le champ `pageScript` existant (#161).
 - Breaking change (package alpha, pas de dépréciation) — closes #174.
@@ -559,18 +628,23 @@ EOF
 
 1. `ar-stepper-step-change` cancelable → Task 2.
 2. `ar-stepper-step-changed`, annonce déplacée et résolue à la confirmation → Task 2.
-3. `_pendingFocusPath` conservé, regroupé dans le même bloc → Task 2 (Step 3a).
-4. `_pendingFocusPath` vidé si annulé → Task 2 (Step 3c).
-5. Guard premier rendu → Task 2 (Step 3a), via `this.hasUpdated` natif de Lit (pas de champ
+3. `_pendingFocusPath` conservé, regroupé dans le même bloc → Task 2 (Step 3b).
+4. `_pendingFocusPath` vidé si annulé → Task 2 (Step 3d).
+5. Guard premier rendu → Task 2 (Step 3b), via `this.hasUpdated` natif de Lit (pas de champ
    privé à ajouter — vérifié via la doc Lit officielle : `false` pendant tout le premier cycle
    `updated()`/`firstUpdated()`, `true` à partir du suivant).
-6. Docs : style Utilisation aligné + `pageScript` → Task 3.
+6. Détail `{ from, to }` (revu en cours de brainstorming) → Task 2 (Step 3a, 3d, 3e), Task 3
+   (Steps 1-2, exemples de doc).
+7. Docs : style Utilisation aligné + `pageScript` → Task 3.
 
-**Cohérence des types/signatures** : `ArStepperStepChangeDetail { path }` réutilisé identique
-partout. `_emitChanged(detail: ArStepperStepChangeDetail): void` défini et utilisé uniquement en
-Task 2. Pas de référence à un nom non défini dans une task antérieure.
+**Cohérence des types/signatures** : `ArStepperStepChangeDetail { from: string; to: string }`
+réutilisé identique partout (interface, les deux dispatches, JSDoc, tests, doc). `_emitChanged
+(detail: ArStepperStepChangeDetail): void` défini et utilisé uniquement en Task 2. Pas de
+référence résiduelle à `.detail.path` — vérifié dans `stepper.test.ts` (Step 1 de la Task 2) et
+`stepper.browser.test.ts` (Step 6 de la Task 2, seul autre fichier qui lisait ce champ).
 
 **Pas de régression sur le describe `focus après activation d'un lien`** : vérifié
 manuellement contre les 5 tests existants (lignes 367-474 du fichier avant modification) — tous
-confirment déjà `currentPath` explicitement avant d'asserter le focus, donc aucune modification
-requise et ils doivent continuer à passer tels quels (vérifié en Step 4 de la Task 2).
+confirment déjà `currentPath` explicitement avant d'asserter le focus et n'inspectent pas la
+forme du `detail`, donc aucune modification requise et ils doivent continuer à passer tels quels
+(vérifié en Step 4 de la Task 2).

--- a/docs/superpowers/plans/2026-08-11-stepper-controlled-current-events-plan.md
+++ b/docs/superpowers/plans/2026-08-11-stepper-controlled-current-events-plan.md
@@ -1,0 +1,578 @@
+# `ar-stepper` : deux événements demande/confirmation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `ar-stepper-step-change` devient annulable et n'annonce plus rien immédiatement au clic ; un nouvel event `ar-stepper-step-changed` (non-cancelable) et l'annonce aria-live ne se déclenchent que quand `currentPath` a réellement transitionné — le mécanisme de focus existant (`_pendingFocusPath`) est conservé tel quel mais regroupé dans le même point d'entrée.
+
+**Architecture:** Miroir du pattern livré sur `ar-pagination` (#161, PR #173), adapté à un composant déjà partiellement contrôlé : `currentPath` ne bougeait déjà jamais tout seul (sauf `follow-scroll`), et le focus était déjà gardé par confirmation. Seule l'annonce a11y était prématurée — elle rejoint le focus dans un unique bloc `updated()` guardé par confirmation réelle (`_hasRenderedOnce` + `changed.has('currentPath')` + `from !== to`).
+
+**Tech Stack:** Lit 3, TypeScript, Vitest (happy-dom), @open-wc/testing + @web/test-runner (Chromium réel), Astro 6 + MDX (docs).
+
+## Global Constraints
+
+- Breaking change direct, sans dépréciation (package en `0.1.0-alpha.8`, règle CLAUDE.md).
+- Prettier : 100 caractères, 4 espaces, quotes simples.
+- `import type` pour tous les imports de types.
+- Conventional Commits (commitlint + Husky) — un commit par étape complète.
+- Branches `fix/<desc>` depuis `dev`, PR vers `dev`.
+- Référence de design : `docs/superpowers/specs/2026-08-11-stepper-controlled-current-events-design.md`.
+- Le marqueur `@cancelable` dans le JSDoc `@event` doit être le tout dernier token de la
+  description (regex end-anchored côté doc, `apps/docs/src/utils/events.ts`) — piège déjà
+  rencontré et corrigé sur #161, à ne pas reproduire.
+
+---
+
+### Task 1: Créer la branche de travail
+
+**Files:** aucun.
+
+- [ ] **Step 1: Créer la branche depuis `dev`**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git checkout dev
+git pull origin dev
+git checkout -b fix/174-stepper-step-events
+```
+
+---
+
+### Task 2: `ar-stepper-step-change` cancelable, `ar-stepper-step-changed`, annonce/focus regroupés
+
+**Files:**
+
+- Modify: `packages/core/src/components/stepper/stepper.ts:84` (JSDoc `@event`), `:158` (champ
+  privé), `:240-264` (`updated()`), `:458-491` (`onClickLink`)
+- Test: `packages/core/src/components/stepper/stepper.test.ts` (describes `événements`,
+  `annonces a11y`, nouveau describe `événement ar-stepper-step-changed`)
+
+**Interfaces:**
+
+- Consumes: `ArStepperStepChangeDetail` (déjà défini, `stepper.ts:26-29`, `{ path: string }`).
+- Produces: `private _emitChanged(detail: ArStepperStepChangeDetail): void` — dispatch
+  `ar-stepper-step-changed` (non-cancelable). Rien d'autre dans ce plan n'en dépend.
+
+- [ ] **Step 1: Écrire les tests qui doivent échouer contre l'implémentation actuelle**
+
+Dans `packages/core/src/components/stepper/stepper.test.ts` :
+
+1. Ajouter `import type { ArStepperStepChangeDetail } from './stepper.js';` en haut du fichier,
+   à côté de `import type { ArStepper } from './stepper.js';`.
+
+2. Dans le describe `événements` (lignes 243-285), ajouter ces deux tests à la fin, avant
+   l'accolade fermante du describe :
+
+```typescript
+it('ar-stepper-step-change est cancelable', async () => {
+    const el = await fixtureWithItems(`
+                <ar-stepper current-path="/b" mode="edit">
+                    <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
+                    <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
+                </ar-stepper>
+            `);
+    const handler = vi.fn();
+    el.addEventListener('ar-stepper-step-change', handler);
+
+    const link = requireQuery<HTMLAnchorElement>(shadow(el), 'a[data-path="/a"]');
+    link.click();
+
+    expect(handler).toHaveBeenCalledOnce();
+    const event = handler.mock.calls[0][0] as CustomEvent;
+    expect(event.cancelable).toBe(true);
+});
+
+it('preventDefault() sur ar-stepper-step-change bloque toute suite : currentPath inchangé, focus reste sur le lien cliqué', async () => {
+    const el = await fixtureWithItems(`
+                <ar-stepper current-path="/b" mode="edit">
+                    <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
+                    <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
+                </ar-stepper>
+            `);
+    el.addEventListener('ar-stepper-step-change', (e) => e.preventDefault());
+    const changedHandler = vi.fn();
+    el.addEventListener('ar-stepper-step-changed', changedHandler);
+
+    const link = requireQuery<HTMLAnchorElement>(shadow(el), 'a[data-path="/a"]');
+    link.focus();
+    link.click();
+    await waitForUpdate(el);
+
+    expect(el.currentPath).toBe('/b');
+    expect(changedHandler).not.toHaveBeenCalled();
+    expect(shadow(el).activeElement).toBe(link);
+});
+```
+
+3. Ajouter un nouveau describe juste après le describe `événements` (avant le describe
+   `navigation — preventDefault sur les liens sans href réel`) :
+
+```typescript
+describe('événement ar-stepper-step-changed', () => {
+    it("n'est pas émis tant que currentPath n'a pas réellement changé", async () => {
+        const el = await fixtureWithItems(`
+                <ar-stepper current-path="/b" mode="edit">
+                    <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
+                    <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
+                </ar-stepper>
+            `);
+        const handler = vi.fn();
+        el.addEventListener('ar-stepper-step-changed', handler);
+
+        const link = requireQuery<HTMLAnchorElement>(shadow(el), 'a[data-path="/a"]');
+        link.click();
+        await waitForUpdate(el);
+
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('est émis avec { path }, non cancelable, quand currentPath change (réassignation externe)', async () => {
+        const el = await fixtureWithItems(`
+                <ar-stepper current-path="/b" mode="edit">
+                    <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
+                    <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
+                </ar-stepper>
+            `);
+        const handler = vi.fn();
+        el.addEventListener('ar-stepper-step-changed', handler);
+
+        el.currentPath = '/a';
+        await waitForUpdate(el);
+
+        expect(handler).toHaveBeenCalledOnce();
+        const event = handler.mock.calls[0][0] as CustomEvent<ArStepperStepChangeDetail>;
+        expect(event.cancelable).toBe(false);
+        expect(event.detail).toEqual({ path: '/a' });
+    });
+
+    it("n'est pas émis au premier rendu", async () => {
+        const handler = vi.fn();
+        const el = await fixtureWithItems(`
+                <ar-stepper current-path="/b" mode="edit">
+                    <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
+                    <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
+                </ar-stepper>
+            `);
+        el.addEventListener('ar-stepper-step-changed', handler);
+        await waitForUpdate(el);
+
+        expect(handler).not.toHaveBeenCalled();
+    });
+});
+```
+
+4. Remplacer entièrement le describe `annonces a11y` (lignes 803-856) par :
+
+```typescript
+describe('annonces a11y', () => {
+    afterEach(() => {
+        document.querySelectorAll('[data-ar-live-region]').forEach((node) => node.remove());
+    });
+
+    it("n'annonce rien tant que currentPath n'est pas confirmé par le consommateur", async () => {
+        vi.spyOn(window, 'matchMedia').mockReturnValue({
+            matches: true,
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+        } as unknown as MediaQueryList);
+
+        const el = await fixtureWithItems(`
+                <ar-stepper current-path="/b" mode="edit">
+                    <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
+                    <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
+                </ar-stepper>
+            `);
+
+        const link = shadow(el).querySelector<HTMLAnchorElement>('a[data-path="/a"]');
+        if (!link) throw new Error('Lien vers /a introuvable');
+        link.click();
+        await new Promise((resolve) => setTimeout(resolve, 60));
+
+        expect(document.getElementById('ar-live-region-polite')).toBeNull();
+    });
+
+    it('un clic confirmé sur une étape de premier niveau annonce son label', async () => {
+        vi.spyOn(window, 'matchMedia').mockReturnValue({
+            matches: true,
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+        } as unknown as MediaQueryList);
+
+        const el = await fixtureWithItems(`
+                <ar-stepper current-path="/b" mode="edit">
+                    <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
+                    <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
+                </ar-stepper>
+            `);
+        el.addEventListener('ar-stepper-step-change', (e) => {
+            el.currentPath = (e as CustomEvent<ArStepperStepChangeDetail>).detail.path;
+        });
+
+        const link = shadow(el).querySelector<HTMLAnchorElement>('a[data-path="/a"]');
+        if (!link) throw new Error('Lien vers /a introuvable');
+        link.click();
+        await waitForUpdate(el);
+        await new Promise((resolve) => setTimeout(resolve, 60));
+
+        expect(document.getElementById('ar-live-region-polite')?.textContent).toBe('Étape A');
+    });
+
+    it('un clic confirmé sur une sous-étape annonce son label (branche flatMap)', async () => {
+        vi.spyOn(window, 'matchMedia').mockReturnValue({
+            matches: true,
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+        } as unknown as MediaQueryList);
+
+        const el = await fixtureWithItems(`
+                <ar-stepper current-path="/a" mode="edit">
+                    <ar-stepper-item path="/a" label="Étape A">
+                        <ar-stepper-item path="/a/1" label="Sous-étape 1"></ar-stepper-item>
+                        <ar-stepper-item path="/a/2" label="Sous-étape 2"></ar-stepper-item>
+                    </ar-stepper-item>
+                    <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
+                </ar-stepper>
+            `);
+        el.addEventListener('ar-stepper-step-change', (e) => {
+            el.currentPath = (e as CustomEvent<ArStepperStepChangeDetail>).detail.path;
+        });
+
+        const link = shadow(el).querySelector<HTMLAnchorElement>('a[data-path="/a/2"]');
+        if (!link) throw new Error('Lien vers /a/2 introuvable');
+        link.click();
+        await waitForUpdate(el);
+        await new Promise((resolve) => setTimeout(resolve, 60));
+
+        expect(document.getElementById('ar-live-region-polite')?.textContent).toBe('Sous-étape 2');
+    });
+});
+```
+
+Ne pas toucher au describe `focus après activation d'un lien` (lignes 367-474) : ses 5 tests
+confirment déjà `currentPath` explicitement avant d'asserter le focus (pattern déjà aligné sur le
+nouveau modèle) — ils doivent continuer à passer sans modification une fois l'implémentation
+faite (Step 4 vérifie ça).
+
+- [ ] **Step 2: Lancer les tests, vérifier qu'ils échouent contre le code actuel**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+npx vitest run packages/core/src/components/stepper/stepper.test.ts
+```
+
+Expected : échecs sur `event.cancelable` (event actuel non cancelable), sur `preventDefault()`
+sans effet, sur `ar-stepper-step-changed` jamais émis, sur les annonces qui se déclenchent
+encore immédiatement au clic au lieu d'attendre confirmation.
+
+- [ ] **Step 3: Implémenter dans `stepper.ts`**
+
+3a. Ajouter le champ privé juste après `private _pendingFocusPath: string | undefined;`
+(ligne 158) :
+
+```typescript
+    // Distingue le tout premier cycle updated() (où currentPath "change" par rapport à sa
+    // valeur pré-upgrade non définie) des transitions réelles ultérieures — sans ce flag,
+    // ar-stepper-step-changed/l'annonce/le focus se déclencheraient au montage initial.
+    private _hasRenderedOnce = false;
+```
+
+3b. Remplacer le bloc de fin de `updated()` (lignes 258-263) :
+
+```typescript
+if (changed.has('currentPath') && this.currentPath === this._pendingFocusPath) {
+    this.shadowRoot?.querySelector<HTMLElement>(`[data-path="${this._pendingFocusPath}"]`)?.focus();
+}
+this._pendingFocusPath = undefined;
+```
+
+par :
+
+```typescript
+if (this._hasRenderedOnce && changed.has('currentPath')) {
+    const from = changed.get('currentPath') as string;
+    const to = this.currentPath;
+    if (from !== to) {
+        this._emitChanged({ path: to });
+        announceA11y(this.navigation.currentNode?.label ?? to, 'polite');
+        if (to === this._pendingFocusPath) {
+            this.shadowRoot?.querySelector<HTMLElement>(`[data-path="${to}"]`)?.focus();
+        }
+    }
+}
+this._pendingFocusPath = undefined;
+this._hasRenderedOnce = true;
+```
+
+3c. Ajouter la méthode privée, par exemple juste après `getScrollTargets()` (avant la section
+`// ── Events ──`, ligne 456) :
+
+```typescript
+    private _emitChanged(detail: ArStepperStepChangeDetail): void {
+        this.dispatchEvent(
+            new CustomEvent<ArStepperStepChangeDetail>('ar-stepper-step-changed', {
+                bubbles: true,
+                composed: true,
+                detail,
+            }),
+        );
+    }
+```
+
+3d. Dans `onClickLink` (lignes 458-491), remplacer :
+
+```typescript
+        const detail: ArStepperStepChangeDetail = { path };
+
+        this.dispatchEvent(
+            new CustomEvent('ar-stepper-step-change', { bubbles: true, composed: true, detail }),
+        );
+
+        // Force un cycle de rendu même si aucune propriété réactive ne change : c'est ce
+        // cycle qui, dans updated(), valide (ou expire) l'intention de focus — garantit la
+        // fenêtre "un seul cycle" même si le consommateur ignore l'event. Placé après le
+        // dispatchEvent pour laisser une chance à une mutation synchrone/quasi-synchrone
+        // (ex. Vue nextTick) du consommateur d'être planifiée dans le même cycle Lit.
+        this.requestUpdate();
+
+        announceA11y(node?.label ?? path, 'polite');
+    };
+```
+
+par :
+
+```typescript
+        const detail: ArStepperStepChangeDetail = { path };
+
+        const proceed = this.dispatchEvent(
+            new CustomEvent('ar-stepper-step-change', {
+                bubbles: true,
+                composed: true,
+                cancelable: true,
+                detail,
+            }),
+        );
+        if (!proceed) {
+            this._pendingFocusPath = undefined;
+        }
+
+        // Force un cycle de rendu même si aucune propriété réactive ne change : c'est ce
+        // cycle qui, dans updated(), valide (ou expire) l'intention de focus — garantit la
+        // fenêtre "un seul cycle" même si le consommateur ignore l'event. Placé après le
+        // dispatchEvent pour laisser une chance à une mutation synchrone/quasi-synchrone
+        // (ex. Vue nextTick) du consommateur d'être planifiée dans le même cycle Lit.
+        this.requestUpdate();
+    };
+```
+
+3e. Mettre à jour le JSDoc `@event` (ligne 84) — remplacer :
+
+```typescript
+ * @event {CustomEvent<{ path: string }>} ar-stepper-step-change - Émis au clic sur une étape.
+```
+
+par :
+
+```typescript
+ * @event {CustomEvent<{ path: string }>} ar-stepper-step-change - Émis avant le changement
+ *   d'étape, au clic. Annulable via `preventDefault()` : bloque la navigation, `currentPath`
+ *   ne change pas. Contient `path`. @cancelable
+ * @event {CustomEvent<{ path: string }>} ar-stepper-step-changed - Émis quand `currentPath` a
+ *   réellement changé (réassignation externe suite à la confirmation du consommateur, ou via
+ *   `follow-scroll`). Non annulable. Contient `path`.
+```
+
+- [ ] **Step 4: Lancer les tests, vérifier qu'ils passent**
+
+```bash
+npx vitest run packages/core/src/components/stepper/stepper.test.ts
+```
+
+Expected : PASS sur l'ensemble du fichier, y compris les 5 tests inchangés du describe `focus
+après activation d'un lien` (Step 1 ne les a pas modifiés).
+
+- [ ] **Step 5: Lancer la suite complète du package pour détecter une régression ailleurs**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane && npm run test --workspace=packages/core
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Lancer les tests navigateur (le mécanisme de focus/#154 est touché)**
+
+```bash
+npm run test:browser --workspace=packages/core
+```
+
+Expected: PASS — `stepper.browser.test.ts` écoute déjà `ar-stepper-step-change` et confirme
+`currentPath` avant d'asserter le focus (`stepper.browser.test.ts:128`), aucune modification de
+ce fichier n'est nécessaire.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/src/components/stepper/stepper.ts packages/core/src/components/stepper/stepper.test.ts
+git commit -m "fix(stepper): step-change annulable, ajoute step-changed, annonce apres confirmation (#174)"
+```
+
+---
+
+### Task 3: Documentation (`ar-stepper.mdx`)
+
+**Files:**
+
+- Modify: `apps/docs/src/content/components/ar-stepper.mdx`
+
+- [ ] **Step 1: Réécrire la sous-section "Écouter le changement d'étape"**
+
+Remplacer les lignes 116-124 par :
+
+````mdx
+### Écouter le changement d'étape
+
+Lorsque l'utilisateur souhaite changer d'étape, un événement `ar-stepper-step-change` est émis avec `{ path }` dans `event.detail`.
+Mettez à jour la propriété `currentPath` du composant avec `event.detail.path` une fois le nouveau contenu chargé pour synchroniser l'étape active du stepper.
+
+```js
+document.addEventListener('ar-stepper-step-change', (e) => {
+    /* Mettez à jour le contenu de l'étape, puis l'étape active du composant */
+    e.target.currentPath = e.detail.path;
+});
+```
+````
+
+````
+
+Les sous-sections suivantes ("Mode `create` vs `edit`", `follow-scroll`, "Navigation
+programmatique", lignes 126-153) restent inchangées.
+
+- [ ] **Step 2: Ajouter le champ `pageScript` au frontmatter**
+
+Dans le frontmatter (avant la fermeture `---` de la ligne 68, juste après le dernier élément de
+`variants`), ajouter au même niveau que `variants` :
+
+```yaml
+pageScript: |
+    <script>
+        document.addEventListener('ar-stepper-step-change', (e) => {
+            /* Mettez à jour le contenu de l'étape, puis l'étape active du composant */
+            e.target.currentPath = e.detail.path;
+        });
+    </script>
+````
+
+Aucune modification de schema/template nécessaire — le champ `pageScript` existe déjà
+(`apps/docs/src/content.config.ts`, `apps/docs/src/pages/components/[slug].astro`), livré avec
+#161.
+
+- [ ] **Step 3: Vérifier**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+npx prettier --check apps/docs/src/content/components/ar-stepper.mdx
+npm run build --workspace=apps/docs
+```
+
+Expected : Prettier clean, build Astro réussi (toutes les pages, y compris `ar-stepper`).
+Vérifier dans le HTML généré (`apps/docs/dist/components/stepper/index.html`) que le `<script>`
+de `pageScript` est bien présent, une seule fois, hors de la boucle des variantes — même
+vérification que celle faite manuellement pour `ar-pagination` (#161).
+
+- [ ] **Step 4: Vérification visuelle**
+
+```bash
+npm run dev --workspace=apps/docs
+```
+
+Ouvrir la page `ar-stepper` de la doc, cliquer sur une étape cliquable dans chacune des 3
+démos : l'étape active doit visuellement changer. Redémarrer le serveur si le changement de
+frontmatter ne semble pas pris en compte (cf. #161 : le schema de contenu Astro peut nécessiter
+un redémarrage complet, pas seulement un rafraîchissement navigateur).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/docs/src/content/components/ar-stepper.mdx
+git commit -m "docs(stepper): documente step-changed, aligne le style Utilisation, ajoute pageScript (#174)"
+```
+
+---
+
+### Task 4: Vérification finale et PR
+
+**Files:** aucun nouveau.
+
+- [ ] **Step 1: Suite complète (Vitest + WTR browser)**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+npm run test:all
+```
+
+Expected: PASS sur l'ensemble du monorepo.
+
+- [ ] **Step 2: Regénérer le manifest CEM (JSDoc `@event` modifié)**
+
+```bash
+npm run build:manifest --workspace=packages/core
+git status --short
+```
+
+`dist/` est gitignoré (jamais commité) — cette étape ne fait que vérifier que la commande tourne
+sans erreur et que le marqueur `@cancelable` est bien reconnu (cf. Global Constraints).
+
+- [ ] **Step 3: Lint**
+
+```bash
+npm run lint
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Push et création de la PR**
+
+```bash
+git push -u origin fix/174-stepper-step-events
+gh pr create --base dev --title "fix(stepper): step-change annulable, ajoute step-changed (#174)" --body "$(cat <<'EOF'
+## Résumé
+
+- `ar-stepper-step-change` devient annulable (`preventDefault()` bloque la navigation).
+- Nouvel event `ar-stepper-step-changed` (non-cancelable), émis quand `currentPath` a réellement transitionné (confirmation externe ou `follow-scroll`).
+- L'annonce aria-live est déplacée du clic vers cette confirmation réelle — le stepper ne "ment" plus sur l'état affiché pendant un chargement async qui échouerait.
+- Le mécanisme de focus (`_pendingFocusPath`) est inchangé fonctionnellement, juste regroupé au même point d'entrée.
+- Doc alignée sur le style adopté pour `ar-pagination` ; démos live câblées via le champ `pageScript` existant (#161).
+- Breaking change (package alpha, pas de dépréciation) — closes #174.
+
+Design : `docs/superpowers/specs/2026-08-11-stepper-controlled-current-events-design.md`
+Plan : `docs/superpowers/plans/2026-08-11-stepper-controlled-current-events-plan.md`
+
+## Test plan
+
+- [ ] `npm run test:all` passe
+- [ ] Démos de la doc `ar-stepper` vérifiées manuellement (clic change bien l'étape dans les 3 variantes + playground)
+- [ ] `npm run lint` passe
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+## Self-Review
+
+**Couverture du spec** :
+
+1. `ar-stepper-step-change` cancelable → Task 2.
+2. `ar-stepper-step-changed`, annonce déplacée et résolue à la confirmation → Task 2.
+3. `_pendingFocusPath` conservé, regroupé dans le même bloc → Task 2 (Step 3b).
+4. `_pendingFocusPath` vidé si annulé → Task 2 (Step 3d).
+5. `_hasRenderedOnce` → Task 2 (Step 3a).
+6. Docs : style Utilisation aligné + `pageScript` → Task 3.
+
+**Cohérence des types/signatures** : `ArStepperStepChangeDetail { path }` réutilisé identique
+partout. `_emitChanged(detail: ArStepperStepChangeDetail): void` défini et utilisé uniquement en
+Task 2. `_hasRenderedOnce` déclaré et lu dans la même task. Pas de référence à un nom non défini
+dans une task antérieure.
+
+**Pas de régression sur le describe `focus après activation d'un lien`** : vérifié
+manuellement contre les 5 tests existants (lignes 367-474 du fichier avant modification) — tous
+confirment déjà `currentPath` explicitement avant d'asserter le focus, donc aucune modification
+requise et ils doivent continuer à passer tels quels (vérifié en Step 4 de la Task 2).

--- a/docs/superpowers/plans/2026-08-11-stepper-controlled-current-events-plan.md
+++ b/docs/superpowers/plans/2026-08-11-stepper-controlled-current-events-plan.md
@@ -4,7 +4,7 @@
 
 **Goal:** `ar-stepper-step-change` devient annulable et n'annonce plus rien immédiatement au clic ; un nouvel event `ar-stepper-step-changed` (non-cancelable) et l'annonce aria-live ne se déclenchent que quand `currentPath` a réellement transitionné — le mécanisme de focus existant (`_pendingFocusPath`) est conservé tel quel mais regroupé dans le même point d'entrée.
 
-**Architecture:** Miroir du pattern livré sur `ar-pagination` (#161, PR #173), adapté à un composant déjà partiellement contrôlé : `currentPath` ne bougeait déjà jamais tout seul (sauf `follow-scroll`), et le focus était déjà gardé par confirmation. Seule l'annonce a11y était prématurée — elle rejoint le focus dans un unique bloc `updated()` guardé par confirmation réelle (`_hasRenderedOnce` + `changed.has('currentPath')` + `from !== to`).
+**Architecture:** Miroir du pattern livré sur `ar-pagination` (#161, PR #173), adapté à un composant déjà partiellement contrôlé : `currentPath` ne bougeait déjà jamais tout seul (sauf `follow-scroll`), et le focus était déjà gardé par confirmation. Seule l'annonce a11y était prématurée — elle rejoint le focus dans un unique bloc `updated()` guardé par confirmation réelle (`this.hasUpdated` natif de Lit + `changed.has('currentPath')` + `from !== to`).
 
 **Tech Stack:** Lit 3, TypeScript, Vitest (happy-dom), @open-wc/testing + @web/test-runner (Chromium réel), Astro 6 + MDX (docs).
 
@@ -41,8 +41,8 @@ git checkout -b fix/174-stepper-step-events
 
 **Files:**
 
-- Modify: `packages/core/src/components/stepper/stepper.ts:84` (JSDoc `@event`), `:158` (champ
-  privé), `:240-264` (`updated()`), `:458-491` (`onClickLink`)
+- Modify: `packages/core/src/components/stepper/stepper.ts:84` (JSDoc `@event`), `:240-264`
+  (`updated()`), `:458-491` (`onClickLink`)
 - Test: `packages/core/src/components/stepper/stepper.test.ts` (describes `événements`,
   `annonces a11y`, nouveau describe `événement ar-stepper-step-changed`)
 
@@ -265,17 +265,7 @@ encore immédiatement au clic au lieu d'attendre confirmation.
 
 - [ ] **Step 3: Implémenter dans `stepper.ts`**
 
-3a. Ajouter le champ privé juste après `private _pendingFocusPath: string | undefined;`
-(ligne 158) :
-
-```typescript
-    // Distingue le tout premier cycle updated() (où currentPath "change" par rapport à sa
-    // valeur pré-upgrade non définie) des transitions réelles ultérieures — sans ce flag,
-    // ar-stepper-step-changed/l'annonce/le focus se déclencheraient au montage initial.
-    private _hasRenderedOnce = false;
-```
-
-3b. Remplacer le bloc de fin de `updated()` (lignes 258-263) :
+3a. Remplacer le bloc de fin de `updated()` (lignes 258-263) :
 
 ```typescript
 if (changed.has('currentPath') && this.currentPath === this._pendingFocusPath) {
@@ -287,7 +277,11 @@ this._pendingFocusPath = undefined;
 par :
 
 ```typescript
-if (this._hasRenderedOnce && changed.has('currentPath')) {
+// this.hasUpdated (natif Lit, ReactiveElement) : false pendant tout le premier cycle
+// updated()/firstUpdated(), true à partir du suivant — distingue le montage initial (où
+// currentPath "change" par rapport à sa valeur pré-upgrade non définie) des transitions
+// réelles ultérieures, sans champ privé dédié.
+if (this.hasUpdated && changed.has('currentPath')) {
     const from = changed.get('currentPath') as string;
     const to = this.currentPath;
     if (from !== to) {
@@ -299,10 +293,13 @@ if (this._hasRenderedOnce && changed.has('currentPath')) {
     }
 }
 this._pendingFocusPath = undefined;
-this._hasRenderedOnce = true;
 ```
 
-3c. Ajouter la méthode privée, par exemple juste après `getScrollTargets()` (avant la section
+Note : `this.hasUpdated` est déjà `false` pendant l'exécution de ce tout premier `updated()`
+(Lit ne le passe à `true` qu'après ce cycle) — le guard fonctionne donc correctement dès le
+montage, sans champ privé supplémentaire à déclarer ni à réinitialiser.
+
+3b. Ajouter la méthode privée, par exemple juste après `getScrollTargets()` (avant la section
 `// ── Events ──`, ligne 456) :
 
 ```typescript
@@ -317,7 +314,7 @@ this._hasRenderedOnce = true;
     }
 ```
 
-3d. Dans `onClickLink` (lignes 458-491), remplacer :
+3c. Dans `onClickLink` (lignes 458-491), remplacer :
 
 ```typescript
         const detail: ArStepperStepChangeDetail = { path };
@@ -363,7 +360,7 @@ par :
     };
 ```
 
-3e. Mettre à jour le JSDoc `@event` (ligne 84) — remplacer :
+3d. Mettre à jour le JSDoc `@event` (ligne 84) — remplacer :
 
 ```typescript
  * @event {CustomEvent<{ path: string }>} ar-stepper-step-change - Émis au clic sur une étape.
@@ -562,15 +559,16 @@ EOF
 
 1. `ar-stepper-step-change` cancelable → Task 2.
 2. `ar-stepper-step-changed`, annonce déplacée et résolue à la confirmation → Task 2.
-3. `_pendingFocusPath` conservé, regroupé dans le même bloc → Task 2 (Step 3b).
-4. `_pendingFocusPath` vidé si annulé → Task 2 (Step 3d).
-5. `_hasRenderedOnce` → Task 2 (Step 3a).
+3. `_pendingFocusPath` conservé, regroupé dans le même bloc → Task 2 (Step 3a).
+4. `_pendingFocusPath` vidé si annulé → Task 2 (Step 3c).
+5. Guard premier rendu → Task 2 (Step 3a), via `this.hasUpdated` natif de Lit (pas de champ
+   privé à ajouter — vérifié via la doc Lit officielle : `false` pendant tout le premier cycle
+   `updated()`/`firstUpdated()`, `true` à partir du suivant).
 6. Docs : style Utilisation aligné + `pageScript` → Task 3.
 
 **Cohérence des types/signatures** : `ArStepperStepChangeDetail { path }` réutilisé identique
 partout. `_emitChanged(detail: ArStepperStepChangeDetail): void` défini et utilisé uniquement en
-Task 2. `_hasRenderedOnce` déclaré et lu dans la même task. Pas de référence à un nom non défini
-dans une task antérieure.
+Task 2. Pas de référence à un nom non défini dans une task antérieure.
 
 **Pas de régression sur le describe `focus après activation d'un lien`** : vérifié
 manuellement contre les 5 tests existants (lignes 367-474 du fichier avant modification) — tous

--- a/docs/superpowers/specs/2026-08-11-stepper-controlled-current-events-design.md
+++ b/docs/superpowers/specs/2026-08-11-stepper-controlled-current-events-design.md
@@ -87,8 +87,21 @@ pré-upgrade non définie.
 
 **Docs** (`apps/docs/src/content/components/ar-stepper.mdx`) :
 
-- Section "Utilisation" à vérifier/enrichir avec le nouvel event `ar-stepper-step-changed` et sa
-  relation avec l'annonce a11y.
+- Sous-section "Écouter le changement d'étape" réécrite dans le style désormais adopté sur
+  `ar-pagination.mdx` (deux phrases directes + un seul exemple de code, pas de reformulation
+  supplémentaire pour `-changed` — la table "Référence API" documente déjà l'annulabilité et le
+  détail des deux events) :
+    ```js
+    document.addEventListener('ar-stepper-step-change', (e) => {
+        /* Mettez à jour le contenu de l'étape, puis l'étape active du composant */
+        e.target.currentPath = e.detail.path;
+    });
+    ```
+    Les autres sous-sections ("Mode `create` vs `edit`", "`follow-scroll`", "Navigation
+    programmatique") restent inchangées — non affectées par ce chantier.
+- Champ `pageScript` ajouté au frontmatter (mécanisme déjà générique, livré avec #161 — aucune
+  modification de schema/template nécessaire), avec le même snippet que ci-dessus, pour garder
+  les démos live des variantes interactives. Referme le point "hors scope" identifié plus bas.
 
 **Tests** (`stepper.test.ts`, `stepper.browser.test.ts`, `stepper.a11y.test.ts`) :
 
@@ -100,9 +113,10 @@ pré-upgrade non définie.
 
 ## Hors scope
 
-- Démos live de `ar-stepper.mdx` non câblées (pas d'équivalent `pageScript`) — trou similaire à
-  celui identifié et corrigé sur `ar-pagination.mdx`, mentionné dans l'issue #174 mais traité
-  séparément si besoin.
 - Retouche du mécanisme `_pendingFocusPath` lui-même (structure arbre/desktop-mobile) — il
   fonctionne déjà correctement, seul son point de déclenchement est regroupé avec les deux autres
   conséquences de la confirmation.
+
+**Mise à jour** : le point "démos live non câblées" initialement listé ici est finalement traité
+dans ce chantier (cf. section Docs ci-dessus) — le mécanisme `pageScript` livré avec #161 est déjà
+générique, aucune raison de le reporter.

--- a/docs/superpowers/specs/2026-08-11-stepper-controlled-current-events-design.md
+++ b/docs/superpowers/specs/2026-08-11-stepper-controlled-current-events-design.md
@@ -20,17 +20,29 @@ chargement échoue, l'annonce a déjà eu lieu alors que le contenu réel n'a pa
 
 ## Décisions issues du brainstorming
 
-### 1. Deux événements, même détail `{ path }`
+### 1. Deux événements, détail aligné sur `ar-pagination` : `{ from, to }`
 
 - **`ar-stepper-step-change`** (devient `cancelable: true`, inchangé sinon) — dispatché au clic
-  depuis `onClickLink`, avant toute confirmation. `detail: { path }`.
+  depuis `onClickLink`, avant toute confirmation. `detail: { from, to }`.
 - **`ar-stepper-step-changed`** (nouveau, `cancelable: false`) — dispatché depuis `updated()`
   quand `currentPath` a réellement transitionné, quelle qu'en soit la source (réassignation
-  externe suite à confirmation, ou `follow-scroll`). `detail: { path }`.
+  externe suite à confirmation, ou `follow-scroll`). `detail: { from, to }`.
 
-Pas de renommage vers `{ from, to }` façon `ar-pagination` — `path` est déjà la terminologie
-établie de `ar-stepper` (propriété unique, pas de position numérique), pas de valeur ajoutée à
-aligner la forme du détail entre les deux composants.
+**Revu en cours de brainstorming** : `ArStepperStepChangeDetail` passe de `{ path: string }` à
+`{ from: string; to: string }` — décision initiale (garder `path`) revisée après discussion.
+`from`/`to` n'est pas réservé aux positions numériques ordonnées : c'est l'idiome standard pour
+décrire une transition d'état (routeurs, machines à états — `transition(from, event) → to`),
+sans notion d'ordre ni de distance requise — `ar-stepper` est fondamentalement un système de
+navigation comme `ar-pagination`, avec des "pages" nommées (`path`) plutôt que numérotées.
+`ar-pagination` a déjà établi le précédent "nom de champ de l'event ≠ nom de la propriété"
+(`event.detail.to` → assigné à `el.current`) ; faire pareil ici (`event.detail.to` →
+`el.currentPath`) suit ce pattern déjà en place, pas une nouvelle incohérence. `from` a aussi une
+utilité concrète (marquer l'étape précédente comme visitée, garde de navigation, analytics) que
+`path` seul n'exposait pas.
+
+Impact du renommage : `ArStepperStepChangeDetail` (interface), les deux dispatches
+(`onClickLink`/`updated()`), le JSDoc `@event`, les exemples de doc, et tous les tests qui
+lisent `.detail.path` (à remplacer par `.detail.to`, avec `.detail.from` disponible en plus).
 
 ### 2. Annonce a11y déplacée vers la confirmation, résolue à ce moment-là
 
@@ -88,7 +100,8 @@ fonctionnelle de le retoucher ici).
   effectuer le focus déjà prévu — guardé par `this.hasUpdated`.
 - JSDoc `@event` mis à jour (deux entrées, `@cancelable` sur la première — cf. régression trouvée
   en revue finale sur #161, à ne pas reproduire ici).
-- Nouvelle méthode privée `_emitChanged({ path })` (miroir de `_emitChanged` sur `ArPagination`).
+- Nouvelle méthode privée `_emitChanged({ from, to })` (miroir de `_emitChanged` sur
+  `ArPagination`).
 
 **Docs** (`apps/docs/src/content/components/ar-stepper.mdx`) :
 
@@ -99,7 +112,7 @@ fonctionnelle de le retoucher ici).
     ```js
     document.addEventListener('ar-stepper-step-change', (e) => {
         /* Mettez à jour le contenu de l'étape, puis l'étape active du composant */
-        e.target.currentPath = e.detail.path;
+        e.target.currentPath = e.detail.to;
     });
     ```
     Les autres sous-sections ("Mode `create` vs `edit`", "`follow-scroll`", "Navigation

--- a/docs/superpowers/specs/2026-08-11-stepper-controlled-current-events-design.md
+++ b/docs/superpowers/specs/2026-08-11-stepper-controlled-current-events-design.md
@@ -66,11 +66,16 @@ Amélioration mineure : si `event.preventDefault()` est appelé sur `ar-stepper-
 d'attendre l'expiration naturelle en fin de cycle — pas d'intention de focus à conserver pour une
 navigation refusée.
 
-### 5. Flag `_hasRenderedOnce`
+### 5. Guard premier rendu : `this.hasUpdated` natif de Lit, pas de champ dédié
 
-Ajouté (comme sur `ar-pagination`) pour ne déclencher ni `-changed`, ni l'annonce, ni le focus au
-tout premier rendu — évite un faux positif quand `currentPath` "change" par rapport à sa valeur
-pré-upgrade non définie.
+Contrairement à `ar-pagination` (qui a ajouté un champ privé `_hasRenderedOnce`), `ar-stepper`
+utilise `this.hasUpdated` — propriété native `ReactiveElement`, `false` pendant tout le premier
+cycle `updated()`/`firstUpdated()`, `true` à partir du suivant (vérifié via la doc Lit
+officielle). Évite un faux positif quand `currentPath` "change" par rapport à sa valeur
+pré-upgrade non définie, sans introduire de champ redondant avec ce que le framework fournit
+déjà. **Note pour un futur ménage** : `ArPagination._hasRenderedOnce` (#161) pourrait être
+simplifié de la même façon, mais c'est hors scope de #174 (code déjà mergé, pas de raison
+fonctionnelle de le retoucher ici).
 
 ## Impact
 
@@ -80,7 +85,7 @@ pré-upgrade non définie.
   retire l'appel `announceA11y` (ligne 490) ; vide `_pendingFocusPath` si l'event est annulé.
 - `updated()` (:240-264) : bloc `changed.has('currentPath')` existant étendu pour dispatcher
   `ar-stepper-step-changed`, annoncer (label résolu via `this.navigation.currentNode`), et
-  effectuer le focus déjà prévu — guardé par le nouveau `_hasRenderedOnce`.
+  effectuer le focus déjà prévu — guardé par `this.hasUpdated`.
 - JSDoc `@event` mis à jour (deux entrées, `@cancelable` sur la première — cf. régression trouvée
   en revue finale sur #161, à ne pas reproduire ici).
 - Nouvelle méthode privée `_emitChanged({ path })` (miroir de `_emitChanged` sur `ArPagination`).

--- a/docs/superpowers/specs/2026-08-11-stepper-controlled-current-events-design.md
+++ b/docs/superpowers/specs/2026-08-11-stepper-controlled-current-events-design.md
@@ -1,0 +1,108 @@
+# Design — `ar-stepper` : deux événements demande/confirmation
+
+**Statut :** Validé (en attente de plan d'implémentation)
+**Date :** 2026-08-11
+**Contexte :** issue [#174](https://github.com/jogo-labs/ariane/issues/174) — suivi identifié en marge de
+#161 (`ar-pagination`, PR #173)
+
+## Contexte
+
+`ar-stepper.currentPath` est déjà un modèle contrôlé : le composant ne le mute jamais lui-même
+(sauf via `follow-scroll`, qui le fait pour une raison différente — synchronisation avec le
+scroll, pas une action de clic). Le focus (`_pendingFocusPath`, `stepper.ts:158,462,258-263`)
+est déjà correctement gardé par confirmation.
+
+Le trou réel : `onClickLink` (`stepper.ts:458-491`) dispatche `ar-stepper-step-change` (non
+annulable aujourd'hui) **et** appelle `announceA11y(node?.label ?? path, 'polite')`
+immédiatement au clic (ligne 490), sans attendre que le consommateur confirme la navigation en
+réassignant `currentPath`. Si le stepper pilote un contenu chargé de façon asynchrone et que ce
+chargement échoue, l'annonce a déjà eu lieu alors que le contenu réel n'a pas changé.
+
+## Décisions issues du brainstorming
+
+### 1. Deux événements, même détail `{ path }`
+
+- **`ar-stepper-step-change`** (devient `cancelable: true`, inchangé sinon) — dispatché au clic
+  depuis `onClickLink`, avant toute confirmation. `detail: { path }`.
+- **`ar-stepper-step-changed`** (nouveau, `cancelable: false`) — dispatché depuis `updated()`
+  quand `currentPath` a réellement transitionné, quelle qu'en soit la source (réassignation
+  externe suite à confirmation, ou `follow-scroll`). `detail: { path }`.
+
+Pas de renommage vers `{ from, to }` façon `ar-pagination` — `path` est déjà la terminologie
+établie de `ar-stepper` (propriété unique, pas de position numérique), pas de valeur ajoutée à
+aligner la forme du détail entre les deux composants.
+
+### 2. Annonce a11y déplacée vers la confirmation, résolue à ce moment-là
+
+L'appel à `announceA11y` sort de `onClickLink` et se fait depuis le bloc `updated()` qui gère
+`changed.has('currentPath')`, une fois la transition confirmée réelle. Le label annoncé est
+résolu à ce moment via `this.navigation.currentNode?.label` (état vivant de l'arbre après
+`willUpdate()` → `this.navigation.setCurrentPath(...)`), pas figé sur le `node` trouvé au clic —
+plus correct si l'arbre a changé entre temps, et cohérent avec le principe "rien n'est affirmé
+avant confirmation".
+
+### 3. Focus : mécanisme `_pendingFocusPath` conservé, unifié dans le même bloc
+
+Pas de changement de logique : `_pendingFocusPath` n'est posé que dans `onClickLink`, jamais dans
+`handleScrollChange` — le scroll ne vole donc toujours pas le focus. Le check
+`this.currentPath === this._pendingFocusPath` et le focus qui en découle sont simplement
+regroupés dans le même bloc `updated()` que le dispatch de `-changed` et l'annonce, plutôt que
+dispersés — un seul point d'entrée pour "la transition est confirmée, voici les 3 conséquences
+(event, annonce, focus éventuel)".
+
+**Precision technique actée en discussion** (à ne pas perdre en implémentation) : le gate sur la
+confirmation n'est pas un délai arbitraire imposé au focus — c'est une nécessité mécanique. Le
+lien cliqué reste un `<a>` focalisable tant que `currentPath` n'est pas confirmé (aucun re-rendu
+ne le remplace), donc le focus n'a _jamais quitté_ l'élément cliqué dans ce cas : rien à faire.
+Sans le gate, `focusAfterUpdate` ciblerait `[part~="current"]` qui pointerait encore vers
+l'**ancienne** étape active, arrachant le focus du lien cliqué pour le renvoyer en arrière — le
+contraire de l'effet recherché. Le gate garantit que le focus ne bouge que quand il y a
+effectivement un nouvel élément vers lequel aller.
+
+### 4. `_pendingFocusPath` vidé immédiatement si `-change` est annulé
+
+Amélioration mineure : si `event.preventDefault()` est appelé sur `ar-stepper-step-change`,
+`_pendingFocusPath` est remis à `undefined` tout de suite après le `dispatchEvent` plutôt que
+d'attendre l'expiration naturelle en fin de cycle — pas d'intention de focus à conserver pour une
+navigation refusée.
+
+### 5. Flag `_hasRenderedOnce`
+
+Ajouté (comme sur `ar-pagination`) pour ne déclencher ni `-changed`, ni l'annonce, ni le focus au
+tout premier rendu — évite un faux positif quand `currentPath` "change" par rapport à sa valeur
+pré-upgrade non définie.
+
+## Impact
+
+**Composant** (`packages/core/src/components/stepper/stepper.ts`) :
+
+- `onClickLink` (:458-491) : ajoute `cancelable: true` au dispatch de `ar-stepper-step-change` ;
+  retire l'appel `announceA11y` (ligne 490) ; vide `_pendingFocusPath` si l'event est annulé.
+- `updated()` (:240-264) : bloc `changed.has('currentPath')` existant étendu pour dispatcher
+  `ar-stepper-step-changed`, annoncer (label résolu via `this.navigation.currentNode`), et
+  effectuer le focus déjà prévu — guardé par le nouveau `_hasRenderedOnce`.
+- JSDoc `@event` mis à jour (deux entrées, `@cancelable` sur la première — cf. régression trouvée
+  en revue finale sur #161, à ne pas reproduire ici).
+- Nouvelle méthode privée `_emitChanged({ path })` (miroir de `_emitChanged` sur `ArPagination`).
+
+**Docs** (`apps/docs/src/content/components/ar-stepper.mdx`) :
+
+- Section "Utilisation" à vérifier/enrichir avec le nouvel event `ar-stepper-step-changed` et sa
+  relation avec l'annonce a11y.
+
+**Tests** (`stepper.test.ts`, `stepper.browser.test.ts`, `stepper.a11y.test.ts`) :
+
+- Nouveaux cas : `ar-stepper-step-change` est `cancelable` ; `preventDefault()` bloque tout (pas
+  de `-changed`, pas d'annonce, pas de focus, `_pendingFocusPath` vidé) ; `-changed` ne fire
+  qu'après réassignation externe de `currentPath` (ou via `follow-scroll`) ; annonce n'a lieu
+  qu'après confirmation, avec le bon label.
+- Vérifier qu'aucun test existant ne dépendait de l'annonce immédiate au clic (à adapter sinon).
+
+## Hors scope
+
+- Démos live de `ar-stepper.mdx` non câblées (pas d'équivalent `pageScript`) — trou similaire à
+  celui identifié et corrigé sur `ar-pagination.mdx`, mentionné dans l'issue #174 mais traité
+  séparément si besoin.
+- Retouche du mécanisme `_pendingFocusPath` lui-même (structure arbre/desktop-mobile) — il
+  fonctionne déjà correctement, seul son point de déclenchement est regroupé avec les deux autres
+  conséquences de la confirmation.

--- a/packages/core/src/components/stepper/stepper.browser.test.ts
+++ b/packages/core/src/components/stepper/stepper.browser.test.ts
@@ -126,7 +126,7 @@ describe('ar-stepper — browser', () => {
             await elementUpdated(el);
 
             el.addEventListener('ar-stepper-step-change', (event: Event) => {
-                el.currentPath = (event as CustomEvent<{ path: string }>).detail.path;
+                el.currentPath = (event as CustomEvent<{ from: string; to: string }>).detail.to;
             });
 
             const shadowRoot = el.shadowRoot as ShadowRoot;

--- a/packages/core/src/components/stepper/stepper.test.ts
+++ b/packages/core/src/components/stepper/stepper.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ArStepper } from './stepper.js';
+import type { ArStepperStepChangeDetail } from './stepper.js';
 import { fixture, waitForUpdate } from '../../test-utils.js';
 import './index.js';
 import '../stepper-item/index.js';
@@ -241,7 +242,7 @@ describe('ArStepper', () => {
     // ── Événements ───────────────────────────────────────────────────────────
 
     describe('événements', () => {
-        it('émet ar-stepper-step-change au clic sur un lien', async () => {
+        it('émet ar-stepper-step-change au clic sur un lien, avec { from, to }', async () => {
             const el = await fixtureWithItems(`
                 <ar-stepper current-path="/b" mode="edit">
                     <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
@@ -252,15 +253,53 @@ describe('ArStepper', () => {
             const handler = vi.fn();
             el.addEventListener('ar-stepper-step-change', handler);
 
-            const link = shadow(el).querySelector<HTMLAnchorElement>('a[part~="step-link"]');
-            if (link) {
-                link.click();
-                expect(handler).toHaveBeenCalledOnce();
-                const event = handler.mock.calls[0][0] as CustomEvent;
-                expect(event.detail).toHaveProperty('path');
-            }
+            const link = requireQuery<HTMLAnchorElement>(shadow(el), 'a[data-path="/a"]');
+            link.click();
+
+            expect(handler).toHaveBeenCalledOnce();
+            const event = handler.mock.calls[0][0] as CustomEvent<ArStepperStepChangeDetail>;
+            expect(event.detail).toEqual({ from: '/b', to: '/a' });
 
             el.removeEventListener('ar-stepper-step-change', handler);
+        });
+
+        it('ar-stepper-step-change est cancelable', async () => {
+            const el = await fixtureWithItems(`
+                <ar-stepper current-path="/b" mode="edit">
+                    <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
+                    <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
+                </ar-stepper>
+            `);
+            const handler = vi.fn();
+            el.addEventListener('ar-stepper-step-change', handler);
+
+            const link = requireQuery<HTMLAnchorElement>(shadow(el), 'a[data-path="/a"]');
+            link.click();
+
+            expect(handler).toHaveBeenCalledOnce();
+            const event = handler.mock.calls[0][0] as CustomEvent;
+            expect(event.cancelable).toBe(true);
+        });
+
+        it('preventDefault() sur ar-stepper-step-change bloque toute suite : currentPath inchangé, focus reste sur le lien cliqué', async () => {
+            const el = await fixtureWithItems(`
+                <ar-stepper current-path="/b" mode="edit">
+                    <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
+                    <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
+                </ar-stepper>
+            `);
+            el.addEventListener('ar-stepper-step-change', (e) => e.preventDefault());
+            const changedHandler = vi.fn();
+            el.addEventListener('ar-stepper-step-changed', changedHandler);
+
+            const link = requireQuery<HTMLAnchorElement>(shadow(el), 'a[data-path="/a"]');
+            link.focus();
+            link.click();
+            await waitForUpdate(el);
+
+            expect(el.currentPath).toBe('/b');
+            expect(changedHandler).not.toHaveBeenCalled();
+            expect(shadow(el).activeElement).toBe(link);
         });
 
         it("n'émet plus step-changed (nom court) au clic", async () => {
@@ -281,6 +320,58 @@ describe('ArStepper', () => {
             }
 
             el.removeEventListener('step-changed', handler);
+        });
+    });
+
+    describe('événement ar-stepper-step-changed', () => {
+        it("n'est pas émis tant que currentPath n'a pas réellement changé", async () => {
+            const el = await fixtureWithItems(`
+                <ar-stepper current-path="/b" mode="edit">
+                    <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
+                    <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
+                </ar-stepper>
+            `);
+            const handler = vi.fn();
+            el.addEventListener('ar-stepper-step-changed', handler);
+
+            const link = requireQuery<HTMLAnchorElement>(shadow(el), 'a[data-path="/a"]');
+            link.click();
+            await waitForUpdate(el);
+
+            expect(handler).not.toHaveBeenCalled();
+        });
+
+        it('est émis avec { from, to }, non cancelable, quand currentPath change (réassignation externe)', async () => {
+            const el = await fixtureWithItems(`
+                <ar-stepper current-path="/b" mode="edit">
+                    <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
+                    <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
+                </ar-stepper>
+            `);
+            const handler = vi.fn();
+            el.addEventListener('ar-stepper-step-changed', handler);
+
+            el.currentPath = '/a';
+            await waitForUpdate(el);
+
+            expect(handler).toHaveBeenCalledOnce();
+            const event = handler.mock.calls[0][0] as CustomEvent<ArStepperStepChangeDetail>;
+            expect(event.cancelable).toBe(false);
+            expect(event.detail).toEqual({ from: '/b', to: '/a' });
+        });
+
+        it("n'est pas émis au premier rendu", async () => {
+            const handler = vi.fn();
+            const el = await fixtureWithItems(`
+                <ar-stepper current-path="/b" mode="edit">
+                    <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
+                    <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
+                </ar-stepper>
+            `);
+            el.addEventListener('ar-stepper-step-changed', handler);
+            await waitForUpdate(el);
+
+            expect(handler).not.toHaveBeenCalled();
         });
     });
 
@@ -805,7 +896,7 @@ describe('ArStepper', () => {
             document.querySelectorAll('[data-ar-live-region]').forEach((node) => node.remove());
         });
 
-        it('un clic sur une étape de premier niveau annonce son label', async () => {
+        it("n'annonce rien tant que currentPath n'est pas confirmé par le consommateur", async () => {
             vi.spyOn(window, 'matchMedia').mockReturnValue({
                 matches: true,
                 addEventListener: vi.fn(),
@@ -824,10 +915,36 @@ describe('ArStepper', () => {
             link.click();
             await new Promise((resolve) => setTimeout(resolve, 60));
 
+            expect(document.getElementById('ar-live-region-polite')).toBeNull();
+        });
+
+        it('un clic confirmé sur une étape de premier niveau annonce son label', async () => {
+            vi.spyOn(window, 'matchMedia').mockReturnValue({
+                matches: true,
+                addEventListener: vi.fn(),
+                removeEventListener: vi.fn(),
+            } as unknown as MediaQueryList);
+
+            const el = await fixtureWithItems(`
+                <ar-stepper current-path="/b" mode="edit">
+                    <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
+                    <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
+                </ar-stepper>
+            `);
+            el.addEventListener('ar-stepper-step-change', (e) => {
+                el.currentPath = (e as CustomEvent<ArStepperStepChangeDetail>).detail.to;
+            });
+
+            const link = shadow(el).querySelector<HTMLAnchorElement>('a[data-path="/a"]');
+            if (!link) throw new Error('Lien vers /a introuvable');
+            link.click();
+            await waitForUpdate(el);
+            await new Promise((resolve) => setTimeout(resolve, 60));
+
             expect(document.getElementById('ar-live-region-polite')?.textContent).toBe('Étape A');
         });
 
-        it('un clic sur une sous-étape annonce son label (branche flatMap)', async () => {
+        it('un clic confirmé sur une sous-étape annonce son label (branche flatMap)', async () => {
             vi.spyOn(window, 'matchMedia').mockReturnValue({
                 matches: true,
                 addEventListener: vi.fn(),
@@ -843,10 +960,14 @@ describe('ArStepper', () => {
                     <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
                 </ar-stepper>
             `);
+            el.addEventListener('ar-stepper-step-change', (e) => {
+                el.currentPath = (e as CustomEvent<ArStepperStepChangeDetail>).detail.to;
+            });
 
             const link = shadow(el).querySelector<HTMLAnchorElement>('a[data-path="/a/2"]');
             if (!link) throw new Error('Lien vers /a/2 introuvable');
             link.click();
+            await waitForUpdate(el);
             await new Promise((resolve) => setTimeout(resolve, 60));
 
             expect(document.getElementById('ar-live-region-polite')?.textContent).toBe(

--- a/packages/core/src/components/stepper/stepper.test.ts
+++ b/packages/core/src/components/stepper/stepper.test.ts
@@ -302,6 +302,27 @@ describe('ArStepper', () => {
             expect(shadow(el).activeElement).toBe(link);
         });
 
+        it("preventDefault() sur ar-stepper-step-change bloque aussi la navigation native quand l'étape a un href réel", async () => {
+            // Contrat documenté (JSDoc @event) : preventDefault() bloque la navigation, sans
+            // qualification sur la présence d'un href réel. Un href réel (ex: "#etape-2-1",
+            // utilisé par la doc pour les sous-étapes) doit donc aussi voir son comportement
+            // natif d'ancre bloqué quand le consommateur annule l'event.
+            const el = await fixtureWithItems(`
+                <ar-stepper current-path="/b" mode="edit">
+                    <ar-stepper-item path="/a" href="#etape-2-1" label="Étape A"></ar-stepper-item>
+                    <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
+                </ar-stepper>
+            `);
+            el.addEventListener('ar-stepper-step-change', (e) => e.preventDefault());
+
+            const link = requireQuery<HTMLAnchorElement>(shadow(el), 'a[data-path="/a"]');
+            const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+            link.dispatchEvent(clickEvent);
+
+            expect(clickEvent.defaultPrevented).toBe(true);
+            expect(el.currentPath).toBe('/b');
+        });
+
         it("n'émet plus step-changed (nom court) au clic", async () => {
             const el = await fixtureWithItems(`
                 <ar-stepper current-path="/b" mode="edit">
@@ -361,17 +382,24 @@ describe('ArStepper', () => {
         });
 
         it("n'est pas émis au premier rendu", async () => {
+            // Le listener est attaché sur document AVANT le montage : l'event bubble
+            // (bubbles: true, composed: true) donc si le garde-fou _hasRenderedOnce était
+            // absent, l'émission aurait lieu pendant fixtureWithItems() et serait captée ici.
             const handler = vi.fn();
-            const el = await fixtureWithItems(`
-                <ar-stepper current-path="/b" mode="edit">
-                    <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
-                    <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
-                </ar-stepper>
-            `);
-            el.addEventListener('ar-stepper-step-changed', handler);
-            await waitForUpdate(el);
+            document.addEventListener('ar-stepper-step-changed', handler);
 
-            expect(handler).not.toHaveBeenCalled();
+            try {
+                await fixtureWithItems(`
+                    <ar-stepper current-path="/b" mode="edit">
+                        <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
+                        <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
+                    </ar-stepper>
+                `);
+
+                expect(handler).not.toHaveBeenCalled();
+            } finally {
+                document.removeEventListener('ar-stepper-step-changed', handler);
+            }
         });
     });
 

--- a/packages/core/src/components/stepper/stepper.ts
+++ b/packages/core/src/components/stepper/stepper.ts
@@ -24,7 +24,11 @@ import { warn } from '../../utils/warn.js';
 
 /** Détail de l'événement émis lors d'une demande ou d'une confirmation de changement d'étape */
 export interface ArStepperStepChangeDetail {
-    /** Chemin de l'étape courante avant la transition */
+    /**
+     * Chemin de l'étape courante avant la transition. Peut être `''` si le stepper
+     * est monté sans `current-path` initial et que `currentPath` est assigné pour la
+     * première fois.
+     */
     from: string;
     /** Chemin de l'étape cible (demandée sur `-change`, confirmée sur `-changed`) */
     to: string;
@@ -517,6 +521,7 @@ export class ArStepper extends LitElement {
         );
         if (!proceed) {
             this._pendingFocusPath = undefined;
+            event.preventDefault();
         }
 
         // Force un cycle de rendu même si aucune propriété réactive ne change : c'est ce

--- a/packages/core/src/components/stepper/stepper.ts
+++ b/packages/core/src/components/stepper/stepper.ts
@@ -22,10 +22,12 @@ import { renderDesktop, renderMobile } from './stepper.renderer.js';
 import { ArStepperItem } from '../stepper-item/stepper-item.js';
 import { warn } from '../../utils/warn.js';
 
-/** Détail de l'événement émis lors d'un changement d'étape */
+/** Détail de l'événement émis lors d'une demande ou d'une confirmation de changement d'étape */
 export interface ArStepperStepChangeDetail {
-    /** Chemin (`href`) de l'étape sélectionnée */
-    path: string;
+    /** Chemin de l'étape courante avant la transition */
+    from: string;
+    /** Chemin de l'étape cible (demandée sur `-change`, confirmée sur `-changed`) */
+    to: string;
 }
 
 /**
@@ -81,7 +83,12 @@ export interface ArStepperStepChangeDetail {
  * @cssprop --ar-panel-max-width - Largeur maximale du panel partagé.
  * @cssprop --ar-panel-show-duration - Durée de l'animation d'ouverture du panel partagé (respecte `prefers-reduced-motion`).
  *
- * @event {CustomEvent<{ path: string }>} ar-stepper-step-change - Émis au clic sur une étape.
+ * @event {CustomEvent<{ from: string, to: string }>} ar-stepper-step-change - Émis avant le
+ *   changement d'étape, au clic. Annulable via `preventDefault()` : bloque la navigation,
+ *   `currentPath` ne change pas. Contient `from` et `to`. @cancelable
+ * @event {CustomEvent<{ from: string, to: string }>} ar-stepper-step-changed - Émis quand
+ *   `currentPath` a réellement changé (réassignation externe suite à la confirmation du
+ *   consommateur, ou via `follow-scroll`). Non annulable. Contient `from` et `to`.
  */
 export class ArStepper extends LitElement {
     static override styles: CSSResultGroup = [resetStyles, utilitiesStyles, panelStyles, styles];
@@ -155,6 +162,13 @@ export class ArStepper extends LitElement {
     private _mediaQueryList: MediaQueryList | undefined;
     private _responsiveQuery: string | undefined;
     private _dropdownAttached = false;
+    // Distingue le tout premier cycle updated() (où `currentPath` "change" par rapport à sa
+    // valeur pré-upgrade non définie) des transitions réelles ultérieures. `this.hasUpdated`
+    // (natif Lit) ne convient pas ici : Lit le passe à `true` AVANT d'invoquer updated() sur
+    // ce tout premier cycle, donc il vaut déjà `true` pendant son exécution — vérifié
+    // empiriquement contre @lit/reactive-element (hasUpdated est assigné dans _$didUpdate()
+    // avant l'appel à updated()). Même pattern que ArPagination._hasRenderedOnce.
+    private _hasRenderedOnce = false;
     private _pendingFocusPath: string | undefined;
     private readonly _onMediaQueryChange = (event: MediaQueryListEvent) => {
         this.applyResponsiveMode(event.matches);
@@ -255,11 +269,18 @@ export class ArStepper extends LitElement {
                 });
             }
         }
-        if (changed.has('currentPath') && this.currentPath === this._pendingFocusPath) {
-            this.shadowRoot
-                ?.querySelector<HTMLElement>(`[data-path="${this._pendingFocusPath}"]`)
-                ?.focus();
+        if (this._hasRenderedOnce && changed.has('currentPath')) {
+            const from = changed.get('currentPath') as string;
+            const to = this.currentPath;
+            if (from !== to) {
+                this._emitChanged({ from, to });
+                announceA11y(this.navigation.currentNode?.label ?? to, 'polite');
+                if (to === this._pendingFocusPath) {
+                    this.shadowRoot?.querySelector<HTMLElement>(`[data-path="${to}"]`)?.focus();
+                }
+            }
         }
+        this._hasRenderedOnce = true;
         this._pendingFocusPath = undefined;
     }
 
@@ -453,6 +474,16 @@ export class ArStepper extends LitElement {
         return this.navigation.tree.flatMap((step) => step.children.map((sub) => sub.path));
     }
 
+    private _emitChanged(detail: ArStepperStepChangeDetail): void {
+        this.dispatchEvent(
+            new CustomEvent<ArStepperStepChangeDetail>('ar-stepper-step-changed', {
+                bubbles: true,
+                composed: true,
+                detail,
+            }),
+        );
+    }
+
     // ── Events ───────────────────────────────────────────────────────────────
 
     private onClickLink = (event: MouseEvent): void => {
@@ -474,11 +505,19 @@ export class ArStepper extends LitElement {
             event.preventDefault();
         }
 
-        const detail: ArStepperStepChangeDetail = { path };
+        const detail: ArStepperStepChangeDetail = { from: this.currentPath, to: path };
 
-        this.dispatchEvent(
-            new CustomEvent('ar-stepper-step-change', { bubbles: true, composed: true, detail }),
+        const proceed = this.dispatchEvent(
+            new CustomEvent('ar-stepper-step-change', {
+                bubbles: true,
+                composed: true,
+                cancelable: true,
+                detail,
+            }),
         );
+        if (!proceed) {
+            this._pendingFocusPath = undefined;
+        }
 
         // Force un cycle de rendu même si aucune propriété réactive ne change : c'est ce
         // cycle qui, dans updated(), valide (ou expire) l'intention de focus — garantit la
@@ -486,8 +525,6 @@ export class ArStepper extends LitElement {
         // dispatchEvent pour laisser une chance à une mutation synchrone/quasi-synchrone
         // (ex. Vue nextTick) du consommateur d'être planifiée dans le même cycle Lit.
         this.requestUpdate();
-
-        announceA11y(node?.label ?? path, 'polite');
     };
 
     private handleScrollChange = (event: CustomEvent<string>): void => {


### PR DESCRIPTION
## Résumé

- `ar-stepper-step-change` devient annulable (`preventDefault()` bloque la navigation).
- Nouvel event `ar-stepper-step-changed` (non-cancelable), émis quand `currentPath` a réellement transitionné (confirmation externe ou `follow-scroll`).
- Le détail des deux events passe de `{ path }` à `{ from, to }`, aligné sur `ar-pagination` — `ar-stepper` est fondamentalement un système de navigation comme `ar-pagination`, avec des pages nommées plutôt que numérotées.
- L'annonce aria-live est déplacée du clic vers la confirmation réelle — le stepper ne "ment" plus sur l'état affiché pendant un chargement async qui échouerait.
- Le mécanisme de focus (`_pendingFocusPath`) est inchangé fonctionnellement, juste regroupé au même point d'entrée.
- Doc alignée sur le style adopté pour `ar-pagination` ; démos live câblées via le champ `pageScript` existant (#161).
- Breaking change (package alpha, pas de dépréciation)

Design : `docs/superpowers/specs/2026-08-11-stepper-controlled-current-events-design.md`
Plan : `docs/superpowers/plans/2026-08-11-stepper-controlled-current-events-plan.md`

## Test plan

- [ ] `npm run test:all` passe
- [ ] Démos de la doc `ar-stepper` vérifiées manuellement (clic change bien l'étape dans les 3 variantes + playground)
- [ ] `npm run lint` passe

Closes #174 

🤖 Generated with [Claude Code](https://claude.com/claude-code)