### PR TITLE
feat(pagination): mode compact (prev/next + label de position)

### DIFF
--- a/apps/docs/src/content/components/ar-pagination.mdx
+++ b/apps/docs/src/content/components/ar-pagination.mdx
@@ -74,7 +74,9 @@ import WcagRef from '../../components/WcagRef.astro';
 Le composant adapte son contenu automatiquement à la largeur du conteneur dans lequel il est positionné (pas celle du viewport) :
 Lorsque l'espace disponible n'est plus jugé suffisant, les numéros de page sont remplacés par un `<select>` de saut de page,
 peuplé du même jeu de pages qu'à largeur confortable — sauf en mode `compact`, qui ne bascule jamais et reste identique quelle
-que soit la largeur.
+que soit la largeur. Ce mode n'offre donc aucun filet de sécurité anti-débordement à largeur extrême (contrairement au mode
+adaptatif ci-dessus) : à vous de vérifier que le label et les boutons prev/next restent lisibles dans le contexte d'usage visé
+(ex. panneau de détail, drawer).
 
 ## Utilisation
 

--- a/apps/docs/src/content/components/ar-pagination.mdx
+++ b/apps/docs/src/content/components/ar-pagination.mdx
@@ -23,6 +23,11 @@ variants:
       description: Pagination à 20 pages, page 18 active (fin de la liste).
       html: |
           <ar-pagination current="18" total="20"></ar-pagination>
