### PR TITLE
feat(dialog): personnalisation du header (header-actions, without-header)

### DIFF
--- a/apps/docs/src/components/Playground.astro
+++ b/apps/docs/src/components/Playground.astro
@@ -519,7 +519,7 @@ const showPlayground = displayMode === 'demo';
      * (ar-pagination, ResizeObserver) se retrouve donc contraint à la largeur de son
      * contenu au lieu de la largeur réelle du preview.
      */
-    .preview :global(ar-pagination) {
+    .preview > :global(ar-pagination) {
         flex: 1 1 100%;
     }
 </style>

--- a/apps/docs/src/content/components/ar-dialog.mdx
+++ b/apps/docs/src/content/components/ar-dialog.mdx
@@ -57,7 +57,7 @@ variants:
           </ar-dialog>
     - name: without-header
       label: Sans header
-      description: 'without-header retire titre, actions et bouton de fermeture — label reste requis pour le nom accessible (aria-label). Prévoir un moyen de fermeture (ici close-on-backdrop).'
+      description: without-header retire titre, actions et bouton de fermeture — label reste requis pour le nom accessible (aria-label). Prévoir un moyen de fermeture (ici close-on-backdrop).
       html: |
           <button class="btn btn-primary" data-ar-dialog-open="demo-without-header">Ouvrir</button>
           <ar-dialog id="demo-without-header" label="Aperçu image" without-header close-on-backdrop>
@@ -112,7 +112,7 @@ import WcagRef from '../../components/WcagRef.astro';
 
 - Élément `<dialog>` natif avec `role="dialog"`, `aria-labelledby`, `aria-describedby` et `aria-modal`.
 - Quand `without-header` est actif, `aria-label` (basé sur `label`) remplace `aria-labelledby` — le nom accessible reste garanti même sans header visible.
-- Le focus est déplacé à l'ouverture sur l'élément portant `autofocus`, ou à défaut sur le premier élément focalisable, ou sur le bouton de fermeture si aucun n'est présent — conforme
+- Le focus est déplacé à l'ouverture sur l'élément portant `autofocus`, ou à défaut sur le premier élément focalisable, ou sur le bouton de fermeture si aucun n'est présent, ou sur le `<dialog>` lui-même si le header est absent — conforme
     <WcagRef
         criterion="2.1.2"
         summary="No Keyboard Trap : le focus clavier peut toujours quitter un composant via les touches standard (Escape, Tab)."
@@ -175,6 +175,14 @@ ar-dialog::part(title) {
     overflow: hidden;
     clip: rect(0, 0, 0, 0);
     white-space: nowrap;
+}
+```
+
+Cette technique sort le titre du flux (`position: absolute`), ce qui rompt le `margin-inline-end: auto` utilisé par le composant pour aligner `header-actions` et le bouton de fermeture en fin de header. Complétez avec `justify-content` sur `::part(header)` pour conserver cet alignement :
+
+```css
+ar-dialog::part(header) {
+    justify-content: flex-end;
 }
 ```
 

--- a/apps/docs/src/content/components/ar-dialog.mdx
+++ b/apps/docs/src/content/components/ar-dialog.mdx
@@ -165,6 +165,14 @@ Le slot `header-actions` place des actions additionnelles entre le titre et le b
 </ar-dialog>
 ```
 
+Le conteneur des actions expose son propre `::part(header-actions)`, indépendant du layout titre/fermeture — utile pour définir un espacement entre plusieurs actions sans affecter le reste du header :
+
+```css
+ar-dialog::part(header-actions) {
+    gap: 0.5rem;
+}
+```
+
 Pour masquer visuellement le titre sans casser le nom accessible du dialog, masquez `::part(title)` avec la technique sr-only standard — pas `display: none` ni `visibility: hidden`, qui peuvent faire perdre le nom accessible calculé via `aria-labelledby` dans certains navigateurs :
 
 ```css

--- a/apps/docs/src/content/components/ar-dialog.mdx
+++ b/apps/docs/src/content/components/ar-dialog.mdx
@@ -194,6 +194,52 @@ ar-dialog::part(header) {
 }
 ```
 
+**Layout avancé dans `header-actions`.** Le slot n'est pas limité à des boutons isolés — un seul
+enfant slotté peut lui-même être un conteneur avec son propre layout interne. Exemple : un drawer
+affichant le détail d'une offre d'emploi parmi une liste de résultats, avec un titre sr-only (masqué
+via la technique `::part(title)` ci-dessus, complété par un `<h2>` visible dans le contenu), un
+groupe d'actions plaqué à gauche et une pagination pour naviguer entre les résultats sans fermer le
+drawer :
+
+```html
+<ar-dialog id="job-detail" label="Détail de l'offre n°1234" mode="drawer">
+    <div
+        slot="header-actions"
+        style="display:flex; justify-content:space-between; align-items:center; width:100%;"
+    >
+        <div class="actions">
+            <button data-ar-dismiss>Marquer comme lu</button>
+            <button>Postuler</button>
+        </div>
+        <nav class="pagination" aria-label="Résultats">
+            <button aria-label="Offre précédente">‹</button>
+            <span>3 / 50</span>
+            <button aria-label="Offre suivante">›</button>
+        </nav>
+    </div>
+    <h2>Développeur·se Frontend Senior</h2>
+    <p>Description de l'offre…</p>
+</ar-dialog>
+```
+
+```css
+#job-detail::part(title) {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+}
+```
+
+Le `width: 100%` posé par le consommateur sur son propre conteneur suffit à occuper tout l'espace
+disponible dans `::part(header-actions)` — pas besoin de `flex` supplémentaire côté thème. Le
+`justify-content: space-between` interne (light DOM, entièrement sous contrôle du consommateur)
+répartit ensuite actions et pagination. Notez qu'ici `::part(header) { justify-content: flex-end }`
+n'est pas nécessaire : le conteneur d'actions occupant déjà toute la largeur disponible, il ne
+reste aucun espace à redistribuer.
+
 Pour retirer entièrement le header (titre, actions, bouton de fermeture), utilisez `without-header`. `label` devient alors requis, et un moyen de fermeture doit rester disponible (ici `close-on-backdrop`) :
 
 ```html

--- a/apps/docs/src/content/components/ar-dialog.mdx
+++ b/apps/docs/src/content/components/ar-dialog.mdx
@@ -46,6 +46,23 @@ variants:
               <button class="btn btn-secondary" slot="footer" data-ar-dismiss>Annuler</button>
               <button class="btn btn-danger" slot="footer" data-ar-accept>Supprimer</button>
           </ar-dialog>
+    - name: header-actions
+      label: Actions dans le header
+      description: Le slot header-actions place des actions additionnelles avant le bouton de fermeture (ex. bouton plein écran).
+      html: |
+          <button class="btn btn-primary" data-ar-dialog-open="demo-header-actions">Ouvrir</button>
+          <ar-dialog id="demo-header-actions" label="Rapport mensuel">
+              <button slot="header-actions" aria-label="Plein écran" style="width:2rem;height:2rem;border:none;background:transparent;cursor:pointer;font-size:1rem;">⤢</button>
+              <p>Contenu du dialog, avec une action additionnelle dans le header.</p>
+          </ar-dialog>
+    - name: without-header
+      label: Sans header
+      description: 'without-header retire titre, actions et bouton de fermeture — label reste requis pour le nom accessible (aria-label). Prévoir un moyen de fermeture (ici close-on-backdrop).'
+      html: |
+          <button class="btn btn-primary" data-ar-dialog-open="demo-without-header">Ouvrir</button>
+          <ar-dialog id="demo-without-header" label="Aperçu image" without-header close-on-backdrop>
+              <img src="https://placehold.co/480x270" alt="Aperçu" style="display:block;width:100%;" />
+          </ar-dialog>
     - name: autofocus
       label: Focus initial
       description: Posez `autofocus` sur l'élément qui doit recevoir le focus à l'ouverture — ici un champ de recherche dans un drawer.
@@ -94,6 +111,7 @@ import WcagRef from '../../components/WcagRef.astro';
 ### Pris en charge automatiquement
 
 - Élément `<dialog>` natif avec `role="dialog"`, `aria-labelledby`, `aria-describedby` et `aria-modal`.
+- Quand `without-header` est actif, `aria-label` (basé sur `label`) remplace `aria-labelledby` — le nom accessible reste garanti même sans header visible.
 - Le focus est déplacé à l'ouverture sur l'élément portant `autofocus`, ou à défaut sur le premier élément focalisable, ou sur le bouton de fermeture si aucun n'est présent — conforme
     <WcagRef
         criterion="2.1.2"
@@ -112,6 +130,7 @@ import WcagRef from '../../components/WcagRef.astro';
 ### À votre charge
 
 - **Fournir un `label` descriptif.** Un fallback `Dialogue` existe, mais il doit rester un filet de sécurité, pas le libellé final du composant. Un avertissement est émis dans la console si ni `label` ni `slot="label"` ne sont fournis.
+- **`without-header` retire le bouton de fermeture.** `label` devient requis (le slot `label` HTML est sans effet dans ce mode), et un moyen de fermeture doit rester accessible — `close-on-backdrop`, ou une action `data-ar-dismiss`/`data-ar-accept` dans votre contenu. Un avertissement est émis en développement si aucun n'est détecté (Échap reste toujours disponible).
 - **Toujours proposer une issue claire.** Le backdrop est statique par défaut : prévoir un bouton de fermeture visible ou une action `data-ar-dismiss`.
 - **Si vous bloquez la fermeture, renseigner `prevented-message`.** Le message doit expliquer quoi faire pour continuer ou confirmer l'action.
 - **Piloter le focus initial si nécessaire.** Posez `autofocus` sur l'élément qui doit recevoir le focus à l'ouverture — utile par exemple pour un champ de saisie dans un drawer.
@@ -132,6 +151,38 @@ Plutôt que de piloter `open` en JavaScript, un élément cliquable peut ouvrir 
         <button data-ar-dismiss>Annuler</button>
         <button data-ar-accept>Confirmer</button>
     </div>
+</ar-dialog>
+```
+
+### Personnaliser le header
+
+Le slot `header-actions` place des actions additionnelles entre le titre et le bouton de fermeture :
+
+```html
+<ar-dialog label="Rapport mensuel">
+    <button slot="header-actions" aria-label="Plein écran">⤢</button>
+    <p>Contenu du dialog.</p>
+</ar-dialog>
+```
+
+Pour masquer visuellement le titre sans casser le nom accessible du dialog, masquez `::part(title)` avec la technique sr-only standard — pas `display: none` ni `visibility: hidden`, qui peuvent faire perdre le nom accessible calculé via `aria-labelledby` dans certains navigateurs :
+
+```css
+ar-dialog::part(title) {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+}
+```
+
+Pour retirer entièrement le header (titre, actions, bouton de fermeture), utilisez `without-header`. `label` devient alors requis, et un moyen de fermeture doit rester disponible (ici `close-on-backdrop`) :
+
+```html
+<ar-dialog label="Aperçu image" without-header close-on-backdrop>
+    <img src="/apercu.jpg" alt="Aperçu" />
 </ar-dialog>
 ```
 

--- a/apps/docs/src/content/components/ar-dialog.mdx
+++ b/apps/docs/src/content/components/ar-dialog.mdx
@@ -55,6 +55,43 @@ variants:
               <button slot="header-actions" aria-label="Plein écran" style="width:2rem;height:2rem;border:none;background:transparent;cursor:pointer;font-size:1rem;">⤢</button>
               <p>Contenu du dialog, avec une action additionnelle dans le header.</p>
           </ar-dialog>
+    - name: header-actions-advanced
+      label: Actions + pagination dans le header
+      description: Un seul enfant slotté dans header-actions peut porter son propre layout — ici des actions à gauche et une pagination compacte à droite, titre du drawer masqué visuellement (sr-only) au profit d'un titre visible dans le contenu.
+      html: |
+          <style>
+              .demo-job-detail::part(title) {
+                  position: absolute;
+                  width: 1px;
+                  height: 1px;
+                  overflow: hidden;
+                  clip: rect(0, 0, 0, 0);
+                  white-space: nowrap;
+              }
+              .demo-job-actions {
+                  display: flex;
+                  justify-content: space-between;
+                  align-items: center;
+                  width: 100%;
+                  gap: 0.5rem;
+              }
+              .demo-job-actions .actions {
+                  display: flex;
+                  gap: 0.5rem;
+              }
+          </style>
+          <button class="btn btn-primary" data-ar-dialog-open="demo-job-detail">Voir une offre</button>
+          <ar-dialog id="demo-job-detail" class="demo-job-detail" label="Détail de l'offre n°1234" mode="drawer">
+              <div slot="header-actions" class="demo-job-actions">
+                  <div class="actions">
+                      <button class="btn btn-primary">Postuler</button>
+                      <button aria-label="Partager le lien" style="width:2rem;height:2rem;border:none;background:transparent;cursor:pointer;font-size:1rem;">🔗</button>
+                  </div>
+                  <ar-pagination current="3" total="50"></ar-pagination>
+              </div>
+              <h2>Développeur·se Frontend Senior</h2>
+              <p>Description de l'offre…</p>
+          </ar-dialog>
     - name: without-header
       label: Sans header
       description: without-header retire titre, actions et bouton de fermeture — label reste requis pour le nom accessible (aria-label). Prévoir un moyen de fermeture (ici close-on-backdrop).
@@ -194,51 +231,9 @@ ar-dialog::part(header) {
 }
 ```
 
-**Layout avancé dans `header-actions`.** Le slot n'est pas limité à des boutons isolés — un seul
-enfant slotté peut lui-même être un conteneur avec son propre layout interne. Exemple : un drawer
-affichant le détail d'une offre d'emploi parmi une liste de résultats, avec un titre sr-only (masqué
-via la technique `::part(title)` ci-dessus, complété par un `<h2>` visible dans le contenu), un
-groupe d'actions plaqué à gauche et une pagination pour naviguer entre les résultats sans fermer le
-drawer :
-
-```html
-<ar-dialog id="job-detail" label="Détail de l'offre n°1234" mode="drawer">
-    <div
-        slot="header-actions"
-        style="display:flex; justify-content:space-between; align-items:center; width:100%;"
-    >
-        <div class="actions">
-            <button data-ar-dismiss>Marquer comme lu</button>
-            <button>Postuler</button>
-        </div>
-        <nav class="pagination" aria-label="Résultats">
-            <button aria-label="Offre précédente">‹</button>
-            <span>3 / 50</span>
-            <button aria-label="Offre suivante">›</button>
-        </nav>
-    </div>
-    <h2>Développeur·se Frontend Senior</h2>
-    <p>Description de l'offre…</p>
-</ar-dialog>
-```
-
-```css
-#job-detail::part(title) {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-}
-```
-
-Le `width: 100%` posé par le consommateur sur son propre conteneur suffit à occuper tout l'espace
-disponible dans `::part(header-actions)` — pas besoin de `flex` supplémentaire côté thème. Le
-`justify-content: space-between` interne (light DOM, entièrement sous contrôle du consommateur)
-répartit ensuite actions et pagination. Notez qu'ici `::part(header) { justify-content: flex-end }`
-n'est pas nécessaire : le conteneur d'actions occupant déjà toute la largeur disponible, il ne
-reste aucun espace à redistribuer.
+Le slot n'est pas limité à des boutons isolés — un seul enfant slotté peut lui-même porter son
+propre layout interne (actions à gauche, pagination à droite, titre sr-only…). Voir l'exemple
+« Actions + pagination dans le header » ci-dessus pour une démonstration complète.
 
 Pour retirer entièrement le header (titre, actions, bouton de fermeture), utilisez `without-header`. `label` devient alors requis, et un moyen de fermeture doit rester disponible (ici `close-on-backdrop`) :
 

--- a/apps/docs/src/content/components/ar-dialog.mdx
+++ b/apps/docs/src/content/components/ar-dialog.mdx
@@ -77,7 +77,14 @@ variants:
               }
               .demo-job-actions .actions {
                   display: flex;
+                  align-items: center;
                   gap: 0.5rem;
+              }
+              .demo-job-actions ar-pagination {
+                  /* Garde la pagination en mode compact (select) : au-delà, l'espace laissé
+                     disponible par le layout de header-actions suffit à afficher la liste
+                     numérotée complète, pas souhaitable dans un header de drawer. */
+                  max-width: 230px;
               }
           </style>
           <button class="btn btn-primary" data-ar-dialog-open="demo-job-detail">Voir une offre</button>

--- a/apps/docs/src/content/components/ar-dialog.mdx
+++ b/apps/docs/src/content/components/ar-dialog.mdx
@@ -48,19 +48,32 @@ variants:
           </ar-dialog>
     - name: header-actions
       label: Actions dans le header
-      description: Le slot header-actions place des actions additionnelles avant le bouton de fermeture (ex. bouton plein écran).
+      description: Le slot header-actions permet d'ajouter des actions additionnelles avant le bouton de fermeture (ex. bouton plein écran).
       html: |
           <button class="btn btn-primary" data-ar-dialog-open="demo-header-actions">Ouvrir</button>
           <ar-dialog id="demo-header-actions" label="Rapport mensuel">
-              <button slot="header-actions" aria-label="Plein écran" style="width:2rem;height:2rem;border:none;background:transparent;cursor:pointer;font-size:1rem;">⤢</button>
-              <p>Contenu du dialog, avec une action additionnelle dans le header.</p>
+              <button class="btn btn-secondary" slot="header-actions" aria-label="Passer en plein écran" style="font-size: 1.5rem">⤢</button>
+              <p style="margin: 0">Contenu du dialog, avec une action additionnelle dans le header.</p>
           </ar-dialog>
     - name: header-actions-advanced
-      label: Actions + pagination dans le header
-      description: Un seul enfant slotté dans header-actions peut porter son propre layout — ici des actions à gauche et une pagination compacte à droite, titre du drawer masqué visuellement (sr-only) au profit d'un titre visible dans le contenu.
+      label: Header avancé
+      description: Un seul enfant slotté dans header-actions peut porter son propre layout — ici des actions à gauche et une pagination compacte à droite, titre du drawer masqué visuellement (sr-only) au profit d'un titre secondaire visible dans le contenu.
       html: |
+          <button class="btn btn-primary" data-ar-dialog-open="demo-header-advanced">Ouvrir le drawer</button>
+          <ar-dialog id="demo-header-advanced" class="demo-header-advanced" label="Titre accessible du volet" mode="drawer">
+              <div slot="header-actions" class="demo-header-advanced-actions">
+                  <div class="actions">
+                      <button class="btn btn-primary">Action 1</button>
+                      <button class="btn btn-secondary">Action 2</button>
+                  </div>
+                  <ar-pagination current="3" total="10"></ar-pagination>
+              </div>
+              <h2>Titre secondaire du volet</h2>
+              <p>Contenu du volet</p>
+          </ar-dialog>
           <style>
-              .demo-job-detail::part(title) {
+              /* Masquage accessible du titre */
+              .demo-header-advanced::part(title) {
                   position: absolute;
                   width: 1px;
                   height: 1px;
@@ -68,35 +81,23 @@ variants:
                   clip: rect(0, 0, 0, 0);
                   white-space: nowrap;
               }
-              .demo-job-actions {
+
+              /* Style minimal pour la layout de bloc d'actions */
+              .demo-header-advanced-actions {
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+                width: 100%;
+                gap: 0.5rem;
+
+                .actions {
                   display: flex;
-                  justify-content: space-between;
                   align-items: center;
-                  width: 100%;
-                  gap: 0.5rem;
-              }
-              .demo-job-actions .actions {
-                  display: flex;
-                  align-items: center;
-                  /* flex: 1 1 100% réclame l'espace en priorité sur la pagination (qui reste à
-                     sa taille de contenu par défaut) — garde ar-pagination en mode compact
-                     (select) sans dépendre d'une largeur en dur liée à son rendu interne. */
                   flex: 1 1 100%;
                   gap: 0.5rem;
+                }
               }
           </style>
-          <button class="btn btn-primary" data-ar-dialog-open="demo-job-detail">Voir une offre</button>
-          <ar-dialog id="demo-job-detail" class="demo-job-detail" label="Détail de l'offre n°1234" mode="drawer">
-              <div slot="header-actions" class="demo-job-actions">
-                  <div class="actions">
-                      <button class="btn btn-primary">Postuler</button>
-                      <button aria-label="Partager le lien" style="width:2rem;height:2rem;border:none;background:transparent;cursor:pointer;font-size:1rem;">🔗</button>
-                  </div>
-                  <ar-pagination current="3" total="50"></ar-pagination>
-              </div>
-              <h2>Développeur·se Frontend Senior</h2>
-              <p>Description de l'offre…</p>
-          </ar-dialog>
     - name: without-header
       label: Sans header
       description: without-header retire titre, actions et bouton de fermeture — label reste requis pour le nom accessible (aria-label). Prévoir un moyen de fermeture (ici close-on-backdrop).

--- a/apps/docs/src/content/components/ar-dialog.mdx
+++ b/apps/docs/src/content/components/ar-dialog.mdx
@@ -78,13 +78,11 @@ variants:
               .demo-job-actions .actions {
                   display: flex;
                   align-items: center;
+                  /* flex: 1 1 100% réclame l'espace en priorité sur la pagination (qui reste à
+                     sa taille de contenu par défaut) — garde ar-pagination en mode compact
+                     (select) sans dépendre d'une largeur en dur liée à son rendu interne. */
+                  flex: 1 1 100%;
                   gap: 0.5rem;
-              }
-              .demo-job-actions ar-pagination {
-                  /* Garde la pagination en mode compact (select) : au-delà, l'espace laissé
-                     disponible par le layout de header-actions suffit à afficher la liste
-                     numérotée complète, pas souhaitable dans un header de drawer. */
-                  max-width: 230px;
               }
           </style>
           <button class="btn btn-primary" data-ar-dialog-open="demo-job-detail">Voir une offre</button>

--- a/docs/superpowers/plans/2026-08-12-dialog-header-actions-wrapper-plan.md
+++ b/docs/superpowers/plans/2026-08-12-dialog-header-actions-wrapper-plan.md
@@ -1,0 +1,261 @@
+# ar-dialog : wrapper part="header-actions" — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Amender la PR #179 (encore ouverte, pas mergée) : entourer `<slot name="header-actions">` d'un wrapper `<div part="header-actions">` rendu conditionnellement, pour permettre au thème/consommateur de piloter `gap`/`flex-wrap` des actions indépendamment du layout titre/close — cf. amendement du 2026-08-12 dans `docs/superpowers/specs/2026-08-11-dialog-header-customization-design.md`.
+
+**Architecture:** Un seul fichier de logique (`dialog.ts`), un ajout CSS ciblé (`dialog.styles.ts`), extension des tests existants (`dialog.test.ts`), mise à jour doc (`ar-dialog.mdx`). Branche existante `feat/dialog-header-customization` (PR #179 déjà ouverte) — ce plan ajoute un commit à cette même branche, pas une nouvelle branche.
+
+**Tech Stack:** Lit 3, TypeScript, Vitest.
+
+## Global Constraints
+
+- Prettier : 100 caractères, 4 espaces, quotes simples.
+- Pattern de rendu conditionnel à répliquer : celui du `footer` existant (`dialog.ts:324-328`) —
+  `${this._slotController.test('X') ? html\`...\` : nothing}`.
+- `HasSlotController` (`packages/core/src/controllers/has-slot.controller.ts`) : le constructeur
+  prend une liste de noms de slots à surveiller (`new HasSlotController(this, 'footer', 'label')`,
+  `dialog.ts:195`) — ajouter `'header-actions'` à cette liste, ne pas créer un second controller.
+- Pas de nouveau token CSS (`--ar-*`) — le wrapper n'a pas de valeur de design imposée par défaut
+  (pas de `gap` par défaut, cohérent avec l'absence de gap sur `footer` aujourd'hui).
+- Branche : `feat/dialog-header-customization` (déjà checked out, ne pas créer de nouvelle branche).
+  PR existante : #179. Ce plan ajoute un commit à cette branche, poussé sur la même PR.
+
+---
+
+## File Structure
+
+- `packages/core/src/components/dialog/dialog.ts` — `_slotController` étend sa liste surveillée ;
+  `render()` enveloppe le slot `header-actions` dans un wrapper conditionnel ; JSDoc `@csspart
+header-actions`.
+- `packages/core/src/components/dialog/dialog.styles.ts` — nouvelle règle `[part='header-actions']`.
+- `packages/core/src/components/dialog/dialog.test.ts` — étend le describe `'slot header-actions'`
+  existant avec les tests de rendu conditionnel (absent/présent/disparition dynamique).
+- `apps/docs/src/content/components/ar-dialog.mdx` — note sur `::part(header-actions)` dans la
+  section "Personnaliser le header".
+
+---
+
+### Task 1 : wrapper `part="header-actions"` conditionnel
+
+**Files:**
+
+- Modify: `packages/core/src/components/dialog/dialog.ts:195` (liste `HasSlotController`),
+  `dialog.ts:50-64` (JSDoc), `dialog.ts:293-320` (`render()`)
+- Modify: `packages/core/src/components/dialog/dialog.styles.ts:124-135` (section Header)
+- Test: `packages/core/src/components/dialog/dialog.test.ts`
+- Modify: `apps/docs/src/content/components/ar-dialog.mdx`
+
+**Interfaces:**
+
+- Ne change aucune API publique existante (pas de nouvel attribut/propriété) — uniquement la
+  structure interne du DOM rendu (nouveau wrapper `part="header-actions"`) et son CSS associé.
+
+- [ ] **Step 1 : écrire les tests (échec attendu)**
+
+Le describe `'slot header-actions'` existe déjà dans `dialog.test.ts` (ajouté par une tâche
+précédente). Remplacer entièrement son contenu par :
+
+```ts
+describe('slot header-actions', () => {
+    it('le wrapper part="header-actions" est absent du DOM sans contenu assigné', async () => {
+        el = await fixture('<ar-dialog></ar-dialog>');
+        expect(getPart(el, 'header-actions')).toBeNull();
+    });
+
+    it('le wrapper part="header-actions" est présent si un enfant slot="header-actions" est fourni', async () => {
+        el = await fixture(`
+                <ar-dialog label="Titre">
+                    <button slot="header-actions">Action</button>
+                </ar-dialog>
+            `);
+        expect(getPart(el, 'header-actions')).not.toBeNull();
+    });
+
+    it('le wrapper disparaît dynamiquement si le slot="header-actions" est retiré', async () => {
+        el = await fixture(`
+                <ar-dialog label="Titre">
+                    <button slot="header-actions" id="a">Action</button>
+                </ar-dialog>
+            `);
+        expect(getPart(el, 'header-actions')).not.toBeNull();
+
+        (el.querySelector('#a') as Element).remove();
+        await waitForUpdate(el);
+
+        expect(getPart(el, 'header-actions')).toBeNull();
+    });
+
+    it('le slot header-actions est rendu dans le wrapper', async () => {
+        el = await fixture(`
+                <ar-dialog label="Titre">
+                    <button slot="header-actions">Action</button>
+                </ar-dialog>
+            `);
+        const wrapper = getPart(el, 'header-actions') as HTMLElement;
+        expect(wrapper.querySelector('slot[name="header-actions"]')).not.toBeNull();
+    });
+
+    it('le contenu slot="header-actions" est assigné', async () => {
+        el = await fixture(`
+                <ar-dialog label="Titre">
+                    <button slot="header-actions" id="action-btn">Plein écran</button>
+                </ar-dialog>
+            `);
+        const slotEl = requireShadow(el).querySelector<HTMLSlotElement>(
+            'slot[name="header-actions"]',
+        );
+        expect(slotEl).not.toBeNull();
+        const assigned = slotEl!.assignedElements();
+        expect(assigned).toHaveLength(1);
+        expect((assigned[0] as HTMLElement).id).toBe('action-btn');
+    });
+
+    it('le wrapper header-actions est positionné avant le bouton close', async () => {
+        el = await fixture(`
+                <ar-dialog label="Titre">
+                    <button slot="header-actions">Action</button>
+                </ar-dialog>
+            `);
+        const header = getPart(el, 'header') as HTMLElement;
+        const wrapper = getPart(el, 'header-actions');
+        const closeBtn = header.querySelector('[data-ar-dismiss]');
+        expect(wrapper).not.toBeNull();
+        expect(closeBtn).not.toBeNull();
+        const position = wrapper!.compareDocumentPosition(closeBtn!);
+        expect(Boolean(position & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
+    });
+
+    it('le wrapper header-actions est absent du DOM quand without-header est actif', async () => {
+        el = await fixture(`
+                <ar-dialog without-header label="Titre">
+                    <button slot="header-actions">Action</button>
+                </ar-dialog>
+            `);
+        expect(getPart(el, 'header-actions')).toBeNull();
+        expect(requireShadow(el).querySelector('slot[name="header-actions"]')).toBeNull();
+    });
+});
+```
+
+Cela remplace les anciens tests `'le slot header-actions est rendu dans le header'` et `'le slot
+header-actions est positionné avant le bouton close'` (qui vérifiaient l'ancien DOM sans wrapper)
+par les nouveaux ci-dessus. Chercher `describe('slot header-actions'` dans `dialog.test.ts` pour
+localiser le bloc à remplacer intégralement.
+
+- [ ] **Step 2 : vérifier que les tests échouent**
+
+Run: `cd packages/core && npx vitest run src/components/dialog/dialog.test.ts -t "header-actions"`
+Expected: FAIL — `getPart(el, 'header-actions')` retourne toujours `null` même avec du contenu
+slotté (pas encore de wrapper avec ce `part`), et le test "absent sans contenu" échoue aussi
+puisqu'aujourd'hui le `<slot>` est toujours rendu sans condition.
+
+- [ ] **Step 3 : étendre `_slotController`**
+
+Dans `dialog.ts:195`, remplacer :
+
+```ts
+    private readonly _slotController = new HasSlotController(this, 'footer', 'label');
+```
+
+par :
+
+```ts
+    private readonly _slotController = new HasSlotController(this, 'footer', 'label', 'header-actions');
+```
+
+- [ ] **Step 4 : envelopper le slot dans `render()`**
+
+Dans `dialog.ts`, remplacer la ligne (actuelle ligne 301) :
+
+```ts
+                          <slot name="header-actions"></slot>
+```
+
+par :
+
+```ts
+                          ${this._slotController.test('header-actions')
+                              ? html`<div part="header-actions">
+                                    <slot name="header-actions"></slot>
+                                </div>`
+                              : nothing}
+```
+
+- [ ] **Step 5 : ajouter le CSS du wrapper**
+
+Dans `dialog.styles.ts`, dans la section `/* ── Header ── */` (après le bloc `header { ... }` /
+`h1 { ... }`, avant `[part='close'] { ... }`), ajouter :
+
+```css
+[part='header-actions'] {
+    display: flex;
+    align-items: center;
+}
+```
+
+- [ ] **Step 6 : mettre à jour le JSDoc**
+
+Dans `dialog.ts`, remplacer la ligne `@csspart header` existante et ajouter une nouvelle ligne
+juste après (dans le bloc JSDoc de la classe, section `@csspart`) :
+
+```ts
+ * @csspart header - L'en-tête contenant le titre et le bouton de fermeture. Absent du DOM si `without-header` est actif.
+ * @csspart header-actions - Le conteneur des actions additionnelles du header (slot `header-actions`). Absent du DOM si le slot est vide ou si `without-header` est actif.
+```
+
+- [ ] **Step 7 : mettre à jour la doc Astro**
+
+Dans `apps/docs/src/content/components/ar-dialog.mdx`, section "Personnaliser le header", juste
+après le premier exemple de code (le snippet illustrant `header-actions`), ajouter un paragraphe :
+
+````md
+Le conteneur des actions expose son propre `::part(header-actions)`, indépendant du layout
+titre/fermeture — utile pour définir un espacement entre plusieurs actions sans affecter le reste
+du header :
+
+```css
+ar-dialog::part(header-actions) {
+    gap: 0.5rem;
+}
+```
+````
+
+````
+
+- [ ] **Step 8 : vérifier que les tests passent**
+
+Run: `cd packages/core && npx vitest run src/components/dialog/dialog.test.ts`
+Expected: PASS (ensemble du fichier).
+
+Run: `cd packages/core && npx web-test-runner 'src/components/dialog/dialog.a11y.test.ts' 'src/components/dialog/dialog.browser.test.ts'`
+Expected: PASS (aucune régression — ces fichiers ne testent pas directement `header-actions` mais
+partagent le même `render()`).
+
+- [ ] **Step 9 : prettier/eslint**
+
+Run: `npx prettier --check packages/core/src/components/dialog/dialog.ts packages/core/src/components/dialog/dialog.styles.ts packages/core/src/components/dialog/dialog.test.ts apps/docs/src/content/components/ar-dialog.mdx`
+Run: `npx eslint packages/core/src/components/dialog/dialog.ts`
+Expected: clean. `--write` puis re-vérifier si Prettier signale un écart.
+
+- [ ] **Step 10 : commit**
+
+```bash
+git add packages/core/src/components/dialog/dialog.ts packages/core/src/components/dialog/dialog.styles.ts packages/core/src/components/dialog/dialog.test.ts apps/docs/src/content/components/ar-dialog.mdx
+git commit -m "fix(dialog): wrapper part=\"header-actions\" pour un contrôle flex indépendant (#145)"
+````
+
+---
+
+## Self-Review
+
+**Couverture** : les 3 aspects de l'amendement (wrapper conditionnel, CSS indépendant, doc
+`::part(header-actions)`) sont couverts par les steps 1-7. Rendu conditionnel testé dans les 3 cas
+(absent/présent/disparition dynamique), cohérent avec le pattern `footer` déjà en place et déjà
+testé de la même façon ailleurs dans ce fichier.
+
+**Placeholders** : aucun — code exact fourni à chaque step.
+
+**Cohérence des noms** : `part="header-actions"` (wrapper) et `slot="header-actions"` (nom du
+slot, inchangé) sont deux concepts distincts qui partagent intentionnellement le même nom (décidé
+dans l'amendement du spec) — pas une incohérence, un choix assumé documenté.

--- a/docs/superpowers/specs/2026-08-11-dialog-header-customization-design.md
+++ b/docs/superpowers/specs/2026-08-11-dialog-header-customization-design.md
@@ -54,6 +54,26 @@ et le bouton close (donc juste avant lui dans l'ordre de tabulation). Alignement
 WebAwesome sur ce point précis (même nom de slot, même position) — ici la convergence est
 justifiée par un vrai besoin partagé, pas par mimétisme.
 
+**Amendement (2026-08-12, avant merge de la PR #179)** : décision initiale (pas de wrapper dédié,
+`<slot name="header-actions">` directement enfant flex de `header`) revue après revue manuelle de
+la PR. `<slot>` a `display: contents` par défaut (feuille de style UA du HTML Living Standard,
+vérifié empiriquement) — chaque nœud slotté devient donc un item flex indépendant de `header`,
+pas un groupe. Deux conséquences bloquantes pour le cas d'usage réel de #145 (actions dans un
+header de _drawer_, contexte mobile-first) :
+
+- Un `gap` posé sur `::part(header)` s'appliquerait uniformément entre tous les items (titre↔action,
+  action↔action, action↔close) — impossible d'espacer les actions entre elles sans aussi espacer
+  le titre et le close.
+- `flex-wrap` sur `header` ferait potentiellement passer le titre à la ligne en même temps que les
+  actions en cas de manque de place — pas isolable au groupe d'actions seul.
+
+**Nouvelle décision** : wrapper dédié `<div part="header-actions">` autour du `<slot
+name="header-actions">`, rendu conditionnellement (même pattern que le footer existant —
+`_slotController.test('header-actions')`, pas de boîte fantôme si le slot est vide). Le wrapper a
+son propre `display: flex` pour permettre un contrôle indépendant du `gap`/`flex-wrap` des actions,
+sans toucher au layout titre/close de `header`. `header-actions` (nom du slot) devient aussi le nom
+du `csspart` du wrapper — pas de collision, un seul concept exposé au consommateur.
+
 ### 2. Titre non visible (mais toujours nommé pour l'a11y)
 
 **Pas de nouvel attribut.** `part="title"` existe déjà sur le `h1` — le consommateur masque
@@ -136,21 +156,27 @@ enchaînement de `??` — quand `[data-ar-dismiss]` n'existe plus dans le shadow
 - Nouvelle propriété `@property({ reflect: true, type: Boolean, attribute: 'without-header' })
 withoutHeader = false;`.
 - `render()` : le bloc `<header>` devient conditionnel sur `!this.withoutHeader` (pattern miroir
-  du footer existant). Ajout du slot `header-actions` entre le titre et le bouton close, dans le
-  header. `aria-labelledby`/`aria-label` sur le `<dialog>` racine devient conditionnel sur
-  `this.withoutHeader`.
+  du footer existant). Ajout, entre le titre et le bouton close, d'un wrapper `<div
+part="header-actions">` contenant `<slot name="header-actions"></slot>`, rendu conditionnellement
+  sur `this._slotController.test('header-actions')` (même pattern que le footer — pas de boîte
+  vide si le slot n'a pas de contenu assigné). `aria-labelledby`/`aria-label` sur le `<dialog>`
+  racine devient conditionnel sur `this.withoutHeader`.
+- `_slotController` (`HasSlotController`) étend sa liste surveillée de `('footer', 'label')` à
+  `('footer', 'label', 'header-actions')`.
 - Nouvelle méthode privée `_warnIfNoCloseMechanism()` (ou extension de `_warnIfMissingLabel`),
   appelée depuis `updated()`, une seule fois (même pattern `_hasWarnedX` que l'existant).
 - Warning dev pour `slot="label"` fourni sans prop `label` en mode `without-header`.
-- JSDoc : nouveau `@slot header-actions`, nouveau `@csspart` si nécessaire (aucun a priori — pas
-  de wrapper dédié prévu pour `header-actions`, le slot s'insère directement dans `header`),
-  `@attr without-header` documenté avec la contrainte "label requis dans ce mode".
+- JSDoc : nouveau `@slot header-actions`, nouveau `@csspart header-actions` (le wrapper, absent du
+  DOM si le slot est vide ou si `without-header` est actif), `@attr without-header` documenté avec
+  la contrainte "label requis dans ce mode".
 
 **Styles** (`packages/core/src/components/dialog/dialog.styles.ts`) :
 
-- Positionnement du contenu du slot `header-actions` dans le `header` (`display: flex` déjà en
-  place sur `header` — le nouveau slot s'intègre dans le flow existant, entre le titre et
-  `[part='close']`).
+- `[part='header-actions']` : `display: flex; align-items: center;` — conteneur flex indépendant
+  pour permettre au thème de piloter `gap`/`flex-wrap` des actions sans affecter le layout
+  titre/close de `header`. Pas de valeur de `gap` imposée par défaut (cohérent avec l'absence de
+  gap sur `footer` aujourd'hui — le thème ou le consommateur reste libre de la définir via
+  `::part(header-actions)`).
 
 **Docs** (`apps/docs/src/content/components/ar-dialog.mdx`) :
 
@@ -165,7 +191,9 @@ withoutHeader = false;`.
 
 - `without-header` : header absent du DOM rendu, `aria-label` posé au lieu de `aria-labelledby`,
   slot `label` sans effet (warning émis si fourni sans prop `label`).
-- `header-actions` : slot rendu et positionné avant le bouton close.
+- `header-actions` : wrapper `part="header-actions"` absent du DOM sans contenu assigné, présent
+  et positionné avant le bouton close dès qu'un enfant `slot="header-actions"` est fourni,
+  disparaît dynamiquement si retiré (même trio de tests que le footer conditionnel existant).
 - Warning dev émis quand `without-header` + `closeOnBackdrop=false` + aucun élément
   dismiss/accept dans le contenu ; absent sinon (close-on-backdrop actif, ou élément dismiss
   présent).

--- a/packages/core/src/components/dialog/dialog.a11y.test.ts
+++ b/packages/core/src/components/dialog/dialog.a11y.test.ts
@@ -90,4 +90,24 @@ describe('ar-dialog — accessibilité', () => {
         expect(dialogEl.getAttribute('role')).to.equal('dialog');
         expect(dialogEl.getAttribute('aria-modal')).to.equal('true');
     });
+
+    it('sans without-header, aria-labelledby est utilisé (pas aria-label)', () => {
+        const dialogEl = requireDialog(el);
+        expect(dialogEl.hasAttribute('aria-labelledby')).to.equal(true);
+        expect(dialogEl.hasAttribute('aria-label')).to.equal(false);
+    });
+
+    it('avec without-header, aria-label remplace aria-labelledby', async () => {
+        el.remove();
+        el = await fixture(html`<ar-dialog without-header label="Titre sans header"></ar-dialog>`);
+        const dialogEl = requireDialog(el);
+        expect(dialogEl.hasAttribute('aria-labelledby')).to.equal(false);
+        expect(dialogEl.getAttribute('aria-label')).to.equal('Titre sans header');
+    });
+
+    it('avec without-header, le header est absent du DOM', async () => {
+        el.remove();
+        el = await fixture(html`<ar-dialog without-header label="Titre"></ar-dialog>`);
+        expect(requireShadow(el).querySelector('header')).to.equal(null);
+    });
 });

--- a/packages/core/src/components/dialog/dialog.browser.test.ts
+++ b/packages/core/src/components/dialog/dialog.browser.test.ts
@@ -160,5 +160,18 @@ describe('ar-dialog — browser', () => {
             expect(document.activeElement).to.equal(trigger);
             trigger.remove();
         });
+
+        it('sans header (without-header) et sans contenu focalisable, le focus retombe sur le <dialog>', async () => {
+            el = await fixture(html`
+                <ar-dialog without-header label="Sans header">
+                    <p>Contenu non interactif.</p>
+                </ar-dialog>
+            `);
+            el.open = true;
+            await aTimeout(50);
+
+            const dialogEl = getDialogEl(el);
+            expect(el.shadowRoot?.activeElement).to.equal(dialogEl);
+        });
     });
 });

