### PR TITLE
fix: raccourci unpkg cassé + minification CSS/HTML CDN prod (#177)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Ne charge chaque composant que lorsqu'il est utilisé dans la page. Aucun outil 
 
 ```html
 <script type="module" src="https://unpkg.com/@ariane-ui/core/cdn/autoloader.prod.js"></script>
-<link rel="stylesheet" href="https://unpkg.com/@ariane-ui/core/themes/default.css" />
+<link rel="stylesheet" href="https://unpkg.com/@ariane-ui/core/dist/styles/themes/default.css" />
 ```
 
 > En développement local, remplacez `autoloader.prod.js` par `autoloader.js` pour obtenir des avertissements détaillés dans la console.
@@ -39,7 +39,7 @@ Charge tous les composants en une seule requête.
 
 ```html
 <script type="module" src="https://unpkg.com/@ariane-ui/core/cdn/index.prod.js"></script>
-<link rel="stylesheet" href="https://unpkg.com/@ariane-ui/core/themes/default.css" />
+<link rel="stylesheet" href="https://unpkg.com/@ariane-ui/core/dist/styles/themes/default.css" />
 ```
 
 ### Via npm _(avec bundler)_

--- a/apps/docs/src/pages/getting-started/quickstart.astro
+++ b/apps/docs/src/pages/getting-started/quickstart.astro
@@ -14,13 +14,13 @@ const tocEntries = [
 ];
 
 const codeAutoloader = `<script type="module" src="https://unpkg.com/@ariane-ui/core/cdn/autoloader.prod.js"></scr` + `ipt>
-<link rel="stylesheet" href="https://unpkg.com/@ariane-ui/core/themes/default.css" />`;
+<link rel="stylesheet" href="https://unpkg.com/@ariane-ui/core/dist/styles/themes/default.css" />`;
 
 const codeAutoloaderDev = `<script type="module" src="https://unpkg.com/@ariane-ui/core/cdn/autoloader.js"></scr` + `ipt>
-<link rel="stylesheet" href="https://unpkg.com/@ariane-ui/core/themes/default.css" />`;
+<link rel="stylesheet" href="https://unpkg.com/@ariane-ui/core/dist/styles/themes/default.css" />`;
 
 const codeBundle = `<script type="module" src="https://unpkg.com/@ariane-ui/core/cdn/index.prod.js"></scr` + `ipt>
-<link rel="stylesheet" href="https://unpkg.com/@ariane-ui/core/themes/default.css" />`;
+<link rel="stylesheet" href="https://unpkg.com/@ariane-ui/core/dist/styles/themes/default.css" />`;
 
 const codeUsage = `<ar-alert version="success">
   <span slot="title">Succès</span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1993,14 +1993,36 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -2013,7 +2035,7 @@
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -3164,6 +3186,16 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sveltejs/acorn-typescript": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.12.tgz",
+      "integrity": "sha512-J1jNYG23QWd67UfrQSFHtjhV37r9mVi0gdc12A3MWPldOjRK35Xk+um+qACPVjgw3AleiqoyEAhok8Wm3q46NA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8.9.0"
+      }
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
@@ -4742,9 +4774,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -5298,6 +5330,13 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -6428,8 +6467,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -8345,6 +8384,61 @@
       "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
       "license": "MIT"
     },
+    "node_modules/html-minifier-next": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/html-minifier-next/-/html-minifier-next-7.5.2.tgz",
+      "integrity": "sha512-6AKrQB7c35D9HNF5qDwipKfjVK5cT1N+RahIo36AuCsw8kGr68BVQhfvEIJB17pKejZltFPJp8MrbiI4E1TObw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^15.0.0",
+        "entities": "^8.0.0",
+        "lightningcss": "^1.33.0",
+        "svgo": "^4.0.2",
+        "terser": "^5.49.0"
+      },
+      "bin": {
+        "hmn": "cli.js",
+        "html-minifier-next": "cli.js"
+      },
+      "engines": {
+        "node": ">=22.13"
+      },
+      "funding": {
+        "url": "https://github.com/j9t/html-minifier-next?sponsor=1"
+      },
+      "peerDependencies": {
+        "@swc/core": "^1.15.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/html-minifier-next/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/html-minifier-next/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/html-void-elements": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
@@ -9247,6 +9341,268 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "devOptional": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -10931,6 +11287,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minify-literals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/minify-literals/-/minify-literals-2.1.0.tgz",
+      "integrity": "sha512-mW+XTP36dQVZd3n5pgohy94GQ+ZpfEUU+W8jsTVaNyfiEF5fknlIiikNTfsseXkaXwFoXdTUjcDszWrT2C7fHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sveltejs/acorn-typescript": "^1.0.10",
+        "acorn": "^8.17.0",
+        "html-minifier-next": "^7.0.0",
+        "lightningcss": "^1.32.0",
+        "magic-string": "^0.30.21"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/minimatch": {
@@ -12958,6 +13331,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/space-separated-tokens": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
@@ -13143,9 +13537,9 @@
       }
     },
     "node_modules/svgo": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
-      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+      "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",
@@ -13227,6 +13621,32 @@
       "dependencies": {
         "streamx": "^2.12.5"
       }