+    - name: compact
+      label: Mode compact
+      description: Mode compact — uniquement précédent/suivant et un label de position, identique en mobile et desktop.
+      html: |
+          <ar-pagination compact current="4" total="12"></ar-pagination>
 pageScript: |
     <script>
         document.addEventListener('ar-pagination-page-change', (e) => {

--- a/apps/docs/src/content/components/ar-pagination.mdx
+++ b/apps/docs/src/content/components/ar-pagination.mdx
@@ -73,7 +73,8 @@ import WcagRef from '../../components/WcagRef.astro';
 
 Le composant adapte son contenu automatiquement à la largeur du conteneur dans lequel il est positionné (pas celle du viewport) :
 Lorsque l'espace disponible n'est plus jugé suffisant, les numéros de page sont remplacés par un `<select>` de saut de page,
-peuplé du même jeu de pages qu'à largeur confortable.
+peuplé du même jeu de pages qu'à largeur confortable — sauf en mode `compact`, qui ne bascule jamais et reste identique quelle
+que soit la largeur.
 
 ## Utilisation
 

--- a/docs/superpowers/plans/2026-08-12-pagination-compact-mode.md
+++ b/docs/superpowers/plans/2026-08-12-pagination-compact-mode.md
@@ -85,35 +85,32 @@ describe('mode compact — cycle de vie ResizeObserver', () => {
 
     it('compact=false (défaut) : instancie un ResizeObserver au montage', async () => {
         el = await fixture('<ar-pagination></ar-pagination>');
-        expect(
-            (el as unknown as { _resizeObserver?: ResizeObserver })._resizeObserver,
-        ).toBeInstanceOf(ResizeObserver);
+        // @ts-expect-error accès à un champ privé pour vérifier l'instanciation du ResizeObserver
+        expect(el._resizeObserver).toBeInstanceOf(ResizeObserver);
     });
 
     it("compact=true : n'instancie aucun ResizeObserver au montage", async () => {
         el = await fixture('<ar-pagination compact></ar-pagination>');
-        expect(
-            (el as unknown as { _resizeObserver?: ResizeObserver })._resizeObserver,
-        ).toBeUndefined();
+        // @ts-expect-error accès à un champ privé pour vérifier l'absence de ResizeObserver
+        expect(el._resizeObserver).toBeUndefined();
     });
 
     it('passer compact de true à false attache le ResizeObserver', async () => {
         el = await fixture('<ar-pagination compact></ar-pagination>');
-        expect(
-            (el as unknown as { _resizeObserver?: ResizeObserver })._resizeObserver,
-        ).toBeUndefined();
+        // @ts-expect-error accès à un champ privé pour vérifier l'absence de ResizeObserver
+        expect(el._resizeObserver).toBeUndefined();
 
         el.compact = false;
         await waitForUpdate(el);
 
-        expect(
-            (el as unknown as { _resizeObserver?: ResizeObserver })._resizeObserver,
-        ).toBeInstanceOf(ResizeObserver);
+        // @ts-expect-error accès à un champ privé pour vérifier l'instanciation du ResizeObserver
+        expect(el._resizeObserver).toBeInstanceOf(ResizeObserver);
     });
 
     it('passer compact de false à true déconnecte le ResizeObserver existant', async () => {
         el = await fixture('<ar-pagination></ar-pagination>');
-        const observer = (el as unknown as { _resizeObserver?: ResizeObserver })._resizeObserver;
+        // @ts-expect-error accès à un champ privé pour récupérer le ResizeObserver interne
+        const observer = el._resizeObserver;
         expect(observer).toBeInstanceOf(ResizeObserver);
         const disconnectSpy = vi.spyOn(observer as ResizeObserver, 'disconnect');
 
@@ -121,12 +118,19 @@ describe('mode compact — cycle de vie ResizeObserver', () => {
         await waitForUpdate(el);
 
         expect(disconnectSpy).toHaveBeenCalled();
-        expect(
-            (el as unknown as { _resizeObserver?: ResizeObserver })._resizeObserver,
-        ).toBeUndefined();
+        // @ts-expect-error accès à un champ privé pour vérifier la déconnexion
+        expect(el._resizeObserver).toBeUndefined();
     });
 });
 ```
+
+Accès à un champ `private` depuis un test : `private` n'existe qu'au niveau TypeScript (effacé à la
+compilation), donc rien n'empêche l'accès à l'exécution — seul le compilateur le refuserait sans
+`@ts-expect-error`. C'est déjà la convention de ce fichier (`el._budget = 2` ailleurs dans
+`pagination.test.ts`, avec le même commentaire) : chaque accès est précédé de son propre
+`@ts-expect-error` plutôt que d'un cast global `as unknown as {...}` (ce dernier pattern existe dans
+`pagination.a11y.test.ts`/`pagination.browser.test.ts`, mais pas dans ce fichier — on garde la
+convention locale à chaque fichier de test, pas de mélange).
 
 - [ ] **Step 2: Lancer les tests et vérifier qu'ils échouent**
 
@@ -146,9 +150,6 @@ Dans `pagination.ts`, juste après la propriété `total` (après la ligne `tota
     /**
      * Mode compact : uniquement les boutons précédent/suivant et un label de position
      * ("Page X / Y"), navigation strictement séquentielle (pas de saut direct à une page).
-     * Rendu identique en mobile et desktop — contrairement au repli automatique en `<select>`
-     * (comportement par défaut de ce composant), ce mode n'est jamais déclenché par la largeur
-     * du conteneur : c'est un mode à activer explicitement via cet attribut.
      * @attr compact
      * @default false
      */
@@ -188,6 +189,12 @@ par :
 ```typescript
     override connectedCallback(): void {
         super.connectedCallback();
+        // `_initialized` reste faux ici au tout premier montage (le shadow DOM n'existe pas
+        // encore, `_setupResizeObserver` ne trouverait pas `[part="nav"]`) — ce n'est donc PAS un
+        // doublon avec l'appel dans `firstUpdated()` ci-dessous, qui gère ce premier montage une
+        // fois le rendu initial fait. Cet appel-ci ne joue que lors d'une reconnexion ultérieure
+        // (élément déplacé/réinséré dans le DOM après un premier montage), pour réattacher
+        // l'observer que `disconnectedCallback` a démonté à la déconnexion précédente.
         if (this._initialized && !this.compact) this._setupResizeObserver();
     }
 
@@ -248,8 +255,13 @@ par :
 ```typescript
         if (changed.has('total')) {
             const digits = String(Math.max(this.total, 1)).length;
-            if (this._prevTotalDigits && digits !== this._prevTotalDigits && !this.compact) {
+            if (!this.compact && this._prevTotalDigits && digits !== this._prevTotalDigits) {
 ```
+
+`!this.compact` en tête plutôt qu'en fin de condition : sort de la condition avant même d'évaluer
+`_prevTotalDigits`/`digits`, cohérent avec l'intention (« en mode compact, toute cette logique de
+remesure ne s'applique pas ») plutôt que de la laisser en dernière clause comme une restriction
+accessoire.
 
 (le reste du bloc — `this._needsRemeasure = true; this._recalculateBudget();` puis
 `this._prevTotalDigits = digits;` — ne change pas.)
@@ -802,38 +814,21 @@ frontmatter, ajouter une entrée après `20-pages-end` (avant `pageScript:`) :
       <ar-pagination compact current="4" total="12"></ar-pagination>
 ```
 
-- [ ] **Step 2: Ajouter une section "Mode compact" dans le corps de la page**
+Pas de section de prose supplémentaire à ajouter dans le corps de la page : `ComponentApi.astro`
+(`apps/docs/src/components/ComponentApi.astro:53`) affiche `attr.description` directement depuis le
+JSDoc `@attr` du composant — le texte déjà écrit en Task 2 Step 3 ("Mode compact : uniquement les
+boutons précédent/suivant...") apparaîtra donc tel quel dans le tableau d'attributs auto-généré.
+Ajouter une section manuelle dupliquerait cette description sans rien apporter ; la démo de la
+Step 1 ci-dessus suffit à montrer le rendu.
 
-Dans le corps du fichier, ajouter une nouvelle section après `## Comportement responsive` (avant
-`## Utilisation`) :
-
-````markdown
-## Mode compact
-
-L'attribut booléen `compact` remplace la numérotation par un simple prev/next accompagné d'un
-label de position non cliquable ("Page 4 / 12"). Contrairement au repli automatique en `<select>`
-décrit ci-dessus, ce mode est **fixe** : il ne réagit pas à la largeur du conteneur, le rendu est
-identique en mobile et en desktop. Adapté aux contextes où seule une navigation séquentielle
-(page suivante/précédente) est utile — par exemple un panneau de détail ou un drawer.
-
-```html
-<ar-pagination compact current="4" total="12"></ar-pagination>
-```
-````
-
-La navigation reste strictement séquentielle dans ce mode : il n'y a pas de saut direct à une page
-arbitraire (pas de numéros cliquables, pas de `<select>`).
-
-````
-
-- [ ] **Step 3: Régénérer le manifest CEM (fait apparaître `compact`/`page-label`/`label` dans le tableau d'API auto-généré)**
+- [ ] **Step 2: Régénérer le manifest CEM (fait apparaître `compact`/`page-label`/`label` dans le tableau d'API auto-généré)**
 
 ```bash
 cd /Users/jon/Code/Active_projects/ariane
 npm run build:manifest
-````
+```
 
-- [ ] **Step 4: Vérifier visuellement la page de doc en local**
+- [ ] **Step 3: Vérifier visuellement la page de doc en local**
 
 ```bash
 cd /Users/jon/Code/Active_projects/ariane
@@ -848,7 +843,7 @@ Ouvrir la page `ar-pagination`, vérifier que :
 
 Arrêter le serveur (`Ctrl+C`) une fois vérifié.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 4: Commit**
 
 ```bash
 cd /Users/jon/Code/Active_projects/ariane

--- a/docs/superpowers/plans/2026-08-12-pagination-compact-mode.md
+++ b/docs/superpowers/plans/2026-08-12-pagination-compact-mode.md
@@ -1,0 +1,924 @@
+# Mode compact `ar-pagination` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ajouter un attribut booléen `compact` à `ar-pagination` qui remplace la numérotation par
+un simple prev/next + label de position (`Page X / Y`), rendu identique en mobile et desktop, sans
+bascule responsive.
+
+**Architecture:** Extension du composant `ArPagination` existant (`packages/core/src/components/pagination/pagination.ts`).
+Le mode compact court-circuite entièrement le `ResizeObserver`/calcul de budget existant (utilisé
+par le repli automatique en `<select>`, comportement par défaut inchangé) et bifurque tôt dans
+`render()` vers un template dédié réutilisant le squelette DOM et les `csspart` `prev`/`next`
+existants.
+
+**Tech Stack:** Lit 3, TypeScript, Vitest (unit, happy-dom), @web/test-runner + axe-core (browser/a11y), Astro/MDX (docs).
+
+## Global Constraints
+
+- Prettier : 100 caractères, 4 espaces, guillemets simples.
+- `import type` pour tout import de type.
+- Conventional Commits (commitlint + Husky) pour chaque commit.
+- Composant headless : aucun fallback cosmétique `var(--token)` dans `pagination.styles.ts` —
+  toute valeur de design va dans `packages/core/src/styles/themes/default.css`.
+- Nouveau token `--ar-*` custom property : uniquement si consommé via `var()` dans
+  `pagination.styles.ts` (sinon ce n'est pas un `@cssprop`, cf. décision spec — pas de nouveau
+  token ici, `::part(label)` est stylé directement dans `default.css`).
+- Branche créée depuis `dev`, nommage `feat/<desc>` ; PR vers `dev`, jamais de push direct sur `main`.
+- Design de référence : `docs/superpowers/specs/2026-08-12-pagination-compact-mode-design.md`
+  (issue [#180](https://github.com/jogo-labs/ariane/issues/180)).
+
+---
+
+## Task 1: Créer la branche de travail
+
+**Files:** aucun.
+
+- [ ] **Step 1: Créer et checkout la branche depuis `dev`**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git checkout dev
+git pull origin dev
+git checkout -b feat/pagination-compact-mode
+```
+
+---
+
+## Task 2: Propriété `compact` + court-circuit du cycle de vie `ResizeObserver`
+
+**Files:**
+
+- Modify: `packages/core/src/components/pagination/pagination.ts`
+- Test: `packages/core/src/components/pagination/pagination.test.ts`
+
+**Interfaces:**
+
+- Produces: `ArPagination.compact: boolean` (propriété réactive, reflétée, défaut `false`).
+  Toute la logique de rendu de la Task 3 lit cette propriété via `this.compact`.
+
+Cette tâche ne touche pas encore `render()` — uniquement la propriété et le cycle de vie
+(`connectedCallback`, `firstUpdated`, `updated`). Le rendu visuel du mode compact arrive en Task 3 ;
+tant qu'il n'existe pas, `compact=true` désactive juste le `ResizeObserver` sans changer l'affichage
+(non testé ici, couvert par les tests de Task 3).
+
+- [ ] **Step 1: Écrire les tests unitaires du cycle de vie (échouent, `compact` n'existe pas encore)**
+
+Dans `packages/core/src/components/pagination/pagination.test.ts`, ajouter un nouveau `describe`
+juste avant `describe("part d'état item--current", ...)` (ligne ~435) :
+
+```typescript
+// ── Mode compact — cycle de vie ResizeObserver ──────────────────────────
+
+describe('mode compact — cycle de vie ResizeObserver', () => {
+    it('compact vaut false par défaut', async () => {
+        el = await fixture('<ar-pagination></ar-pagination>');
+        expect(el.compact).toBe(false);
+    });
+
+    it('reflète compact en attribut HTML', async () => {
+        el = await fixture('<ar-pagination></ar-pagination>');
+        el.compact = true;
+        await waitForUpdate(el);
+        expect(el.hasAttribute('compact')).toBe(true);
+    });
+
+    it('compact=false (défaut) : instancie un ResizeObserver au montage', async () => {
+        el = await fixture('<ar-pagination></ar-pagination>');
+        expect(
+            (el as unknown as { _resizeObserver?: ResizeObserver })._resizeObserver,
+        ).toBeInstanceOf(ResizeObserver);
+    });
+
+    it("compact=true : n'instancie aucun ResizeObserver au montage", async () => {
+        el = await fixture('<ar-pagination compact></ar-pagination>');
+        expect(
+            (el as unknown as { _resizeObserver?: ResizeObserver })._resizeObserver,
+        ).toBeUndefined();
+    });
+
+    it('passer compact de true à false attache le ResizeObserver', async () => {
+        el = await fixture('<ar-pagination compact></ar-pagination>');
+        expect(
+            (el as unknown as { _resizeObserver?: ResizeObserver })._resizeObserver,
+        ).toBeUndefined();
+
+        el.compact = false;
+        await waitForUpdate(el);
+
+        expect(
+            (el as unknown as { _resizeObserver?: ResizeObserver })._resizeObserver,
+        ).toBeInstanceOf(ResizeObserver);
+    });
+
+    it('passer compact de false à true déconnecte le ResizeObserver existant', async () => {
+        el = await fixture('<ar-pagination></ar-pagination>');
+        const observer = (el as unknown as { _resizeObserver?: ResizeObserver })._resizeObserver;
+        expect(observer).toBeInstanceOf(ResizeObserver);
+        const disconnectSpy = vi.spyOn(observer as ResizeObserver, 'disconnect');
+
+        el.compact = true;
+        await waitForUpdate(el);
+
+        expect(disconnectSpy).toHaveBeenCalled();
+        expect(
+            (el as unknown as { _resizeObserver?: ResizeObserver })._resizeObserver,
+        ).toBeUndefined();
+    });
+});
+```
+
+- [ ] **Step 2: Lancer les tests et vérifier qu'ils échouent**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+npm run test --workspace=packages/core -- pagination.test.ts
+```
+
+Attendu : échecs sur `el.compact` (propriété inexistante — TypeScript refusera même la compilation
+du test, ce qui est le signal d'échec attendu à ce stade).
+
+- [ ] **Step 3: Ajouter la propriété `compact`**
+
+Dans `pagination.ts`, juste après la propriété `total` (après la ligne `total: number = ArPagination.DEFAULT_TOTAL;`, avant `@state() private _budget?: number;`) :
+
+```typescript
+    /**
+     * Mode compact : uniquement les boutons précédent/suivant et un label de position
+     * ("Page X / Y"), navigation strictement séquentielle (pas de saut direct à une page).
+     * Rendu identique en mobile et desktop — contrairement au repli automatique en `<select>`
+     * (comportement par défaut de ce composant), ce mode n'est jamais déclenché par la largeur
+     * du conteneur : c'est un mode à activer explicitement via cet attribut.
+     * @attr compact
+     * @default false
+     */
+    @property({ reflect: true, type: Boolean })
+    compact: boolean = false;
+
+```
+
+- [ ] **Step 4: Court-circuiter `connectedCallback` et `firstUpdated`**
+
+Remplacer :
+
+```typescript
+    override connectedCallback(): void {
+        super.connectedCallback();
+        if (this._initialized) this._setupResizeObserver();
+    }
+
+    override firstUpdated(): void {
+        this._initialized = true;
+        this._setupResizeObserver();
+        // Une police web chargée après le premier paint peut changer la largeur mesurée des
+        // items (ex. police variable, chargement asynchrone) : force une remesure une fois
+        // les polices prêtes. `document.fonts` est absent de certains environnements de test
+        // (happy-dom) — garde défensive.
+        if (document.fonts) {
+            void document.fonts.ready.then(() => {
+                this._needsRemeasure = true;
+                this._recalculateBudget();
+            });
+        }
+    }
+```
+
+par :
+
+```typescript
+    override connectedCallback(): void {
+        super.connectedCallback();
+        if (this._initialized && !this.compact) this._setupResizeObserver();
+    }
+
+    override firstUpdated(): void {
+        this._initialized = true;
+        // Mode compact : pas de repli automatique en <select>, donc aucun besoin de mesurer la
+        // largeur disponible — le ResizeObserver et la remesure liée aux polices web seraient un
+        // travail pur perte, court-circuités entièrement ici.
+        if (this.compact) return;
+        this._setupResizeObserver();
+        // Une police web chargée après le premier paint peut changer la largeur mesurée des
+        // items (ex. police variable, chargement asynchrone) : force une remesure une fois
+        // les polices prêtes. `document.fonts` est absent de certains environnements de test
+        // (happy-dom) — garde défensive.
+        if (document.fonts) {
+            void document.fonts.ready.then(() => {
+                this._needsRemeasure = true;
+                this._recalculateBudget();
+            });
+        }
+    }
+```
+
+- [ ] **Step 5: Gérer le toggle runtime et court-circuiter la remesure liée à `total` dans `updated()`**
+
+Remplacer le début de `updated()` :
+
+```typescript
+    override updated(changed: Map<string, unknown>): void {
+        if (changed.has('total') && this.total < 1) {
+```
+
+par :
+
+```typescript
+    override updated(changed: Map<string, unknown>): void {
+        if (changed.has('compact')) {
+            if (this.compact) {
+                this._resizeObserver?.disconnect();
+                this._resizeObserver = undefined;
+            } else if (this._initialized) {
+                this._setupResizeObserver();
+            }
+        }
+        if (changed.has('total') && this.total < 1) {
+```
+
+Puis, dans le même `updated()`, remplacer :
+
+```typescript
+        if (changed.has('total')) {
+            const digits = String(Math.max(this.total, 1)).length;
+            if (this._prevTotalDigits && digits !== this._prevTotalDigits) {
+```
+
+par :
+
+```typescript
+        if (changed.has('total')) {
+            const digits = String(Math.max(this.total, 1)).length;
+            if (this._prevTotalDigits && digits !== this._prevTotalDigits && !this.compact) {
+```
+
+(le reste du bloc — `this._needsRemeasure = true; this._recalculateBudget();` puis
+`this._prevTotalDigits = digits;` — ne change pas.)
+
+- [ ] **Step 6: Lancer les tests et vérifier qu'ils passent**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+npm run test --workspace=packages/core -- pagination.test.ts
+```
+
+Attendu : tous les tests passent (les 6 nouveaux + les existants, non régressés).
+
+- [ ] **Step 7: Lint et build TypeScript**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+npm run lint --workspace=packages/core
+npm run build:types --workspace=packages/core
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git add packages/core/src/components/pagination/pagination.ts packages/core/src/components/pagination/pagination.test.ts
+git commit -m "feat(pagination): ajoute la propriété compact et court-circuite le ResizeObserver (#180)"
+```
+
+---
+
+## Task 3: Rendu du mode compact (label + réordonnancement DOM)
+
+**Files:**
+
+- Modify: `packages/core/src/components/pagination/pagination.ts`
+- Test: `packages/core/src/components/pagination/pagination.test.ts`
+
+**Interfaces:**
+
+- Consumes: `ArPagination.compact: boolean` (Task 2).
+- Produces: nouveau `csspart` `page-label` (le `<li>` englobant) et `label` (le `<span>` interne),
+  nouvelle méthode protégée `renderCompactLabel(current: number, total: number): TemplateResult`.
+
+- [ ] **Step 1: Écrire les tests unitaires du rendu compact (échouent, aucun rendu dédié n'existe encore)**
+
+Dans `pagination.test.ts`, ajouter un nouveau `describe` juste après le `describe('mode compact — cycle de vie ResizeObserver', ...)` ajouté en Task 2 :
+
+```typescript
+describe('mode compact — rendu', () => {
+    it('rend le label "Page X / Y" avec part="label" et aria-hidden', async () => {
+        el = await fixture('<ar-pagination compact current="3" total="12"></ar-pagination>');
+        const label = requirePart(el, 'label');
+        expect(label.textContent?.trim()).toBe('Page 3 / 12');
+        expect(label.getAttribute('aria-hidden')).toBe('true');
+    });
+
+    it('le <li> englobant du label porte part="item page-label"', async () => {
+        el = await fixture('<ar-pagination compact current="3" total="12"></ar-pagination>');
+        const label = requirePart(el, 'label');
+        const li = label.closest('[part~="page-label"]');
+        expect(li?.getAttribute('part')).toBe('item page-label');
+    });
+
+    it('ordre DOM : label, prev, next', async () => {
+        el = await fixture('<ar-pagination compact current="3" total="12"></ar-pagination>');
+        const shadow = el.shadowRoot as ShadowRoot;
+        const items = Array.from(shadow.querySelectorAll('[part~="item"]'));
+        expect(items).toHaveLength(3);
+        expect(items[0]?.getAttribute('part')).toBe('item page-label');
+        expect(partContains(items[1] as Element, 'prev')).toBe(true);
+        expect(partContains(items[2] as Element, 'next')).toBe(true);
+    });
+
+    it("n'affiche aucun numéro de page ni <select> de saut de page", async () => {
+        el = await fixture('<ar-pagination compact current="3" total="12"></ar-pagination>');
+        const shadow = el.shadowRoot as ShadowRoot;
+        expect(shadow.querySelectorAll('[part~="link"], [part~="current"]').length).toBe(0);
+        expect(shadow.querySelector('[part~="select"]')).toBeNull();
+    });
+
+    it('total=1 : label affiche "Page 1 / 1", prev et next désactivés', async () => {
+        el = await fixture('<ar-pagination compact current="1" total="1"></ar-pagination>');
+        expect(requirePart(el, 'label').textContent?.trim()).toBe('Page 1 / 1');
+        expect(partContains(requirePart(el, 'prev'), 'nav-btn--disabled')).toBe(true);
+        expect(partContains(requirePart(el, 'next'), 'nav-btn--disabled')).toBe(true);
+    });
+
+    it('prev désactivé en page 1, next actif', async () => {
+        el = await fixture('<ar-pagination compact current="1" total="12"></ar-pagination>');
+        expect(requirePart(el, 'prev').getAttribute('aria-disabled')).toBe('true');
+        expect(requirePart(el, 'next').getAttribute('aria-disabled')).toBe('false');
+    });
+
+    it('next désactivé en dernière page, prev actif', async () => {
+        el = await fixture('<ar-pagination compact current="12" total="12"></ar-pagination>');
+        expect(requirePart(el, 'next').getAttribute('aria-disabled')).toBe('true');
+        expect(requirePart(el, 'prev').getAttribute('aria-disabled')).toBe('false');
+    });
+
+    it('le label se met à jour après un changement de page confirmé', async () => {
+        el = await fixture('<ar-pagination compact current="3" total="12"></ar-pagination>');
+        el.addEventListener('ar-pagination-page-change', (e) => {
+            el.current = (e as CustomEvent<ArPaginationPageChangeDetail>).detail.to;
+        });
+        (requirePart(el, 'next') as HTMLElement).click();
+        await waitForUpdate(el);
+        expect(requirePart(el, 'label').textContent?.trim()).toBe('Page 4 / 12');
+    });
+
+    it('prev/next émettent ar-pagination-page-change en mode compact ({from, to})', async () => {
+        el = await fixture('<ar-pagination compact current="3" total="12"></ar-pagination>');
+        const handler = vi.fn();
+        el.addEventListener('ar-pagination-page-change', handler);
+        (requirePart(el, 'next') as HTMLElement).click();
+        await waitForUpdate(el);
+        expect(handler).toHaveBeenCalledOnce();
+        const detail = (handler.mock.calls[0][0] as CustomEvent<ArPaginationPageChangeDetail>)
+            .detail;
+        expect(detail).toEqual({ from: 3, to: 4 });
+    });
+});
+```
+
+- [ ] **Step 2: Lancer les tests et vérifier qu'ils échouent**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+npm run test --workspace=packages/core -- pagination.test.ts
+```
+
+Attendu : échecs sur `requirePart(el, 'label')` (part introuvable — `Error: Part "label" not found`).
+
+- [ ] **Step 3: Ajouter `nothing` à l'import `lit`**
+
+Remplacer la première ligne de `pagination.ts` :
+
+```typescript
+import { LitElement, type TemplateResult, type CSSResultGroup, html } from 'lit';
+```
+
+par :
+
+```typescript
+import { LitElement, type TemplateResult, type CSSResultGroup, html, nothing } from 'lit';
+```
+
+- [ ] **Step 4: Ajouter les entrées JSDoc `@csspart page-label` et `@csspart label`**
+
+Dans le bloc JSDoc de la classe `ArPagination`, juste après la ligne :
+
+```typescript
+ * @csspart select - L'élément `<select>` de saut de page. Personnalisable via `::part(select)`
+ *   (apparence). Conserve l'apparence native du navigateur (flèche incluse) par défaut.
+```
+
+ajouter :
+
+```typescript
+ * @csspart page-label - Le `<li>` englobant le label de position en mode compact (`compact`),
+ *   affiché à la place de la liste de pages. Sur le modèle de `page-select`.
+ * @csspart label - Le `<span>` du label de position en mode compact ("Page X / Y"), non
+ *   cliquable et masqué aux lecteurs d'écran (`aria-hidden`, l'information équivalente est déjà
+ *   portée par le landmark et les `aria-label` prev/next). Personnalisable via `::part(label)`.
+```
+
+- [ ] **Step 5: Ajouter la méthode `renderCompactLabel`**
+
+Juste après la méthode `renderPageSelect` (avant `private _onSelectChange`), ajouter :
+
+```typescript
+    /**
+     * Génère le `<li>` du label de position en mode compact ("Page X / Y"), affiché avant
+     * prev/next. `aria-hidden` sur le `<span>` : le `<p>` sr-only du landmark et les
+     * `aria-label` "Page précédente"/"Page suivante" portent déjà l'information équivalente
+     * pour le lecteur d'écran — sans ce marquage, le texte serait annoncé deux fois.
+     */
+    protected renderCompactLabel(current: number, total: number): TemplateResult {
+        return html`<li part="item page-label">
+            <span part="label" aria-hidden="true">Page ${current} / ${total}</span>
+        </li>`;
+    }
+
+```
+
+- [ ] **Step 6: Court-circuiter le calcul des pages et brancher `render()` sur le mode compact**
+
+Remplacer :
+
+```typescript
+const floorSlots = 5;
+// Calculé une seule fois : réutilisé pour la décision de mode ci-dessous ET pour le
+// rendu des boutons numérotés (repeat) si on reste en mode boutons.
+const pages = _calculatePages(current, total, this._budget);
+```
+
+par :
+
+```typescript
+const floorSlots = 5;
+// Calculé une seule fois : réutilisé pour la décision de mode ci-dessous ET pour le
+// rendu des boutons numérotés (repeat) si on reste en mode boutons. En mode compact,
+// aucun numéro n'est jamais affiché — court-circuité à un tableau vide plutôt que de
+// calculer une fenêtre de pages qui ne sera jamais rendue.
+const pages = this.compact ? [] : _calculatePages(current, total, this._budget);
+```
+
+Puis remplacer :
+
+```typescript
+const useSelectMode =
+    this._budget !== undefined && (this._budget < floorSlots || isMinimalWindowWithDoubleEllipsis);
+```
+
+par :
+
+```typescript
+const useSelectMode =
+    !this.compact &&
+    this._budget !== undefined &&
+    (this._budget < floorSlots || isMinimalWindowWithDoubleEllipsis);
+```
+
+Enfin, remplacer le corps du `<ul>` :
+
+```typescript
+            <ul part="list" @click=${this._onPageChange}>
+                <li part="item">
+                    <a
+                        part="prev nav-btn${isPreviousDisabled ? ' nav-btn--disabled' : ''}"
+                        href="javascript:;"
+                        aria-disabled=${isPreviousDisabled}
+                        @click=${this._onPreviousPage}
+                    >
+                        <slot name="prev-icon">${this._defaultPrevIcon()}</slot>
+                        <span class="sr-only"
+                            >Page précédente (page ${previousPageNumber} sur ${total})</span
+                        >
+                    </a>
+                </li>
+
+                ${useSelectMode
+                    ? this.renderPageSelect(current, total)
+                    : repeat(
+                          pages,
+                          (page) => page,
+                          (page) => {
+                              // -1 et -2 sont des sentinelles représentant les ellipses
+                              return page === -1 || page === -2
+                                  ? html` <li part="item" aria-hidden="true">
+                                        <span part="ellipsis">...</span>
+                                    </li>`
+                                  : this.renderPage(page, page === current, total);
+                          },
+                      )}
+
+                <li part="item">
+                    <a
+                        part="next nav-btn${isNextDisabled ? ' nav-btn--disabled' : ''}"
+                        href="javascript:;"
+                        aria-disabled=${isNextDisabled}
+                        @click=${this._onNextPage}
+                    >
+                        <slot name="next-icon">${this._defaultNextIcon()}</slot>
+                        <span class="sr-only"
+                            >Page suivante (page ${nextPageNumber} sur ${total})</span
+                        >
+                    </a>
+                </li>
+            </ul>
+        </nav>`;
+```
+
+par :
+
+```typescript
+            <ul part="list" @click=${this._onPageChange}>
+                ${this.compact ? this.renderCompactLabel(current, total) : nothing}
+
+                <li part="item">
+                    <a
+                        part="prev nav-btn${isPreviousDisabled ? ' nav-btn--disabled' : ''}"
+                        href="javascript:;"
+                        aria-disabled=${isPreviousDisabled}
+                        @click=${this._onPreviousPage}
+                    >
+                        <slot name="prev-icon">${this._defaultPrevIcon()}</slot>
+                        <span class="sr-only"
+                            >Page précédente (page ${previousPageNumber} sur ${total})</span
+                        >
+                    </a>
+                </li>
+
+                ${this.compact
+                    ? nothing
+                    : useSelectMode
+                      ? this.renderPageSelect(current, total)
+                      : repeat(
+                            pages,
+                            (page) => page,
+                            (page) => {
+                                // -1 et -2 sont des sentinelles représentant les ellipses
+                                return page === -1 || page === -2
+                                    ? html` <li part="item" aria-hidden="true">
+                                          <span part="ellipsis">...</span>
+                                      </li>`
+                                    : this.renderPage(page, page === current, total);
+                            },
+                        )}
+
+                <li part="item">
+                    <a
+                        part="next nav-btn${isNextDisabled ? ' nav-btn--disabled' : ''}"
+                        href="javascript:;"
+                        aria-disabled=${isNextDisabled}
+                        @click=${this._onNextPage}
+                    >
+                        <slot name="next-icon">${this._defaultNextIcon()}</slot>
+                        <span class="sr-only"
+                            >Page suivante (page ${nextPageNumber} sur ${total})</span
+                        >
+                    </a>
+                </li>
+            </ul>
+        </nav>`;
+```
+
+- [ ] **Step 7: Lancer les tests et vérifier qu'ils passent**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+npm run test --workspace=packages/core -- pagination.test.ts
+```
+
+Attendu : tous les tests passent (les 9 nouveaux de cette task + les 6 de Task 2 + l'intégralité de
+la suite existante, non régressée — en particulier `describe('palier select sous le plancher', ...)`
+qui dépend de `_budget`/`_calculatePages`, inchangés en mode non-compact).
+
+- [ ] **Step 8: Lint et build TypeScript**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+npm run lint --workspace=packages/core
+npm run build:types --workspace=packages/core
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git add packages/core/src/components/pagination/pagination.ts packages/core/src/components/pagination/pagination.test.ts
+git commit -m "feat(pagination): rendu du mode compact (label + prev/next) (#180)"
+```
+
+---
+
+## Task 4: Thème par défaut — couleur du label
+
+**Files:**
+
+- Modify: `packages/core/src/styles/themes/default.css`
+
+**Interfaces:**
+
+- Consumes: `csspart` `label` produit en Task 3.
+
+- [ ] **Step 1: Ajouter la règle de couleur pour `::part(label)`**
+
+Dans `packages/core/src/styles/themes/default.css`, dans le bloc `ar-pagination { ... }` (débute
+ligne ~1087), juste après la règle `&::part(select) { ... }` (qui se termine par le
+`background-repeat: no-repeat;` suivi de `}`), ajouter :
+
+```css
+/* Même couleur de texte que link/prev/next (`--ar-color-text`) : le label doit rester
+           visuellement cohérent avec le reste du composant, bien qu'il ne soit pas interactif
+           (pas de background-color ni d'état hover/focus/active, contrairement aux parts
+           cliquables ci-dessus). */
+&::part(label) {
+    color: var(--ar-color-text);
+}
+```
+
+- [ ] **Step 2: Vérifier visuellement dans les docs en local**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+npm run dev
+```
+
+Ouvrir la page `ar-pagination` dans le navigateur (`apps/docs`), inspecter temporairement l'élément
+avec `document.querySelector('ar-pagination').compact = true` dans la console devtools pour
+vérifier que le label est lisible (couleur cohérente avec le reste du composant). Arrêter le
+serveur (`Ctrl+C`) une fois vérifié — ce test manuel n'a pas de commande de validation automatisée,
+la démo dédiée arrive en Task 6.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git add packages/core/src/styles/themes/default.css
+git commit -m "style(pagination): couleur du label en mode compact dans le thème par défaut (#180)"
+```
+
+---
+
+## Task 5: Tests d'accessibilité et tests navigateur
+
+**Files:**
+
+- Modify: `packages/core/src/components/pagination/pagination.a11y.test.ts`
+- Modify: `packages/core/src/components/pagination/pagination.browser.test.ts`
+
+**Interfaces:**
+
+- Consumes: attribut `compact`, `csspart` `label`/`page-label` (Task 2 et 3).
+
+- [ ] **Step 1: Ajouter les tests axe-core du mode compact**
+
+Dans `pagination.a11y.test.ts`, ajouter un nouveau `describe` après le `describe('ar-pagination — accessibilité', ...)` existant (avant la fermeture du fichier) :
+
+```typescript
+describe('ar-pagination — mode compact — accessibilité', () => {
+    it('page milieu de liste, mode compact, est accessible', async () => {
+        const el = await fixture(
+            html`<ar-pagination compact current="4" total="12"></ar-pagination>`,
+        );
+        await expect(el).to.be.accessible();
+    });
+
+    it('première page, mode compact (prev désactivé), est accessible', async () => {
+        const el = await fixture(
+            html`<ar-pagination compact current="1" total="12"></ar-pagination>`,
+        );
+        await expect(el).to.be.accessible();
+    });
+
+    it('dernière page, mode compact (next désactivé), est accessible', async () => {
+        const el = await fixture(
+            html`<ar-pagination compact current="12" total="12"></ar-pagination>`,
+        );
+        await expect(el).to.be.accessible();
+    });
+
+    it('total=1, mode compact (prev et next désactivés), est accessible', async () => {
+        const el = await fixture(
+            html`<ar-pagination compact current="1" total="1"></ar-pagination>`,
+        );
+        await expect(el).to.be.accessible();
+    });
+});
+```
+
+- [ ] **Step 2: Ajouter les tests navigateur du mode compact**
+
+Dans `pagination.browser.test.ts`, ajouter un nouveau `describe` juste avant la fermeture du
+`describe('ar-pagination — browser', ...)` (après le `describe('invariant anti-débordement ...')`) :
+
+```typescript
+describe('mode compact (#180) — pas de bascule responsive', () => {
+    it('reste en mode compact quelle que soit la largeur du conteneur', async () => {
+        const wrapper = await fixture(
+            html`<div style="width: 900px;">
+                <ar-pagination compact current="8" total="15"></ar-pagination>
+            </div>`,
+        );
+        const el = wrapper.querySelector('ar-pagination') as HTMLElement;
+        await elementUpdated(el);
+
+        const shadow = el.shadowRoot as ShadowRoot;
+        expect(shadow.querySelector('[part~="label"]')).to.not.equal(null);
+        expect(shadow.querySelectorAll('[part~="link"], [part~="current"]').length).to.equal(0);
+        expect(shadow.querySelector('[part~="select"]')).to.equal(null);
+
+        wrapper.style.width = '90px';
+        await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        // À 90px, le mode adaptatif basculerait sur un <select> (cf. test existant "bascule
+        // sur un <select>..." plus haut dans ce fichier) — le mode compact doit rester
+        // strictement identique, aucune bascule.
+        expect(shadow.querySelector('[part~="label"]')).to.not.equal(null);
+        expect(shadow.querySelector('[part~="select"]')).to.equal(null);
+        expect(shadow.querySelectorAll('[part~="link"], [part~="current"]').length).to.equal(0);
+    });
+
+    it('un clic sur next confirmé garde le focus sur le bouton actionné', async () => {
+        const el = await fixture(
+            html`<ar-pagination compact current="3" total="12"></ar-pagination>`,
+        );
+        el.addEventListener('ar-pagination-page-change', (e) => {
+            (el as unknown as { current: number }).current = (
+                e as CustomEvent<{ from: number; to: number }>
+            ).detail.to;
+        });
+        const shadowRoot = el.shadowRoot as ShadowRoot;
+        const next = shadowRoot.querySelector('[part~="next"]') as HTMLElement;
+
+        next.focus();
+        next.click();
+        await elementUpdated(el);
+
+        expect(shadowRoot.activeElement).to.equal(next);
+        expect((el as unknown as { current: number }).current).to.equal(4);
+    });
+});
+```
+
+- [ ] **Step 3: Lancer les tests navigateur et vérifier qu'ils passent**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+npm run test:browser --workspace=packages/core
+```
+
+Attendu : tous les tests passent, y compris les axe-core (aucune violation) et les nouveaux tests
+navigateur. Si le runner échoue au démarrage (cold-start Playwright), relancer une fois —
+comportement connu du projet (cf. `browserStartTimeout` 60s en CI), pas un signe de régression.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git add packages/core/src/components/pagination/pagination.a11y.test.ts packages/core/src/components/pagination/pagination.browser.test.ts
+git commit -m "test(pagination): couverture a11y et navigateur du mode compact (#180)"
+```
+
+---
+
+## Task 6: Documentation
+
+**Files:**
+
+- Modify: `apps/docs/src/content/components/ar-pagination.mdx`
+
+**Interfaces:**
+
+- Consumes: attribut `compact`, JSDoc de `pagination.ts` (Task 2, 3 — régénère le manifest CEM
+  dont dépend le tableau d'API auto-généré par `ComponentApi.astro`, sans édition manuelle).
+
+- [ ] **Step 1: Ajouter une démo "Mode compact" dans le frontmatter**
+
+Dans `apps/docs/src/content/components/ar-pagination.mdx`, dans la liste `variants:` du
+frontmatter, ajouter une entrée après `20-pages-end` (avant `pageScript:`) :
+
+```yaml
+- name: compact
+  label: Mode compact
+  description: Mode compact — uniquement précédent/suivant et un label de position, identique en mobile et desktop.
+  html: |
+      <ar-pagination compact current="4" total="12"></ar-pagination>
+```
+
+- [ ] **Step 2: Ajouter une section "Mode compact" dans le corps de la page**
+
+Dans le corps du fichier, ajouter une nouvelle section après `## Comportement responsive` (avant
+`## Utilisation`) :
+
+````markdown
+## Mode compact
+
+L'attribut booléen `compact` remplace la numérotation par un simple prev/next accompagné d'un
+label de position non cliquable ("Page 4 / 12"). Contrairement au repli automatique en `<select>`
+décrit ci-dessus, ce mode est **fixe** : il ne réagit pas à la largeur du conteneur, le rendu est
+identique en mobile et en desktop. Adapté aux contextes où seule une navigation séquentielle
+(page suivante/précédente) est utile — par exemple un panneau de détail ou un drawer.
+
+```html
+<ar-pagination compact current="4" total="12"></ar-pagination>
+```
+````
+
+La navigation reste strictement séquentielle dans ce mode : il n'y a pas de saut direct à une page
+arbitraire (pas de numéros cliquables, pas de `<select>`).
+
+````
+
+- [ ] **Step 3: Régénérer le manifest CEM (fait apparaître `compact`/`page-label`/`label` dans le tableau d'API auto-généré)**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+npm run build:manifest
+````
+
+- [ ] **Step 4: Vérifier visuellement la page de doc en local**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+npm run dev
+```
+
+Ouvrir la page `ar-pagination`, vérifier que :
+
+- la démo "Mode compact" s'affiche correctement (prev/next + label "Page 4 / 12"),
+- le tableau d'attributs auto-généré liste `compact`,
+- le tableau de `csspart` auto-généré liste `page-label` et `label`.
+
+Arrêter le serveur (`Ctrl+C`) une fois vérifié.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git add apps/docs/src/content/components/ar-pagination.mdx packages/core/custom-elements.json
+git commit -m "docs(pagination): documente le mode compact (#180)"
+```
+
+---
+
+## Task 7: Vérification finale et Pull Request
+
+**Files:** aucun nouveau — vérification de bout en bout.
+
+- [ ] **Step 1: Lancer la suite de tests complète**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+npm run test:all
+```
+
+Attendu : tous les tests passent (Vitest + WTR), sans régression sur le reste de la suite
+`ar-pagination` ni des autres composants.
+
+- [ ] **Step 2: Build complet du package core**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+npm run build --workspace=packages/core
+```
+
+Attendu : build sans erreur (manifest, bundles, CSS, types).
+
+- [ ] **Step 3: Pousser la branche**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git push -u origin feat/pagination-compact-mode
+```
+
+- [ ] **Step 4: Créer la Pull Request vers `dev`**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+gh pr create --base dev --title "feat(pagination): mode compact (prev/next + label de position)" --body "$(cat <<'EOF'
+## Résumé
+
+- Ajoute un attribut booléen `compact` à `ar-pagination` : uniquement prev/next + label de
+  position non cliquable ("Page X / Y"), navigation strictement séquentielle, rendu identique en
+  mobile et desktop (pas de bascule responsive comme le repli automatique en `<select>` existant).
+- Court-circuite entièrement le `ResizeObserver`/calcul de budget en mode compact (y compris au
+  toggle runtime de l'attribut).
+- Nouveaux `csspart` `page-label`/`label`, stylés dans le thème par défaut.
+- Design : `docs/superpowers/specs/2026-08-12-pagination-compact-mode-design.md`
+
+Closes #180
+
+## Test plan
+
+- [x] Tests unitaires (Vitest) : propriété `compact`, cycle de vie `ResizeObserver`, rendu DOM,
+      événements `ar-pagination-page-change`.
+- [x] Tests a11y (axe-core) : 4 configurations (milieu, bord début, bord fin, total=1).
+- [x] Tests navigateur (WTR) : absence de bascule responsive, focus après clic next.
+- [x] `npm run test:all` et `npm run build --workspace=packages/core` passent.
+- [ ] Revue manuelle de la démo "Mode compact" sur `apps/docs` (npm run dev) une fois la PR ouverte.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: Rapporter l'URL de la PR à l'utilisateur**
+
+Aucune commande — indiquer l'URL retournée par `gh pr create` dans la réponse finale.

--- a/docs/superpowers/specs/2026-08-12-pagination-compact-mode-design.md
+++ b/docs/superpowers/specs/2026-08-12-pagination-compact-mode-design.md
@@ -1,0 +1,147 @@
+# Design — `ar-pagination` : mode compact (prev/next + label)
+
+**Statut :** Validé (en attente de plan d'implémentation)
+**Date :** 2026-08-12
+**Contexte :** issue [#180](https://github.com/jogo-labs/ariane/issues/180), née pendant la revue de
+la démo « Header avancé » d'`ar-dialog` (#145, PR #179)
+
+## Reconceptualisation du vocabulaire existant
+
+Point tranché en amont, car il détermine le nom disponible pour la suite. Le comportement actuel
+de repli automatique en `<select>` (piloté par `ResizeObserver`, cf.
+`2026-08-10-pagination-select-fallback-design.md`) était jusqu'ici informellement appelé
+« compact » dans les échanges (PR #179). Ce nom est **libéré** : le repli auto redevient
+simplement le comportement par défaut du composant — sans attribut, sans nom d'API dédié,
+documenté comme « adaptatif » en interne/doc si besoin de le désigner. `compact` devient le nom du
+nouveau mode explicite décrit ci-dessous.
+
+Alternative écartée : un attribut `mode="compact"` façon `ar-dialog` (`mode="modal"|"drawer"`).
+Écarté par YAGNI — ni `ar-pagination` ni `ar-dialog` n'ont aujourd'hui de second mode identifié qui
+justifierait la syntaxe extensible `mode="..."`. Un attribut booléen simple suffit à l'unique
+distinction connue (numéroté adaptatif vs compact). Si un vrai second mode apparaît un jour (ici ou
+sur `ar-dialog`), la migration vers `mode="compact"` sera un changement mineur, acceptable en
+alpha.
+
+## API publique
+
+Nouvelle propriété :
+
+```ts
+@property({ reflect: true, type: Boolean })
+compact: boolean = false;
+```
+
+- `compact=false` (défaut) : comportement actuel inchangé — numérotation avec repli automatique en
+  `<select>` selon l'espace disponible.
+- `compact=true` : nouveau rendu — uniquement prev/next + un label de position non cliquable
+  (`Page X / Y`), **identique en mobile et desktop**, pas de bascule responsive.
+- Pas de mécanisme i18n pour le texte du label : cohérent avec le reste du composant, dont tous les
+  textes/`aria-label` sont déjà en dur en français, sans infrastructure i18n dans Ariane à ce jour.
+  Hors scope de #180.
+
+## DOM / rendu
+
+Le squelette `<nav part="nav"><ul part="list">` est conservé pour les deux modes — seul le contenu
+de la liste change. En mode compact, `<ul>` contient 3 `<li>` :
+
+```html
+<nav part="nav" role="navigation" aria-labelledby="ar-pagination">
+    <p id="ar-pagination" class="sr-only">Pagination, page X sur Y</p>
+    <ul part="list">
+        <li part="item page-label">
+            <span part="label" aria-hidden="true">Page X / Y</span>
+        </li>
+        <li part="item">
+            <a part="prev nav-btn..." href="javascript:;" aria-disabled="...">…</a>
+        </li>
+        <li part="item">
+            <a part="next nav-btn..." href="javascript:;" aria-disabled="...">…</a>
+        </li>
+    </ul>
+</nav>
+```
+
+- **Ordre DOM `label, prev, next`** (validé) : le label en premier positionne naturellement le
+  contenu au début du flow logique (gauche en LTR, droite en RTL), sans CSS `order` ni logique
+  supplémentaire. Alternative écartée : `prev, label, next` — aurait nécessité un repositionnement
+  CSS pour respecter l'exigence de l'issue (label à gauche/début), sans bénéfice identifié.
+- Les parts `prev`/`next`/`nav-btn`/`nav-btn--disabled` sont **strictement identiques** entre les
+  deux modes — un thème stylant `::part(nav-btn)` fonctionne sans changement en mode compact.
+  `aria-disabled` calculé exactement comme aujourd'hui (`current <= 1` / `current >= total`).
+- Nouveaux `csspart` : **`page-label`** (le `<li>` englobant, sur le modèle de `page-select`) et
+  **`label`** (le `<span>` interne, sur le modèle de `select`).
+- `total === 1` : prev et next tous deux désactivés, label affiche « Page 1 / 1 » — cohérent avec
+  le comportement actuel en mode numéroté.
+
+## Accessibilité
+
+- Le `<p id="ar-pagination">` sr-only existant (« Pagination, page X sur Y ») et les `aria-label`
+  « Page précédente (page X sur Y) » / « Page suivante » déjà posés sur prev/next restent
+  **inchangés** et portent toute l'information nécessaire au lecteur d'écran.
+- Le `<span part="label">` visible porte donc **`aria-hidden="true"`** : sans ce marquage, le
+  lecteur d'écran lirait le texte « Page X / Y » en plus du `<p>` sr-only déjà mis à jour à chaque
+  changement de page — double annonce. Ce pattern (séparer texte visible `aria-hidden` et
+  équivalent sr-only) est déjà celui de `renderPageLabel()` pour les numéros de page en mode
+  adaptatif.
+- Aucune annonce dédiée supplémentaire n'est nécessaire : `_announcePageChange()` (existant, `role`
+  polite) continue de couvrir le changement de page dans les deux modes.
+
+## Comportement / cycle de vie
+
+- **Court-circuit total** du calcul de largeur en mode compact (validé — alternative « observer
+  conservé mais ignoré » écartée pour éviter un travail de mesure inutile et un état interne plus
+  difficile à raisonner) :
+    - `connectedCallback`/`firstUpdated` ne montent pas le `ResizeObserver` si `compact === true`.
+    - `_recalculateBudget()` n'est jamais appelé, `_budget`/`_calculatePages` ne sont pas utilisés
+      pour le rendu.
+- **Toggle runtime** de `compact` géré dans `updated()` via `changed.has('compact')` :
+    - passage à `true` → `this._resizeObserver?.disconnect()`.
+    - passage à `false` (si `_initialized`) → `this._setupResizeObserver()`.
+    - Cas limite peu probable en usage réel, mais gratuit à couvrir puisque
+      `_setupResizeObserver()`/`disconnect()` existent déjà.
+- `render()` bifurque tôt : `this.compact ? this.renderCompact(...) : <rendu existant>`. Les
+  calculs `previousPageNumber`/`nextPageNumber`/`isPreviousDisabled`/`isNextDisabled`, déjà en tête
+  de `render()`, restent communs aux deux branches.
+- `_onPreviousPage`/`_onNextPage`/`_requestPageChange`/`_emitChanged`/`_announcePageChange` :
+  **inchangés**, réutilisés tels quels. Les événements `ar-pagination-page-change`/
+  `ar-pagination-page-changed` se comportent identiquement dans les deux modes (modèle contrôlé
+  préservé, cf. `2026-08-10-pagination-controlled-current-design.md`).
+- Pas de gestion de `_pendingFocusPage` en mode compact : comme aujourd'hui pour prev/next (seul le
+  clic sur un numéro de page pose ce flag), le focus reste naturellement sur le bouton prev/next
+  cliqué — aucun changement de comportement de focus à implémenter.
+
+## Style / thème
+
+- `--ar-pagination-btn-size` et `--ar-pagination-transition-duration` s'appliquent identiquement
+  aux deux modes (mêmes parts `prev`/`next`/`nav-btn`).
+- Nouveau part `label` : token de couleur/typo à définir dans `themes/default.css` au moment du
+  plan d'implémentation, après relecture de `pagination.styles.ts` pour rester cohérent avec les
+  tokens déjà exposés par le composant plutôt que d'en inventer un nouveau à l'aveugle (headless —
+  pas de fallback cosmétique dans `pagination.styles.ts`, cf. philosophie du projet).
+- Aucun style spécifique au mode compact n'est imposé par le composant pour l'agencement visuel
+  prev/next (absence de gap, coins internes non arrondis, etc.) : **hors scope**, laissé au
+  consommateur via `ar-pagination[compact]::part(prev)` / `::part(next)`. Le composant reste
+  headless sur ce point, comme sur le reste de son style.
+
+## Tests
+
+- **Unit** (`pagination.test.ts`) : rendu du label avec le texte attendu selon `current`/`total`,
+  `aria-hidden` posé sur `part="label"`, absence d'instanciation de `ResizeObserver` en mode
+  compact, `disabled` correct sur prev/next aux bornes (`current=1`, `current=total`, `total=1`),
+  toggle runtime de `compact` (attache/détache l'observer).
+- **A11y** (`pagination.a11y.test.ts`) : passage axe-core sur le rendu compact, vérification de
+  l'absence de double annonce (le `<p>` sr-only porte l'info, le label visible est `aria-hidden`).
+- **Browser** (`pagination.browser.test.ts`) : navigation clavier/clic prev/next en mode compact,
+  focus après clic reste sur le bouton actionné.
+- **Doc** (`apps/docs/src/content/components/ar-pagination.mdx`) : nouvelle démo mode compact, mise
+  à jour du tableau des attributs (`compact`) et des csspart (`page-label`, `label`).
+
+## Hors scope
+
+- Attribut `mode="compact"` extensible — écarté par YAGNI, cf. section « Reconceptualisation ».
+- i18n du texte du label et des `aria-label` prev/next — cohérent avec l'absence d'infrastructure
+  i18n dans le reste du composant/projet.
+- Style par défaut du composant pour l'agencement visuel prev/next en mode compact (gap, arrondis
+  internes) — laissé au consommateur via `::part()`, le composant reste headless.
+- Navigation directe à une page arbitraire en mode compact — l'issue #180 précise explicitement une
+  navigation strictement séquentielle ; pas de saut de page dans ce mode.

--- a/docs/superpowers/specs/2026-08-12-pagination-compact-mode-design.md
+++ b/docs/superpowers/specs/2026-08-12-pagination-compact-mode-design.md
@@ -75,9 +75,9 @@ de la liste change. En mode compact, `<ul>` contient 3 `<li>` :
 
 ## Accessibilité
 
-- Le `<p id="ar-pagination">` sr-only existant (« Pagination, page X sur Y ») et les `aria-label`
-  « Page précédente (page X sur Y) » / « Page suivante » déjà posés sur prev/next restent
-  **inchangés** et portent toute l'information nécessaire au lecteur d'écran.
+- Le `<p id="ar-pagination">` sr-only existant (« Pagination, page X sur Y ») et le texte
+  accessible (sr-only) « Page précédente (page X sur Y) » / « Page suivante » déjà posé sur
+  prev/next restent **inchangés** et portent toute l'information nécessaire au lecteur d'écran.
 - Le `<span part="label">` visible porte donc **`aria-hidden="true"`** : sans ce marquage, le
   lecteur d'écran lirait le texte « Page X / Y » en plus du `<p>` sr-only déjà mis à jour à chaque
   changement de page — double annonce. Ce pattern (séparer texte visible `aria-hidden` et
@@ -139,8 +139,8 @@ de la liste change. En mode compact, `<ul>` contient 3 `<li>` :
 ## Hors scope
 
 - Attribut `mode="compact"` extensible — écarté par YAGNI, cf. section « Reconceptualisation ».
-- i18n du texte du label et des `aria-label` prev/next — cohérent avec l'absence d'infrastructure
-  i18n dans le reste du composant/projet.
+- i18n du texte du label et du texte accessible (sr-only) de prev/next — cohérent avec l'absence
+  d'infrastructure i18n dans le reste du composant/projet.
 - Style par défaut du composant pour l'agencement visuel prev/next en mode compact (gap, arrondis
   internes) — laissé au consommateur via `::part()`, le composant reste headless.
 - Navigation directe à une page arbitraire en mode compact — l'issue #180 précise explicitement une

--- a/packages/core/src/components/pagination/pagination.a11y.test.ts
+++ b/packages/core/src/components/pagination/pagination.a11y.test.ts
@@ -38,3 +38,33 @@ describe('ar-pagination — accessibilité', () => {
         await expect(el).to.be.accessible();
     });
 });
+
+describe('ar-pagination — mode compact — accessibilité', () => {
+    it('page milieu de liste, mode compact, est accessible', async () => {
+        const el = await fixture(
+            html`<ar-pagination compact current="4" total="12"></ar-pagination>`,
+        );
+        await expect(el).to.be.accessible();
+    });
+
+    it('première page, mode compact (prev désactivé), est accessible', async () => {
+        const el = await fixture(
+            html`<ar-pagination compact current="1" total="12"></ar-pagination>`,
+        );
+        await expect(el).to.be.accessible();
+    });
+
+    it('dernière page, mode compact (next désactivé), est accessible', async () => {
+        const el = await fixture(
+            html`<ar-pagination compact current="12" total="12"></ar-pagination>`,
+        );
+        await expect(el).to.be.accessible();
+    });
+
+    it('total=1, mode compact (prev et next désactivés), est accessible', async () => {
+        const el = await fixture(
+            html`<ar-pagination compact current="1" total="1"></ar-pagination>`,
+        );
+        await expect(el).to.be.accessible();
+    });
+});

--- a/packages/core/src/components/pagination/pagination.browser.test.ts
+++ b/packages/core/src/components/pagination/pagination.browser.test.ts
@@ -418,6 +418,44 @@ describe('ar-pagination — browser', () => {
             expect(shadow.querySelectorAll('[part~="link"], [part~="current"]').length).to.equal(0);
         });
 
+        it('bascule compact→false→true→false remplace correctement un <select> déjà actif', async () => {
+            async function waitForResize(): Promise<void> {
+                await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+                await new Promise((resolve) => setTimeout(resolve, 50));
+            }
+
+            // 1. Instance non compacte dans un conteneur étroit : le vrai ResizeObserver doit
+            //    faire basculer le composant sur le palier <select> (précondition).
+            const wrapper = await fixture(
+                html`<div style="width: 90px;">
+                    <ar-pagination current="8" total="15"></ar-pagination>
+                </div>`,
+            );
+            const el = wrapper.querySelector('ar-pagination') as HTMLElement;
+            await elementUpdated(el);
+            await waitForResize();
+
+            const shadow = el.shadowRoot as ShadowRoot;
+            expect(shadow.querySelector('[part~="select"]')).to.not.equal(null);
+
+            // 2. Passage en mode compact alors que le <select> est déjà affiché : doit le
+            //    remplacer par le label, sans attendre de resize (compact ne dépend pas de la
+            //    largeur).
+            (el as unknown as { compact: boolean }).compact = true;
+            await elementUpdated(el);
+
+            expect(shadow.querySelector('[part~="select"]')).to.equal(null);
+            expect(shadow.querySelector('[part~="label"]')).to.not.equal(null);
+
+            // 3. Retour en mode non compact, toujours dans le conteneur étroit : le
+            //    ResizeObserver doit se rattacher et remesurer, restaurant le <select>.
+            (el as unknown as { compact: boolean }).compact = false;
+            await elementUpdated(el);
+            await waitForResize();
+
+            expect(shadow.querySelector('[part~="select"]')).to.not.equal(null);
+        });
+
         it('un clic sur next confirmé garde le focus sur le bouton actionné', async () => {
             const el = await fixture(
                 html`<ar-pagination compact current="3" total="12"></ar-pagination>`,

--- a/packages/core/src/components/pagination/pagination.browser.test.ts
+++ b/packages/core/src/components/pagination/pagination.browser.test.ts
@@ -390,4 +390,52 @@ describe('ar-pagination — browser', () => {
             }
         });
     });
+
+    describe('mode compact (#180) — pas de bascule responsive', () => {
+        it('reste en mode compact quelle que soit la largeur du conteneur', async () => {
+            const wrapper = await fixture(
+                html`<div style="width: 900px;">
+                    <ar-pagination compact current="8" total="15"></ar-pagination>
+                </div>`,
+            );
+            const el = wrapper.querySelector('ar-pagination') as HTMLElement;
+            await elementUpdated(el);
+
+            const shadow = el.shadowRoot as ShadowRoot;
+            expect(shadow.querySelector('[part~="label"]')).to.not.equal(null);
+            expect(shadow.querySelectorAll('[part~="link"], [part~="current"]').length).to.equal(0);
+            expect(shadow.querySelector('[part~="select"]')).to.equal(null);
+
+            wrapper.style.width = '90px';
+            await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+            await new Promise((resolve) => setTimeout(resolve, 50));
+
+            // À 90px, le mode adaptatif basculerait sur un <select> (cf. test existant "bascule
+            // sur un <select>..." plus haut dans ce fichier) — le mode compact doit rester
+            // strictement identique, aucune bascule.
+            expect(shadow.querySelector('[part~="label"]')).to.not.equal(null);
+            expect(shadow.querySelector('[part~="select"]')).to.equal(null);
+            expect(shadow.querySelectorAll('[part~="link"], [part~="current"]').length).to.equal(0);
+        });
+
+        it('un clic sur next confirmé garde le focus sur le bouton actionné', async () => {
+            const el = await fixture(
+                html`<ar-pagination compact current="3" total="12"></ar-pagination>`,
+            );
+            el.addEventListener('ar-pagination-page-change', (e) => {
+                (el as unknown as { current: number }).current = (
+                    e as CustomEvent<{ from: number; to: number }>
+                ).detail.to;
+            });
+            const shadowRoot = el.shadowRoot as ShadowRoot;
+            const next = shadowRoot.querySelector('[part~="next"]') as HTMLElement;
+
+            next.focus();
+            next.click();
+            await elementUpdated(el);
+
+            expect(shadowRoot.activeElement).to.equal(next);
+            expect((el as unknown as { current: number }).current).to.equal(4);
+        });
+    });
 });

--- a/packages/core/src/components/pagination/pagination.test.ts
+++ b/packages/core/src/components/pagination/pagination.test.ts
@@ -432,6 +432,61 @@ describe('ArPagination', () => {
         });
     });
 
+    // ── Mode compact — cycle de vie ResizeObserver ──────────────────────────
+
+    describe('mode compact — cycle de vie ResizeObserver', () => {
+        it('compact vaut false par défaut', async () => {
+            el = await fixture('<ar-pagination></ar-pagination>');
+            expect(el.compact).toBe(false);
+        });
+
+        it('reflète compact en attribut HTML', async () => {
+            el = await fixture('<ar-pagination></ar-pagination>');
+            el.compact = true;
+            await waitForUpdate(el);
+            expect(el.hasAttribute('compact')).toBe(true);
+        });
+
+        it('compact=false (défaut) : instancie un ResizeObserver au montage', async () => {
+            el = await fixture('<ar-pagination></ar-pagination>');
+            // @ts-expect-error accès à un champ privé pour vérifier l'instanciation du ResizeObserver
+            expect(el._resizeObserver).toBeInstanceOf(ResizeObserver);
+        });
+
+        it("compact=true : n'instancie aucun ResizeObserver au montage", async () => {
+            el = await fixture('<ar-pagination compact></ar-pagination>');
+            // @ts-expect-error accès à un champ privé pour vérifier l'absence de ResizeObserver
+            expect(el._resizeObserver).toBeUndefined();
+        });
+
+        it('passer compact de true à false attache le ResizeObserver', async () => {
+            el = await fixture('<ar-pagination compact></ar-pagination>');
+            // @ts-expect-error accès à un champ privé pour vérifier l'absence de ResizeObserver
+            expect(el._resizeObserver).toBeUndefined();
+
+            el.compact = false;
+            await waitForUpdate(el);
+
+            // @ts-expect-error accès à un champ privé pour vérifier l'instanciation du ResizeObserver
+            expect(el._resizeObserver).toBeInstanceOf(ResizeObserver);
+        });
+
+        it('passer compact de false à true déconnecte le ResizeObserver existant', async () => {
+            el = await fixture('<ar-pagination></ar-pagination>');
+            // @ts-expect-error accès à un champ privé pour récupérer le ResizeObserver interne
+            const observer = el._resizeObserver;
+            expect(observer).toBeInstanceOf(ResizeObserver);
+            const disconnectSpy = vi.spyOn(observer as ResizeObserver, 'disconnect');
+
+            el.compact = true;
+            await waitForUpdate(el);
+
+            expect(disconnectSpy).toHaveBeenCalled();
+            // @ts-expect-error accès à un champ privé pour vérifier la déconnexion
+            expect(el._resizeObserver).toBeUndefined();
+        });
+    });
+
     describe("part d'état item--current", () => {
         it('le <li> de la page active porte part="item item--current"', async () => {
             el = await fixture('<ar-pagination current="3" total="5"></ar-pagination>');

--- a/packages/core/src/components/pagination/pagination.test.ts
+++ b/packages/core/src/components/pagination/pagination.test.ts
@@ -625,18 +625,18 @@ describe('ArPagination', () => {
     });
 
     describe('mode compact — rendu', () => {
-        it('rend le label "Page X / Y" avec part="label" et aria-hidden', async () => {
+        it('rend le label "Page X / Y" avec part="label"', async () => {
             el = await fixture('<ar-pagination compact current="3" total="12"></ar-pagination>');
             const label = requireLabel(el);
             expect(label.textContent?.trim()).toBe('Page 3 / 12');
-            expect(label.getAttribute('aria-hidden')).toBe('true');
         });
 
-        it('le <li> englobant du label porte part="item page-label"', async () => {
+        it('le <li> englobant du label porte part="item page-label" et aria-hidden', async () => {
             el = await fixture('<ar-pagination compact current="3" total="12"></ar-pagination>');
             const label = requireLabel(el);
             const li = label.closest('[part~="page-label"]');
             expect(li?.getAttribute('part')).toBe('item page-label');
+            expect(li?.getAttribute('aria-hidden')).toBe('true');
         });
 
         it('ordre DOM : label, prev, next', async () => {

--- a/packages/core/src/components/pagination/pagination.test.ts
+++ b/packages/core/src/components/pagination/pagination.test.ts
@@ -13,6 +13,21 @@ function partContains(el: Element, token: string): boolean {
     return (el.getAttribute('part') ?? '').split(/\s+/).includes(token);
 }
 
+/**
+ * Retourne le `<span part="label">` du mode compact (`renderCompactLabel`).
+ *
+ * `requirePart(el, 'label')` ne convient pas ici : happy-dom scinde aussi `~=` sur les
+ * tirets (mise en garde documentée dans test-utils.ts), donc `[part~="label"]` matche à
+ * tort le `<li part="item page-label">` englobant — rencontré en premier dans l'ordre du
+ * document — avant le `<span part="label">` réel. Sélecteur d'attribut exact (`=`) sur le
+ * `<span>` pour contourner ce faux positif propre à l'environnement de test.
+ */
+function requireLabel(el: ArPagination): Element {
+    const found = el.shadowRoot?.querySelector('span[part="label"]');
+    if (!found) throw new Error('Part "label" (span) not found in shadow DOM');
+    return found;
+}
+
 describe('ArPagination', () => {
     let el: ArPagination;
 
@@ -606,6 +621,80 @@ describe('ArPagination', () => {
             await waitForUpdate(el);
             expect(el.current).toBe(4);
             expect(el.shadowRoot?.activeElement).toBe(nextBtn);
+        });
+    });
+
+    describe('mode compact — rendu', () => {
+        it('rend le label "Page X / Y" avec part="label" et aria-hidden', async () => {
+            el = await fixture('<ar-pagination compact current="3" total="12"></ar-pagination>');
+            const label = requireLabel(el);
+            expect(label.textContent?.trim()).toBe('Page 3 / 12');
+            expect(label.getAttribute('aria-hidden')).toBe('true');
+        });
+
+        it('le <li> englobant du label porte part="item page-label"', async () => {
+            el = await fixture('<ar-pagination compact current="3" total="12"></ar-pagination>');
+            const label = requireLabel(el);
+            const li = label.closest('[part~="page-label"]');
+            expect(li?.getAttribute('part')).toBe('item page-label');
+        });
+
+        it('ordre DOM : label, prev, next', async () => {
+            el = await fixture('<ar-pagination compact current="3" total="12"></ar-pagination>');
+            const shadow = el.shadowRoot as ShadowRoot;
+            const items = Array.from(shadow.querySelectorAll('[part~="item"]'));
+            expect(items).toHaveLength(3);
+            expect(items[0]?.getAttribute('part')).toBe('item page-label');
+            expect((items[1] as Element).querySelector('[part~="prev"]')).not.toBeNull();
+            expect((items[2] as Element).querySelector('[part~="next"]')).not.toBeNull();
+        });
+
+        it("n'affiche aucun numéro de page ni <select> de saut de page", async () => {
+            el = await fixture('<ar-pagination compact current="3" total="12"></ar-pagination>');
+            const shadow = el.shadowRoot as ShadowRoot;
+            expect(shadow.querySelectorAll('[part~="link"], [part~="current"]').length).toBe(0);
+            expect(shadow.querySelector('[part~="select"]')).toBeNull();
+        });
+
+        it('total=1 : label affiche "Page 1 / 1", prev et next désactivés', async () => {
+            el = await fixture('<ar-pagination compact current="1" total="1"></ar-pagination>');
+            expect(requireLabel(el).textContent?.trim()).toBe('Page 1 / 1');
+            expect(partContains(requirePart(el, 'prev'), 'nav-btn--disabled')).toBe(true);
+            expect(partContains(requirePart(el, 'next'), 'nav-btn--disabled')).toBe(true);
+        });
+
+        it('prev désactivé en page 1, next actif', async () => {
+            el = await fixture('<ar-pagination compact current="1" total="12"></ar-pagination>');
+            expect(requirePart(el, 'prev').getAttribute('aria-disabled')).toBe('true');
+            expect(requirePart(el, 'next').getAttribute('aria-disabled')).toBe('false');
+        });
+
+        it('next désactivé en dernière page, prev actif', async () => {
+            el = await fixture('<ar-pagination compact current="12" total="12"></ar-pagination>');
+            expect(requirePart(el, 'next').getAttribute('aria-disabled')).toBe('true');
+            expect(requirePart(el, 'prev').getAttribute('aria-disabled')).toBe('false');
+        });
+
+        it('le label se met à jour après un changement de page confirmé', async () => {
+            el = await fixture('<ar-pagination compact current="3" total="12"></ar-pagination>');
+            el.addEventListener('ar-pagination-page-change', (e) => {
+                el.current = (e as CustomEvent<ArPaginationPageChangeDetail>).detail.to;
+            });
+            (requirePart(el, 'next') as HTMLElement).click();
+            await waitForUpdate(el);
+            expect(requireLabel(el).textContent?.trim()).toBe('Page 4 / 12');
+        });
+
+        it('prev/next émettent ar-pagination-page-change en mode compact ({from, to})', async () => {
+            el = await fixture('<ar-pagination compact current="3" total="12"></ar-pagination>');
+            const handler = vi.fn();
+            el.addEventListener('ar-pagination-page-change', handler);
+            (requirePart(el, 'next') as HTMLElement).click();
+            await waitForUpdate(el);
+            expect(handler).toHaveBeenCalledOnce();
+            const detail = (handler.mock.calls[0][0] as CustomEvent<ArPaginationPageChangeDetail>)
+                .detail;
+            expect(detail).toEqual({ from: 3, to: 4 });
         });
     });
 

--- a/packages/core/src/components/pagination/pagination.ts
+++ b/packages/core/src/components/pagination/pagination.ts
@@ -91,6 +91,7 @@ export class ArPagination extends LitElement {
     /**
      * Mode compact : uniquement les boutons précédent/suivant et un label de position
      * ("Page X / Y"), navigation strictement séquentielle (pas de saut direct à une page).
+     * Rendu identique quelle que soit la largeur du conteneur (pas de repli en `<select>`).
      * @attr compact
      * @default false
      */
@@ -226,15 +227,17 @@ export class ArPagination extends LitElement {
         }
         if (changed.has('total')) {
             const digits = String(Math.max(this.total, 1)).length;
-            if (!this.compact && this._prevTotalDigits && digits !== this._prevTotalDigits) {
+            if (this._prevTotalDigits && digits !== this._prevTotalDigits) {
                 // Le nombre de chiffres du total a changé (ex. 9 → 10, 99 → 100) : la largeur
                 // d'item mesurée précédemment (figée sur l'ancien total) n'est plus fiable —
                 // marque une remesure comme due avant le prochain calcul de budget. La remesure
                 // effective n'a lieu que si un item numérique est rendu (cf. `_needsRemeasure`) ;
                 // sinon la dernière valeur connue de `_itemWidth` reste utilisée pour ne pas
-                // bloquer le composant au palier texte.
+                // bloquer le composant au palier texte. Le flag est posé même en mode compact
+                // (où aucun recalcul n'a lieu ici) pour que la remesure soit bien effectuée si le
+                // composant repasse en mode non compact avec ce total.
                 this._needsRemeasure = true;
-                this._recalculateBudget();
+                if (!this.compact) this._recalculateBudget();
             }
             this._prevTotalDigits = digits;
         }
@@ -442,13 +445,14 @@ export class ArPagination extends LitElement {
 
     /**
      * Génère le `<li>` du label de position en mode compact ("Page X / Y"), affiché avant
-     * prev/next. `aria-hidden` sur le `<span>` : le `<p>` sr-only du landmark et les
-     * `aria-label` "Page précédente"/"Page suivante" portent déjà l'information équivalente
-     * pour le lecteur d'écran — sans ce marquage, le texte serait annoncé deux fois.
+     * prev/next. `aria-hidden` sur le `<li>` : le `<p>` sr-only du landmark et le texte
+     * accessible (sr-only) de prev/next portent déjà l'information équivalente pour le lecteur
+     * d'écran — sans ce marquage, le texte serait annoncé deux fois (et un `<li>` sans contenu
+     * accessible serait sinon exposé vide dans l'arbre d'accessibilité).
      */
     protected renderCompactLabel(current: number, total: number): TemplateResult {
-        return html`<li part="item page-label">
-            <span part="label" aria-hidden="true">Page ${current} / ${total}</span>
+        return html`<li part="item page-label" aria-hidden="true">
+            <span part="label">Page ${current} / ${total}</span>
         </li>`;
     }
 

--- a/packages/core/src/components/pagination/pagination.ts
+++ b/packages/core/src/components/pagination/pagination.ts
@@ -50,7 +50,8 @@ export interface ArPaginationPageChangeDetail {
  *   affiché à la place de la liste de pages. Sur le modèle de `page-select`.
  * @csspart label - Le `<span>` du label de position en mode compact ("Page X / Y"), non
  *   cliquable et masqué aux lecteurs d'écran (`aria-hidden`, l'information équivalente est déjà
- *   portée par le landmark et les `aria-label` prev/next). Personnalisable via `::part(label)`.
+ *   portée par le landmark et le texte accessible (sr-only) de prev/next). Personnalisable via
+ *   `::part(label)`.
  *
  * @slot prev-icon - Icône du bouton "Page précédente". Remplace le chevron SVG par défaut.
  * @slot next-icon - Icône du bouton "Page suivante". Remplace le chevron SVG par défaut.
@@ -136,17 +137,7 @@ export class ArPagination extends LitElement {
         // largeur disponible — le ResizeObserver et la remesure liée aux polices web seraient un
         // travail pur perte, court-circuités entièrement ici.
         if (this.compact) return;
-        this._setupResizeObserver();
-        // Une police web chargée après le premier paint peut changer la largeur mesurée des
-        // items (ex. police variable, chargement asynchrone) : force une remesure une fois
-        // les polices prêtes. `document.fonts` est absent de certains environnements de test
-        // (happy-dom) — garde défensive.
-        if (document.fonts) {
-            void document.fonts.ready.then(() => {
-                this._needsRemeasure = true;
-                this._recalculateBudget();
-            });
-        }
+        this._setupAdaptiveMeasurement();
     }
 
     override disconnectedCallback(): void {
@@ -160,6 +151,27 @@ export class ArPagination extends LitElement {
         if (!nav) return;
         this._resizeObserver = new ResizeObserver(() => this._recalculateBudget());
         this._resizeObserver.observe(nav);
+    }
+
+    /**
+     * Monte le `ResizeObserver` et arme la remesure liée aux polices web — les deux points
+     * d'entrée du mode adaptatif (montage initial non compact, et retour à l'adaptatif après
+     * un passage par le mode compact) doivent réarmer les deux, pas seulement l'observer :
+     * sans ce regroupement, un montage compact suivi d'un passage tardif en adaptatif se
+     * retrouvait sans le hook `fonts.ready`, jamais installé au premier montage court-circuité.
+     */
+    private _setupAdaptiveMeasurement(): void {
+        this._setupResizeObserver();
+        // Une police web chargée après le premier paint peut changer la largeur mesurée des
+        // items (ex. police variable, chargement asynchrone) : force une remesure une fois
+        // les polices prêtes. `document.fonts` est absent de certains environnements de test
+        // (happy-dom) — garde défensive.
+        if (document.fonts) {
+            void document.fonts.ready.then(() => {
+                this._needsRemeasure = true;
+                this._recalculateBudget();
+            });
+        }
     }
 
     private _recalculateBudget(): void {
@@ -204,12 +216,18 @@ export class ArPagination extends LitElement {
     }
 
     override updated(changed: Map<string, unknown>): void {
-        if (changed.has('compact')) {
+        // `_hasRenderedOnce` (posé false→true seulement en fin de cycle, cf. plus bas) exclut le
+        // tout premier `updated()` : `compact` n'a pas de `useDefault`, donc `changed.has('compact')`
+        // est déjà vrai à ce premier cycle même si l'attribut n'a jamais été posé/modifié — sans
+        // cette garde, un montage non compact appellerait `_setupAdaptiveMeasurement()` deux fois
+        // de suite (une fois via `firstUpdated()`, une fois ici), créant un `ResizeObserver`
+        // jetable à chaque montage.
+        if (this._hasRenderedOnce && changed.has('compact')) {
             if (this.compact) {
                 this._resizeObserver?.disconnect();
                 this._resizeObserver = undefined;
             } else if (this._initialized) {
-                this._setupResizeObserver();
+                this._setupAdaptiveMeasurement();
             }
         }
         if (changed.has('total') && this.total < 1) {
@@ -297,34 +315,6 @@ export class ArPagination extends LitElement {
         const isPreviousDisabled = current <= 1;
         const previousPageNumber = _clamp(current - 1, 1, total > 1 ? total - 1 : 1);
         const nextPageNumber = _clamp(current + 1, 1, total);
-        // Plancher uniforme (5, le plus grand des deux planchers algorithmiques de
-        // `_calculatePages`) plutôt que 3 en bord de liste / 5 sinon : sinon, à largeur égale,
-        // la bascule vers le select dépendrait de la position de `current` (une page en bord
-        // resterait en boutons plus longtemps qu'une page intermédiaire) — incohérent du point
-        // de vue de l'utilisateur, qui ne doit pas voir un mode différent selon la page active
-        // sans changement de largeur. 5 est sûr : c'est déjà le plancher réel en position non-bord,
-        // donc aucun risque de débordement (contrairement à forcer 3, qui ferait tenter un rendu
-        // à 5 items dans un budget de 3-4 slots).
-        const floorSlots = 5;
-        // Calculé une seule fois : réutilisé pour la décision de mode ci-dessous ET pour le
-        // rendu des boutons numérotés (repeat) si on reste en mode boutons. En mode compact,
-        // aucun numéro n'est jamais affiché — court-circuité à un tableau vide plutôt que de
-        // calculer une fenêtre de pages qui ne sera jamais rendue.
-        const pages = this.compact ? [] : _calculatePages(current, total, this._budget);
-        // Cas particulier : à budget=5 exactement (position non-bord, loin des deux extrémités),
-        // `_calculatePages` retombe sur sa fenêtre minimale [1, -1, current, -2, total] — 5 slots
-        // dont 2 ellipses purement décoratives, pour seulement 3 pages réellement cliquables.
-        // Le select offre alors plus de valeur pour le même espace (jusqu'à 9 pages réelles,
-        // cf. `renderPageSelect`) : basculer vers lui même si le budget brut suffirait
-        // techniquement à afficher cette fenêtre. Repli strictement plus sûr que les boutons
-        // qu'il remplace (un `<select>` fermé est plus étroit que la fenêtre à 5 slots qu'il
-        // aurait fallu rendre), donc aucun risque de débordement supplémentaire.
-        const isMinimalWindowWithDoubleEllipsis =
-            pages.length === 5 && pages.includes(-1) && pages.includes(-2);
-        const useSelectMode =
-            !this.compact &&
-            this._budget !== undefined &&
-            (this._budget < floorSlots || isMinimalWindowWithDoubleEllipsis);
 
         return html` <nav part="nav" role="navigation" aria-labelledby="ar-pagination">
             <p id="ar-pagination" class="sr-only">Pagination, page ${current} sur ${total}</p>
@@ -345,22 +335,7 @@ export class ArPagination extends LitElement {
                     </a>
                 </li>
 
-                ${this.compact
-                    ? nothing
-                    : useSelectMode
-                      ? this.renderPageSelect(current, total)
-                      : repeat(
-                            pages,
-                            (page) => page,
-                            (page) => {
-                                // -1 et -2 sont des sentinelles représentant les ellipses
-                                return page === -1 || page === -2
-                                    ? html` <li part="item" aria-hidden="true">
-                                          <span part="ellipsis">...</span>
-                                      </li>`
-                                    : this.renderPage(page, page === current, total);
-                            },
-                        )}
+                ${this.compact ? nothing : this.renderPageContent(current, total)}
 
                 <li part="item">
                     <a
@@ -377,6 +352,53 @@ export class ArPagination extends LitElement {
                 </li>
             </ul>
         </nav>`;
+    }
+
+    /**
+     * Génère le contenu de la liste de pages en mode adaptatif : numéros de page (avec
+     * ellipses) ou `<select>` de saut de page selon `_budget`. N'est jamais appelée en mode
+     * compact (`compact`) — `render()` bifurque directement vers `renderCompactLabel` dans ce
+     * cas, donc aucune garde `!this.compact` n'est nécessaire ici.
+     */
+    protected renderPageContent(current: number, total: number): TemplateResult {
+        // Plancher uniforme (5, le plus grand des deux planchers algorithmiques de
+        // `_calculatePages`) plutôt que 3 en bord de liste / 5 sinon : sinon, à largeur égale,
+        // la bascule vers le select dépendrait de la position de `current` (une page en bord
+        // resterait en boutons plus longtemps qu'une page intermédiaire) — incohérent du point
+        // de vue de l'utilisateur, qui ne doit pas voir un mode différent selon la page active
+        // sans changement de largeur. 5 est sûr : c'est déjà le plancher réel en position non-bord,
+        // donc aucun risque de débordement (contrairement à forcer 3, qui ferait tenter un rendu
+        // à 5 items dans un budget de 3-4 slots).
+        const floorSlots = 5;
+        const pages = _calculatePages(current, total, this._budget);
+        // Cas particulier : à budget=5 exactement (position non-bord, loin des deux extrémités),
+        // `_calculatePages` retombe sur sa fenêtre minimale [1, -1, current, -2, total] — 5 slots
+        // dont 2 ellipses purement décoratives, pour seulement 3 pages réellement cliquables.
+        // Le select offre alors plus de valeur pour le même espace (jusqu'à 9 pages réelles,
+        // cf. `renderPageSelect`) : basculer vers lui même si le budget brut suffirait
+        // techniquement à afficher cette fenêtre. Repli strictement plus sûr que les boutons
+        // qu'il remplace (un `<select>` fermé est plus étroit que la fenêtre à 5 slots qu'il
+        // aurait fallu rendre), donc aucun risque de débordement supplémentaire.
+        const isMinimalWindowWithDoubleEllipsis =
+            pages.length === 5 && pages.includes(-1) && pages.includes(-2);
+        const useSelectMode =
+            this._budget !== undefined &&
+            (this._budget < floorSlots || isMinimalWindowWithDoubleEllipsis);
+
+        return html`${useSelectMode
+            ? this.renderPageSelect(current, total)
+            : repeat(
+                  pages,
+                  (page) => page,
+                  (page) => {
+                      // -1 et -2 sont des sentinelles représentant les ellipses
+                      return page === -1 || page === -2
+                          ? html` <li part="item" aria-hidden="true">
+                                <span part="ellipsis">...</span>
+                            </li>`
+                          : this.renderPage(page, page === current, total);
+                  },
+              )}`;
     }
 
     /** Génère le `<li>` d'une page. Surcharger en sous-classe si besoin. */

--- a/packages/core/src/components/pagination/pagination.ts
+++ b/packages/core/src/components/pagination/pagination.ts
@@ -1,4 +1,4 @@
-import { LitElement, type TemplateResult, type CSSResultGroup, html } from 'lit';
+import { LitElement, type TemplateResult, type CSSResultGroup, html, nothing } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import utilitiesStyles from '../../styles/utilities.styles.js';
@@ -46,6 +46,11 @@ export interface ArPaginationPageChangeDetail {
  *   minimal).
  * @csspart select - L'élément `<select>` de saut de page. Personnalisable via `::part(select)`
  *   (apparence). Conserve l'apparence native du navigateur (flèche incluse) par défaut.
+ * @csspart page-label - Le `<li>` englobant le label de position en mode compact (`compact`),
+ *   affiché à la place de la liste de pages. Sur le modèle de `page-select`.
+ * @csspart label - Le `<span>` du label de position en mode compact ("Page X / Y"), non
+ *   cliquable et masqué aux lecteurs d'écran (`aria-hidden`, l'information équivalente est déjà
+ *   portée par le landmark et les `aria-label` prev/next). Personnalisable via `::part(label)`.
  *
  * @slot prev-icon - Icône du bouton "Page précédente". Remplace le chevron SVG par défaut.
  * @slot next-icon - Icône du bouton "Page suivante". Remplace le chevron SVG par défaut.
@@ -299,8 +304,10 @@ export class ArPagination extends LitElement {
         // à 5 items dans un budget de 3-4 slots).
         const floorSlots = 5;
         // Calculé une seule fois : réutilisé pour la décision de mode ci-dessous ET pour le
-        // rendu des boutons numérotés (repeat) si on reste en mode boutons.
-        const pages = _calculatePages(current, total, this._budget);
+        // rendu des boutons numérotés (repeat) si on reste en mode boutons. En mode compact,
+        // aucun numéro n'est jamais affiché — court-circuité à un tableau vide plutôt que de
+        // calculer une fenêtre de pages qui ne sera jamais rendue.
+        const pages = this.compact ? [] : _calculatePages(current, total, this._budget);
         // Cas particulier : à budget=5 exactement (position non-bord, loin des deux extrémités),
         // `_calculatePages` retombe sur sa fenêtre minimale [1, -1, current, -2, total] — 5 slots
         // dont 2 ellipses purement décoratives, pour seulement 3 pages réellement cliquables.
@@ -312,12 +319,15 @@ export class ArPagination extends LitElement {
         const isMinimalWindowWithDoubleEllipsis =
             pages.length === 5 && pages.includes(-1) && pages.includes(-2);
         const useSelectMode =
+            !this.compact &&
             this._budget !== undefined &&
             (this._budget < floorSlots || isMinimalWindowWithDoubleEllipsis);
 
         return html` <nav part="nav" role="navigation" aria-labelledby="ar-pagination">
             <p id="ar-pagination" class="sr-only">Pagination, page ${current} sur ${total}</p>
             <ul part="list" @click=${this._onPageChange}>
+                ${this.compact ? this.renderCompactLabel(current, total) : nothing}
+
                 <li part="item">
                     <a
                         part="prev nav-btn${isPreviousDisabled ? ' nav-btn--disabled' : ''}"
@@ -332,20 +342,22 @@ export class ArPagination extends LitElement {
                     </a>
                 </li>
 
-                ${useSelectMode
-                    ? this.renderPageSelect(current, total)
-                    : repeat(
-                          pages,
-                          (page) => page,
-                          (page) => {
-                              // -1 et -2 sont des sentinelles représentant les ellipses
-                              return page === -1 || page === -2
-                                  ? html` <li part="item" aria-hidden="true">
-                                        <span part="ellipsis">...</span>
-                                    </li>`
-                                  : this.renderPage(page, page === current, total);
-                          },
-                      )}
+                ${this.compact
+                    ? nothing
+                    : useSelectMode
+                      ? this.renderPageSelect(current, total)
+                      : repeat(
+                            pages,
+                            (page) => page,
+                            (page) => {
+                                // -1 et -2 sont des sentinelles représentant les ellipses
+                                return page === -1 || page === -2
+                                    ? html` <li part="item" aria-hidden="true">
+                                          <span part="ellipsis">...</span>
+                                      </li>`
+                                    : this.renderPage(page, page === current, total);
+                            },
+                        )}
 
                 <li part="item">
                     <a
@@ -425,6 +437,18 @@ export class ArPagination extends LitElement {
                           </option>`,
                 )}
             </select>
+        </li>`;
+    }
+
+    /**
+     * Génère le `<li>` du label de position en mode compact ("Page X / Y"), affiché avant
+     * prev/next. `aria-hidden` sur le `<span>` : le `<p>` sr-only du landmark et les
+     * `aria-label` "Page précédente"/"Page suivante" portent déjà l'information équivalente
+     * pour le lecteur d'écran — sans ce marquage, le texte serait annoncé deux fois.
+     */
+    protected renderCompactLabel(current: number, total: number): TemplateResult {
+        return html`<li part="item page-label">
+            <span part="label" aria-hidden="true">Page ${current} / ${total}</span>
         </li>`;
     }
 

--- a/packages/core/src/components/pagination/pagination.ts
+++ b/packages/core/src/components/pagination/pagination.ts
@@ -83,6 +83,15 @@ export class ArPagination extends LitElement {
     @property({ reflect: true, type: Number, useDefault: true })
     total: number = ArPagination.DEFAULT_TOTAL;
 
+    /**
+     * Mode compact : uniquement les boutons précédent/suivant et un label de position
+     * ("Page X / Y"), navigation strictement séquentielle (pas de saut direct à une page).
+     * @attr compact
+     * @default false
+     */
+    @property({ reflect: true, type: Boolean })
+    compact: boolean = false;
+
     @state() private _budget?: number;
     private _resizeObserver?: ResizeObserver | undefined;
     private _itemWidth = 0;
@@ -106,11 +115,21 @@ export class ArPagination extends LitElement {
 
     override connectedCallback(): void {
         super.connectedCallback();
-        if (this._initialized) this._setupResizeObserver();
+        // `_initialized` reste faux ici au tout premier montage (le shadow DOM n'existe pas
+        // encore, `_setupResizeObserver` ne trouverait pas `[part="nav"]`) — ce n'est donc PAS un
+        // doublon avec l'appel dans `firstUpdated()` ci-dessous, qui gère ce premier montage une
+        // fois le rendu initial fait. Cet appel-ci ne joue que lors d'une reconnexion ultérieure
+        // (élément déplacé/réinséré dans le DOM après un premier montage), pour réattacher
+        // l'observer que `disconnectedCallback` a démonté à la déconnexion précédente.
+        if (this._initialized && !this.compact) this._setupResizeObserver();
     }
 
     override firstUpdated(): void {
         this._initialized = true;
+        // Mode compact : pas de repli automatique en <select>, donc aucun besoin de mesurer la
+        // largeur disponible — le ResizeObserver et la remesure liée aux polices web seraient un
+        // travail pur perte, court-circuités entièrement ici.
+        if (this.compact) return;
         this._setupResizeObserver();
         // Une police web chargée après le premier paint peut changer la largeur mesurée des
         // items (ex. police variable, chargement asynchrone) : force une remesure une fois
@@ -179,6 +198,14 @@ export class ArPagination extends LitElement {
     }
 
     override updated(changed: Map<string, unknown>): void {
+        if (changed.has('compact')) {
+            if (this.compact) {
+                this._resizeObserver?.disconnect();
+                this._resizeObserver = undefined;
+            } else if (this._initialized) {
+                this._setupResizeObserver();
+            }
+        }
         if (changed.has('total') && this.total < 1) {
             warn('ar-pagination', `total doit être ≥ 1. Valeur reçue : ${this.total}.`);
         }
@@ -194,7 +221,7 @@ export class ArPagination extends LitElement {
         }
         if (changed.has('total')) {
             const digits = String(Math.max(this.total, 1)).length;
-            if (this._prevTotalDigits && digits !== this._prevTotalDigits) {
+            if (!this.compact && this._prevTotalDigits && digits !== this._prevTotalDigits) {
                 // Le nombre de chiffres du total a changé (ex. 9 → 10, 99 → 100) : la largeur
                 // d'item mesurée précédemment (figée sur l'ancien total) n'est plus fiable —
                 // marque une remesure comme due avant le prochain calcul de budget. La remesure

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -1185,6 +1185,14 @@
                 calc(100% - 1.1rem) center;
         }
 
+        /* Même couleur de texte que link/prev/next (`--ar-color-text`) : le label doit rester
+           visuellement cohérent avec le reste du composant, bien qu'il ne soit pas interactif
+           (pas de background-color ni d'état hover/focus/active, contrairement aux parts
+           cliquables ci-dessus). */
+        &::part(label) {
+            color: var(--ar-color-text);
+        }
+
         &::part(current) {
             background-color: var(--ar-color-bg);
             color: var(--ar-color-interactive);

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -1085,8 +1085,12 @@
     }
 
     ar-pagination {
-        &::part(list) {
+        &:not([compact])::part(list) {
             column-gap: 0.25rem;
+        }
+
+        &::part(page-label) {
+            padding-right: 0.5rem;
         }
 
         &::part(link),
@@ -1101,7 +1105,16 @@
         &::part(prev),
         &::part(next),
         &::part(select) {
-            border-radius: var(--ar-border-radius-xl);
+            border-radius: var(--ar-border-radius-lg);
+        }
+
+        &[compact]::part(prev) {
+            border-radius: var(--ar-border-radius-xl) 0 0 var(--ar-border-radius-lg);
+            border-right: 1px solid var(--ar-color-neutral-80);
+        }
+
+        &[compact]::part(next) {
+            border-radius: 0 var(--ar-border-radius-xl) var(--ar-border-radius-lg) 0;
         }
 
         /* Ordre volontaire : :focus-visible avant :hover avant :active, à spécificité égale, pour


### PR DESCRIPTION
## Résumé

- Ajoute un attribut booléen `compact` à `ar-pagination` : uniquement prev/next + label de
  position non cliquable ("Page X / Y"), navigation strictement séquentielle, rendu identique en
  mobile et desktop (pas de bascule responsive comme le repli automatique en `<select>` existant).
- Court-circuite entièrement le `ResizeObserver`/calcul de budget en mode compact (y compris au
  toggle runtime de l'attribut).
- Nouveaux `csspart` `page-label`/`label`, stylés dans le thème par défaut.
- Design : `docs/superpowers/specs/2026-08-12-pagination-compact-mode-design.md`

Closes #180

## Test plan

- [x] Tests unitaires (Vitest) : propriété `compact`, cycle de vie `ResizeObserver`, rendu DOM,
      événements `ar-pagination-page-change`.
- [x] Tests a11y (axe-core) : 4 configurations (milieu, bord début, bord fin, total=1).
- [x] Tests navigateur (WTR) : absence de bascule responsive, focus après clic next.
- [x] `npm run test:all` et `npm run build --workspace=packages/core` passent.
- [ ] Revue manuelle de la démo "Mode compact" sur `apps/docs` (npm run dev) une fois la PR ouverte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)