--- a/packages/core/src/components/dialog/dialog.browser.test.ts
+++ b/packages/core/src/components/dialog/dialog.browser.test.ts
@@ -72,6 +72,19 @@ describe('ar-dialog — browser', () => {
             await aTimeout(ANIM_CLOSE);
             expect(count).to.equal(1);
         });
+
+        it('Escape ferme toujours le dialog en mode without-header', async () => {
+            el.remove();
+            el = await fixture(html`
+                <ar-dialog without-header label="Sans header" open></ar-dialog>
+            `);
+            await aTimeout(ANIM_OPEN);
+
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+            await aTimeout(ANIM_CLOSE);
+
+            expect(getDialogEl(el).open).to.equal(false);
+        });
     });
 
     // ── Scroll lock / unlock ─────────────────────────────────────────────────

--- a/packages/core/src/components/dialog/dialog.browser.test.ts
+++ b/packages/core/src/components/dialog/dialog.browser.test.ts
@@ -187,4 +187,31 @@ describe('ar-dialog — browser', () => {
             expect(el.shadowRoot?.activeElement).to.equal(dialogEl);
         });
     });
+
+    // ── Layout header-actions ─────────────────────────────────────────────────
+
+    describe('layout header-actions', () => {
+        it('le bouton close reste centré verticalement même quand header-actions est plus haut que lui', async () => {
+            el = await fixture(html`
+                <ar-dialog label="Titre">
+                    <div slot="header-actions" style="height: 80px; display: flex;">
+                        Contenu haut
+                    </div>
+                </ar-dialog>
+            `);
+            el.open = true;
+            await aTimeout(50);
+
+            const shadow = el.shadowRoot!;
+            const headerEl = shadow.querySelector('[part="header"]') as HTMLElement;
+            const closeEl = shadow.querySelector('[part="close"]') as HTMLElement;
+
+            const headerRect = headerEl.getBoundingClientRect();
+            const closeRect = closeEl.getBoundingClientRect();
+            const headerCenterY = headerRect.y + headerRect.height / 2;
+            const closeCenterY = closeRect.y + closeRect.height / 2;
+
+            expect(Math.abs(closeCenterY - headerCenterY)).to.be.lessThan(3);
+        });
+    });
 });