+    },
+    "node_modules/terser": {
+      "version": "5.50.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.50.0.tgz",
+      "integrity": "sha512-CN9BVxWhgS/hRxtUMjtC2uRWSTcSfQFHMDWma6sKKfIivCD91sM+FOPfvwoaRMqCSrUpe1nv3jDamd9eEQ4y+w==",
+      "devOptional": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/text-decoder": {
       "version": "1.2.7",
@@ -14812,6 +15232,7 @@
         "custom-element-vs-code-integration": "^1.5.0",
         "esbuild": "^0.28.0",
         "happy-dom": "^20.8.9",
+        "minify-literals": "^2.1.0",
         "sinon": "^22.0.0",
         "vitest": "^4.1.8"
       }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,6 +63,7 @@
     "custom-element-vs-code-integration": "^1.5.0",
     "esbuild": "^0.28.0",
     "happy-dom": "^20.8.9",
+    "minify-literals": "^2.1.0",
     "sinon": "^22.0.0",
     "vitest": "^4.1.8"
   },

--- a/packages/core/scripts/build-bundles.js
+++ b/packages/core/scripts/build-bundles.js
@@ -25,8 +25,10 @@
 
 import esbuild from 'esbuild';
 import { readdirSync, mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs';
+import { readFile } from 'fs/promises';
 import { join, relative, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { minifyHTMLLiterals } from 'minify-literals';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
@@ -84,6 +86,35 @@ const cdnEntryPoints = {
     index: join(SRC, 'index.ts'),
     autoloader: join(SRC, 'autoloader.ts'),
 };
+
+// ─── Plugin : minification des templates `html`/`css` (Lit) ──────────────────
+//
+// esbuild `minify: true` minifie la syntaxe JS mais ne touche pas au contenu
+// des template literals — un composant expédie donc son CSS (`css\`...\``)
+// et son markup (`html\`...\``) tels qu'écrits en source (indentation,
+// commentaires) même dans un bundle CDN "prod". `minify-literals` fait ce
+// travail correctement : parsing du TS via acorn (gère les décorateurs Lit),
+// minification CSS via lightningcss, HTML via html-minifier-next, et surtout
+// une minification partielle correcte autour des interpolations `${...}`
+// (quasi systématiques dans les `html\`\`` de Lit pour les bindings
+// d'événements/attributs) — un scan naïf de template literal les ignorerait
+// presque tous.
+function minifyLitTemplatesPlugin() {
+    return {
+        name: 'minify-lit-templates',
+        setup(build) {
+            build.onLoad({ filter: /\.ts$/ }, async (args) => {
+                const source = await readFile(args.path, 'utf8');
+                if (!source.includes('html`') && !source.includes('css`')) return null;
+
+                const result = await minifyHTMLLiterals(source, { fileName: args.path });
+                if (!result) return null;
+
+                return { contents: result.code, loader: 'ts' };
+            });
+        },
+    };
+}
 
 // ─── Options communes ─────────────────────────────────────────────────────────
 
@@ -194,6 +225,7 @@ async function buildCdnProd() {
         chunkNames: 'chunks/[name]-[hash]',
         define: { __DEV__: 'false' },
         metafile: true,
+        plugins: [minifyLitTemplatesPlugin()],
     };
 
     const result = await esbuild.build(options);


### PR DESCRIPTION
## Résumé

Traite les deux points de #177 :

### 1. Raccourci unpkg cassé (`themes/default.css`)

`unpkg.com/@ariane-ui/core/themes/default.css` retourne 404 en pratique : unpkg ne résout pas les alias `exports` wildcard (`"./themes/*.css": "./dist/styles/themes/*.css"`), il ne sert que les chemins réels du tarball publié. Corrige les usages existants dans `quickstart.astro` (3 occurrences) et `README.md` (2 occurrences) en pointant vers le chemin réel `dist/styles/themes/default.css`. `shadow-dom.astro` utilisait déjà le chemin réel (corrigé via #170).

### 2. CSS et HTML non minifiés dans le bundle CDN prod

`esbuild minify: true` ne minifie pas le contenu des template literals — chaque composant expédiait son CSS (`css\`\``) **et son markup** (`html\`\``, hors scope initial de l'issue mais même cause racine) non compressés dans `cdn/*.prod.js`.

Ajoute un plugin esbuild basé sur [`minify-literals`](https://www.npmjs.com/package/minify-literals) (lightningcss pour le CSS, html-minifier-next pour le HTML, parsing TS via acorn qui gère les décorateurs Lit) appliqué uniquement au build CDN prod — `dist/` (npm, re-minifié par le bundler consommateur) et `cdn/*.js` (dev) restent inchangés.

**~16% de réduction** sur `cdn/*.prod.js` (198 371 → 165 973 octets).

Reste hors scope de cette PR : l'audit général des fichiers publiés demandé dans #177 (troisième volet, plus large).

## Test plan

- [x] `npm run test` — 882 + 59 tests passent
- [x] `npx prettier --check` / `eslint` clean sur les fichiers modifiés
- [x] Vérifié empiriquement que `dist/styles/themes/default.css` existe dans le build
- [x] Comparé npm audit avant/après ajout de `minify-literals` — 8 vulnérabilités préexistantes, aucune régression introduite
- [x] Smoke test Playwright/Chromium réel sur le bundle CDN prod local : `ar-alert` (rendu shadow DOM), `ar-tooltip` (hover + showDelay, popover-open), `ar-dialog` (`open` → `showModal()` natif) — tous fonctionnels avec le CSS/HTML minifiés, aucune erreur console

🤖 Generated with [Claude Code](https://claude.com/claude-code)