### PR TITLE
feat(core): export CSSStyleSheet du thème + doc shadow DOM applicatif (#170)

### DIFF
--- a/apps/docs/scripts/check-build.js
+++ b/apps/docs/scripts/check-build.js
@@ -20,6 +20,7 @@ const EXPECTED_PAGES = [
     'index.html',
     'getting-started/quickstart/index.html',
     'getting-started/utilisation/index.html',
+    'getting-started/shadow-dom/index.html',
 ];
 
 let hasError = false;

--- a/apps/docs/src/components/SiteNav.astro
+++ b/apps/docs/src/components/SiteNav.astro
@@ -29,7 +29,8 @@ interface NavLink {
 
 const gettingStartedLinks: NavLink[] = [
     { href: '/getting-started/quickstart', label: 'Démarrage rapide', ariaCurrent: undefined },
-    { href: '/getting-started/utilisation',  label: 'Utilisation',  ariaCurrent: undefined },
+    { href: '/getting-started/utilisation', label: 'Utilisation', ariaCurrent: undefined },
+    { href: '/getting-started/shadow-dom', label: 'Shadow DOM applicatif', ariaCurrent: undefined },
 ].map((link) => ({
     ...link,
     ariaCurrent: currentPath === link.href ? ('page' as const) : undefined,

--- a/apps/docs/src/pages/getting-started/shadow-dom.astro
+++ b/apps/docs/src/pages/getting-started/shadow-dom.astro
@@ -7,20 +7,20 @@ const tocEntries = [
     { id: 'charger-le-theme', label: 'Charger le thème dans votre shadow root', level: 1 as const },
 ];
 
-const codeLinkMethod = `class MonApp extends HTMLElement {
+const codeAdoptedStyleSheetsCdn = `<script type="module">
+import { defaultTheme } from 'https://unpkg.com/@ariane-ui/core/themes/default.js';
+
+class MonApp extends HTMLElement {
     connectedCallback() {
         const shadow = this.attachShadow({ mode: 'open' });
-
-        const link = document.createElement('link');
-        link.rel = 'stylesheet';
-        link.href = 'https://unpkg.com/@ariane-ui/core/themes/default.css';
-
-        shadow.append(link, document.createElement('ar-datepicker'));
+        shadow.adoptedStyleSheets = [defaultTheme];
+        shadow.append(document.createElement('ar-datepicker'));
     }
 }
-customElements.define('mon-app', MonApp);`;
+customElements.define('mon-app', MonApp);
+</script>`;
 
-const codeAdoptedStyleSheets = `import { defaultTheme } from '@ariane-ui/core/themes/default.js';
+const codeAdoptedStyleSheetsNpm = `import { defaultTheme } from '@ariane-ui/core/themes/default.js';
 
 class MonApp extends HTMLElement {
     connectedCallback() {
@@ -54,23 +54,16 @@ customElements.define('mon-app', MonApp);`;
             <div>
                 <h3 class="section-title">Pourquoi <code>::part()</code> ne traverse pas la frontière</h3>
                 <p>
-                    Les <strong>tokens</strong> (CSS Custom Properties, <code>--ar-*</code>)
-                    continuent de fonctionner sans rien faire : les custom properties héritent
-                    naturellement à travers les frontières de shadow DOM, y compris la vôtre. Cela
-                    suppose toujours qu'un thème (<code>default.css</code> ou équivalent) reste
-                    chargé au niveau document comme d'habitude — ce guide n'ajoute que l'étape
-                    supplémentaire nécessaire pour <code>::part()</code> à l'intérieur de votre
-                    propre shadow root.
+                    Les <strong>tokens</strong> (<code>--ar-*</code>) traversent la frontière par
+                    héritage CSS natif — rien à faire, à condition que le thème reste chargé au
+                    niveau document comme d'habitude.
                 </p>
                 <p>
-                    <strong><code>::part()</code></strong> en revanche ne peut pas atteindre les
-                    composants Ariane depuis <code>default.css</code> chargé au niveau du document
-                    : votre shadow root est une frontière que vous avez créée, et
-                    <code>default.css</code> chargé au niveau document ne partage plus le même
-                    arbre DOM que les composants Ariane qu'il cible à l'intérieur de votre shadow
-                    root. C'est le fonctionnement standard du Shadow DOM — qui crée une frontière
-                    est responsable d'y importer ce dont il a besoin, ce n'est pas une lacune
-                    d'Ariane à corriger.
+                    <strong><code>::part()</code></strong> ne traverse pas : votre shadow root est
+                    une frontière que vous avez créée, elle ne partage plus le même arbre DOM que
+                    <code>default.css</code> chargé au niveau document. C'est le fonctionnement
+                    standard du Shadow DOM — qui crée une frontière est responsable d'y importer ce
+                    dont elle a besoin.
                 </p>
             </div>
         </section>
@@ -79,50 +72,40 @@ customElements.define('mon-app', MonApp);`;
             <div>
                 <h3 class="section-title">Charger le thème dans votre shadow root</h3>
                 <p>
-                    Deux méthodes équivalentes en résultat visuel — chargez le thème
-                    <em>dans</em> votre shadow root plutôt qu'au niveau document.
+                    Ariane publie <code>@ariane-ui/core/themes/default.js</code>, un export du
+                    thème sous forme de <code>CSSStyleSheet</code> déjà construit
+                    (<code>defaultTheme</code>), à adopter directement dans votre shadow root via
+                    <code>shadow.adoptedStyleSheets</code>. Chargement synchrone (pas de FOUC), et
+                    une seule feuille parsée, partageable telle quelle entre plusieurs shadow roots
+                    de votre application — le module n'est évalué qu'une fois, chaque import y
+                    compris depuis des fichiers différents pointe vers la même instance.
                 </p>
             </div>
 
             <section class="subsection">
-                <h4 class="subsection-title">Via <code>&lt;link&gt;</code> (universel)</h4>
-                <p>
-                    Un <code>&lt;link&gt;</code> classique, inséré dans votre shadow root plutôt
-                    qu'au niveau document. Fonctionne dans tous les navigateurs, un fetch/parse
-                    par instance de shadow root.
-                </p>
-                <pre><code class="language-js" set:text={codeLinkMethod} /></pre>
+                <h4 class="subsection-title">Via CDN <span class="badge">Recommandé</span></h4>
+                <pre><code class="language-html" set:text={codeAdoptedStyleSheetsCdn} /></pre>
             </section>
 
             <section class="subsection">
-                <h4 class="subsection-title">
-                    Via <code>adoptedStyleSheets</code> <span class="badge">Recommandé</span>
-                </h4>
-                <p>
-                    Ariane publie <code>@ariane-ui/core/themes/default.js</code>, un export du
-                    thème sous forme de <code>CSSStyleSheet</code> déjà construit
-                    (<code>defaultTheme</code>). Chargement synchrone (pas de FOUC), et une seule
-                    feuille parsée, partageable telle quelle entre plusieurs shadow roots de votre
-                    application via <code>shadow.adoptedStyleSheets</code> — le module n'est évalué
-                    qu'une fois, chaque import y compris depuis des fichiers différents pointe vers
-                    la même instance.
-                </p>
-                <pre><code class="language-js" set:text={codeAdoptedStyleSheets} /></pre>
-                <p class="hint">
-                    <code>default.js</code> ne contient que les règles <code>::part()</code>, pas
-                    les tokens — les tokens n'ont besoin d'aucune de ces deux méthodes (héritage
-                    CSS natif, cf. section précédente).
-                </p>
-                <div class="callout">
-                    <p class="callout-title">Compatibilité</p>
-                    <p>
-                        <code>CSSStyleSheet</code> constructible et
-                        <code>adoptedStyleSheets</code> sont supportés par tous les navigateurs
-                        majeurs actuels (Safari 16.4+, mars 2023). Sans cette contrainte, préférez
-                        la méthode <code>&lt;link&gt;</code> ci-dessus.
-                    </p>
-                </div>
+                <h4 class="subsection-title">Via npm <span class="badge badge-subtle">Avec bundler</span></h4>
+                <pre><code class="language-js" set:text={codeAdoptedStyleSheetsNpm} /></pre>
             </section>
+
+            <p class="hint">
+                <code>default.js</code> ne contient que les règles <code>::part()</code>, pas les
+                tokens — les tokens n'ont besoin d'aucune de ces méthodes (héritage CSS natif, cf.
+                section précédente).
+            </p>
+
+            <ar-alert variant="info" class="doc-callout-alert">
+                <span slot="title">Compatibilité</span>
+                <span slot="content">
+                    <code>CSSStyleSheet</code> constructible et <code>adoptedStyleSheets</code>
+                    sont supportés par tous les navigateurs majeurs actuels (Safari 16.4+, mars
+                    2023).
+                </span>
+            </ar-alert>
         </section>
     </div>
 

--- a/apps/docs/src/pages/getting-started/shadow-dom.astro
+++ b/apps/docs/src/pages/getting-started/shadow-dom.astro
@@ -3,10 +3,10 @@ import Layout from '../../layouts/Layout.astro';
 import TableOfContents from '../../components/TableOfContents.astro';
 
 const tocEntries = [
-    { id: 'pourquoi',         label: 'Pourquoi ::part() ne traverse pas',    level: 1 as const },
-    { id: 'charger-le-theme', label: 'Charger le thème dans votre shadow root', level: 1 as const },
-    { id: 'votre-theme',      label: 'Construire votre propre thème',       level: 2 as const },
-    { id: 'theme-ariane',     label: "Utiliser le thème par défaut d'Ariane", level: 2 as const },
+    { id: 'pourquoi',         label: 'Pourquoi ::part() ne traverse pas',       level: 1 as const },
+    { id: 'charger-le-theme', label: 'Charger un thème dans votre shadow root', level: 1 as const },
+    { id: 'preparez-theme',   label: 'Préparez votre thème',                   level: 2 as const },
+    { id: 'theme-ariane',     label: "Utiliser le thème par défaut d'Ariane",  level: 2 as const },
 ];
 
 const codeAdoptedStyleSheetsCdnComponent = `// mon-app.js — définition du composant, fichier séparé de la page
@@ -21,12 +21,6 @@ class MonApp extends HTMLElement {
 }
 customElements.define('mon-app', MonApp);`;
 
-const codeAdoptedStyleSheetsCdnPage = `<!-- Enregistre ar-datepicker et les autres composants Ariane, cf. Démarrage rapide -->
-<script type="module" src="https://unpkg.com/@ariane-ui/core/cdn/autoloader.prod.js"></scr` + `ipt>
-<script type="module" src="/mon-app.js"></scr` + `ipt>
-
-<mon-app></mon-app>`;
-
 const codeAdoptedStyleSheetsNpmComponent = `// mon-app.js — définition du composant, fichier séparé de la page
 import { defaultTheme } from '@ariane-ui/core/themes/default.js';
 
@@ -39,16 +33,29 @@ export class MonApp extends HTMLElement {
 }
 customElements.define('mon-app', MonApp);`;
 
-const codeAdoptedStyleSheetsNpmPage = `// main.js
-import '@ariane-ui/core'; // enregistre les composants Ariane
-import './mon-app.js';`;
+const codeCustomTheme = `// mon-theme.js — généré par votre build à partir de votre fichier CSS
+export const monTheme = new CSSStyleSheet();
 
-const codeCustomTheme = `const monTheme = new CSSStyleSheet();
+/* Injectez le contenu de votre fichier CSS ci-dessous */
 monTheme.replaceSync(\`
-    ar-datepicker::part(panel) { border-radius: 1rem; }
+    ar-datepicker::part(panel) {
+        width: 20rem;
+        padding: 1rem;
+    }
+    ...
 \`);
 
-shadow.adoptedStyleSheets = [monTheme];`;
+// mon-app.js — définition du composant, importe le fichier ainsi créé
+import { monTheme } from 'mon-theme.js';
+
+export class MonApp extends HTMLElement {
+    connectedCallback() {
+        const shadow = this.attachShadow({ mode: 'open' });
+        // Importez le thème dans le shadowRoot
+        shadow.adoptedStyleSheets = [monTheme];
+    }
+}
+customElements.define('mon-app', MonApp);`;
 ---
 
 <Layout
@@ -60,100 +67,87 @@ shadow.adoptedStyleSheets = [monTheme];`;
         <div class="page-header">
             <h2 class="page-title">Ariane dans un shadow DOM applicatif</h2>
             <p class="summary">
-                Ce guide s'applique si votre application encapsule sa propre page ou une partie de
-                son contenu dans un <em>web component</em> avec son propre shadow DOM, et y
-                instancie des composants Ariane à l'intérieur. C'est un cas différent de
-                l'imbrication interne à la librairie (un composant Ariane qui en instancie un
-                autre dans son propre shadow root) — ici c'est votre propre frontière shadow DOM,
-                pas celle d'Ariane.
+                Si votre application encapsule sa propre page ou une partie de
+                son contenu dans un <em>web component</em> avec son propre shadow DOM, le thème CSS
+                ne s'appliquera que partiellement à vos composants.<br>
+                Il s'agit là d'une contrainte inhérente au shadow DOM, mais cette page vous guidera
+                pour vous aider à afficher vos composants correctement.
             </p>
         </div>
 
         <section id="pourquoi" class="main-section">
             <div>
-                <h3 class="section-title">Pourquoi <code>::part()</code> ne traverse pas la frontière</h3>
+                <h3 class="section-title">Que se passe-t-il ?</h3>
                 <p>
-                    Les <strong>tokens</strong> (<code>--ar-*</code>) traversent la frontière par
-                    héritage CSS natif — rien à faire, à condition que le thème reste chargé au
-                    niveau document comme d'habitude.
+                    Les <strong>CSS Custom properties</strong> de votre thème chargé dans le document
+                    traversent la frontière du shadow DOM par héritage CSS natif.
                 </p>
                 <p>
-                    <strong><code>::part()</code></strong> ne traverse pas : votre shadow root est
-                    une frontière que vous avez créée, elle ne partage plus le même arbre DOM que
-                    <code>default.css</code> chargé au niveau document. C'est le fonctionnement
-                    standard du Shadow DOM — qui crée une frontière est responsable d'y importer ce
-                    dont elle a besoin.
+                    Les règles utilisant <strong><code>::part()</code></strong> par contre ne peuvent pas
+                    traverser le shadow DOM de votre composant et les règles de votre thème ne s'appliquent
+                    donc pas.<br>
+                    C'est la raison pour laquelle votre thème ne s'applique que partiellement.
                 </p>
             </div>
         </section>
 
         <section id="charger-le-theme" class="main-section">
             <div>
-                <h3 class="section-title">Charger le thème dans votre shadow root</h3>
+                <h3 class="section-title">Charger le thème dans le shadow root</h3>
                 <p>
-                    N'importe quelle feuille CSS peut devenir un <code>CSSStyleSheet</code>
-                    adoptable, à assigner directement à <code>shadow.adoptedStyleSheets</code> :
-                    chargement synchrone (pas de FOUC), et une seule feuille parsée, partageable
-                    telle quelle entre plusieurs shadow roots de votre application.
+                    N'importe quelle feuille de style peut être transformée en
+                    <a href="https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/CSSStyleSheet"
+                    target="_blank" rel="noopener" title="Visiter la page dédiée sur MDN (nouvel onglet)"><code>CSSStyleSheet</code></a>.
+                    Elle peut ensuite être "adoptée" par chaque composant qui en a besoin, chacun partageant
+                    une même instance chargée et parsée une seule fois.<br>
+                    Contrairement au chargement du CSS via une balise <code>&lt;link&gt;</code>,
+                    les <code>adoptedStyleSheets</code> permettent un chargement synchrone (pas de FOUC).
                 </p>
+
+                <ar-alert variant="info" class="doc-callout-alert">
+                    <p class="doc-callout-alert-title">Compatibilité</p>
+                    <div class="doc-callout-alert-content">
+                        <p>
+                            <code>CSSStyleSheet</code> constructible et <code>adoptedStyleSheets</code>
+                            sont supportés par tous les navigateurs majeurs actuels (Safari 16.4+, mars
+                            2023).
+                        </p>
+                    </div>
+                </ar-alert>
             </div>
 
-            <section id="votre-theme" class="subsection">
-                <h4 class="subsection-title">Construire votre propre thème</h4>
+            <section id="preparez-theme" class="subsection">
+                <h4 class="subsection-title">Préparez votre thème</h4>
                 <p>
-                    Le cas le plus courant : votre application a déjà son propre thème, local à
-                    votre code — la technique est la même quel que soit le CSS :
+                    Le plus souvent votre application a déjà son propre thème, local à votre code
+                    — la technique est la même quel que soit le CSS.<br>
+                    Il s'agit de créer à partir de votre fichier CSS une version <code>*.js</code>
+                    qui sera utilisée en complément de votre fichier CSS.
                 </p>
                 <pre><code class="language-js" set:text={codeCustomTheme} /></pre>
+                <ar-alert variant="info" class="doc-callout-alert">
+                    <p class="doc-callout-alert-title">N'importez pas les tokens</p>
+                    <div class="doc-callout-alert-content">
+                        <p>
+                            Les CSS Custom properties n'ont pas besoin d'être incluses dans cette version JS,
+                            le sélecteur <code>:root</code> ne s'appliquant pas dans le contexte du shadow DOM.
+                        </p>
+                    </div>
+                </ar-alert>
             </section>
 
             <section id="theme-ariane" class="subsection">
                 <h4 class="subsection-title">Utiliser le thème par défaut d'Ariane</h4>
                 <p>
-                    Ariane publie son propre thème packagé de la même façon —
-                    <code>@ariane-ui/core/themes/default.js</code> exporte <code>defaultTheme</code>,
-                    prêt à l'emploi si vous préférez repartir de celui-ci plutôt que d'écrire le
-                    vôtre.
-                </p>
-                <p>
-                    Le composant qui englobe le contenu de votre page vit dans son propre fichier,
-                    comme dans une vraie application — c'est <em>ce fichier</em> qui importe
-                    <code>defaultTheme</code>, peu importe où il est lui-même chargé depuis. Un
-                    import d'URL absolue (<code>https://unpkg.com/...</code>) se résout toujours de
-                    la même façon, quel que soit l'endroit d'où le module qui l'importe est
-                    lui-même servi.
+                    Si vous utilisez le thème Ariane dans votre projet, celui-ci est packagé en JS
+                    et utilisable via le CDN ou le paquet npm.
                 </p>
 
                 <p><strong>Via CDN :</strong></p>
                 <pre><code class="language-js" set:text={codeAdoptedStyleSheetsCdnComponent} /></pre>
-                <p>Chargé depuis la page, aux côtés de l'autoloader habituel :</p>
-                <pre><code class="language-html" set:text={codeAdoptedStyleSheetsCdnPage} /></pre>
-                <p class="hint">
-                    Chemin complet <code>dist/styles/themes/default.js</code>, pas le raccourci
-                    <code>themes/default.js</code> : unpkg ne résout pas les alias de l'
-                    <code>exports</code> du <code>package.json</code>, seulement les chemins de
-                    fichiers réels.
-                </p>
 
                 <p><strong>Via npm :</strong></p>
                 <pre><code class="language-js" set:text={codeAdoptedStyleSheetsNpmComponent} /></pre>
-                <p>Importé depuis votre point d'entrée :</p>
-                <pre><code class="language-js" set:text={codeAdoptedStyleSheetsNpmPage} /></pre>
-
-                <p class="hint">
-                    <code>default.js</code> ne contient que les règles <code>::part()</code>, pas
-                    les tokens — les tokens n'ont besoin d'aucune de ces méthodes (héritage CSS
-                    natif, cf. section précédente).
-                </p>
-
-                <ar-alert variant="info" class="doc-callout-alert">
-                    <p class="doc-callout-alert-title">Compatibilité</p>
-                    <p>
-                        <code>CSSStyleSheet</code> constructible et <code>adoptedStyleSheets</code>
-                        sont supportés par tous les navigateurs majeurs actuels (Safari 16.4+, mars
-                        2023).
-                    </p>
-                </ar-alert>
             </section>
         </section>
     </div>
@@ -163,10 +157,4 @@ shadow.adoptedStyleSheets = [monTheme];`;
 
 <style>
     @import '../../styles/doc-prose.css';
-
-    .hint {
-        font-size: 0.875rem;
-        color: var(--doc-text-muted);
-        margin-top: -0.5rem;
-    }
 </style>

--- a/apps/docs/src/pages/getting-started/shadow-dom.astro
+++ b/apps/docs/src/pages/getting-started/shadow-dom.astro
@@ -6,24 +6,11 @@ const tocEntries = [
     { id: 'pourquoi',         label: 'Pourquoi ::part() ne traverse pas',    level: 1 as const },
     { id: 'charger-le-theme', label: 'Charger le thème dans votre shadow root', level: 1 as const },
     { id: 'votre-theme',      label: 'Construire votre propre thème',       level: 2 as const },
+    { id: 'theme-ariane',     label: "Utiliser le thème par défaut d'Ariane", level: 2 as const },
 ];
 
-const codeAdoptedStyleSheetsCdn = `<script type="module" src="https://unpkg.com/@ariane-ui/core/cdn/autoloader.prod.js"></scr` + `ipt>
-<script type="module">
-import { defaultTheme } from 'https://unpkg.com/@ariane-ui/core/themes/default.js';
-
-class MonApp extends HTMLElement {
-    connectedCallback() {
-        const shadow = this.attachShadow({ mode: 'open' });
-        shadow.adoptedStyleSheets = [defaultTheme];
-        shadow.append(document.createElement('ar-datepicker'));
-    }
-}
-customElements.define('mon-app', MonApp);
-</scr` + `ipt>`;
-
-const codeAdoptedStyleSheetsNpm = `import '@ariane-ui/core'; // enregistre les composants — fichier distinct du thème
-import { defaultTheme } from '@ariane-ui/core/themes/default.js';
+const codeAdoptedStyleSheetsCdnComponent = `// mon-app.js — définition du composant, fichier séparé de la page
+import { defaultTheme } from 'https://unpkg.com/@ariane-ui/core/dist/styles/themes/default.js';
 
 class MonApp extends HTMLElement {
     connectedCallback() {
@@ -33,6 +20,28 @@ class MonApp extends HTMLElement {
     }
 }
 customElements.define('mon-app', MonApp);`;
+
+const codeAdoptedStyleSheetsCdnPage = `<!-- Enregistre ar-datepicker et les autres composants Ariane, cf. Démarrage rapide -->
+<script type="module" src="https://unpkg.com/@ariane-ui/core/cdn/autoloader.prod.js"></scr` + `ipt>
+<script type="module" src="/mon-app.js"></scr` + `ipt>
+
+<mon-app></mon-app>`;
+
+const codeAdoptedStyleSheetsNpmComponent = `// mon-app.js — définition du composant, fichier séparé de la page
+import { defaultTheme } from '@ariane-ui/core/themes/default.js';
+
+export class MonApp extends HTMLElement {
+    connectedCallback() {
+        const shadow = this.attachShadow({ mode: 'open' });
+        shadow.adoptedStyleSheets = [defaultTheme];
+        shadow.append(document.createElement('ar-datepicker'));
+    }
+}
+customElements.define('mon-app', MonApp);`;
+
+const codeAdoptedStyleSheetsNpmPage = `// main.js
+import '@ariane-ui/core'; // enregistre les composants Ariane
+import './mon-app.js';`;
 
 const codeCustomTheme = `const monTheme = new CSSStyleSheet();
 monTheme.replaceSync(\`
@@ -87,52 +96,64 @@ shadow.adoptedStyleSheets = [monTheme];`;
                     chargement synchrone (pas de FOUC), et une seule feuille parsée, partageable
                     telle quelle entre plusieurs shadow roots de votre application.
                 </p>
-                <p>
-                    Ariane publie son propre thème packagé ainsi —
-                    <code>@ariane-ui/core/themes/default.js</code> exporte <code>defaultTheme</code>,
-                    prêt à l'emploi. Les exemples ci-dessous l'utilisent pour illustrer la
-                    technique, mais l'objectif est que vous puissiez faire de même avec
-                    <strong>votre propre thème</strong> (voir <a href="#votre-theme">plus bas</a>).
-                    Notez aussi que le thème est un fichier distinct des composants eux-mêmes —
-                    <code>ar-datepicker</code> doit être enregistré séparément (autoloader, bundle,
-                    ou <code>import '@ariane-ui/core'</code>), comme dans le
-                    <a href="/getting-started/quickstart">Démarrage rapide</a>.
-                </p>
             </div>
-
-            <section class="subsection">
-                <h4 class="subsection-title">Via CDN <span class="badge">Recommandé</span></h4>
-                <pre><code class="language-html" set:text={codeAdoptedStyleSheetsCdn} /></pre>
-            </section>
-
-            <section class="subsection">
-                <h4 class="subsection-title">Via npm <span class="badge badge-subtle">Avec bundler</span></h4>
-                <pre><code class="language-js" set:text={codeAdoptedStyleSheetsNpm} /></pre>
-            </section>
-
-            <p class="hint">
-                <code>default.js</code> ne contient que les règles <code>::part()</code>, pas les
-                tokens — les tokens n'ont besoin d'aucune de ces méthodes (héritage CSS natif, cf.
-                section précédente).
-            </p>
-
-            <ar-alert variant="info" class="doc-callout-alert">
-                <span slot="title">Compatibilité</span>
-                <span slot="content">
-                    <code>CSSStyleSheet</code> constructible et <code>adoptedStyleSheets</code>
-                    sont supportés par tous les navigateurs majeurs actuels (Safari 16.4+, mars
-                    2023).
-                </span>
-            </ar-alert>
 
             <section id="votre-theme" class="subsection">
                 <h4 class="subsection-title">Construire votre propre thème</h4>
                 <p>
-                    <code>defaultTheme</code> n'a rien de spécial — c'est le même
-                    <code>CSSStyleSheet</code> constructible que vous pouvez créer avec votre
-                    propre CSS :
+                    Le cas le plus courant : votre application a déjà son propre thème, local à
+                    votre code — la technique est la même quel que soit le CSS :
                 </p>
                 <pre><code class="language-js" set:text={codeCustomTheme} /></pre>
+            </section>
+
+            <section id="theme-ariane" class="subsection">
+                <h4 class="subsection-title">Utiliser le thème par défaut d'Ariane</h4>
+                <p>
+                    Ariane publie son propre thème packagé de la même façon —
+                    <code>@ariane-ui/core/themes/default.js</code> exporte <code>defaultTheme</code>,
+                    prêt à l'emploi si vous préférez repartir de celui-ci plutôt que d'écrire le
+                    vôtre.
+                </p>
+                <p>
+                    Le composant qui englobe le contenu de votre page vit dans son propre fichier,
+                    comme dans une vraie application — c'est <em>ce fichier</em> qui importe
+                    <code>defaultTheme</code>, peu importe où il est lui-même chargé depuis. Un
+                    import d'URL absolue (<code>https://unpkg.com/...</code>) se résout toujours de
+                    la même façon, quel que soit l'endroit d'où le module qui l'importe est
+                    lui-même servi.
+                </p>
+
+                <p><strong>Via CDN :</strong></p>
+                <pre><code class="language-js" set:text={codeAdoptedStyleSheetsCdnComponent} /></pre>
+                <p>Chargé depuis la page, aux côtés de l'autoloader habituel :</p>
+                <pre><code class="language-html" set:text={codeAdoptedStyleSheetsCdnPage} /></pre>
+                <p class="hint">
+                    Chemin complet <code>dist/styles/themes/default.js</code>, pas le raccourci
+                    <code>themes/default.js</code> : unpkg ne résout pas les alias de l'
+                    <code>exports</code> du <code>package.json</code>, seulement les chemins de
+                    fichiers réels.
+                </p>
+
+                <p><strong>Via npm :</strong></p>
+                <pre><code class="language-js" set:text={codeAdoptedStyleSheetsNpmComponent} /></pre>
+                <p>Importé depuis votre point d'entrée :</p>
+                <pre><code class="language-js" set:text={codeAdoptedStyleSheetsNpmPage} /></pre>
+
+                <p class="hint">
+                    <code>default.js</code> ne contient que les règles <code>::part()</code>, pas
+                    les tokens — les tokens n'ont besoin d'aucune de ces méthodes (héritage CSS
+                    natif, cf. section précédente).
+                </p>
+
+                <ar-alert variant="info" class="doc-callout-alert">
+                    <p class="doc-callout-alert-title">Compatibilité</p>
+                    <p>
+                        <code>CSSStyleSheet</code> constructible et <code>adoptedStyleSheets</code>
+                        sont supportés par tous les navigateurs majeurs actuels (Safari 16.4+, mars
+                        2023).
+                    </p>
+                </ar-alert>
             </section>
         </section>
     </div>

--- a/apps/docs/src/pages/getting-started/shadow-dom.astro
+++ b/apps/docs/src/pages/getting-started/shadow-dom.astro
@@ -5,9 +5,11 @@ import TableOfContents from '../../components/TableOfContents.astro';
 const tocEntries = [
     { id: 'pourquoi',         label: 'Pourquoi ::part() ne traverse pas',    level: 1 as const },
     { id: 'charger-le-theme', label: 'Charger le thème dans votre shadow root', level: 1 as const },
+    { id: 'votre-theme',      label: 'Construire votre propre thème',       level: 2 as const },
 ];
 
-const codeAdoptedStyleSheetsCdn = `<script type="module">
+const codeAdoptedStyleSheetsCdn = `<script type="module" src="https://unpkg.com/@ariane-ui/core/cdn/autoloader.prod.js"></scr` + `ipt>
+<script type="module">
 import { defaultTheme } from 'https://unpkg.com/@ariane-ui/core/themes/default.js';
 
 class MonApp extends HTMLElement {
@@ -18,9 +20,10 @@ class MonApp extends HTMLElement {
     }
 }
 customElements.define('mon-app', MonApp);
-</script>`;
+</scr` + `ipt>`;
 
-const codeAdoptedStyleSheetsNpm = `import { defaultTheme } from '@ariane-ui/core/themes/default.js';
+const codeAdoptedStyleSheetsNpm = `import '@ariane-ui/core'; // enregistre les composants — fichier distinct du thème
+import { defaultTheme } from '@ariane-ui/core/themes/default.js';
 
 class MonApp extends HTMLElement {
     connectedCallback() {
@@ -30,6 +33,13 @@ class MonApp extends HTMLElement {
     }
 }
 customElements.define('mon-app', MonApp);`;
+
+const codeCustomTheme = `const monTheme = new CSSStyleSheet();
+monTheme.replaceSync(\`
+    ar-datepicker::part(panel) { border-radius: 1rem; }
+\`);
+
+shadow.adoptedStyleSheets = [monTheme];`;
 ---
 
 <Layout
@@ -72,13 +82,21 @@ customElements.define('mon-app', MonApp);`;
             <div>
                 <h3 class="section-title">Charger le thème dans votre shadow root</h3>
                 <p>
-                    Ariane publie <code>@ariane-ui/core/themes/default.js</code>, un export du
-                    thème sous forme de <code>CSSStyleSheet</code> déjà construit
-                    (<code>defaultTheme</code>), à adopter directement dans votre shadow root via
-                    <code>shadow.adoptedStyleSheets</code>. Chargement synchrone (pas de FOUC), et
-                    une seule feuille parsée, partageable telle quelle entre plusieurs shadow roots
-                    de votre application — le module n'est évalué qu'une fois, chaque import y
-                    compris depuis des fichiers différents pointe vers la même instance.
+                    N'importe quelle feuille CSS peut devenir un <code>CSSStyleSheet</code>
+                    adoptable, à assigner directement à <code>shadow.adoptedStyleSheets</code> :
+                    chargement synchrone (pas de FOUC), et une seule feuille parsée, partageable
+                    telle quelle entre plusieurs shadow roots de votre application.
+                </p>
+                <p>
+                    Ariane publie son propre thème packagé ainsi —
+                    <code>@ariane-ui/core/themes/default.js</code> exporte <code>defaultTheme</code>,
+                    prêt à l'emploi. Les exemples ci-dessous l'utilisent pour illustrer la
+                    technique, mais l'objectif est que vous puissiez faire de même avec
+                    <strong>votre propre thème</strong> (voir <a href="#votre-theme">plus bas</a>).
+                    Notez aussi que le thème est un fichier distinct des composants eux-mêmes —
+                    <code>ar-datepicker</code> doit être enregistré séparément (autoloader, bundle,
+                    ou <code>import '@ariane-ui/core'</code>), comme dans le
+                    <a href="/getting-started/quickstart">Démarrage rapide</a>.
                 </p>
             </div>
 
@@ -106,6 +124,16 @@ customElements.define('mon-app', MonApp);`;
                     2023).
                 </span>
             </ar-alert>
+
+            <section id="votre-theme" class="subsection">
+                <h4 class="subsection-title">Construire votre propre thème</h4>
+                <p>
+                    <code>defaultTheme</code> n'a rien de spécial — c'est le même
+                    <code>CSSStyleSheet</code> constructible que vous pouvez créer avec votre
+                    propre CSS :
+                </p>
+                <pre><code class="language-js" set:text={codeCustomTheme} /></pre>
+            </section>
         </section>
     </div>
 

--- a/apps/docs/src/pages/getting-started/shadow-dom.astro
+++ b/apps/docs/src/pages/getting-started/shadow-dom.astro
@@ -56,7 +56,11 @@ customElements.define('mon-app', MonApp);`;
                 <p>
                     Les <strong>tokens</strong> (CSS Custom Properties, <code>--ar-*</code>)
                     continuent de fonctionner sans rien faire : les custom properties héritent
-                    naturellement à travers les frontières de shadow DOM, y compris la vôtre.
+                    naturellement à travers les frontières de shadow DOM, y compris la vôtre. Cela
+                    suppose toujours qu'un thème (<code>default.css</code> ou équivalent) reste
+                    chargé au niveau document comme d'habitude — ce guide n'ajoute que l'étape
+                    supplémentaire nécessaire pour <code>::part()</code> à l'intérieur de votre
+                    propre shadow root.
                 </p>
                 <p>
                     <strong><code>::part()</code></strong> en revanche ne peut pas atteindre les

--- a/apps/docs/src/pages/getting-started/shadow-dom.astro
+++ b/apps/docs/src/pages/getting-started/shadow-dom.astro
@@ -3,10 +3,10 @@ import Layout from '../../layouts/Layout.astro';
 import TableOfContents from '../../components/TableOfContents.astro';
 
 const tocEntries = [
-    { id: 'pourquoi',         label: 'Pourquoi ::part() ne traverse pas',       level: 1 as const },
-    { id: 'charger-le-theme', label: 'Charger un thème dans votre shadow root', level: 1 as const },
-    { id: 'preparez-theme',   label: 'Préparez votre thème',                   level: 2 as const },
-    { id: 'theme-ariane',     label: "Utiliser le thème par défaut d'Ariane",  level: 2 as const },
+    { id: 'pourquoi',         label: 'Un style appliqué partiellement',   level: 1 as const },
+    { id: 'charger-un-theme', label: 'Charger un thème',                  level: 1 as const },
+    { id: 'preparez-theme',   label: 'Préparez votre thème',              level: 2 as const },
+    { id: 'theme-defaut',     label: 'Utiliser le thème par défaut',      level: 2 as const },
 ];
 
 const codeAdoptedStyleSheetsCdnComponent = `// mon-app.js — définition du composant, fichier séparé de la page
@@ -65,7 +65,7 @@ customElements.define('mon-app', MonApp);`;
 >
     <div class="page-container">
         <div class="page-header">
-            <h2 class="page-title">Ariane dans un shadow DOM applicatif</h2>
+            <h2 class="page-title">Utiliser Ariane dans un shadow DOM</h2>
             <p class="summary">
                 Si votre application encapsule sa propre page ou une partie de
                 son contenu dans un <em>web component</em> avec son propre shadow DOM, le thème CSS
@@ -77,13 +77,11 @@ customElements.define('mon-app', MonApp);`;
 
         <section id="pourquoi" class="main-section">
             <div>
-                <h3 class="section-title">Que se passe-t-il ?</h3>
+                <h3 class="section-title">Un style appliqué partiellement ?</h3>
                 <p>
                     Les <strong>CSS Custom properties</strong> de votre thème chargé dans le document
-                    traversent la frontière du shadow DOM par héritage CSS natif.
-                </p>
-                <p>
-                    Les règles utilisant <strong><code>::part()</code></strong> par contre ne peuvent pas
+                    traversent la frontière du shadow DOM par héritage CSS natif.<br>
+                    Les règles utilisant <code>::part()</code> par contre ne peuvent pas
                     traverser le shadow DOM de votre composant et les règles de votre thème ne s'appliquent
                     donc pas.<br>
                     C'est la raison pour laquelle votre thème ne s'applique que partiellement.
@@ -91,9 +89,9 @@ customElements.define('mon-app', MonApp);`;
             </div>
         </section>
 
-        <section id="charger-le-theme" class="main-section">
+        <section id="charger-un-theme" class="main-section">
             <div>
-                <h3 class="section-title">Charger le thème dans le shadow root</h3>
+                <h3 class="section-title">Charger un thème</h3>
                 <p>
                     N'importe quelle feuille de style peut être transformée en
                     <a href="https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/CSSStyleSheet"
@@ -104,7 +102,7 @@ customElements.define('mon-app', MonApp);`;
                     les <code>adoptedStyleSheets</code> permettent un chargement synchrone (pas de FOUC).
                 </p>
 
-                <ar-alert variant="info" class="doc-callout-alert">
+                <ar-alert variant="info" class="doc-callout-alert" style="margin-top: 1rem">
                     <p class="doc-callout-alert-title">Compatibilité</p>
                     <div class="doc-callout-alert-content">
                         <p>
@@ -136,8 +134,8 @@ customElements.define('mon-app', MonApp);`;
                 </ar-alert>
             </section>
 
-            <section id="theme-ariane" class="subsection">
-                <h4 class="subsection-title">Utiliser le thème par défaut d'Ariane</h4>
+            <section id="theme-defaut" class="subsection">
+                <h4 class="subsection-title">Utiliser le thème par défaut</h4>
                 <p>
                     Si vous utilisez le thème Ariane dans votre projet, celui-ci est packagé en JS
                     et utilisable via le CDN ou le paquet npm.

--- a/apps/docs/src/pages/getting-started/shadow-dom.astro
+++ b/apps/docs/src/pages/getting-started/shadow-dom.astro
@@ -1,0 +1,136 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import TableOfContents from '../../components/TableOfContents.astro';
+
+const tocEntries = [
+    { id: 'pourquoi',         label: 'Pourquoi ::part() ne traverse pas',    level: 1 as const },
+    { id: 'charger-le-theme', label: 'Charger le thème dans votre shadow root', level: 1 as const },
+];
+
+const codeLinkMethod = `class MonApp extends HTMLElement {
+    connectedCallback() {
+        const shadow = this.attachShadow({ mode: 'open' });
+
+        const link = document.createElement('link');
+        link.rel = 'stylesheet';
+        link.href = 'https://unpkg.com/@ariane-ui/core/themes/default.css';
+
+        shadow.append(link, document.createElement('ar-datepicker'));
+    }
+}
+customElements.define('mon-app', MonApp);`;
+
+const codeAdoptedStyleSheets = `import { defaultTheme } from '@ariane-ui/core/themes/default.js';
+
+class MonApp extends HTMLElement {
+    connectedCallback() {
+        const shadow = this.attachShadow({ mode: 'open' });
+        shadow.adoptedStyleSheets = [defaultTheme];
+        shadow.append(document.createElement('ar-datepicker'));
+    }
+}
+customElements.define('mon-app', MonApp);`;
+---
+
+<Layout
+    title="Ariane dans un shadow DOM applicatif"
+    currentPath="/getting-started/shadow-dom"
+    showToc={true}
+>
+    <div class="page-container">
+        <div class="page-header">
+            <h2 class="page-title">Ariane dans un shadow DOM applicatif</h2>
+            <p class="summary">
+                Ce guide s'applique si votre application encapsule sa propre page ou une partie de
+                son contenu dans un <em>web component</em> avec son propre shadow DOM, et y
+                instancie des composants Ariane à l'intérieur. C'est un cas différent de
+                l'imbrication interne à la librairie (un composant Ariane qui en instancie un
+                autre dans son propre shadow root) — ici c'est votre propre frontière shadow DOM,
+                pas celle d'Ariane.
+            </p>
+        </div>
+
+        <section id="pourquoi" class="main-section">
+            <div>
+                <h3 class="section-title">Pourquoi <code>::part()</code> ne traverse pas la frontière</h3>
+                <p>
+                    Les <strong>tokens</strong> (CSS Custom Properties, <code>--ar-*</code>)
+                    continuent de fonctionner sans rien faire : les custom properties héritent
+                    naturellement à travers les frontières de shadow DOM, y compris la vôtre.
+                </p>
+                <p>
+                    <strong><code>::part()</code></strong> en revanche ne peut pas atteindre les
+                    composants Ariane depuis <code>default.css</code> chargé au niveau du document
+                    : votre shadow root est une frontière que vous avez créée, et
+                    <code>default.css</code> chargé au niveau document ne partage plus le même
+                    arbre DOM que les composants Ariane qu'il cible à l'intérieur de votre shadow
+                    root. C'est le fonctionnement standard du Shadow DOM — qui crée une frontière
+                    est responsable d'y importer ce dont il a besoin, ce n'est pas une lacune
+                    d'Ariane à corriger.
+                </p>
+            </div>
+        </section>
+
+        <section id="charger-le-theme" class="main-section">
+            <div>
+                <h3 class="section-title">Charger le thème dans votre shadow root</h3>
+                <p>
+                    Deux méthodes équivalentes en résultat visuel — chargez le thème
+                    <em>dans</em> votre shadow root plutôt qu'au niveau document.
+                </p>
+            </div>
+
+            <section class="subsection">
+                <h4 class="subsection-title">Via <code>&lt;link&gt;</code> (universel)</h4>
+                <p>
+                    Un <code>&lt;link&gt;</code> classique, inséré dans votre shadow root plutôt
+                    qu'au niveau document. Fonctionne dans tous les navigateurs, un fetch/parse
+                    par instance de shadow root.
+                </p>
+                <pre><code class="language-js" set:text={codeLinkMethod} /></pre>
+            </section>
+
+            <section class="subsection">
+                <h4 class="subsection-title">
+                    Via <code>adoptedStyleSheets</code> <span class="badge">Recommandé</span>
+                </h4>
+                <p>
+                    Ariane publie <code>@ariane-ui/core/themes/default.js</code>, un export du
+                    thème sous forme de <code>CSSStyleSheet</code> déjà construit
+                    (<code>defaultTheme</code>). Chargement synchrone (pas de FOUC), et une seule
+                    feuille parsée, partageable telle quelle entre plusieurs shadow roots de votre
+                    application via <code>shadow.adoptedStyleSheets</code> — le module n'est évalué
+                    qu'une fois, chaque import y compris depuis des fichiers différents pointe vers
+                    la même instance.
+                </p>
+                <pre><code class="language-js" set:text={codeAdoptedStyleSheets} /></pre>
+                <p class="hint">
+                    <code>default.js</code> ne contient que les règles <code>::part()</code>, pas
+                    les tokens — les tokens n'ont besoin d'aucune de ces deux méthodes (héritage
+                    CSS natif, cf. section précédente).
+                </p>
+                <div class="callout">
+                    <p class="callout-title">Compatibilité</p>
+                    <p>
+                        <code>CSSStyleSheet</code> constructible et
+                        <code>adoptedStyleSheets</code> sont supportés par tous les navigateurs
+                        majeurs actuels (Safari 16.4+, mars 2023). Sans cette contrainte, préférez
+                        la méthode <code>&lt;link&gt;</code> ci-dessus.
+                    </p>
+                </div>
+            </section>
+        </section>
+    </div>
+
+    <TableOfContents entries={tocEntries} slot="toc" />
+</Layout>
+
+<style>
+    @import '../../styles/doc-prose.css';
+
+    .hint {
+        font-size: 0.875rem;
+        color: var(--doc-text-muted);
+        margin-top: -0.5rem;
+    }
+</style>

--- a/apps/docs/src/styles/doc-prose.css
+++ b/apps/docs/src/styles/doc-prose.css
@@ -174,7 +174,18 @@ pre code {
     text-transform: uppercase;
     letter-spacing: 0.06em;
     color: var(--doc-accent);
-    margin: 0 0 0.4rem;
+    padding: 0 0 0.4rem;
+    margin: 0;
+}
+
+.doc-callout-alert-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+
+    p {
+        margin: 0;
+    }
 }
 
 .badge-subtle {

--- a/apps/docs/src/styles/doc-prose.css
+++ b/apps/docs/src/styles/doc-prose.css
@@ -42,6 +42,10 @@
 
 .main-section {
     gap: 2rem;
+
+    > div p {
+        margin: 0;
+    }
 }
 
 .subsection {
@@ -115,6 +119,16 @@ pre {
     padding: 1rem 1.25rem;
     overflow-x: auto;
     margin: 0;
+}
+
+code {
+    font-family: 'Fira Code', 'Cascadia Code', monospace;
+    font-size: 0.9rem;
+    display: inline-block;
+    line-height: 1.6;
+    background-color: var(--doc-accent-bg);
+    color: var(--doc-accent);
+    font-weight: 500;
 }
 
 pre code {

--- a/apps/docs/src/styles/doc-prose.css
+++ b/apps/docs/src/styles/doc-prose.css
@@ -168,6 +168,15 @@ pre code {
     --ar-alert-color: var(--doc-text);
 }
 
+.doc-callout-alert-title {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--doc-accent);
+    margin: 0 0 0.4rem;
+}
+
 .badge-subtle {
     font-size: 0.7rem;
     font-weight: 600;

--- a/apps/docs/src/styles/doc-prose.css
+++ b/apps/docs/src/styles/doc-prose.css
@@ -161,6 +161,13 @@ pre code {
     color: var(--doc-text);
 }
 
+.doc-callout-alert {
+    --ar-alert-bg: var(--doc-accent-bg);
+    --ar-alert-border: var(--doc-accent-border);
+    --ar-alert-icon: var(--doc-accent);
+    --ar-alert-color: var(--doc-text);
+}
+
 .badge-subtle {
     font-size: 0.7rem;
     font-weight: 600;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,8 @@
     "./cdn.prod": "./cdn/index.prod.js",
     "./cdn/autoloader": "./cdn/autoloader.js",
     "./cdn/autoloader.prod": "./cdn/autoloader.prod.js",
-    "./themes/*": "./dist/styles/themes/*.css",
+    "./themes/*.css": "./dist/styles/themes/*.css",
+    "./themes/*.js": "./dist/styles/themes/*.js",
     "./custom-elements.json": "./dist/custom-elements.json",
     "./dist/*": "./dist/*"
   },

--- a/packages/core/scripts/build-css.js
+++ b/packages/core/scripts/build-css.js
@@ -5,13 +5,21 @@
  * Traite les fichiers CSS globaux (thèmes, utilities) :
  * - Minifie via esbuild
  * - Copie vers dist/styles/ avec les fichiers originaux non-minifiés
+ * - Pour les fichiers sous src/styles/themes/, génère en plus un module JS
+ *   jumeau (<nom>.js) exportant un CSSStyleSheet déjà peuplé avec la partie
+ *   "composants" du thème (règles ::part()), pour adoption via
+ *   shadowRoot.adoptedStyleSheets dans un shadow DOM applicatif (#170).
+ *   La partie tokens (:root) est volontairement exclue : :root ne matche
+ *   rien dans un shadow root adopté (il désigne toujours l'élément racine du
+ *   document), l'inclure serait du poids mort. Les tokens traversent déjà la
+ *   frontière shadow DOM par héritage CSS, sans action requise.
  *
  * Les styles des composants (button.styles.ts) ne passent PAS ici :
  * ils sont du TypeScript traité par build-bundles.js.
  */
 
 import esbuild from 'esbuild';
-import { readdirSync, mkdirSync, existsSync } from 'fs';
+import { readdirSync, mkdirSync, existsSync, readFileSync, writeFileSync } from 'fs';
 import { join, dirname, relative, extname } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -19,7 +27,14 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
 const CSS_SRC = join(ROOT, 'src', 'styles');
 const CSS_OUT = join(ROOT, 'dist', 'styles');
+const THEMES_SRC = join(CSS_SRC, 'themes');
 const WATCH = process.argv.includes('--watch');
+
+// Marqueur de split entre la partie tokens (:root) et la partie composants
+// (::part()) d'un fichier de thème. Distinct du titre de section décoratif
+// juste après (ex. "THÈME COMPOSANTS") : ce marqueur est le seul repère
+// fiable pour ce script, il ne doit pas être renommé.
+const SPLIT_ANCHOR = 'build-split-anchor: components';
 
 /**
  * Scan récursif pour trouver tous les fichiers CSS.
@@ -38,6 +53,92 @@ function findCssFiles(dir) {
         }
     }
     return results;
+}
+
+/**
+ * Convertit un nom de fichier kebab-case en camelCase.
+ * @param {string} str
+ * @returns {string}
+ */
+function toCamelCase(str) {
+    return str.replace(/[-_]+([a-zA-Z0-9])/g, (_, char) => char.toUpperCase());
+}
+
+/**
+ * Pour chaque fichier de thème sous src/styles/themes/, génère un module JS
+ * jumeau exportant un CSSStyleSheet peuplé avec la partie "composants" du
+ * thème (tout ce qui suit SPLIT_ANCHOR dans le fichier source).
+ * @returns {Promise<void>}
+ */
+async function generateThemeJsExports() {
+    const themeFiles = findCssFiles(THEMES_SRC);
+
+    for (const file of themeFiles) {
+        const source = readFileSync(file, 'utf8');
+        const anchorIndex = source.indexOf(SPLIT_ANCHOR);
+
+        if (anchorIndex === -1) {
+            throw new Error(
+                `[build-css] Ancre "${SPLIT_ANCHOR}" introuvable dans ` +
+                    `${relative(ROOT, file)} — requise pour générer l'export ` +
+                    'CSSStyleSheet du thème (voir scripts/build-css.js).',
+            );
+        }
+
+        // L'ancre se trouve à l'intérieur d'un commentaire CSS.
+        // Trouver la fermeture */ pour extraire uniquement le CSS des composants.
+        const searchStart = anchorIndex + SPLIT_ANCHOR.length;
+        const commentEndIndex = source.indexOf('*/', searchStart);
+
+        if (commentEndIndex === -1) {
+            throw new Error(
+                `[build-css] Commentaire d'ancre non fermé dans ` +
+                    `${relative(ROOT, file)} — le commentaire contenant ` +
+                    `"${SPLIT_ANCHOR}" doit être fermé par */ (voir scripts/build-css.js).`,
+            );
+        }
+
+        // Extraire le CSS après la fermeture du commentaire
+        let componentsSource = source.slice(commentEndIndex + 2);
+
+        // Le CSS des composants est enrobé dans une @layer, qui se ferme par une }
+        // à la fin du fichier. Quand on extrait juste les composants, cette }
+        // orpheline cause une erreur de syntaxe. La retirer.
+        componentsSource = componentsSource.trimEnd();
+        if (componentsSource.endsWith('}')) {
+            componentsSource = componentsSource.slice(0, -1).trimEnd();
+        }
+
+        const { code: minified, warnings } = await esbuild.transform(componentsSource, {
+            loader: 'css',
+            minify: true,
+        });
+
+        // Vérifier qu'il n'y a pas de warnings de syntaxe CSS
+        if (warnings.length > 0) {
+            const warningMessages = warnings
+                .map(
+                    (w) =>
+                        `  - ${w.text} (${w.location ? `ligne ${w.location.line}` : 'position inconnue'})`,
+                )
+                .join('\n');
+            throw new Error(
+                `[build-css] Warnings de transformation CSS dans ` +
+                    `${relative(ROOT, file)}:\n${warningMessages}\n` +
+                    'Voir scripts/build-css.js pour les détails.',
+            );
+        }
+
+        const basename = relative(THEMES_SRC, file).replace(/\.css$/, '');
+        const exportName = `${toCamelCase(basename)}Theme`;
+        const jsContent =
+            `export const ${exportName} = new CSSStyleSheet();\n` +
+            `${exportName}.replaceSync(${JSON.stringify(minified)});\n`;
+
+        const outDir = join(CSS_OUT, 'themes');
+        mkdirSync(outDir, { recursive: true });
+        writeFileSync(join(outDir, `${basename}.js`), jsContent);
+    }
 }
 
 const cssFiles = findCssFiles(CSS_SRC);
@@ -67,9 +168,15 @@ const ctx = await esbuild.context({
 
 if (WATCH) {
     await ctx.watch();
+    // Génération initiale seulement : un fichier thème modifié en watch ne
+    // régénère pas automatiquement son .js jumeau. Limitation acceptée —
+    // npm run build (utilisé pour vérifier un changement réel) régénère
+    // toujours tout depuis zéro.
+    await generateThemeJsExports();
     console.log('[css] watching...');
 } else {
     await ctx.rebuild();
+    await generateThemeJsExports();
     await ctx.dispose();
     console.log(`✓ CSS: ${cssFiles.length} file(s) → dist/styles/`);
 }

--- a/packages/core/scripts/build-css.js
+++ b/packages/core/scripts/build-css.js
@@ -98,16 +98,16 @@ async function generateThemeJsExports() {
             );
         }
 
-        // Extraire le CSS après la fermeture du commentaire
-        let componentsSource = source.slice(commentEndIndex + 2);
-
-        // Le CSS des composants est enrobé dans une @layer, qui se ferme par une }
-        // à la fin du fichier. Quand on extrait juste les composants, cette }
-        // orpheline cause une erreur de syntaxe. La retirer.
-        componentsSource = componentsSource.trimEnd();
-        if (componentsSource.endsWith('}')) {
-            componentsSource = componentsSource.slice(0, -1).trimEnd();
-        }
+        // Extraire le CSS après la fermeture du commentaire. Dans le fichier
+        // source, ce CSS est enrobé dans une @layer ariane.theme { ... } dont
+        // l'ouverture précède l'ancre et dont la fermeture } se trouve en fin
+        // de fichier. On la ré-enrobe dans une @layer fraîche et complète
+        // (plutôt que de retirer la } de fermeture d'origine) pour préserver
+        // le layering : sans lui, les règles ::part() de default.js seraient
+        // non-layered alors qu'elles le sont dans default.css, cassant
+        // l'équivalence de cascade entre les deux méthodes de chargement
+        // documentées (<link> vs adoptedStyleSheets — cf. #170).
+        const componentsSource = `@layer ariane.theme {\n${source.slice(commentEndIndex + 2)}`;
 
         const { code: minified, warnings } = await esbuild.transform(componentsSource, {
             loader: 'css',


### PR DESCRIPTION
## Résumé

- Nouvel export `@ariane-ui/core/themes/default.js` (`defaultTheme`, `CSSStyleSheet` déjà peuplé) pour adoption via `shadowRoot.adoptedStyleSheets` dans un shadow DOM applicatif.
- Ne contient que la partie "composants" du thème (règles `::part()` et sélecteurs de type comme `ar-datepicker { ... }`), toujours enveloppée dans `@layer ariane.theme` — pas les tokens (`:root` ne matche rien dans un shadow root adopté, et les tokens héritent déjà sans action requise).
- Corrige au passage un bug préexistant dans l'export npm `themes/*` (double suffixe `.css.css` sous résolution Node stricte).
- Nouvelle page de doc `/getting-started/shadow-dom` expliquant le pourquoi et les deux méthodes de chargement (`<link>` classique vs `adoptedStyleSheets`), avec rappel que le thème reste requis au niveau document pour les tokens.

Closes #170 (à la release sur `main` — label `status:en-attente-release` à poser après merge, cf. convention du projet).

## Test plan

- [x] `npm run build` (monorepo complet)
- [x] `npm run test` (882 core + 59 docs, tous passants)
- [x] `npm run lint` (0 erreur, 0 warning)
- [x] Vérification manuelle de la résolution du chemin d'export npm (`require.resolve`)
- [x] Vérification manuelle du chemin d'échec explicite (ancre de split manquante)
- [x] Revue subagent-driven-development complète : 3 tasks + revue finale whole-branch (1 correctif Critical en cours de route sur Task 2, 3 correctifs Important en revue finale — tous vérifiés et corrigés)

🤖 Generated with [Claude Code](https://claude.com/claude-code)