--- a/packages/core/src/components/dialog/dialog.styles.ts
+++ b/packages/core/src/components/dialog/dialog.styles.ts
@@ -134,6 +134,11 @@ export default [
             margin-inline-end: auto;
         }
 
+        [part='header-actions'] {
+            display: flex;
+            align-items: center;
+        }
+
         [part='close'] {
             display: flex;
             align-items: center;

--- a/packages/core/src/components/dialog/dialog.styles.ts
+++ b/packages/core/src/components/dialog/dialog.styles.ts
@@ -137,13 +137,22 @@ export default [
         [part='header-actions'] {
             display: flex;
             align-items: center;
+            /* Absorbe l'espace disponible seulement quand h1 est hors flux (::part(title) en
+               position: absolute — cf. doc "titre sr-only") : sinon, margin-inline-end: auto sur
+               h1 consomme déjà tout l'espace libre en priorité sur les marges auto (spec flexbox,
+               résolu avant la distribution flex-grow), donc ce flex: 1 reste sans effet visuel
+               tant que le titre est visible et en flux normal. */
+            flex: 1;
+            /* Garde le contenu collé au bouton close (comme un slot vide) même quand ce
+               conteneur grandit — sans ça, un slot avec un seul petit bouton se retrouverait
+               plaqué au début du header plutôt qu'à côté du close une fois ce flex: 1 actif. */
+            justify-content: flex-end;
         }
 
         [part='close'] {
             display: flex;
             align-items: center;
             justify-content: center;
-            align-self: flex-start;
             flex-shrink: 0;
             /* a11y-fallback: WCAG 2.5.8 (Target Size Minimum) — sans thème chargé, le bouton perdrait sa taille de cible tactile */
             width: var(--ar-dialog-close-size, 2.5rem);

--- a/packages/core/src/components/dialog/dialog.styles.ts
+++ b/packages/core/src/components/dialog/dialog.styles.ts
@@ -126,12 +126,12 @@ export default [
         header {
             display: flex;
             align-items: center;
-            justify-content: space-between;
             flex-shrink: 0;
         }
 
         h1 {
             margin: 0;
+            margin-inline-end: auto;
         }
 
         [part='close'] {

--- a/packages/core/src/components/dialog/dialog.test.ts
+++ b/packages/core/src/components/dialog/dialog.test.ts
@@ -189,6 +189,28 @@ describe('ArDialog', () => {
             expect(getPart(el, 'dialog')).not.toBeNull();
             expect(getPart(el, 'body')).not.toBeNull();
         });
+
+        it('combiné à mode="drawer", le header reste absent et aria-label reste appliqué', async () => {
+            el = await fixture(
+                '<ar-dialog without-header mode="drawer" label="Filtres"></ar-dialog>',
+            );
+            expect(getPart(el, 'header')).toBeNull();
+            expect(getDialogEl(el).getAttribute('aria-label')).toBe('Filtres');
+            expect(getDialogEl(el).hasAttribute('aria-labelledby')).toBe(false);
+        });
+
+        it('bascule without-header à true après le montage remplace aria-labelledby par aria-label', async () => {
+            el = await fixture('<ar-dialog label="Titre"></ar-dialog>');
+            expect(getPart(el, 'header')).not.toBeNull();
+            expect(getDialogEl(el).getAttribute('aria-labelledby')).toBe('dialog-heading');
+
+            el.withoutHeader = true;
+            await waitForUpdate(el);
+
+            expect(getPart(el, 'header')).toBeNull();
+            expect(getDialogEl(el).hasAttribute('aria-labelledby')).toBe(false);
+            expect(getDialogEl(el).getAttribute('aria-label')).toBe('Titre');
+        });
     });
 
     // ── header-actions ───────────────────────────────────────────────────────
@@ -851,7 +873,7 @@ describe('ArDialog', () => {
         it('émet un warn si without-header sans close-on-backdrop ni data-ar-dismiss/accept', async () => {
             const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-            await fixture('<ar-dialog without-header label="Titre"></ar-dialog>');
+            await fixture('<ar-dialog without-header label="Titre" open></ar-dialog>');
 
             const closeWarns = spy.mock.calls.filter((c) => String(c[0]).includes('Échap'));
             expect(closeWarns.length).toBeGreaterThan(0);
@@ -860,7 +882,9 @@ describe('ArDialog', () => {
         it("n'émet pas ce warn si close-on-backdrop est actif", async () => {
             const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-            await fixture('<ar-dialog without-header close-on-backdrop label="Titre"></ar-dialog>');
+            await fixture(
+                '<ar-dialog without-header close-on-backdrop label="Titre" open></ar-dialog>',
+            );
 
             const closeWarns = spy.mock.calls.filter((c) => String(c[0]).includes('Échap'));
             expect(closeWarns).toHaveLength(0);
@@ -870,8 +894,21 @@ describe('ArDialog', () => {
             const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
             await fixture(`
-                <ar-dialog without-header label="Titre">
+                <ar-dialog without-header label="Titre" open>
                     <button data-ar-dismiss>Fermer</button>
+                </ar-dialog>
+            `);
+
+            const closeWarns = spy.mock.calls.filter((c) => String(c[0]).includes('Échap'));
+            expect(closeWarns).toHaveLength(0);
+        });
+
+        it("n'émet pas ce warn si un élément data-ar-accept est présent dans le contenu", async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            await fixture(`
+                <ar-dialog without-header label="Titre" open>
+                    <button data-ar-accept>Confirmer</button>
                 </ar-dialog>
             `);
 
@@ -882,10 +919,34 @@ describe('ArDialog', () => {
         it("n'émet pas ce warn hors mode without-header", async () => {
             const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-            await fixture('<ar-dialog></ar-dialog>');
+            await fixture('<ar-dialog open></ar-dialog>');
 
             const closeWarns = spy.mock.calls.filter((c) => String(c[0]).includes('Échap'));
             expect(closeWarns).toHaveLength(0);
+        });
+
+        it("n'émet pas ce warn au montage initial (avant ouverture), même sans moyen de fermeture", async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            el = await fixture('<ar-dialog without-header label="Titre"></ar-dialog>');
+            await waitForUpdate(el);
+
+            const closeWarns = spy.mock.calls.filter((c) => String(c[0]).includes('Échap'));
+            expect(closeWarns).toHaveLength(0);
+        });
+
+        it("émet ce warn à l'ouverture (_show), pas seulement au montage", async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            el = await fixture('<ar-dialog without-header label="Titre"></ar-dialog>');
+            await waitForUpdate(el);
+            expect(spy.mock.calls.filter((c) => String(c[0]).includes('Échap'))).toHaveLength(0);
+
+            el.open = true;
+            await waitForUpdate(el);
+
+            const closeWarns = spy.mock.calls.filter((c) => String(c[0]).includes('Échap'));
+            expect(closeWarns.length).toBeGreaterThan(0);
         });
     });
 });

--- a/packages/core/src/components/dialog/dialog.test.ts
+++ b/packages/core/src/components/dialog/dialog.test.ts
@@ -157,6 +157,85 @@ describe('ArDialog', () => {
         });
     });
 
+    // ── without-header ───────────────────────────────────────────────────────
+
+    describe('without-header', () => {
+        it('withoutHeader vaut false par défaut', async () => {
+            el = await fixture('<ar-dialog></ar-dialog>');
+            expect(el.withoutHeader).toBe(false);
+        });
+
+        it('without-header reflète en attribut', async () => {
+            el = await fixture('<ar-dialog without-header label="Titre"></ar-dialog>');
+            expect(el.hasAttribute('without-header')).toBe(true);
+            expect(el.withoutHeader).toBe(true);
+        });
+
+        it('le header est présent par défaut', async () => {
+            el = await fixture('<ar-dialog></ar-dialog>');
+            expect(getPart(el, 'header')).not.toBeNull();
+        });
+
+        it('le header est absent du DOM quand without-header est actif', async () => {
+            el = await fixture('<ar-dialog without-header label="Titre"></ar-dialog>');
+            expect(getPart(el, 'header')).toBeNull();
+            expect(getPart(el, 'title')).toBeNull();
+            expect(getPart(el, 'close')).toBeNull();
+            expect(requireShadow(el).querySelector('[data-ar-dismiss]')).toBeNull();
+        });
+
+        it('le dialog et le body restent présents quand without-header est actif', async () => {
+            el = await fixture('<ar-dialog without-header label="Titre"></ar-dialog>');
+            expect(getPart(el, 'dialog')).not.toBeNull();
+            expect(getPart(el, 'body')).not.toBeNull();
+        });
+    });
+
+    // ── header-actions ───────────────────────────────────────────────────────
+
+    describe('slot header-actions', () => {
+        it('le slot header-actions est rendu dans le header', async () => {
+            el = await fixture('<ar-dialog></ar-dialog>');
+            const header = getPart(el, 'header') as HTMLElement;
+            expect(header.querySelector('slot[name="header-actions"]')).not.toBeNull();
+        });
+
+        it('le contenu slot="header-actions" est assigné', async () => {
+            el = await fixture(`
+                <ar-dialog label="Titre">
+                    <button slot="header-actions" id="action-btn">Plein écran</button>
+                </ar-dialog>
+            `);
+            const slotEl = requireShadow(el).querySelector<HTMLSlotElement>(
+                'slot[name="header-actions"]',
+            );
+            expect(slotEl).not.toBeNull();
+            const assigned = slotEl!.assignedElements();
+            expect(assigned).toHaveLength(1);
+            expect((assigned[0] as HTMLElement).id).toBe('action-btn');
+        });
+
+        it('le slot header-actions est positionné avant le bouton close', async () => {
+            el = await fixture(`
+                <ar-dialog label="Titre">
+                    <button slot="header-actions">Action</button>
+                </ar-dialog>
+            `);
+            const header = getPart(el, 'header') as HTMLElement;
+            const slot = header.querySelector('slot[name="header-actions"]');
+            const closeBtn = header.querySelector('[data-ar-dismiss]');
+            expect(slot).not.toBeNull();
+            expect(closeBtn).not.toBeNull();
+            const position = slot!.compareDocumentPosition(closeBtn!);
+            expect(Boolean(position & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
+        });
+
+        it('le slot header-actions est absent du DOM quand without-header est actif', async () => {
+            el = await fixture('<ar-dialog without-header label="Titre"></ar-dialog>');
+            expect(requireShadow(el).querySelector('slot[name="header-actions"]')).toBeNull();
+        });
+    });
+
     // ── Ouverture ─────────────────────────────────────────────────────────────
 
     describe('ouverture', () => {

--- a/packages/core/src/components/dialog/dialog.test.ts
+++ b/packages/core/src/components/dialog/dialog.test.ts
@@ -216,10 +216,42 @@ describe('ArDialog', () => {
     // ── header-actions ───────────────────────────────────────────────────────
 
     describe('slot header-actions', () => {
-        it('le slot header-actions est rendu dans le header', async () => {
+        it('le wrapper part="header-actions" est absent du DOM sans contenu assigné', async () => {
             el = await fixture('<ar-dialog></ar-dialog>');
-            const header = getPart(el, 'header') as HTMLElement;
-            expect(header.querySelector('slot[name="header-actions"]')).not.toBeNull();
+            expect(getPart(el, 'header-actions')).toBeNull();
+        });
+
+        it('le wrapper part="header-actions" est présent si un enfant slot="header-actions" est fourni', async () => {
+            el = await fixture(`
+                <ar-dialog label="Titre">
+                    <button slot="header-actions">Action</button>
+                </ar-dialog>
+            `);
+            expect(getPart(el, 'header-actions')).not.toBeNull();
+        });
+
+        it('le wrapper disparaît dynamiquement si le slot="header-actions" est retiré', async () => {
+            el = await fixture(`
+                <ar-dialog label="Titre">
+                    <button slot="header-actions" id="a">Action</button>
+                </ar-dialog>
+            `);
+            expect(getPart(el, 'header-actions')).not.toBeNull();
+
+            (el.querySelector('#a') as Element).remove();
+            await waitForUpdate(el);
+
+            expect(getPart(el, 'header-actions')).toBeNull();
+        });
+
+        it('le slot header-actions est rendu dans le wrapper', async () => {
+            el = await fixture(`
+                <ar-dialog label="Titre">
+                    <button slot="header-actions">Action</button>
+                </ar-dialog>
+            `);
+            const wrapper = getPart(el, 'header-actions') as HTMLElement;
+            expect(wrapper.querySelector('slot[name="header-actions"]')).not.toBeNull();
         });
 
         it('le contenu slot="header-actions" est assigné', async () => {
@@ -237,23 +269,28 @@ describe('ArDialog', () => {
             expect((assigned[0] as HTMLElement).id).toBe('action-btn');
         });
 
-        it('le slot header-actions est positionné avant le bouton close', async () => {
+        it('le wrapper header-actions est positionné avant le bouton close', async () => {
             el = await fixture(`
                 <ar-dialog label="Titre">
                     <button slot="header-actions">Action</button>
                 </ar-dialog>
             `);
             const header = getPart(el, 'header') as HTMLElement;
-            const slot = header.querySelector('slot[name="header-actions"]');
+            const wrapper = getPart(el, 'header-actions');
             const closeBtn = header.querySelector('[data-ar-dismiss]');
-            expect(slot).not.toBeNull();
+            expect(wrapper).not.toBeNull();
             expect(closeBtn).not.toBeNull();
-            const position = slot!.compareDocumentPosition(closeBtn!);
+            const position = wrapper!.compareDocumentPosition(closeBtn!);
             expect(Boolean(position & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
         });
 
-        it('le slot header-actions est absent du DOM quand without-header est actif', async () => {
-            el = await fixture('<ar-dialog without-header label="Titre"></ar-dialog>');
+        it('le wrapper header-actions est absent du DOM quand without-header est actif', async () => {
+            el = await fixture(`
+                <ar-dialog without-header label="Titre">
+                    <button slot="header-actions">Action</button>
+                </ar-dialog>
+            `);
+            expect(getPart(el, 'header-actions')).toBeNull();
             expect(requireShadow(el).querySelector('slot[name="header-actions"]')).toBeNull();
         });
     });

--- a/packages/core/src/components/dialog/dialog.test.ts
+++ b/packages/core/src/components/dialog/dialog.test.ts
@@ -797,4 +797,95 @@ describe('ArDialog', () => {
             expect(placementWarns).toHaveLength(0);
         });
     });
+
+    describe('warn() — slot label ignoré en mode without-header', () => {
+        afterEach(() => {
+            vi.restoreAllMocks();
+        });
+
+        it('émet un warn si slot="label" est fourni sans la prop label et without-header actif', async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            await fixture(`
+                <ar-dialog without-header>
+                    <span slot="label">Titre riche</span>
+                </ar-dialog>
+            `);
+
+            const slotWarns = spy.mock.calls.filter((c) => String(c[0]).includes('slot="label"'));
+            expect(slotWarns.length).toBeGreaterThan(0);
+        });
+
+        it("n'émet pas ce warn si la prop label est fournie en plus du slot", async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            await fixture(`
+                <ar-dialog without-header label="Titre">
+                    <span slot="label">Titre riche</span>
+                </ar-dialog>
+            `);
+
+            const slotWarns = spy.mock.calls.filter((c) => String(c[0]).includes('slot="label"'));
+            expect(slotWarns).toHaveLength(0);
+        });
+
+        it("n'émet pas ce warn hors mode without-header", async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            await fixture(`
+                <ar-dialog>
+                    <span slot="label">Titre riche</span>
+                </ar-dialog>
+            `);
+
+            const slotWarns = spy.mock.calls.filter((c) => String(c[0]).includes('slot="label"'));
+            expect(slotWarns).toHaveLength(0);
+        });
+    });
+
+    describe('warn() — aucun moyen de fermeture en mode without-header', () => {
+        afterEach(() => {
+            vi.restoreAllMocks();
+        });
+
+        it('émet un warn si without-header sans close-on-backdrop ni data-ar-dismiss/accept', async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            await fixture('<ar-dialog without-header label="Titre"></ar-dialog>');
+
+            const closeWarns = spy.mock.calls.filter((c) => String(c[0]).includes('Échap'));
+            expect(closeWarns.length).toBeGreaterThan(0);
+        });
+
+        it("n'émet pas ce warn si close-on-backdrop est actif", async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            await fixture('<ar-dialog without-header close-on-backdrop label="Titre"></ar-dialog>');
+
+            const closeWarns = spy.mock.calls.filter((c) => String(c[0]).includes('Échap'));
+            expect(closeWarns).toHaveLength(0);
+        });
+
+        it("n'émet pas ce warn si un élément data-ar-dismiss est présent dans le contenu", async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            await fixture(`
+                <ar-dialog without-header label="Titre">
+                    <button data-ar-dismiss>Fermer</button>
+                </ar-dialog>
+            `);
+
+            const closeWarns = spy.mock.calls.filter((c) => String(c[0]).includes('Échap'));
+            expect(closeWarns).toHaveLength(0);
+        });
+
+        it("n'émet pas ce warn hors mode without-header", async () => {
+            const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            await fixture('<ar-dialog></ar-dialog>');
+
+            const closeWarns = spy.mock.calls.filter((c) => String(c[0]).includes('Échap'));
+            expect(closeWarns).toHaveLength(0);
+        });
+    });
 });

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -50,15 +50,16 @@ if (typeof document !== 'undefined') {
 /**
  * @summary Boîte de dialogue modale ou panneau latéral (drawer), accessible et animée.
  *
- * @slot label - Titre du dialog. Remplace la propriété `label` si du HTML est nécessaire.
+ * @slot label - Titre du dialog. Remplace la propriété `label` si du HTML est nécessaire. Sans effet si `without-header` est actif.
+ * @slot header-actions - Actions additionnelles dans le header, positionnées avant le bouton de fermeture (ex. bouton plein écran, menu). Retiré du DOM si `without-header` est actif.
  * @slot - Contenu principal du dialog.
  * @slot footer - Actions du dialog (boutons). Absent du DOM si non fourni.
- * @slot close-icon - Icône du bouton de fermeture. Remplace le SVG "×" par défaut.
+ * @slot close-icon - Icône du bouton de fermeture. Remplace le SVG "×" par défaut. Retiré du DOM si `without-header` est actif.
  *
  * @csspart dialog - L'élément <dialog> racine.
- * @csspart header - L'en-tête contenant le titre et le bouton de fermeture.
+ * @csspart header - L'en-tête contenant le titre et le bouton de fermeture. Absent du DOM si `without-header` est actif.
  * @csspart title - Le titre du dialog.
- * @csspart close - Le bouton de fermeture dans l'en-tête.
+ * @csspart close - Le bouton de fermeture dans l'en-tête. Absent du DOM si `without-header` est actif.
  * @csspart body - La zone de contenu principale.
  * @csspart footer - La zone d'actions (absente du DOM si slot non utilisé).
  *
@@ -113,6 +114,17 @@ export class ArDialog extends LitElement {
      * @default ''
      */
     @property({ reflect: true }) label = '';
+
+    /**
+     * Si présent, retire entièrement le header (titre, actions, bouton de fermeture) du DOM.
+     * La propriété `label` devient alors le seul nom accessible du dialog (`aria-label`) —
+     * elle est requise dans ce mode, le slot `label` (HTML) est sans effet.
+     *
+     * @attr without-header
+     * @default false
+     */
+    @property({ reflect: true, type: Boolean, attribute: 'without-header' })
+    withoutHeader: boolean = false;
 
     /**
      * Mode d'affichage : `modal` (centré avec backdrop) ou `drawer` (panneau latéral).
@@ -239,7 +251,8 @@ export class ArDialog extends LitElement {
             <dialog
                 part="dialog"
                 role="dialog"
-                aria-labelledby="dialog-heading"
+                aria-labelledby=${this.withoutHeader ? nothing : 'dialog-heading'}
+                aria-label=${this.withoutHeader ? headingLabel : nothing}
                 aria-describedby="dialog-body"
                 aria-modal="true"
                 ?inert=${!this.open || this._isClosing}
@@ -248,31 +261,34 @@ export class ArDialog extends LitElement {
                 @pointerdown=${this._handleDialogPointerDown}
                 @pointerup=${this._handleDialogPointerUp}
             >
-                <header part="header">
-                    <h1 part="title" id="dialog-heading">
-                        ${this._slotController.test('label')
-                            ? html`<slot name="label"></slot>`
-                            : headingLabel}
-                    </h1>
-                    <button part="close" type="button" data-ar-dismiss>
-                        <slot name="close-icon">
-                            <svg
-                                aria-hidden="true"
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                stroke-width="1.5"
-                                stroke="currentColor"
-                            >
-                                <path
-                                    stroke-linecap="round"
-                                    stroke-linejoin="round"
-                                    d="M6 18 18 6M6 6l12 12"
-                                ></path>
-                            </svg>
-                        </slot>
-                        <span class="sr-only">${this.closeLabel}</span>
-                    </button>
-                </header>
+                ${this.withoutHeader
+                    ? nothing
+                    : html`<header part="header">
+                          <h1 part="title" id="dialog-heading">
+                              ${this._slotController.test('label')
+                                  ? html`<slot name="label"></slot>`
+                                  : headingLabel}
+                          </h1>
+                          <slot name="header-actions"></slot>
+                          <button part="close" type="button" data-ar-dismiss>
+                              <slot name="close-icon">
+                                  <svg
+                                      aria-hidden="true"
+                                      fill="none"
+                                      viewBox="0 0 24 24"
+                                      stroke-width="1.5"
+                                      stroke="currentColor"
+                                  >
+                                      <path
+                                          stroke-linecap="round"
+                                          stroke-linejoin="round"
+                                          d="M6 18 18 6M6 6l12 12"
+                                      ></path>
+                                  </svg>
+                              </slot>
+                              <span class="sr-only">${this.closeLabel}</span>
+                          </button>
+                      </header>`}
                 <div part="body" id="dialog-body">
                     <slot></slot>
                 </div>

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -194,6 +194,8 @@ export class ArDialog extends LitElement {
 
     private readonly _slotController = new HasSlotController(this, 'footer', 'label');
     private _hasWarnedMissingLabel = false;
+    private _hasWarnedSlotLabelIgnored = false;
+    private _hasWarnedNoCloseMechanism = false;
 
     private _getHeadingLabel(): string {
         return (this.label ?? '').trim() || DEFAULT_DIALOG_LABEL;
@@ -207,6 +209,32 @@ export class ArDialog extends LitElement {
         warn(
             'ar-dialog',
             'Aucun libellé accessible fourni. Ajoutez la propriété "label" ou un enfant direct avec slot="label".',
+        );
+    }
+
+    private _warnIfSlotLabelIgnored(): void {
+        if (this._hasWarnedSlotLabelIgnored) return;
+        if (!this.withoutHeader) return;
+        if ((this.label ?? '').trim()) return;
+        if (!this._slotController.test('label')) return;
+
+        this._hasWarnedSlotLabelIgnored = true;
+        warn(
+            'ar-dialog',
+            'slot="label" est ignoré quand without-header est actif (aria-label ne peut contenir que du texte brut). Utilisez la propriété "label".',
+        );
+    }
+
+    private _warnIfNoCloseMechanism(): void {
+        if (this._hasWarnedNoCloseMechanism) return;
+        if (!this.withoutHeader) return;
+        if (this.closeOnBackdrop) return;
+        if (this.querySelector('[data-ar-dismiss], [data-ar-accept]')) return;
+
+        this._hasWarnedNoCloseMechanism = true;
+        warn(
+            'ar-dialog',
+            'without-header est actif sans close-on-backdrop ni élément [data-ar-dismiss]/[data-ar-accept] dans le contenu : seule la touche Échap permet de fermer ce dialog.',
         );
     }
 
@@ -226,6 +254,8 @@ export class ArDialog extends LitElement {
 
     override updated(changedProperties: PropertyValues<this>): void {
         this._warnIfMissingLabel();
+        this._warnIfSlotLabelIgnored();
+        this._warnIfNoCloseMechanism();
         if (
             (changedProperties.has('placement') || changedProperties.has('mode')) &&
             this.mode === 'modal' &&

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -58,6 +58,7 @@ if (typeof document !== 'undefined') {
  *
  * @csspart dialog - L'élément <dialog> racine.
  * @csspart header - L'en-tête contenant le titre et le bouton de fermeture. Absent du DOM si `without-header` est actif.
+ * @csspart header-actions - Le conteneur des actions additionnelles du header (slot `header-actions`). Absent du DOM si le slot est vide ou si `without-header` est actif.
  * @csspart title - Le titre du dialog.
  * @csspart close - Le bouton de fermeture dans l'en-tête. Absent du DOM si `without-header` est actif.
  * @csspart body - La zone de contenu principale.
@@ -192,7 +193,12 @@ export class ArDialog extends LitElement {
     /** Élément qui avait le focus avant l'ouverture — pour le restaurer à la fermeture. */
     private _triggerElement: Element | null = null;
 
-    private readonly _slotController = new HasSlotController(this, 'footer', 'label');
+    private readonly _slotController = new HasSlotController(
+        this,
+        'footer',
+        'label',
+        'header-actions',
+    );
     private _hasWarnedMissingLabel = false;
     private _hasWarnedSlotLabelIgnored = false;
     private _hasWarnedNoCloseMechanism = false;
@@ -298,7 +304,11 @@ export class ArDialog extends LitElement {
                                   ? html`<slot name="label"></slot>`
                                   : headingLabel}
                           </h1>
-                          <slot name="header-actions"></slot>
+                          ${this._slotController.test('header-actions')
+                              ? html`<div part="header-actions">
+                                    <slot name="header-actions"></slot>
+                                </div>`
+                              : nothing}
                           <button part="close" type="button" data-ar-dismiss>
                               <slot name="close-icon">
                                   <svg

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -255,7 +255,6 @@ export class ArDialog extends LitElement {
     override updated(changedProperties: PropertyValues<this>): void {
         this._warnIfMissingLabel();
         this._warnIfSlotLabelIgnored();
-        this._warnIfNoCloseMechanism();
         if (
             (changedProperties.has('placement') || changedProperties.has('mode')) &&
             this.mode === 'modal' &&
@@ -457,6 +456,7 @@ export class ArDialog extends LitElement {
 
     /** Ouvre le dialog natif, gèle le scroll et enregistre le listener clavier. */
     private _show(): void {
+        this._warnIfNoCloseMechanism();
         this._triggerElement = document.activeElement;
         const showEvent = this._emit('ar-dialog-show');
         if (showEvent.defaultPrevented) {

--- a/packages/core/src/components/pagination/pagination.styles.ts
+++ b/packages/core/src/components/pagination/pagination.styles.ts
@@ -11,6 +11,7 @@ export default css`
         flex-wrap: nowrap;
         justify-content: center;
         padding-inline-start: 0;
+        margin-top: 0;
         margin-bottom: 0;
         list-style: none;
     }

--- a/packages/core/src/components/pagination/pagination.test.ts
+++ b/packages/core/src/components/pagination/pagination.test.ts
@@ -51,6 +51,11 @@ describe('ArPagination', () => {
             expect(partContains(requirePart(el, 'next'), 'next')).toBe(true);
             expect(partContains(requirePart(el, 'next'), 'nav-btn')).toBe(true);
         });
+
+        it('part="list" n\'a pas de margin-top (repli UA du <ul> non réinitialisé sinon)', () => {
+            const list = requirePart(el, 'list') as HTMLElement;
+            expect(getComputedStyle(list).marginTop).toBe('0px');
+        });
     });
 
     // ── Slots d'icônes prev/next ─────────────────────────────────────────────


### PR DESCRIPTION
## Résumé

Implémente le design de `docs/superpowers/specs/2026-08-11-dialog-header-customization-design.md` pour #145 :

- Nouveau slot `header-actions` : actions additionnelles entre le titre et le bouton de fermeture.
- Nouvel attribut `without-header` : retire le header entièrement (titre, actions, close). `label` devient requis, `aria-label` remplace `aria-labelledby`.
- Titre visuellement masqué : aucun nouvel attribut nécessaire, `::part(title)` existant suffit (documenté, avec la contrainte de layout `justify-content: flex-end` sur `::part(header)`).
- Deux nouveaux warnings dev : `slot="label"` ignoré en mode `without-header` sans prop `label`, et absence de moyen de fermeture détectable (`close-on-backdrop`/`data-ar-dismiss`/`data-ar-accept`) en mode `without-header` — vérifié à l'ouverture (`_show()`) plutôt qu'au premier rendu, pour éviter un faux-positif permanent sur du contenu inséré après coup (frameworks React/Vue).
- Question préalable tranchée dans le spec : pas de séparation `ar-dialog`/`ar-drawer` (analyse du code source WebAwesome à l'appui — leur split est une duplication mécanique, pas une divergence architecturale).

## Process

Exécuté en subagent-driven development (6 tâches + revue finale de branche) :
- Task 2-5 : chacune implémentée par un subagent, revue spec+qualité individuelle (toutes approuvées, aucun Critical/Important).
- Revue finale de branche complète (modèle le plus capable) : 1 finding Important (latch permanent du warning fermeture) + 4 Minor, tous corrigés en une vague de correctifs, re-revue ciblée clean.

## Test plan

- [x] Tests unitaires Vitest (`dialog.test.ts`) : structure `without-header`, slot `header-actions`, warnings, toggle runtime, combinaison `mode="drawer"`.
- [x] Tests a11y WTR (`dialog.a11y.test.ts`) : bascule `aria-labelledby`/`aria-label`.
- [x] Tests navigateur (`dialog.browser.test.ts`) : repli de focus sur `<dialog>` sans bouton close, fermeture Échap sous `without-header`.
- [x] `npm run test:all` (903 + 59 Vitest, 263 navigateur), lint, prettier, build : tous verts.
- [x] Doc Astro (`ar-dialog.mdx`) : deux nouveaux variants playground + sections a11y/utilisation mises à jour.

Closes #145 (sera fermée à la release sur `main`, label `status:en-attente-release` entre-temps).