### PR TITLE
fix(core): vocabulaire de rôles ::part()/slot transverses — lot 1 (#181)

### DIFF
--- a/apps/docs/src/components/ComponentApi.astro
+++ b/apps/docs/src/components/ComponentApi.astro
@@ -223,13 +223,15 @@ const hasTransverseParts = (component.cssParts ?? []).some((p) =>
             )}
             {/* ── Tokens d'un composant imbriqué en interne (ex. tooltip dans table-sort) ── */}
             {relatedTokens.length > 0 && (
-                <ar-alert class="related-tokens" variant="info" without-notification>
-                    {relatedTokens.map((rt) => (
-                        <p class="related-tokens-note">
-                            {rt.description}{' '}<br>
-                            <a href={`/components/${getSlug(rt.component)}#api-css-props`}>Voir les tokens de <code>{rt.component}</code></a>.
-                        </p>
-                    ))}
+                <ar-alert class="doc-callout-alert" variant="info" without-notification>
+                    <div class="doc-callout-alert-content">
+                        {relatedTokens.map((rt) => (
+                            <p>
+                                {rt.description}{' '}<br>
+                                <a href={`/components/${getSlug(rt.component)}#api-css-props`}>Voir les tokens de <code>{rt.component}</code></a>.
+                            </p>
+                        ))}
+                    </div>
                 </ar-alert>
             )}
         </section>
@@ -288,30 +290,6 @@ const hasTransverseParts = (component.cssParts ?? []).some((p) =>
 
     .own-props-intro {
         margin-top: 1.875rem;
-    }
-
-    ar-alert.related-tokens {
-        margin-top: 1.875rem;
-
-        &::part(body) {
-            display: flex;
-            flex-direction: column;
-            row-gap: 0.5rem;
-        }
-    }
-
-    .related-tokens-note {
-        margin: 0;
-        font-size: 0.875rem;
-        /* Pas de couleur explicite : hérite de --ar-alert-color posé par ar-alert sur
-           :host — ar-alert calcule déjà un contraste correct contre son propre fond de
-           variante (info/warning/...), un remplacement fixe ici casserait ce contrat
-           pour tout variant dont le fond diffère de la couleur muette de la doc. */
-    }
-
-    .related-tokens-note a {
-        color: inherit;
-        text-decoration: underline;
     }
 
     .token-example pre {

--- a/apps/docs/src/components/ComponentApi.astro
+++ b/apps/docs/src/components/ComponentApi.astro
@@ -140,10 +140,8 @@ const hasTransverseParts = (component.cssParts ?? []).some((p) =>
                 Utilisez <code>::part(name)</code> pour styler ces éléments depuis l'extérieur.
                 {hasTransverseParts && (
                     <>
-                        {' '}
-                        Certaines parts ci-dessous ont aussi un rôle transverse, partagé avec
-                        d'autres composants — voir les{' '}
-                        <a href="/getting-started/naming-conventions">conventions de nommage</a>.
+                        <br>Certaines parts ci-dessous indiquent un rôle transverse, partagé avec
+                        d'autres composants — voir les <a href="/getting-started/naming-conventions">conventions de nommage</a>.
                     </>
                 )}
             </p>

--- a/apps/docs/src/components/ComponentApi.astro
+++ b/apps/docs/src/components/ComponentApi.astro
@@ -9,6 +9,7 @@
 import { type CemDeclaration, getPublicMethods } from '../utils/cem-types.ts';
 import { isCancelableEvent, stripCancelableMarker } from '../utils/events.ts';
 import { getSlug } from '../utils/tag-name.ts';
+import { isTransversePart } from '../utils/transverse-roles.ts';
 
 interface RelatedTokens {
     component:   string;
@@ -26,6 +27,10 @@ const publicMethods = getPublicMethods(component);
 
 const panelProps = (component.cssProperties ?? []).filter((p) => p.name.startsWith('--ar-panel-'));
 const ownProps = (component.cssProperties ?? []).filter((p) => !p.name.startsWith('--ar-panel-'));
+
+const hasTransverseParts = (component.cssParts ?? []).some((p) =>
+    isTransversePart(p.name, component.tagName ?? ''),
+);
 ---
 
 <div class="component-api">
@@ -133,6 +138,14 @@ const ownProps = (component.cssProperties ?? []).filter((p) => !p.name.startsWit
             <h4 id="api-css-parts" class="subsection-title">CSS Parts</h4>
             <p class="hint">
                 Utilisez <code>::part(name)</code> pour styler ces éléments depuis l'extérieur.
+                {hasTransverseParts && (
+                    <>
+                        {' '}
+                        Certaines parts ci-dessous ont aussi un rôle transverse, partagé avec
+                        d'autres composants — voir les{' '}
+                        <a href="/getting-started/naming-conventions">conventions de nommage</a>.
+                    </>
+                )}
             </p>
             <div class="table-wrap">
                 <table>

--- a/apps/docs/src/components/Playground.astro
+++ b/apps/docs/src/components/Playground.astro
@@ -59,7 +59,7 @@ const showPlayground = displayMode === 'demo';
         {/* Ariane est headless : aucun style n'est intégré au composant. Les previews
             ci-dessous chargent le thème de démo `default.css` fourni avec la librairie —
             à ne pas confondre avec un style par défaut intrinsèque au composant. */}
-        <ar-alert variant="info" style="margin-bottom: 1rem">
+        <ar-alert variant="info" without-notification class="doc-callout-alert" style="margin-bottom: 1rem">
             <p style="margin: 0">Les exemples ci-dessous sont affichés avec le thème de démo <code>default.css</code> fourni par Ariane.<br>
             Un composant headless n'a aucun style intégré — remplacez ce thème par le vôtre pour un rendu différent.</p>
         </ar-alert>

--- a/apps/docs/src/components/SiteNav.astro
+++ b/apps/docs/src/components/SiteNav.astro
@@ -31,6 +31,7 @@ const gettingStartedLinks: NavLink[] = [
     { href: '/getting-started/quickstart', label: 'Démarrage rapide', ariaCurrent: undefined },
     { href: '/getting-started/utilisation', label: 'Utilisation', ariaCurrent: undefined },
     { href: '/getting-started/shadow-dom', label: 'Shadow DOM applicatif', ariaCurrent: undefined },
+    { href: '/getting-started/naming-conventions', label: 'Conventions de nommage', ariaCurrent: undefined },
 ].map((link) => ({
     ...link,
     ariaCurrent: currentPath === link.href ? ('page' as const) : undefined,

--- a/apps/docs/src/content/components/ar-charcounter.mdx
+++ b/apps/docs/src/content/components/ar-charcounter.mdx
@@ -32,7 +32,7 @@ variants:
     - name: icon
       label: Icônes dans les slots
       description: |
-          Les slots `icon-warning` et `icon-error` permettent d'ajouter un signal non-couleur
+          Les slots `warning-icon` et `error-icon` permettent d'ajouter un signal non-couleur
           conforme WCAG 1.4.1. Le contenu du slot est rendu à côté du compteur dans l'état correspondant.
       html: |
           <div style="display:flex;flex-direction:column;gap:0.5rem;max-width:400px;">
@@ -40,8 +40,8 @@ variants:
               <textarea id="cc-icon" rows="3"
                   style="width:100%;resize:vertical;"></textarea>
               <ar-charcounter id="cc-icon-counter" for="cc-icon" max="80">
-                  <span slot="icon-warning" aria-hidden="true">⚠️</span>
-                  <span slot="icon-error" aria-hidden="true">❌</span>
+                  <span slot="warning-icon" aria-hidden="true">⚠️</span>
+                  <span slot="error-icon" aria-hidden="true">❌</span>
               </ar-charcounter>
           </div>
     - name: label
@@ -93,4 +93,4 @@ form.addEventListener('submit', (e) => {
 });
 ```
 
-- L'état `warning` et `error` ne doivent pas être communiqués uniquement par la couleur (<WcagRef criterion="4.1.1" summary="Use of Color : la couleur n'est pas utilisée comme le seul moyen de transmettre de l'information." />) : les slots `icon-warning` et `icon-error` permettent d'insérer un signal visuel supplémentaire (icône, symbole) à côté du compteur. Les icônes doivent porter `aria-hidden="true"` pour éviter un doublon d'annonce — l'information est déjà transmise par `aria-live`.
+- L'état `warning` et `error` ne doivent pas être communiqués uniquement par la couleur (<WcagRef criterion="4.1.1" summary="Use of Color : la couleur n'est pas utilisée comme le seul moyen de transmettre de l'information." />) : les slots `warning-icon` et `error-icon` permettent d'insérer un signal visuel supplémentaire (icône, symbole) à côté du compteur. Les icônes doivent porter `aria-hidden="true"` pour éviter un doublon d'annonce — l'information est déjà transmise par `aria-live`.

--- a/apps/docs/src/pages/getting-started/naming-conventions.astro
+++ b/apps/docs/src/pages/getting-started/naming-conventions.astro
@@ -3,17 +3,14 @@ import Layout from '../../layouts/Layout.astro';
 import TableOfContents from '../../components/TableOfContents.astro';
 
 const tocEntries = [
-    { id: 'pourquoi', label: 'Un vocabulaire partagé', level: 1 as const },
-    { id: 'roles-part', label: 'Rôles ::part() transverses', level: 1 as const },
-    { id: 'roles-table', label: 'Table des rôles', level: 2 as const },
-    { id: 'roles-usage', label: 'Comment les utiliser', level: 2 as const },
+    { id: 'semantic-parts', label: 'CSS Part sémantiques', level: 1 as const },
     { id: 'slots', label: 'Conventions de slot', level: 1 as const },
 ];
 ---
 
 <Layout
     title="Conventions de nommage"
-    description="Vocabulaire de rôles ::part() et conventions de slot partagés par tous les composants Ariane."
+    description="Vocabulaire de CSS part sémantiques et conventions de slot partagés par tous les composants Ariane."
     currentPath="/getting-started/naming-conventions"
     showToc={true}
 >
@@ -22,45 +19,27 @@ const tocEntries = [
             <h2 class="page-title">Conventions de nommage</h2>
         </div>
 
-        <section id="pourquoi" class="main-section">
+        <section id="semantic-parts" class="main-section">
             <div>
-                <h3 class="section-title">Un vocabulaire partagé</h3>
+                <h3 class="section-title">CSS Part sémantiques</h3>
                 <p>
-                    Chaque composant Ariane expose ses propres <code>::part()</code> spécifiques
-                    (<code>close</code>, <code>panel</code>, <code>trigger</code>...). En
-                    complément, certains éléments portent aussi un <strong>rôle transverse</strong>
-                    — un second nom générique, partagé par tous les composants qui ont un élément
-                    de même nature. Un rôle transverse s'ajoute toujours au part spécifique
-                    existant, il ne le remplace jamais (sauf la racine du composant, cas
-                    particulier documenté ci-dessous) :
-                    <code>part="input field"</code> sur le champ texte d'<code>ar-datepicker</code>.
+                    En plus de <code>CSS part</code> propres à chacun, les composants Ariane
+                    exposent des CSS part qui ont un rôle <strong>sémantique et transverse</strong>.<br>
+                    Un même élément expose souvent plusieurs CSS part complémentaires, par exemple
+                    <code>control</code> (sémantique) et <code>link</code> (spécifique).
                 </p>
-                <p>
-                    Objectif : apprendre ce vocabulaire une seule fois, puis le reconnaître sur
-                    n'importe quel composant de la librairie, sans redécouvrir le nom de chaque
-                    part composant par composant — et surtout pouvoir écrire une seule règle CSS
-                    qui s'applique à tous les composants concernés d'un coup
-                    (<code>::part(field) {'{ ... }'}</code> style tous les champs de saisie de
-                    la librairie, quel que soit le composant). C'est ce qui rend l'intégration
-                    d'Ariane dans un design system consommateur plus rapide : les décisions de
-                    style transverses (radius d'un bouton, apparence d'un champ) se prennent une
-                    fois, pas composant par composant.
+                <p style="margin-top: 1rem">
+                    Ces <code>::part()</code> sémantiques facilitent la personnalisation des éléments communs à
+                    chacun des composants, permettant une meilleure intégration à un Design System.
                 </p>
-            </div>
-        </section>
-
-        <section id="roles-part" class="main-section">
-            <div>
-                <h3 class="section-title">Rôles <code>::part()</code> transverses</h3>
             </div>
 
             <section id="roles-table" class="subsection">
-                <h4 class="subsection-title">Table des rôles</h4>
                 <div class="table-wrap">
                     <table>
                         <thead>
                             <tr>
-                                <th scope="col">Rôle</th>
+                                <th scope="col">Part sémantique</th>
                                 <th scope="col">Signification</th>
                                 <th scope="col">Exemples</th>
                             </tr>
@@ -69,11 +48,10 @@ const tocEntries = [
                             <tr>
                                 <td><code>(nom du composant)</code></td>
                                 <td>
-                                    Racine du composant. Remplace un éventuel part générique
-                                    existant (<code>base</code>, <code>container</code>) plutôt
-                                    que s'y ajouter — seule exception au principe additif, pour
-                                    éviter une collision de nom lors d'un chaînage
-                                    <code>exportparts</code> si un composant est un jour imbriqué
+                                    Racine du composant. <br>
+                                    Utilisé à la place d'un nom sémantique tel que <code>base</code>
+                                    de sorte à prévenir les collisions de nom lors d'un chaînage
+                                    <code>exportparts</code> quand un composant est imbriqué
                                     dans un autre.
                                 </td>
                                 <td>
@@ -83,16 +61,8 @@ const tocEntries = [
                             </tr>
                             <tr>
                                 <td><code>panel</code></td>
-                                <td>Conteneur flottant secondaire (popover, dropdown...).</td>
+                                <td>Conteneur flottant secondaire (datepicker, dropdown...).</td>
                                 <td><code>ar-datepicker::part(panel)</code></td>
-                            </tr>
-                            <tr>
-                                <td><code>body</code></td>
-                                <td>Zone de contenu principal.</td>
-                                <td>
-                                    <code>ar-dialog::part(body)</code>,
-                                    <code>ar-alert::part(body)</code>
-                                </td>
                             </tr>
                             <tr>
                                 <td><code>trigger</code></td>
@@ -103,6 +73,14 @@ const tocEntries = [
                                 <td><code>header</code> / <code>footer</code></td>
                                 <td>En-tête / pied de composant.</td>
                                 <td><code>ar-datepicker::part(header)</code></td>
+                            </tr>
+                            <tr>
+                                <td><code>body</code></td>
+                                <td>Zone de contenu principal.</td>
+                                <td>
+                                    <code>ar-dialog::part(body)</code>,
+                                    <code>ar-alert::part(body)</code>
+                                </td>
                             </tr>
                             <tr>
                                 <td><code>control</code></td>
@@ -157,17 +135,6 @@ const tocEntries = [
                         </tbody>
                     </table>
                 </div>
-            </section>
-
-            <section id="roles-usage" class="subsection">
-                <h4 class="subsection-title">Comment les utiliser</h4>
-                <p>
-                    Un rôle transverse se cible exactement comme n'importe quel autre part, avec
-                    <code>::part(nom-du-rôle)</code> — la seule différence est qu'il peut
-                    apparaître sur plusieurs composants différents, avec le même nom. La liste
-                    complète des part d'un composant, rôles transverses inclus, reste documentée
-                    sur sa propre page (section « CSS Parts »).
-                </p>
             </section>
         </section>
 

--- a/apps/docs/src/pages/getting-started/naming-conventions.astro
+++ b/apps/docs/src/pages/getting-started/naming-conventions.astro
@@ -1,0 +1,213 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import TableOfContents from '../../components/TableOfContents.astro';
+
+const tocEntries = [
+    { id: 'pourquoi', label: 'Un vocabulaire partagé', level: 1 as const },
+    { id: 'roles-part', label: 'Rôles ::part() transverses', level: 1 as const },
+    { id: 'roles-table', label: 'Table des rôles', level: 2 as const },
+    { id: 'roles-usage', label: 'Comment les utiliser', level: 2 as const },
+    { id: 'slots', label: 'Conventions de slot', level: 1 as const },
+];
+---
+
+<Layout
+    title="Conventions de nommage"
+    description="Vocabulaire de rôles ::part() et conventions de slot partagés par tous les composants Ariane."
+    currentPath="/getting-started/naming-conventions"
+    showToc={true}
+>
+    <div class="page-container">
+        <div class="page-header">
+            <h2 class="page-title">Conventions de nommage</h2>
+        </div>
+
+        <section id="pourquoi" class="main-section">
+            <div>
+                <h3 class="section-title">Un vocabulaire partagé</h3>
+                <p>
+                    Chaque composant Ariane expose ses propres <code>::part()</code> spécifiques
+                    (<code>close</code>, <code>panel</code>, <code>trigger</code>...). En
+                    complément, certains éléments portent aussi un <strong>rôle transverse</strong>
+                    — un second nom générique, partagé par tous les composants qui ont un élément
+                    de même nature. Un rôle transverse s'ajoute toujours au part spécifique
+                    existant, il ne le remplace jamais (sauf la racine du composant, cas
+                    particulier documenté ci-dessous) :
+                    <code>part="close action-button"</code>.
+                </p>
+                <p>
+                    Objectif : apprendre ce vocabulaire une seule fois, puis le reconnaître sur
+                    n'importe quel composant de la librairie, sans redécouvrir le nom de chaque
+                    part composant par composant — et surtout pouvoir écrire une seule règle CSS
+                    qui s'applique à tous les composants concernés d'un coup
+                    (<code>::part(action-button) {'{ ... }'}</code> style tous les boutons d'action de
+                    la librairie, quel que soit le composant). C'est ce qui rend l'intégration
+                    d'Ariane dans un design system consommateur plus rapide : les décisions de
+                    style transverses (radius d'un bouton, apparence d'un champ) se prennent une
+                    fois, pas composant par composant.
+                </p>
+            </div>
+        </section>
+
+        <section id="roles-part" class="main-section">
+            <div>
+                <h3 class="section-title">Rôles <code>::part()</code> transverses</h3>
+            </div>
+
+            <section id="roles-table" class="subsection">
+                <h4 class="subsection-title">Table des rôles</h4>
+                <div class="table-wrap">
+                    <table>
+                        <thead>
+                            <tr>
+                                <th scope="col">Rôle</th>
+                                <th scope="col">Signification</th>
+                                <th scope="col">Exemples</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td><code>(nom du composant)</code></td>
+                                <td>
+                                    Racine du composant. Remplace un éventuel part générique
+                                    existant (<code>base</code>, <code>container</code>) plutôt
+                                    que s'y ajouter — seule exception au principe additif, pour
+                                    éviter une collision de nom lors d'un chaînage
+                                    <code>exportparts</code> si un composant est un jour imbriqué
+                                    dans un autre.
+                                </td>
+                                <td>
+                                    <code>ar-charcounter::part(charcounter)</code>,
+                                    <code>ar-datepicker::part(datepicker)</code>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td><code>panel</code></td>
+                                <td>Conteneur flottant secondaire (popover, dropdown...).</td>
+                                <td><code>ar-datepicker::part(panel)</code></td>
+                            </tr>
+                            <tr>
+                                <td><code>body</code></td>
+                                <td>Zone de contenu principal.</td>
+                                <td>
+                                    <code>ar-dialog::part(body)</code>,
+                                    <code>ar-alert::part(body)</code>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td><code>trigger</code></td>
+                                <td>Ouvre/ferme un panel ou une zone repliable.</td>
+                                <td><code>ar-collapse::part(trigger)</code></td>
+                            </tr>
+                            <tr>
+                                <td><code>header</code> / <code>footer</code></td>
+                                <td>En-tête / pied de composant.</td>
+                                <td><code>ar-datepicker::part(header)</code></td>
+                            </tr>
+                            <tr>
+                                <td><code>control</code></td>
+                                <td>
+                                    Élément interactif générique (hors
+                                    field/action-button/trigger).
+                                </td>
+                                <td>
+                                    <code>ar-pagination::part(link)</code>,
+                                    <code>ar-datepicker::part(day)</code>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td><code>field</code></td>
+                                <td>
+                                    Élément qui reçoit une saisie. Deux sous-rôles standard,
+                                    réutilisables par tout futur composant :
+                                    <code>input</code> (champ texte/textarea) et
+                                    <code>select</code> (liste déroulante).
+                                </td>
+                                <td>
+                                    <code>ar-datepicker::part(input)</code>,
+                                    <code>ar-pagination::part(select)</code>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td><code>action-button</code></td>
+                                <td>
+                                    Bouton qui déclenche une action ponctuelle (pas un toggle de
+                                    panel).
+                                </td>
+                                <td>
+                                    <code>ar-pagination::part(prev)</code>,
+                                    <code>ar-datepicker::part(today-button)</code>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td><code>indicator</code></td>
+                                <td>Marqueur/indicateur visuel.</td>
+                                <td><code>ar-table-sort::part(indicator)</code></td>
+                            </tr>
+                            <tr>
+                                <td><code>label</code></td>
+                                <td>Texte descriptif.</td>
+                                <td><code>ar-datepicker::part(label)</code></td>
+                            </tr>
+                            <tr>
+                                <td><code>icon</code></td>
+                                <td>Icône.</td>
+                                <td><code>ar-alert::part(icon)</code></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+
+            <section id="roles-usage" class="subsection">
+                <h4 class="subsection-title">Comment les utiliser</h4>
+                <p>
+                    Un rôle transverse se cible exactement comme n'importe quel autre part, avec
+                    <code>::part(nom-du-rôle)</code> — la seule différence est qu'il peut
+                    apparaître sur plusieurs composants différents, avec le même nom. La liste
+                    complète des part d'un composant, rôles transverses inclus, reste documentée
+                    sur sa propre page (section « CSS Parts »).
+                </p>
+            </section>
+        </section>
+
+        <section id="slots" class="main-section">
+            <div>
+                <h3 class="section-title">Conventions de slot</h3>
+                <p>
+                    Les <code>&lt;slot&gt;</code> suivent des conventions déjà cohérentes sur
+                    toute la librairie, sans qu'un nouveau vocabulaire ait été nécessaire :
+                </p>
+                <ul>
+                    <li>
+                        <strong>Slot par défaut (sans nom)</strong> — contenu principal du
+                        composant.
+                    </li>
+                    <li>
+                        <strong><code>trigger</code></strong> — même sens que le rôle
+                        <code>trigger</code> des part : élément qui ouvre/ferme le composant.
+                    </li>
+                    <li>
+                        <strong>Suffixe <code>&lt;rôle&gt;-icon</code></strong> — icône
+                        remplaçable associée à un élément précis (<code>close-icon</code>,
+                        <code>home-icon</code>, <code>trigger-icon</code>,
+                        <code>prev-icon</code>/<code>next-icon</code>,
+                        <code>warning-icon</code>/<code>error-icon</code>).
+                    </li>
+                    <li>
+                        <strong><code>header-actions</code></strong>,
+                        <strong><code>footer</code></strong> — reprennent le nom des rôles
+                        <code>::part()</code> homonymes.
+                    </li>
+                </ul>
+            </div>
+        </section>
+    </div>
+
+    <TableOfContents entries={tocEntries} slot="toc" />
+</Layout>
+
+<style>
+    @import '../../styles/doc-prose.css';
+    @import '../../styles/doc-table.css';
+</style>

--- a/apps/docs/src/pages/getting-started/naming-conventions.astro
+++ b/apps/docs/src/pages/getting-started/naming-conventions.astro
@@ -33,14 +33,14 @@ const tocEntries = [
                     de même nature. Un rôle transverse s'ajoute toujours au part spécifique
                     existant, il ne le remplace jamais (sauf la racine du composant, cas
                     particulier documenté ci-dessous) :
-                    <code>part="close action-button"</code>.
+                    <code>part="input field"</code> sur le champ texte d'<code>ar-datepicker</code>.
                 </p>
                 <p>
                     Objectif : apprendre ce vocabulaire une seule fois, puis le reconnaître sur
                     n'importe quel composant de la librairie, sans redécouvrir le nom de chaque
                     part composant par composant — et surtout pouvoir écrire une seule règle CSS
                     qui s'applique à tous les composants concernés d'un coup
-                    (<code>::part(action-button) {'{ ... }'}</code> style tous les boutons d'action de
+                    (<code>::part(field) {'{ ... }'}</code> style tous les champs de saisie de
                     la librairie, quel que soit le composant). C'est ce qui rend l'intégration
                     d'Ariane dans un design system consommateur plus rapide : les décisions de
                     style transverses (radius d'un bouton, apparence d'un champ) se prennent une
@@ -97,7 +97,7 @@ const tocEntries = [
                             <tr>
                                 <td><code>trigger</code></td>
                                 <td>Ouvre/ferme un panel ou une zone repliable.</td>
-                                <td><code>ar-collapse::part(trigger)</code></td>
+                                <td><code>ar-datepicker::part(trigger)</code></td>
                             </tr>
                             <tr>
                                 <td><code>header</code> / <code>footer</code></td>

--- a/apps/docs/src/pages/getting-started/quickstart.astro
+++ b/apps/docs/src/pages/getting-started/quickstart.astro
@@ -63,8 +63,8 @@ const codeVsCodeSettings = `{
     <div class="page-container">
         <div class="page-header">
             <h2 class="page-title">Démarrage rapide</h2>
-            <div id="prerequis" class="callout">
-                <p class="callout-title">Prérequis</p>
+            <ar-alert variant="info" without-notification id="prerequis" class="doc-callout-alert">
+                <p class="doc-callout-alert-title">Prérequis</p>
                 <ul>
                     <li>
                         Un navigateur moderne supportant les
@@ -75,7 +75,7 @@ const codeVsCodeSettings = `{
                     <li>Aucune dépendance framework — fonctionne avec Vue, React, Svelte, ou HTML pur</li>
                     <li><em>Si intégration npm uniquement :</em> Node ≥ 24, npm ≥ 11</li>
                 </ul>
-            </div>
+            </ar-alert>
         </div>
 
 

--- a/apps/docs/src/pages/getting-started/shadow-dom.astro
+++ b/apps/docs/src/pages/getting-started/shadow-dom.astro
@@ -102,7 +102,7 @@ customElements.define('mon-app', MonApp);`;
                     les <code>adoptedStyleSheets</code> permettent un chargement synchrone (pas de FOUC).
                 </p>
 
-                <ar-alert variant="info" class="doc-callout-alert" style="margin-top: 1rem">
+                <ar-alert variant="info" without-notification class="doc-callout-alert" style="margin-top: 1rem">
                     <p class="doc-callout-alert-title">Compatibilité</p>
                     <div class="doc-callout-alert-content">
                         <p>
@@ -123,7 +123,7 @@ customElements.define('mon-app', MonApp);`;
                     qui sera utilisée en complément de votre fichier CSS.
                 </p>
                 <pre><code class="language-js" set:text={codeCustomTheme} /></pre>
-                <ar-alert variant="info" class="doc-callout-alert">
+                <ar-alert variant="info" without-notification class="doc-callout-alert">
                     <p class="doc-callout-alert-title">N'importez pas les tokens</p>
                     <div class="doc-callout-alert-content">
                         <p>

--- a/apps/docs/src/styles/doc-prose.css
+++ b/apps/docs/src/styles/doc-prose.css
@@ -9,6 +9,7 @@
     display: flex;
     flex-direction: column;
     row-gap: 4rem;
+    line-height: 1.6;
 }
 
 .page-header {
@@ -19,7 +20,7 @@
     }
 
     .summary,
-    .callout {
+    .doc-callout-alert {
         margin-top: 1.5rem;
     }
 }
@@ -151,35 +152,31 @@ pre code {
     letter-spacing: 0.02em;
 }
 
-.callout {
-    padding: 1rem 1.25rem;
-    background: var(--doc-accent-bg);
-    border: 1px solid var(--doc-accent-border);
-    border-radius: 0.5rem;
-}
-
-.callout-title {
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    color: var(--doc-accent);
-    margin: 0 0 0.6rem;
-}
-
-.callout ul {
-    margin: 0;
-    padding-left: 1.25rem;
-    font-size: 0.875rem;
-    line-height: 1.7;
-    color: var(--doc-text);
-}
-
 .doc-callout-alert {
     --ar-alert-bg: var(--doc-accent-bg);
     --ar-alert-border: var(--doc-accent-border);
     --ar-alert-icon: var(--doc-accent);
     --ar-alert-color: var(--doc-text);
+
+    margin-top: 1.875rem;
+
+    p {
+        margin: 0;
+        font-size: 0.9rem;
+    }
+
+    ul {
+        margin: 0;
+        padding-left: 1.25rem;
+        font-size: 0.875rem;
+        line-height: 1.7;
+        color: var(--doc-text);
+    }
+
+    a {
+        color: inherit;
+        text-decoration: underline;
+    }
 }
 
 .doc-callout-alert-title {

--- a/apps/docs/src/utils/transverse-roles.test.ts
+++ b/apps/docs/src/utils/transverse-roles.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { isTransversePart, TRANSVERSE_ROLES } from './transverse-roles.js';
+
+describe('isTransversePart', () => {
+    it('reconnaît un rôle du catalogue (ex: action-button)', () => {
+        expect(isTransversePart('action-button', 'ar-pagination')).toBe(true);
+    });
+
+    it('reconnaît le part racine (nom du composant sans préfixe)', () => {
+        expect(isTransversePart('charcounter', 'ar-charcounter')).toBe(true);
+        expect(isTransversePart('datepicker', 'ar-datepicker')).toBe(true);
+    });
+
+    it('rejette un part spécifique sans rôle transverse', () => {
+        expect(isTransversePart('base', 'ar-tab')).toBe(false);
+        expect(isTransversePart('nav', 'ar-tab-group')).toBe(false);
+    });
+
+    it("ne confond pas le nom d'un autre composant avec la racine", () => {
+        expect(isTransversePart('charcounter', 'ar-pagination')).toBe(false);
+    });
+
+    it('contient bien les rôles attendus du chantier #181', () => {
+        expect(TRANSVERSE_ROLES).toContain('control');
+        expect(TRANSVERSE_ROLES).toContain('field');
+        expect(TRANSVERSE_ROLES).toContain('action-button');
+        expect(TRANSVERSE_ROLES).toContain('input');
+        expect(TRANSVERSE_ROLES).toContain('select');
+    });
+});

--- a/apps/docs/src/utils/transverse-roles.ts
+++ b/apps/docs/src/utils/transverse-roles.ts
@@ -1,0 +1,35 @@
+// utils/transverse-roles.ts
+
+import { getSlug } from './tag-name.ts';
+
+/**
+ * Rôles ::part() transverses reconnus (hors racine, qui varie par composant —
+ * voir isTransversePart). Source de vérité unique, à tenir synchronisée avec
+ * la table de /getting-started/naming-conventions.
+ */
+export const TRANSVERSE_ROLES = [
+    'panel',
+    'body',
+    'trigger',
+    'header',
+    'footer',
+    'control',
+    'field',
+    'input',
+    'select',
+    'action-button',
+    'indicator',
+    'label',
+    'icon',
+] as const;
+
+/**
+ * Détecte si un nom de part porte un rôle transverse — soit un rôle du
+ * catalogue ci-dessus, soit le part racine (nom du composant sans préfixe,
+ * ex. "charcounter" pour ar-charcounter), seul rôle transverse qui varie par
+ * composant.
+ */
+export function isTransversePart(partName: string, tagName: string): boolean {
+    if (partName === getSlug(tagName)) return true;
+    return (TRANSVERSE_ROLES as readonly string[]).includes(partName);
+}

--- a/docs/superpowers/plans/2026-08-13-role-parts-vocabulary-181-lot1.md
+++ b/docs/superpowers/plans/2026-08-13-role-parts-vocabulary-181-lot1.md
@@ -1,0 +1,1239 @@
+# Vocabulaire de rôles ::part()/slot transverses — Lot 1 (ar-charcounter, ar-pagination, ar-datepicker) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rétrofit du premier lot du chantier #181 — appliquer le vocabulaire de rôles `::part()`
+transverses (`control`, `field` avec ses sous-rôles `input`/`select`, `action-button`, racine
+nommée d'après le composant) sur `ar-pagination` et `ar-datepicker`, aligner tous les `-btn` sur la
+convention `-button` en toutes lettres, corriger le nommage de slot `ar-charcounter`
+(`icon-warning`/`icon-error` → `warning-icon`/`error-icon`) et sa racine (`container` →
+`charcounter`), publier la nouvelle page de documentation des conventions, et ouvrir la PR vers
+`dev`.
+
+**Architecture:** Chaque rôle transverse est additif (`part="existant nouveau-role"`), sauf la
+racine du composant qui remplace le part générique existant. Chaque endroit qui sélectionne un part
+concerné par égalité stricte (`[part="x"]` en CSS/`@query`/tests) doit être converti en
+sélection « contient » (`[part~="x"]`) avant que ce part ne devienne multi-jetons, sous peine de
+casser silencieusement le style ou la logique interne.
+
+**Tech Stack:** Lit 3, TypeScript, Vitest (unit + a11y jsdom), Web Test Runner (browser), Astro 6
+(site de doc).
+
+## Global Constraints
+
+- Prettier : 100 caractères, 4 espaces, single quotes (déjà appliqué automatiquement par le hook
+  `lint-staged` au commit — ne pas s'inquiéter d'un reformattage après `git commit`).
+- `import type` pour tout import de type.
+- Conventional Commits (commitlint + Husky).
+- Aucun fallback cosmétique dans les composants — headless, tokens dans `themes/default.css`
+  uniquement. Ce lot n'ajoute aucun nouveau token, donc non applicable directement, mais aucune
+  étape de ce plan ne doit en introduire.
+- Projet en alpha : le renommage du slot `ar-charcounter` est un renommage sec, pas de
+  `warnDeprecated`/alias.
+- Spec de référence : `docs/superpowers/specs/2026-08-13-role-parts-vocabulary-181-design.md`.
+
+---
+
+### Task 1: Setup — branche de travail
+
+**Files:** aucun fichier modifié.
+
+- [ ] **Step 1: Créer la branche**
+
+```bash
+cd /Users/jon/Code/Active_projects/ariane
+git checkout dev
+git pull origin dev
+git checkout -b fix/parts-roles-vocabulary-181-lot1
+```
+
+- [ ] **Step 2: Vérifier l'état de départ (tests unitaires)**
+
+Run: `npm test --workspace=packages/core`
+Expected: PASS (baseline avant toute modification).
+
+---
+
+### Task 2: `ar-charcounter` — racine `container` → `charcounter`, slots `icon-warning`/`icon-error` → `warning-icon`/`error-icon`
+
+**Files:**
+
+- Modify: `packages/core/src/components/charcounter/charcounter.ts`
+- Modify: `packages/core/src/components/charcounter/charcounter.styles.ts`
+- Modify: `packages/core/src/components/charcounter/charcounter.test.ts`
+- Modify: `apps/docs/src/content/components/ar-charcounter.mdx`
+
+**Interfaces:**
+
+- Produces: part `charcounter` (racine, remplace `container`) ; slots `warning-icon`/`error-icon`
+  (remplacent `icon-warning`/`icon-error`).
+
+- [ ] **Step 1: Mettre à jour les assertions de test (échec attendu)**
+
+Dans `packages/core/src/components/charcounter/charcounter.test.ts`, ligne 57 :
+
+```ts
+// avant
+it('contient part="container"', () => expect(getPart(el, 'container')).not.toBeNull());
+// après
+it('contient part="charcounter"', () => expect(getPart(el, 'charcounter')).not.toBeNull());
+```
+
+Ligne 82 :
+
+```ts
+// avant
+expect(getPart(el, 'container')).toBeNull();
+// après
+expect(getPart(el, 'charcounter')).toBeNull();
+```
+
+- [ ] **Step 2: Run test pour vérifier l'échec**
+
+Run: `npm test --workspace=packages/core -- charcounter.test.ts`
+Expected: FAIL sur les 2 assertions modifiées (`getPart(el, 'charcounter')` retourne `null` tant
+que le composant n'est pas mis à jour).
+
+- [ ] **Step 3: Renommer le part racine et les slots dans le composant**
+
+Dans `packages/core/src/components/charcounter/charcounter.ts`, JSDoc (lignes 22-25) :
+
+```ts
+// avant
+ * @slot icon-warning - Icône affichée en état warning.
+ * @slot icon-error   - Icône affichée en état error.
+ *
+ * @csspart container - L'élément racine.
+// après
+ * @slot warning-icon - Icône affichée en état warning.
+ * @slot error-icon   - Icône affichée en état error.
+ *
+ * @csspart charcounter - L'élément racine.
+```
+
+Dans le même fichier, `render()` (lignes ~231-234) :
+
+```ts
+// avant
+            <span part="container">
+                <slot name="icon-warning"></slot>
+                <slot name="icon-error"></slot>
+// après
+            <span part="charcounter">
+                <slot name="warning-icon"></slot>
+                <slot name="error-icon"></slot>
+```
+
+- [ ] **Step 4: Mettre à jour les sélecteurs de slot dans les styles**
+
+Dans `packages/core/src/components/charcounter/charcounter.styles.ts` (lignes 18-28) :
+
+```css
+/* avant */
+slot[name='icon-warning'],
+slot[name='icon-error'] {
+    display: none;
+}
+
+:host([state='warning']) slot[name='icon-warning'] {
+    display: contents;
+}
+
+:host([state='error']) slot[name='icon-error'] {
+    display: contents;
+}
+
+/* après */
+slot[name='warning-icon'],
+slot[name='error-icon'] {
+    display: none;
+}
+
+:host([state='warning']) slot[name='warning-icon'] {
+    display: contents;
+}
+
+:host([state='error']) slot[name='error-icon'] {
+    display: contents;
+}
+```
+
+- [ ] **Step 5: Run test pour vérifier le succès**
+
+Run: `npm test --workspace=packages/core -- charcounter.test.ts`
+Expected: PASS (toute la suite `charcounter.test.ts`, pas seulement les 2 assertions touchées —
+vérifier qu'aucune autre régression n'a été introduite).
+
+- [ ] **Step 6: Mettre à jour la démo de documentation**
+
+Dans `apps/docs/src/content/components/ar-charcounter.mdx`, section variante `icon` (autour de la
+ligne 43-44) :
+
+```html
+<!-- avant -->
+<span slot="icon-warning" aria-hidden="true">⚠️</span>
+<span slot="icon-error" aria-hidden="true">❌</span>
+<!-- après -->
+<span slot="warning-icon" aria-hidden="true">⚠️</span>
+<span slot="error-icon" aria-hidden="true">❌</span>
+```
+
+Et dans la description de cette variante ainsi que dans le paragraphe d'accessibilité (recherche
+`icon-warning`/`icon-error` dans tout le fichier — 2 autres occurrences en texte libre, section
+description de variante et section accessibilité) : remplacer `icon-warning`/`icon-error` par
+`warning-icon`/`error-icon` partout où ils apparaissent en tant que noms de slot.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/src/components/charcounter/charcounter.ts \
+        packages/core/src/components/charcounter/charcounter.styles.ts \
+        packages/core/src/components/charcounter/charcounter.test.ts \
+        apps/docs/src/content/components/ar-charcounter.mdx
+git commit -m "fix(charcounter): racine et slots suivent le vocabulaire transverse (#181)"
+```
+
+---
+
+### Task 3: `ar-pagination` — racine + rôles `control`/`field`/`action-button` + `nav-btn`→`nav-button`
+
+**Files:**
+
+- Modify: `packages/core/src/components/pagination/pagination.ts`
+- Modify: `packages/core/src/components/pagination/pagination.test.ts`
+- Modify: `packages/core/src/components/pagination/pagination.browser.test.ts`
+- Modify: `packages/core/src/styles/themes/default.css`
+
+**Interfaces:**
+
+- Produces: part racine `pagination` (additif sur `nav`) ; rôle `control` sur `link`/`current` ;
+  rôle `field` sur `select` ; rôle `action-button` sur `prev`/`next` ; renommage `nav-btn`→
+  `nav-button` (et `nav-btn--disabled`→`nav-button--disabled`), `--ar-pagination-btn-size`→
+  `--ar-pagination-button-size` (convention `-button` en toutes lettres, cf. spec).
+
+- [ ] **Step 1: Renommer `nav-btn` → `nav-button` (convention `-button` en toutes lettres)**
+
+```bash
+sed -i '' 's/nav-btn/nav-button/g' \
+    packages/core/src/components/pagination/pagination.ts \
+    packages/core/src/components/pagination/pagination.test.ts
+sed -i '' 's/--ar-pagination-btn-size/--ar-pagination-button-size/g' \
+    packages/core/src/components/pagination/pagination.ts \
+    packages/core/src/components/pagination/pagination.styles.ts
+sed -i '' 's/nav-btn/nav-button/g; s/--ar-pagination-btn-size/--ar-pagination-button-size/g' \
+    packages/core/src/styles/themes/default.css
+```
+
+Vérifier qu'il ne reste plus aucune trace de l'ancien nom dans ces fichiers :
+
+Run: `grep -rn "nav-btn\|pagination-btn-size" packages/core/src/components/pagination packages/core/src/styles/themes/default.css`
+Expected: aucune sortie.
+
+- [ ] **Step 2: Run tests pour vérifier qu'ils passent toujours (renommage pur, aucun comportement changé)**
+
+Run: `npm test --workspace=packages/core -- pagination.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Corriger les sélecteurs à correspondance exacte AVANT d'ajouter les rôles**
+
+Ces parts vont devenir multi-jetons — toute sélection par égalité stricte doit passer en
+« contient » (`~=`) pour continuer à matcher. Le composant lui-même (`pagination.styles.ts`)
+utilise déjà `[part~=...]` partout (vérifié, aucun changement requis dans ce fichier), mais
+`pagination.ts` et les tests utilisent encore `[part="nav"]`/`[part="link"]`/`[part="current"]`/
+`[part="select"]` en dur à plusieurs endroits.
+
+Dans `packages/core/src/components/pagination/pagination.ts`, lignes 150 et 178 :
+
+```ts
+// avant (les deux occurrences, identiques)
+const nav = this.shadowRoot?.querySelector<HTMLElement>('[part="nav"]');
+// après
+const nav = this.shadowRoot?.querySelector<HTMLElement>('[part~="nav"]');
+```
+
+Commentaire ligne 126 (cohérence, pas fonctionnel) :
+
+```ts
+// avant
+// encore, `_setupResizeObserver` ne trouverait pas `[part="nav"]`) — ce n'est donc PAS un
+// après
+// encore, `_setupResizeObserver` ne trouverait pas `[part~="nav"]`) — ce n'est donc PAS un
+```
+
+- [ ] **Step 4: Corriger les sélecteurs exacts dans les tests**
+
+```bash
+sed -i '' 's/\[part="link"\]/[part~="link"]/g; s/\[part="current"\]/[part~="current"]/g; s/\[part="select"\]/[part~="select"]/g' \
+    packages/core/src/components/pagination/pagination.test.ts
+sed -i '' 's/\[part="current"\]/[part~="current"]/g' \
+    packages/core/src/components/pagination/pagination.browser.test.ts
+```
+
+Vérifier qu'il ne reste plus aucune correspondance exacte sur ces 4 parts :
+
+Run: `grep -n '\[part="nav"\]\|\[part="link"\]\|\[part="current"\]\|\[part="select"\]' packages/core/src/components/pagination/pagination.ts packages/core/src/components/pagination/pagination.test.ts packages/core/src/components/pagination/pagination.browser.test.ts`
+Expected: aucune sortie (0 correspondance).
+
+- [ ] **Step 5: Run tests pour vérifier qu'ils passent toujours (pas de régression du seul fait du `~=`)**
+
+Run: `npm test --workspace=packages/core -- pagination.test.ts`
+Expected: PASS — ce step ne change aucun comportement, seulement la méthode de sélection.
+
+- [ ] **Step 6: Ajouter les nouvelles assertions de rôle (échec attendu)**
+
+Dans `packages/core/src/components/pagination/pagination.test.ts`, ajouter dans le describe
+principal (à la suite des assertions `part="nav"`/`part="list"` existantes, lignes ~48-52) :
+
+```ts
+it('la racine <nav> porte aussi le part transverse "pagination"', () => {
+    expect(partContains(requirePart(el, 'nav'), 'pagination')).toBe(true);
+});
+```
+
+Ajouter à la suite des assertions `prev`/`next` (lignes ~64-67) :
+
+```ts
+it('prev/next portent aussi le rôle transverse "action-button"', () => {
+    expect(partContains(requirePart(el, 'prev'), 'action-button')).toBe(true);
+    expect(partContains(requirePart(el, 'next'), 'action-button')).toBe(true);
+});
+```
+
+Ajouter un test avec `total > budget` pour avoir un `link` rendu (voir un test existant qui force
+ce cas, ex. autour de la ligne 224) :
+
+```ts
+it('link/current portent le rôle transverse "control"', () => {
+    const link = shadow.querySelector('[part~="link"]');
+    expect(link && partContains(link, 'control')).toBe(true);
+});
+```
+
+Et un test pour `select` (dans le describe dédié au mode select, à la suite d'une assertion
+existante ligne ~430) :
+
+```ts
+it('select porte le rôle transverse "field"', () => {
+    const select = shadow.querySelector('[part~="select"]');
+    expect(select && partContains(select, 'field')).toBe(true);
+});
+```
+
+- [ ] **Step 7: Run tests pour vérifier l'échec**
+
+Run: `npm test --workspace=packages/core -- pagination.test.ts`
+Expected: FAIL sur les 4 nouvelles assertions (rôles pas encore ajoutés au composant).
+
+- [ ] **Step 8: Implémenter les rôles dans le composant**
+
+Dans `packages/core/src/components/pagination/pagination.ts`, `render()` (ligne 319) :
+
+```ts
+// avant
+return html` <nav part="nav" role="navigation" aria-labelledby="ar-pagination">
+// après
+return html` <nav part="nav pagination" role="navigation" aria-labelledby="ar-pagination">
+```
+
+Lignes 326 et 342 (prev/next — le part `nav-button` vient déjà du renommage du Step 1) :
+
+```ts
+// avant
+part = "prev nav-button${isPreviousDisabled ? ' nav-button--disabled' : ''}";
+// après
+part = "prev nav-button action-button${isPreviousDisabled ? ' nav-button--disabled' : ''}";
+```
+
+```ts
+// avant
+part = "next nav-button${isNextDisabled ? ' nav-button--disabled' : ''}";
+// après
+part = "next nav-button action-button${isNextDisabled ? ' nav-button--disabled' : ''}";
+```
+
+`renderPageLink()`, part `link` (ligne 423) :
+
+```ts
+// avant
+return html` <a part="link" data-ar-pagination-page="${page}" href="javascript:;">
+// après
+return html` <a part="link control" data-ar-pagination-page="${page}" href="javascript:;">
+```
+
+Part `current` dans le même bloc (ligne 414) :
+
+```ts
+// avant
+return (
+    html` <span
+    part="current"
+    tabindex="-1"
+// après
+return html` < span
+);
+part = 'current control';
+tabindex = '-1';
+```
+
+`renderPageSelect()`, part `select` (ligne 452) :
+
+```ts
+// avant
+<select
+    part="select"
+    aria-labelledby="ar-pagination-select-label"
+// après
+<select
+    part="select field"
+    aria-labelledby="ar-pagination-select-label"
+```
+
+- [ ] **Step 9: Run tests pour vérifier le succès**
+
+Run: `npm test --workspace=packages/core -- pagination.test.ts`
+Expected: PASS (suite complète).
+
+- [ ] **Step 10: Mettre à jour le JSDoc `@csspart`**
+
+Dans `packages/core/src/components/pagination/pagination.ts`, bloc JSDoc (lignes 33-54), ajouter
+une ligne dédiée par rôle transverse introduit, à la suite du `@csspart` du part concerné. Noter
+que `nav-btn`/`nav-btn--disabled` sont déjà devenus `nav-button`/`nav-button--disabled` dans le
+JSDoc existant depuis le Step 1 :
+
+```ts
+// après @csspart nav (ligne 33)
+ * @csspart pagination - Rôle transverse (voir /getting-started/naming-conventions) : racine du
+ *   composant.
+// après @csspart link (ligne 37)
+ * @csspart control - Rôle transverse (voir /getting-started/naming-conventions), porté par `link`
+ *   et `current` : élément interactif générique.
+// après @csspart next (ligne 40)
+ * @csspart action-button - Rôle transverse (voir /getting-started/naming-conventions), porté par
+ *   `prev` et `next` : bouton qui déclenche une action ponctuelle.
+// après @csspart select (ligne 48)
+ * @csspart field - Rôle transverse (voir /getting-started/naming-conventions), porté par `select` :
+ *   élément qui reçoit une saisie. Sous-rôle standard de `field` (avec `input`, cf.
+ *   ar-datepicker), réutilisable par tout futur composant avec une liste déroulante.
+```
+
+(Le rôle `control` n'a besoin que d'une seule ligne `@csspart control`, pas d'une par part porteur
+— même convention que les autres `@csspart` combinés déjà présents dans ce fichier, ex.
+`nav-button`.)
+
+- [ ] **Step 11: Run le build du manifeste pour valider le JSDoc**
+
+Run: `npm run build:manifest --workspace=packages/core`
+Expected: succès, sans erreur de garde-fou `validate-cssprop-defaults.js`.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add packages/core/src/components/pagination/pagination.ts \
+        packages/core/src/components/pagination/pagination.styles.ts \
+        packages/core/src/components/pagination/pagination.test.ts \
+        packages/core/src/components/pagination/pagination.browser.test.ts \
+        packages/core/src/styles/themes/default.css
+git commit -m "fix(pagination): rôles transverses control/field/action-button + racine + nav-button (#181)"
+```
+
+---
+
+### Task 4: `ar-datepicker` — wrapper et part racine `datepicker`
+
+**Files:**
+
+- Modify: `packages/core/src/components/datepicker/datepicker.ts`
+- Modify: `packages/core/src/components/datepicker/datepicker.styles.ts`
+
+**Interfaces:**
+
+- Produces: part racine `datepicker` sur un nouveau `<div part="datepicker">` enveloppant tout le
+  template (le composant n'avait jusqu'ici aucun élément racine unique dans son shadow DOM — le
+  layout flex vivait directement sur `:host`).
+
+Contrairement aux deux tasks précédentes, ce changement est structurel : il n'y a aucun test
+existant qui dépende de la structure DOM plate actuelle (vérifié par recherche —
+`shadowRoot?.children`/`firstElementChild` absents des fichiers de test datepicker), donc pas
+d'étape de correction de sélecteurs de test ici.
+
+- [ ] **Step 1: Écrire le test qui vérifie la présence du wrapper (échec attendu)**
+
+Dans `packages/core/src/components/datepicker/datepicker.test.ts`, ajouter à la suite des
+assertions existantes de structure (après la ligne 22, `part="error"`) :
+
+```ts
+it('contient un div racine part="datepicker" enveloppant tout le contenu', () => {
+    const root = getPart(el, 'datepicker');
+    expect(root).not.toBeNull();
+    expect(root?.contains(getPart(el, 'input'))).toBe(true);
+    expect(root?.contains(getPart(el, 'panel'))).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run test pour vérifier l'échec**
+
+Run: `npm test --workspace=packages/core -- datepicker.test.ts`
+Expected: FAIL (`getPart(el, 'datepicker')` retourne `null`).
+
+- [ ] **Step 3: Envelopper le template dans le wrapper**
+
+Dans `packages/core/src/components/datepicker/datepicker.ts`, `render()` (lignes 227-297),
+envelopper tout le contenu retourné dans un nouveau `<div part="datepicker">` :
+
+```ts
+// avant (début, ligne 227)
+        return html`
+            <label part="label" id="dp-label-${this._uid}" for="dp-input-${this._uid}">
+
+// après
+        return html`
+            <div part="datepicker">
+                <label part="label" id="dp-label-${this._uid}" for="dp-input-${this._uid}">
+```
+
+Et à la fin de la même méthode (ligne 296-297) :
+
+```ts
+// avant
+                ${this.open ? this._renderCalendar(locale) : nothing}
+            </div>
+        `;
+
+// après
+                ${this.open ? this._renderCalendar(locale) : nothing}
+            </div>
+            </div>
+        `;
+```
+
+Réindenter tout le contenu intermédiaire d'un niveau (4 espaces) pour rester cohérent avec le
+reste du fichier — Prettier le fera automatiquement au commit (`lint-staged`), donc l'indentation
+manuelle exacte n'est pas bloquante à cette étape.
+
+- [ ] **Step 4: Déplacer le layout flex de `:host` vers le wrapper**
+
+Dans `packages/core/src/components/datepicker/datepicker.styles.ts` (lignes 4-7) :
+
+```css
+/* avant */
+:host {
+    display: flex;
+    flex-direction: column;
+}
+
+/* après */
+:host {
+    display: block;
+}
+
+[part='datepicker'] {
+    display: flex;
+    flex-direction: column;
+}
+```
+
+- [ ] **Step 5: Run test pour vérifier le succès**
+
+Run: `npm test --workspace=packages/core -- datepicker.test.ts`
+Expected: PASS (suite complète — vérifier particulièrement qu'aucun test existant lié au focus, à
+l'ouverture du panel ou à `AnchoredController.attach()` ne casse : ces derniers ciblent des
+éléments par leur propre part, indépendamment de leur ancêtre).
+
+- [ ] **Step 6: Vérification visuelle (Playwright, browser test existant)**
+
+Run: `npm run test:browser --workspace=packages/core`
+Expected: PASS — `datepicker.browser.test.ts` exerce l'ouverture/fermeture du popover et la
+navigation clavier ; un layout cassé par le wrapper s'y manifesterait (positionnement du popover
+piloté par `AnchoredController.attach(trigger, panel, inputWrapper)`, indépendant de l'ajout d'un
+ancêtre commun, mais à vérifier empiriquement plutôt que supposé).
+
+- [ ] **Step 7: Mettre à jour le JSDoc**
+
+Dans `packages/core/src/components/datepicker/datepicker.ts`, JSDoc, ajouter après `@csspart input`
+(ligne 27) :
+
+```ts
+ * @csspart datepicker - Rôle transverse (voir /getting-started/naming-conventions) : racine du
+ *   composant.
+```
+
+- [ ] **Step 8: Run le build du manifeste**
+
+Run: `npm run build:manifest --workspace=packages/core`
+Expected: succès.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/core/src/components/datepicker/datepicker.ts \
+        packages/core/src/components/datepicker/datepicker.styles.ts \
+        packages/core/src/components/datepicker/datepicker.test.ts
+git commit -m "fix(datepicker): ajoute un wrapper racine part=\"datepicker\" (#181)"
+```
+
+---
+
+### Task 5: `ar-datepicker` — rôle `field` sur `input`
+
+**Files:**
+
+- Modify: `packages/core/src/components/datepicker/datepicker.ts`
+- Modify: `packages/core/src/components/datepicker/datepicker.styles.ts`
+- Modify: `packages/core/src/components/datepicker/datepicker.browser.test.ts`
+
+**Interfaces:**
+
+- Produces: part `input` devient `input field`.
+
+- [ ] **Step 1: Corriger les sélecteurs à correspondance exacte AVANT d'ajouter le rôle**
+
+Dans `packages/core/src/components/datepicker/datepicker.ts`, ligne 157 :
+
+```ts
+// avant
+@query('[part="input"]') private _input!: HTMLInputElement;
+// après
+@query('[part~="input"]') private _input!: HTMLInputElement;
+```
+
+Dans `packages/core/src/components/datepicker/datepicker.styles.ts` :
+
+```bash
+sed -i '' "s/\[part='input'\]/[part~='input']/g" \
+    packages/core/src/components/datepicker/datepicker.styles.ts
+```
+
+Dans `packages/core/src/components/datepicker/datepicker.browser.test.ts`, ligne 86 :
+
+```ts
+// avant
+el.shadowRoot?.querySelector('[part="input"]'),
+// après
+el.shadowRoot?.querySelector('[part~="input"]'),
+```
+
+- [ ] **Step 2: Run tests pour vérifier qu'ils passent toujours (pas de régression du seul fait du `~=`)**
+
+Run: `npm test --workspace=packages/core -- datepicker.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Écrire l'assertion du nouveau rôle (échec attendu)**
+
+Dans `packages/core/src/components/datepicker/datepicker.test.ts`, à la suite de l'assertion
+`part="input"` existante (ligne 16) :
+
+```ts
+it('input porte le rôle transverse "field"', () => {
+    expect(getPart(el, 'input')?.getAttribute('part')?.split(/\s+/)).toContain('field');
+});
+```
+
+(`partContains` est un helper local à `pagination.test.ts`, absent de `datepicker.test.ts` — ne
+pas le réutiliser ici, l'inline `split(/\s+/).toContain(...)` ci-dessus est autosuffisant, même
+pattern que les Tasks 6 et 7.)
+
+- [ ] **Step 4: Run test pour vérifier l'échec**
+
+Run: `npm test --workspace=packages/core -- datepicker.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 5: Ajouter le rôle dans le composant**
+
+Dans `packages/core/src/components/datepicker/datepicker.ts`, `render()` (ligne 235) :
+
+```ts
+// avant
+<input
+    part="input"
+    id="dp-input-${this._uid}"
+// après
+<input
+    part="input field"
+    id="dp-input-${this._uid}"
+```
+
+- [ ] **Step 6: Run test pour vérifier le succès**
+
+Run: `npm test --workspace=packages/core -- datepicker.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Mettre à jour le JSDoc**
+
+Dans `packages/core/src/components/datepicker/datepicker.ts`, JSDoc, après `@csspart input`
+(ligne 27) — attention, l'ordre dans le fichier place déjà `@csspart datepicker` ajouté à la Task 4
+juste après ; ajouter celui-ci juste avant :
+
+```ts
+ * @csspart field - Rôle transverse (voir /getting-started/naming-conventions), porté par `input` :
+ *   élément qui reçoit une saisie. Sous-rôle standard de `field` (avec `select`, cf.
+ *   ar-pagination), réutilisable par tout futur composant avec un champ texte.
+```
+
+- [ ] **Step 8: Run le build du manifeste**
+
+Run: `npm run build:manifest --workspace=packages/core`
+Expected: succès.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/core/src/components/datepicker/datepicker.ts \
+        packages/core/src/components/datepicker/datepicker.styles.ts \
+        packages/core/src/components/datepicker/datepicker.test.ts \
+        packages/core/src/components/datepicker/datepicker.browser.test.ts
+git commit -m "fix(datepicker): rôle transverse field sur input (#181)"
+```
+
+---
+
+### Task 6: `ar-datepicker` — rôle `control` sur `day`
+
+**Files:**
+
+- Modify: `packages/core/src/components/datepicker/datepicker.ts`
+- Modify: `packages/core/src/components/datepicker/datepicker.styles.ts`
+- Modify: `packages/core/src/components/datepicker/datepicker.test.ts`
+- Modify: `packages/core/src/components/datepicker/datepicker.a11y.test.ts`
+- Modify: `packages/core/src/components/datepicker/datepicker.browser.test.ts`
+
+**Interfaces:**
+
+- Produces: part `day` devient `day control`.
+
+- [ ] **Step 1: Corriger tous les sélecteurs à correspondance exacte sur `day` AVANT d'ajouter le rôle**
+
+```bash
+sed -i '' "s/\[part='day'\]/[part~='day']/g" \
+    packages/core/src/components/datepicker/datepicker.styles.ts
+
+sed -i '' 's/\[part="day"\]/[part~="day"]/g' \
+    packages/core/src/components/datepicker/datepicker.test.ts \
+    packages/core/src/components/datepicker/datepicker.a11y.test.ts \
+    packages/core/src/components/datepicker/datepicker.browser.test.ts
+```
+
+Vérifier qu'il ne reste plus aucune correspondance exacte :
+
+Run: `grep -rn "\[part='day'\]\|\[part=\"day\"\]" packages/core/src/components/datepicker/`
+Expected: aucune sortie.
+
+- [ ] **Step 2: Run tests pour vérifier qu'ils passent toujours (pas de régression du seul fait du `~=`)**
+
+Run: `npm test --workspace=packages/core -- datepicker` puis `npm run test:browser --workspace=packages/core`
+Expected: PASS sur les deux.
+
+- [ ] **Step 3: Écrire l'assertion du nouveau rôle (échec attendu)**
+
+Dans `packages/core/src/components/datepicker/datepicker.test.ts`, ajouter un test qui ouvre le
+calendrier et vérifie le rôle sur une cellule jour (s'inspirer d'un test existant qui ouvre déjà
+`open = true` puis interroge `[part~="day"]`, probablement déjà présent autour de la logique de
+grille) :
+
+```ts
+it('les cellules jour portent le rôle transverse "control"', async () => {
+    el.open = true;
+    await waitForUpdate(el);
+    const day = el.shadowRoot?.querySelector('[part~="day"]');
+    expect(day?.getAttribute('part')?.split(/\s+/)).toContain('control');
+});
+```
+
+- [ ] **Step 4: Run test pour vérifier l'échec**
+
+Run: `npm test --workspace=packages/core -- datepicker.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 5: Ajouter le rôle dans `_renderDay`**
+
+Dans `packages/core/src/components/datepicker/datepicker.ts`, `_renderDay()` (ligne 421) :
+
+```ts
+// avant
+<button
+    type="button"
+    part="day"
+    tabindex=${focused ? '0' : '-1'}
+// après
+<button
+    type="button"
+    part="day control"
+    tabindex=${focused ? '0' : '-1'}
+```
+
+- [ ] **Step 6: Run test pour vérifier le succès**
+
+Run: `npm test --workspace=packages/core -- datepicker.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Mettre à jour le JSDoc**
+
+Dans `packages/core/src/components/datepicker/datepicker.ts`, JSDoc, après `@csspart day` (ligne 41) :
+
+```ts
+ * @csspart control - Rôle transverse (voir /getting-started/naming-conventions), porté par `day` :
+ *   élément interactif générique.
+```
+
+- [ ] **Step 8: Run le build du manifeste**
+
+Run: `npm run build:manifest --workspace=packages/core`
+Expected: succès.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/core/src/components/datepicker/datepicker.ts \
+        packages/core/src/components/datepicker/datepicker.styles.ts \
+        packages/core/src/components/datepicker/datepicker.test.ts \
+        packages/core/src/components/datepicker/datepicker.a11y.test.ts \
+        packages/core/src/components/datepicker/datepicker.browser.test.ts
+git commit -m "fix(datepicker): rôle transverse control sur day (#181)"
+```
+
+---
+
+### Task 7: `ar-datepicker` — `nav-btn`/`footer-btn`/`today-btn`/`close-btn` → `-button` + rôle `action-button`
+
+**Files:**
+
+- Modify: `packages/core/src/components/datepicker/datepicker.ts`
+- Modify: `packages/core/src/components/datepicker/datepicker.styles.ts`
+- Modify: `packages/core/src/components/datepicker/datepicker.test.ts`
+- Modify: `packages/core/src/styles/themes/default.css`
+
+**Interfaces:**
+
+- Produces: renommage `nav-btn`→`nav-button`, `footer-btn`→`footer-button`, `today-btn`→
+  `today-button`, `close-btn`→`close-button` (convention `-button` en toutes lettres, cf. spec) ;
+  rôle `action-button` ajouté à `nav-button` (prev-year/prev-month/next-month/next-year) et
+  `footer-button` (today-button/close-button).
+
+- [ ] **Step 1: Renommer `-btn` → `-button` (convention en toutes lettres)**
+
+```bash
+sed -i '' 's/nav-btn/nav-button/g; s/footer-btn/footer-button/g; s/today-btn/today-button/g; s/close-btn/close-button/g' \
+    packages/core/src/components/datepicker/datepicker.ts \
+    packages/core/src/components/datepicker/datepicker.test.ts
+sed -i '' "s/nav-btn/nav-button/g; s/footer-btn/footer-button/g" \
+    packages/core/src/components/datepicker/datepicker.styles.ts
+sed -i '' 's/--ar-datepicker-nav-btn-/--ar-datepicker-nav-button-/g; s/--ar-datepicker-footer-btn-/--ar-datepicker-footer-button-/g' \
+    packages/core/src/components/datepicker/datepicker.ts \
+    packages/core/src/components/datepicker/datepicker.styles.ts \
+    packages/core/src/styles/themes/default.css
+sed -i '' 's/nav-btn/nav-button/g; s/footer-btn/footer-button/g' \
+    packages/core/src/styles/themes/default.css
+```
+
+Vérifier qu'il ne reste plus aucune trace de l'ancien nom :
+
+Run: `grep -rn "nav-btn\|footer-btn\|today-btn\|close-btn" packages/core/src/components/datepicker packages/core/src/styles/themes/default.css`
+Expected: aucune sortie.
+
+- [ ] **Step 2: Run tests pour vérifier qu'ils passent toujours (renommage pur)**
+
+Run: `npm test --workspace=packages/core -- datepicker.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Écrire les assertions du nouveau rôle (échec attendu)**
+
+Dans `packages/core/src/components/datepicker/datepicker.test.ts`, à la suite de l'assertion
+existante sur `today-button`/`close-button` (ex-lignes 333-334, dans un test qui ouvre déjà le
+panel) :
+
+```ts
+it('nav-button et footer-button portent le rôle transverse "action-button"', () => {
+    el.open = true;
+    // (réutiliser le pattern déjà présent dans ce describe pour attendre le rendu du calendrier)
+    const navButton = el.shadowRoot?.querySelector('[part~="nav-button"]');
+    const footerButton = el.shadowRoot?.querySelector('[part~="footer-button"]');
+    expect(navButton?.getAttribute('part')?.split(/\s+/)).toContain('action-button');
+    expect(footerButton?.getAttribute('part')?.split(/\s+/)).toContain('action-button');
+});
+```
+
+Adapter l'attente asynchrone (`await waitForUpdate(el)` ou équivalent) au pattern déjà utilisé par
+les tests voisins de ce describe, pour que la grille/le footer soient effectivement rendus avant
+la requête `querySelector`.
+
+- [ ] **Step 4: Run test pour vérifier l'échec**
+
+Run: `npm test --workspace=packages/core -- datepicker.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 5: Ajouter le rôle sur les 4 boutons de navigation**
+
+Dans `_renderCalendar()` (parts déjà renommées en `nav-button` depuis le Step 1) :
+
+```ts
+// avant (×4, un par bouton nav)
+part = 'nav-button prev-year';
+part = 'nav-button prev-month';
+part = 'nav-button next-month';
+part = 'nav-button next-year';
+// après
+part = 'nav-button prev-year action-button';
+part = 'nav-button prev-month action-button';
+part = 'nav-button next-month action-button';
+part = 'nav-button next-year action-button';
+```
+
+- [ ] **Step 6: Ajouter le rôle sur les 2 boutons du footer**
+
+```ts
+// avant
+part = 'footer-button today-button';
+// après
+part = 'footer-button today-button action-button';
+```
+
+```ts
+// avant
+part = 'footer-button close-button';
+// après
+part = 'footer-button close-button action-button';
+```
+
+- [ ] **Step 7: Run test pour vérifier le succès**
+
+Run: `npm test --workspace=packages/core -- datepicker.test.ts`
+Expected: PASS.
+
+- [ ] **Step 8: Mettre à jour le JSDoc**
+
+Dans le bloc JSDoc, après `@csspart footer-button` (le rôle `action-button` a déjà été introduit
+sur `ar-pagination` — Task 3 — mais chaque composant documente sa propre ligne `@csspart` pour ce
+rôle, même convention que les autres `@csspart`, pas de renvoi inter-composants) :
+
+```ts
+ * @csspart action-button - Rôle transverse (voir /getting-started/naming-conventions), porté par
+ *   les 4 boutons de navigation (`nav-button`) et les 2 boutons du footer (`footer-button`) :
+ *   bouton qui déclenche une action ponctuelle.
+```
+
+- [ ] **Step 9: Run le build du manifeste**
+
+Run: `npm run build:manifest --workspace=packages/core`
+Expected: succès.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add packages/core/src/components/datepicker/datepicker.ts \
+        packages/core/src/components/datepicker/datepicker.styles.ts \
+        packages/core/src/components/datepicker/datepicker.test.ts \
+        packages/core/src/styles/themes/default.css
+git commit -m "fix(datepicker): nav-button/footer-button/today-button/close-button + rôle action-button (#181)"
+```
+
+---
+
+### Task 8: Nouvelle page de doc — conventions de nommage
+
+**Files:**
+
+- Create: `apps/docs/src/pages/getting-started/naming-conventions.astro`
+- Modify: `apps/docs/src/components/SiteNav.astro`
+
+**Interfaces:**
+
+- Consumes: aucune dépendance sur les tasks précédentes autre que leur contenu textuel (les rôles
+  documentés doivent correspondre exactement à ceux effectivement implémentés dans les Tasks 2-7).
+- Produces: route `/getting-started/naming-conventions/`, découverte automatiquement par
+  `apps/docs/tests/a11y/pages.spec.ts` (scan de `dist/` après build, aucune inscription manuelle
+  requise pour ce test).
+
+- [ ] **Step 1: Créer la page**
+
+Créer `apps/docs/src/pages/getting-started/naming-conventions.astro`, sur le modèle de
+`apps/docs/src/pages/getting-started/shadow-dom.astro` (import `Layout` + `TableOfContents`,
+frontmatter avec `tocEntries`) :
+
+```astro
+---
+import Layout from '../../layouts/Layout.astro';
+import TableOfContents from '../../components/TableOfContents.astro';
+
+const tocEntries = [
+    { id: 'pourquoi',      label: 'Un vocabulaire partagé',        level: 1 as const },
+    { id: 'roles-part',    label: 'Rôles ::part() transverses',    level: 1 as const },
+    { id: 'roles-table',   label: 'Table des rôles',               level: 2 as const },
+    { id: 'roles-usage',   label: 'Comment les utiliser',          level: 2 as const },
+    { id: 'slots',         label: 'Conventions de slot',           level: 1 as const },
+];
+---
+
+<Layout title="Conventions de nommage" description="Vocabulaire de rôles ::part() et conventions de slot partagés par tous les composants Ariane.">
+    <article>
+        <h1>Conventions de nommage</h1>
+
+        <section id="pourquoi">
+            <h2>Un vocabulaire partagé</h2>
+            <p>
+                Chaque composant Ariane expose ses propres <code>::part()</code> spécifiques
+                (<code>close</code>, <code>panel</code>, <code>trigger</code>...). En complément,
+                certains éléments portent aussi un <strong>rôle transverse</strong> — un second
+                nom générique, partagé par tous les composants qui ont un élément de même nature.
+                Un rôle transverse s'ajoute toujours au part spécifique existant, il ne le
+                remplace jamais (sauf la racine du composant, cas particulier documenté
+                ci-dessous) : <code>part="close action-button"</code>.
+            </p>
+            <p>
+                Objectif : apprendre ce vocabulaire une seule fois, puis le reconnaître sur
+                n'importe quel composant de la librairie, sans redécouvrir le nom de chaque part
+                composant par composant — et surtout pouvoir écrire une seule règle CSS qui
+                s'applique à tous les composants concernés d'un coup (<code>::part(action-button)
+                { ... }</code> style tous les boutons d'action de la librairie, quel que soit le
+                composant). C'est ce qui rend l'intégration d'Ariane dans un design system
+                consommateur plus rapide : les décisions de style transverses (radius d'un
+                bouton, apparence d'un champ) se prennent une fois, pas composant par composant.
+            </p>
+        </section>
+
+        <section id="roles-part">
+            <h2>Rôles <code>::part()</code> transverses</h2>
+
+            <div id="roles-table">
+                <h3>Table des rôles</h3>
+                <table>
+                    <thead>
+                        <tr>
+                            <th scope="col">Rôle</th>
+                            <th scope="col">Signification</th>
+                            <th scope="col">Exemples</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><code>(nom du composant)</code></td>
+                            <td>Racine du composant. Remplace un éventuel part générique existant
+                                (<code>base</code>, <code>container</code>) plutôt que s'y
+                                ajouter — seule exception au principe additif, pour éviter une
+                                collision de nom lors d'un chaînage <code>exportparts</code> si un
+                                composant est un jour imbriqué dans un autre.</td>
+                            <td><code>ar-charcounter::part(charcounter)</code>,
+                                <code>ar-datepicker::part(datepicker)</code></td>
+                        </tr>
+                        <tr>
+                            <td><code>panel</code></td>
+                            <td>Conteneur flottant secondaire (popover, dropdown...).</td>
+                            <td><code>ar-datepicker::part(panel)</code></td>
+                        </tr>
+                        <tr>
+                            <td><code>body</code></td>
+                            <td>Zone de contenu principal.</td>
+                            <td><code>ar-dialog::part(body)</code>, <code>ar-alert::part(body)</code></td>
+                        </tr>
+                        <tr>
+                            <td><code>trigger</code></td>
+                            <td>Ouvre/ferme un panel ou une zone repliable.</td>
+                            <td><code>ar-collapse::part(trigger)</code></td>
+                        </tr>
+                        <tr>
+                            <td><code>header</code> / <code>footer</code></td>
+                            <td>En-tête / pied de composant.</td>
+                            <td><code>ar-datepicker::part(header)</code></td>
+                        </tr>
+                        <tr>
+                            <td><code>control</code></td>
+                            <td>Élément interactif générique (hors field/action-button/trigger).</td>
+                            <td><code>ar-pagination::part(link)</code>, <code>ar-datepicker::part(day)</code></td>
+                        </tr>
+                        <tr>
+                            <td><code>field</code></td>
+                            <td>Élément qui reçoit une saisie. Deux sous-rôles standard,
+                                réutilisables par tout futur composant : <code>input</code> (champ
+                                texte/textarea) et <code>select</code> (liste déroulante).</td>
+                            <td><code>ar-datepicker::part(input)</code>, <code>ar-pagination::part(select)</code></td>
+                        </tr>
+                        <tr>
+                            <td><code>action-button</code></td>
+                            <td>Bouton qui déclenche une action ponctuelle (pas un toggle de panel).</td>
+                            <td><code>ar-pagination::part(prev)</code>, <code>ar-datepicker::part(today-button)</code></td>
+                        </tr>
+                        <tr>
+                            <td><code>indicator</code></td>
+                            <td>Marqueur/indicateur visuel.</td>
+                            <td><code>ar-table-sort::part(indicator)</code></td>
+                        </tr>
+                        <tr>
+                            <td><code>label</code></td>
+                            <td>Texte descriptif.</td>
+                            <td><code>ar-datepicker::part(label)</code></td>
+                        </tr>
+                        <tr>
+                            <td><code>icon</code></td>
+                            <td>Icône.</td>
+                            <td><code>ar-alert::part(icon)</code></td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+            <div id="roles-usage">
+                <h3>Comment les utiliser</h3>
+                <p>
+                    Un rôle transverse se cible exactement comme n'importe quel autre part, avec
+                    <code>::part(nom-du-rôle)</code> — la seule différence est qu'il peut apparaître
+                    sur plusieurs composants différents, avec le même nom. La liste complète des
+                    part d'un composant, rôles transverses inclus, reste documentée sur sa propre
+                    page (section « CSS Parts »).
+                </p>
+            </div>
+        </section>
+
+        <section id="slots">
+            <h2>Conventions de slot</h2>
+            <p>
+                Les <code>&lt;slot&gt;</code> suivent des conventions déjà cohérentes sur toute la
+                librairie, sans qu'un nouveau vocabulaire ait été nécessaire :
+            </p>
+            <ul>
+                <li><strong>Slot par défaut (sans nom)</strong> — contenu principal du composant.</li>
+                <li><strong><code>trigger</code></strong> — même sens que le rôle <code>trigger</code>
+                    des part : élément qui ouvre/ferme le composant.</li>
+                <li><strong>Suffixe <code>&lt;rôle&gt;-icon</code></strong> — icône remplaçable
+                    associée à un élément précis (<code>close-icon</code>, <code>home-icon</code>,
+                    <code>trigger-icon</code>, <code>prev-icon</code>/<code>next-icon</code>,
+                    <code>warning-icon</code>/<code>error-icon</code>).</li>
+                <li><strong><code>header-actions</code></strong>, <strong><code>footer</code></strong> —
+                    reprennent le nom des rôles <code>::part()</code> homonymes.</li>
+            </ul>
+        </section>
+    </article>
+    <TableOfContents entries={tocEntries} />
+</Layout>
+```
+
+Vérifier au préalable la signature exacte de `Layout.astro` (props `title`/`description`) et de
+`TableOfContents.astro` (prop `entries`) en les lisant avant d'écrire ce fichier — reproduire
+strictement le pattern déjà utilisé par `shadow-dom.astro`.
+
+- [ ] **Step 2: Ajouter le lien de navigation**
+
+Dans `apps/docs/src/components/SiteNav.astro`, tableau `gettingStartedLinks` (lignes 30-33) :
+
+```ts
+// avant
+const gettingStartedLinks: NavLink[] = [
+    { href: '/getting-started/quickstart', label: 'Démarrage rapide', ariaCurrent: undefined },
+    { href: '/getting-started/utilisation', label: 'Utilisation', ariaCurrent: undefined },
+    { href: '/getting-started/shadow-dom', label: 'Shadow DOM applicatif', ariaCurrent: undefined },
+].map((link) => ({
+// après
+const gettingStartedLinks: NavLink[] = [
+    { href: '/getting-started/quickstart', label: 'Démarrage rapide', ariaCurrent: undefined },
+    { href: '/getting-started/utilisation', label: 'Utilisation', ariaCurrent: undefined },
+    { href: '/getting-started/shadow-dom', label: 'Shadow DOM applicatif', ariaCurrent: undefined },
+    { href: '/getting-started/naming-conventions', label: 'Conventions de nommage', ariaCurrent: undefined },
+].map((link) => ({
+```
+
+- [ ] **Step 3: Build et vérification locale**
+
+Run: `npm run build --workspace=apps/docs`
+Expected: succès, génère `apps/docs/dist/getting-started/naming-conventions/index.html`.
+
+- [ ] **Step 4: Vérification a11y automatique**
+
+Run: `npm run test:a11y --workspace=apps/docs`
+Expected: PASS pour la route `/getting-started/naming-conventions/`, découverte automatiquement
+(le script `test:a11y` lance `playwright test`, qui exécute `apps/docs/tests/a11y/pages.spec.ts`
+contre `dist/` généré au Step 3).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/docs/src/pages/getting-started/naming-conventions.astro \
+        apps/docs/src/components/SiteNav.astro
+git commit -m "docs: page conventions de nommage part/slot transverses (#181)"
+```
+
+---
+
+### Task 9: Vérification finale de branche
+
+**Files:** aucun fichier modifié (task de vérification uniquement).
+
+- [ ] **Step 1: Suite de tests complète (core)**
+
+Run: `npm test --workspace=packages/core`
+Expected: PASS, 0 échec.
+
+- [ ] **Step 2: Suite de tests browser (core)**
+
+Run: `npm run test:browser --workspace=packages/core`
+Expected: PASS, 0 échec.
+
+- [ ] **Step 3: Build complet + manifeste**
+
+Run: `npm run build:manifest --workspace=packages/core && npm run build`
+Expected: succès, sans avertissement des garde-fous CI (`validate-cssprop-defaults.js`,
+`validate-no-hardcoded-tokens.js`).
+
+- [ ] **Step 4: Vérification manuelle de cohérence JSDoc vs spec**
+
+Relire la table « Vocabulaire retenu » de
+`docs/superpowers/specs/2026-08-13-role-parts-vocabulary-181-design.md` et confirmer que chaque
+rôle introduit dans ce lot (`control`, `field`, `action-button`, racine nommée) est bien documenté
+avec la mention « Rôle transverse (voir /getting-started/naming-conventions) » sur `ar-pagination`
+et `ar-datepicker`, et que `ar-charcounter` a bien `charcounter`/`warning-icon`/`error-icon`.
+
+- [ ] **Step 5: Grep final — aucune correspondance exacte résiduelle sur les parts multi-jetons de ce lot**
+
+Run: `grep -rn '\[part="nav"\]\|\[part="link"\]\|\[part="current"\]\|\[part="select"\]\|\[part="day"\]\|\[part="input"\]\|\[part='"'"'day'"'"'\]\|\[part='"'"'input'"'"'\]' packages/core/src/components/pagination packages/core/src/components/datepicker`
+Expected: aucune sortie.
+
+- [ ] **Step 6: Lint/format**
+
+Run: `npm run lint`
+Expected: PASS.
+
+---
+
+### Task 10: Créer la Pull Request
+
+**Files:** aucun fichier modifié.
+
+- [ ] **Step 1: Pousser la branche**
+
+```bash
+git push -u origin fix/parts-roles-vocabulary-181-lot1
+```
+
+- [ ] **Step 2: Créer la PR vers `dev`**
+
+```bash
+gh pr create --base dev --title "fix(core): vocabulaire de rôles ::part()/slot transverses — lot 1 (#181)" --body "$(cat <<'EOF'
+## Résumé
+
+Premier lot du chantier #181 (vocabulaire de rôles `::part()`/`slot` transverses) :
+
+- `ar-charcounter` : racine `container` → `charcounter`, slots `icon-warning`/`icon-error` →
+  `warning-icon`/`error-icon` (cohérence avec le suffixe `<rôle>-icon` déjà établi ailleurs).
+- `ar-pagination` : part racine `pagination` (additif sur `nav`), rôles transverses
+  `control`(link/current)/`field`(select)/`action-button`(prev/next), `nav-btn` → `nav-button`.
+- `ar-datepicker` : nouveau wrapper racine `part="datepicker"`, rôles transverses
+  `field`(input)/`control`(day)/`action-button`(nav-button/footer-button), `nav-btn`/`footer-btn`/
+  `today-btn`/`close-btn` → `-button` en toutes lettres.
+- Nouvelle page de doc `/getting-started/naming-conventions` (rôles `::part()` transverses +
+  conventions de `slot`).
+
+Spec : `docs/superpowers/specs/2026-08-13-role-parts-vocabulary-181-design.md`
+Plan : `docs/superpowers/plans/2026-08-13-role-parts-vocabulary-181-lot1.md`
+
+## Test plan
+
+- [ ] `npm test --workspace=packages/core` — PASS
+- [ ] `npm run test:browser --workspace=packages/core` — PASS
+- [ ] `npm run test:a11y --workspace=apps/docs` — PASS
+- [ ] `npm run build:manifest --workspace=packages/core && npm run build` — succès
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Confirmer la création**
+
+Run: `gh pr view --json url --jq .url`
+Expected: affiche l'URL de la PR nouvellement créée, vers `dev`.

--- a/docs/superpowers/specs/2026-08-13-role-parts-vocabulary-181-design.md
+++ b/docs/superpowers/specs/2026-08-13-role-parts-vocabulary-181-design.md
@@ -54,6 +54,12 @@ charcounter) vs absente (spinner, pagination, dialog) ; zone de contenu principa
 button`/`action-item`/`action-card` — PatternFly ; `remove-button` — Vaadin).
 - **`panel` = conteneur flottant** est le sens consensuel (Shoelace/Web Awesome), pas la zone
   animée d'`ar-collapse` — décision inverse de la première intuition de ce brainstorming.
+- **`body`, pas `content`, pour la zone de contenu principal** : Radix formalise explicitement le
+  triptyque _« Header, Body, and Footer, borrowing directly from HTML's document structure »_, et
+  Shoelace/Web Awesome l'appliquent tel quel sur leur dialog (`header`/`body`/`footer`/
+  `close-button`). Spectrum définit certes `content` comme terme séparé, mais de façon redondante
+  avec son propre `body` — aucune source ne traite `content` de façon plus cohérente que `body`.
+  Avec `header`/`footer` déjà retenus comme rôles transverses, `body` en est le complément naturel.
 - Certains systèmes de référence (Salesforce Lightning Design System, en BEM) n'ont **aucun**
   vocabulaire transverse et scopent chaque nom à son composant — confirme que la démarche de
   l'issue #181 n'est pas une évidence universelle, mais un choix cohérent avec la philosophie
@@ -65,7 +71,7 @@ button`/`action-item`/`action-card` — PatternFly ; `remove-button` — Vaadin)
 | -------------------- | --------------------------------------------------------- | ------------------------------------------------ |
 | _(nom du composant)_ | Racine du composant (remplace `base`/`container`/absence) | Web Awesome                                      |
 | `panel`              | Conteneur flottant secondaire                             | Shoelace, Web Awesome                            |
-| `content`            | Zone de contenu principal (remplace/complète `body`)      | Spectrum, notre `ar-collapse` existant           |
+| `body`               | Zone de contenu principal                                 | Radix, Shoelace, Web Awesome, notre existant     |
 | `trigger`            | Ouvre/ferme un panel ou une zone repliable                | Shoelace, Web Awesome, Radix, notre existant     |
 | `header` / `footer`  | En-tête / pied de composant                               | Shoelace, Web Awesome, Radix, notre existant     |
 | `control`            | Élément interactif générique (hors field/action/trigger)  | Spectrum (officiel)                              |
@@ -90,8 +96,10 @@ futur composant a besoin d'un texte d'aide ou d'un marqueur de validation.
 
 **Additif uniquement, jamais de renommage breaking.** Un élément qui a déjà un part spécifique
 gagne le rôle transverse en plus, dans le même attribut `part` : `part="close action-button"`,
-`part="container base"` devient `part="progressbar"` (voir note racine ci-dessous),
-`part="body content"`.
+`part="container base"` devient `part="progressbar"` (voir note racine ci-dessous). `ar-alert`/
+`ar-dialog` n'ont rien à changer, ils utilisent déjà `body` — il devient directement le rôle
+transverse confirmé. Seul `ar-collapse` renomme son ancien `panel` (libéré pour le sens flottant,
+cf. ci-dessus) en `body`.
 
 **Racine du composant — cas particulier.** Contrairement aux autres rôles (additifs), la racine
 n'accumule pas ancien nom + nouveau : le part générique existant (`base` ou `container`) est

--- a/docs/superpowers/specs/2026-08-13-role-parts-vocabulary-181-design.md
+++ b/docs/superpowers/specs/2026-08-13-role-parts-vocabulary-181-design.md
@@ -169,16 +169,15 @@ doc dédiée :
 
 Nouvelle page dédiée dans `apps/docs` (`/getting-started/naming-conventions` ou emplacement équivalent
 choisi au moment du plan d'implémentation, cohérent avec l'architecture de nav existante).
-**Objectif explicite de la page, pas seulement une table de référence passive** : donner au
-consommateur les moyens d'écrire des règles CSS transverses qui facilitent l'intégration
-d'Ariane dans son propre design system — un thème qui style `::part(action-button)` une seule
-fois s'applique à tous les composants qui portent ce rôle, sans dupliquer la règle composant par
-composant. La page inclut donc un exemple « recette » concret de règle multi-composants, pas
-seulement la table des rôles. Deux sections :
+**Objectif explicite de la page, pas seulement une table de référence passive** : expliciter que ce
+vocabulaire existe pour permettre au consommateur d'écrire des règles CSS transverses qui
+facilitent l'intégration d'Ariane dans son propre design system — un thème qui style
+`::part(action-button)` une seule fois s'applique à tous les composants qui portent ce rôle, sans
+dupliquer la règle composant par composant. Cette raison d'être doit être formulée dans
+l'introduction de la page, pas seulement démontrée implicitement par la table. Deux sections :
 
-1. **Rôles `::part()` transverses** : chaque rôle, sa signification, les composants/parts qui le
-   portent, et un exemple de règle CSS ciblant plusieurs composants à la fois via le même rôle.
-   Référencée depuis chaque page composant concernée par au moins un rôle transverse.
+1. **Rôles `::part()` transverses** : chaque rôle, sa signification, et les composants/parts qui le
+   portent. Référencée depuis chaque page composant concernée par au moins un rôle transverse.
 2. **Conventions de `slot`** : slot par défaut = contenu principal, `trigger`, suffixe `<rôle>-icon`,
    `header-actions`/`footer` — documente l'existant, pas de nouveau mécanisme.
 

--- a/docs/superpowers/specs/2026-08-13-role-parts-vocabulary-181-design.md
+++ b/docs/superpowers/specs/2026-08-13-role-parts-vocabulary-181-design.md
@@ -154,16 +154,26 @@ que de la reporter à un futur renommage. Composants sans aucun part racine actu
 pagination, dialog) : le part est simplement ajouté, pas de migration.
 
 **JSDoc `@csspart`.** Une ligne dédiée par rôle transverse (même convention que les parts d'état
-`--current`/`--pending`), marquée explicitement comme rôle transverse avec renvoi vers la page de
-doc dédiée :
+`--current`/`--pending`), avec une description normale — **sans** marqueur « Rôle transverse (voir
+...) » répété sur chaque ligne. Décision révisée après livraison du premier lot : le marqueur par
+ligne, présent sur chaque `@csspart` d'un rôle transverse, s'est révélé répétitif dès qu'un
+composant porte plusieurs rôles (jusqu'à 4 lignes dupliquant la même mention sur `ar-datepicker`).
 
 ```ts
 /**
  * @csspart close - Le bouton de fermeture.
- * @csspart action-button - Rôle transverse (voir /getting-started/naming-conventions) : déclenche une action de
- *   fermeture.
+ * @csspart action-button - Porté par `close` : déclenche une action ponctuelle.
  */
 ```
+
+**Détection automatique + mention unique dans la doc générée.** Plutôt que documenter le caractère
+transverse dans chaque ligne JSDoc, la page composant (`ComponentApi.astro`) détecte
+automatiquement si le composant expose au moins un rôle transverse — comparaison de chaque nom de
+part contre le catalogue des rôles (`apps/docs/src/utils/transverse-roles.ts`, source de vérité
+unique synchronisée avec la table de `/getting-started/naming-conventions`), plus un cas
+particulier pour la racine (nom de part égal au nom du composant sans préfixe). Si détecté, une
+phrase est ajoutée automatiquement au paragraphe d'aide (`hint`) de la section CSS Parts, avec un
+lien cliquable vers `/getting-started/naming-conventions` — pas de répétition par ligne.
 
 ## Documentation
 
@@ -193,9 +203,12 @@ y compris le premier. Ordre des lots suivants à affiner au moment d'écrire le 
 ## Impact `custom-elements.json` / doc générée
 
 Les rôles transverses sont de simples `@csspart` supplémentaires, déjà supportés par le pipeline
-CEM existant — aucun mécanisme nouveau requis côté génération de manifeste. Seule nouveauté :
-détecter et regrouper les parts marqués « rôle transverse » pour alimenter la nouvelle page de doc
-dédiée (mécanisme précis à définir au moment du plan d'implémentation).
+CEM existant — aucun mécanisme nouveau requis côté génération de manifeste. La page de doc dédiée
+(`/getting-started/naming-conventions`) reste écrite à la main (table statique), pas générée
+depuis le manifeste — cf. section « Documentation ». Seule nouveauté côté site de doc :
+`ComponentApi.astro` détecte, pour chaque composant, si l'un de ses parts porte un rôle transverse
+(catalogue dans `apps/docs/src/utils/transverse-roles.ts`) afin d'afficher une mention avec lien
+vers la page dédiée dans le paragraphe d'aide de la section CSS Parts — cf. section « Mécanisme ».
 
 ## Hors scope de ce chantier
 

--- a/docs/superpowers/specs/2026-08-13-role-parts-vocabulary-181-design.md
+++ b/docs/superpowers/specs/2026-08-13-role-parts-vocabulary-181-design.md
@@ -83,7 +83,27 @@ button`/`action-item`/`action-card` — PatternFly ; `remove-button` — Vaadin)
 
 `trigger` et `action-button` restent des rôles frères, pas hiérarchiques : `trigger` uniquement
 pour un toggle de panel/zone repliable, `action-button` pour tout autre bouton de commande (close,
-prev/next, today, footer-btn...).
+prev/next, today, footer-button...).
+
+**`field` a deux spécialisations reconnues, réutilisables par tout futur composant** — même schéma
+générique+spécifique que `control`/`action-button` : `input` (champ texte/textarea) et `select`
+(liste déroulante). Ce ne sont pas de simples noms qui coïncident aujourd'hui sur `ar-datepicker`
+(`input`) et `ar-pagination` (`select`) — ce sont désormais des noms de vocabulaire officiels :
+tout futur composant avec un champ texte doit utiliser `part="input field"`, tout futur composant
+avec une liste déroulante `part="select field"`, plutôt que d'inventer un nom propre. Justification
+pratique (retour utilisateur) : un consommateur qui veut un style de champ cohérent entre un input
+texte et un select a besoin de cibler `::part(field)` pour le commun (bordure, padding, focus-ring)
+tout en gardant `::part(input)`/`::part(select)` pour ce qui diverge structurellement (flèche du
+select, largeur, `appearance`).
+
+**Convention `-button` en toutes lettres, jamais `-btn` abrégé.** `action-button` établit la
+convention en toutes lettres ; les parts déjà existants `nav-btn`/`footer-btn`/`today-btn`/
+`close-btn` (datepicker) et `nav-btn` (pagination), ainsi que les `@cssprop` associés
+(`--ar-pagination-btn-size`, `--ar-datepicker-nav-btn-*`, `--ar-datepicker-footer-btn-*`), sont
+renommés en toutes lettres (`nav-button`, `footer-button`, `today-button`, `close-button`,
+`--ar-pagination-button-size`, etc.) pour rester cohérents avec le reste du vocabulaire. Renommage
+sec (alpha, cf. contrainte projet), entièrement contenu dans les 2 composants déjà dans le
+périmètre de ce lot — aucune extension à d'autres composants.
 
 ## Slots — documenter l'existant, un correctif de cohérence
 
@@ -140,19 +160,25 @@ doc dédiée :
 ```ts
 /**
  * @csspart close - Le bouton de fermeture.
- * @csspart action-button - Rôle transverse (voir /concepts/naming-conventions) : déclenche une action de
+ * @csspart action-button - Rôle transverse (voir /getting-started/naming-conventions) : déclenche une action de
  *   fermeture.
  */
 ```
 
 ## Documentation
 
-Nouvelle page dédiée dans `apps/docs` (`/concepts/naming-conventions` ou emplacement équivalent
-choisi au moment du plan d'implémentation, cohérent avec l'architecture de nav existante), en deux
-sections :
+Nouvelle page dédiée dans `apps/docs` (`/getting-started/naming-conventions` ou emplacement équivalent
+choisi au moment du plan d'implémentation, cohérent avec l'architecture de nav existante).
+**Objectif explicite de la page, pas seulement une table de référence passive** : donner au
+consommateur les moyens d'écrire des règles CSS transverses qui facilitent l'intégration
+d'Ariane dans son propre design system — un thème qui style `::part(action-button)` une seule
+fois s'applique à tous les composants qui portent ce rôle, sans dupliquer la règle composant par
+composant. La page inclut donc un exemple « recette » concret de règle multi-composants, pas
+seulement la table des rôles. Deux sections :
 
-1. **Rôles `::part()` transverses** : chaque rôle, sa signification, et les composants/parts qui le
-   portent. Référencée depuis chaque page composant concernée par au moins un rôle transverse.
+1. **Rôles `::part()` transverses** : chaque rôle, sa signification, les composants/parts qui le
+   portent, et un exemple de règle CSS ciblant plusieurs composants à la fois via le même rôle.
+   Référencée depuis chaque page composant concernée par au moins un rôle transverse.
 2. **Conventions de `slot`** : slot par défaut = contenu principal, `trigger`, suffixe `<rôle>-icon`,
    `header-actions`/`footer` — documente l'existant, pas de nouveau mécanisme.
 

--- a/docs/superpowers/specs/2026-08-13-role-parts-vocabulary-181-design.md
+++ b/docs/superpowers/specs/2026-08-13-role-parts-vocabulary-181-design.md
@@ -1,0 +1,145 @@
+# Design — Vocabulaire de rôles `::part()` transverses
+
+**Statut :** Validé (en attente de plan d'implémentation)
+**Date :** 2026-08-13
+**Contexte :** issue [#181](https://github.com/jogo-labs/ariane/issues/181)
+
+## Problème
+
+Chaque composant Ariane définit ses propres noms de `::part()` (`close`, `header`, `panel`,
+`trigger`...), ce qui oblige un consommateur à apprendre le vocabulaire de chaque composant
+individuellement pour le styliser en profondeur — contraire à l'objectif d'écosystème cohérent
+visé par la philosophie headless du projet.
+
+## Méthode
+
+Avant de fixer la liste de rôles, audit des `@csspart` existants sur les 19 composants (voir
+tableau ci-dessous) puis recherche croisée sur 11 design systems/librairies de référence utilisant
+CSS Shadow Parts ou une vocabulaire d'anatomie transverse documentée : Shoelace, Web Awesome
+(successeur direct de Shoelace, même auteur — déjà notre référence pour la convention `active` /
+`base--selected` d'`ar-tab`), Fluent UI / FAST (Microsoft), Radix UI, Spectrum Design Data (Adobe —
+registre officiel de termes d'anatomie), Primer (GitHub), Salesforce Lightning Design System,
+PatternFly (Red Hat), Atlassian Design System, Ionic, Vaadin. Fluent 2, Carbon (IBM), Polaris
+(Shopify) et Porsche Design System ont aussi été recherchés mais n'exposent pas de convention
+`::part()` documentée publiquement exploitable.
+
+### Constat de l'audit interne
+
+Des noms transverses existent déjà de facto, avec un usage cohérent sur plusieurs composants :
+`trigger` (collapse, breadcrumb, stepper, datepicker), `panel` (dropdown, datepicker, stepper,
+breadcrumb — mais aussi, en collision de sens, la zone animée non-flottante d'`ar-collapse`),
+`header`/`footer` (datepicker, dialog), `label` (datepicker, charcounter, progressbar, pagination).
+Deux incohérences de nommage existantes et sans lien avec l'issue mais relevant du même problème :
+racine du composant nommée `base` (tab, tab-panel, tab-group) vs `container` (progressbar,
+charcounter) vs absente (spinner, pagination, dialog) ; zone de contenu principal nommée `body`
+(alert, dialog) vs `content` (collapse).
+
+### Constat de la recherche externe
+
+- **Convergence claire** sur : racine du composant, conteneur flottant, `trigger`, `header`/
+  `footer`, contenu principal, élément interactif générique, champ de saisie, bouton d'action,
+  indicateur visuel, `label`, `icon`.
+- **Root part nommé d'après le composant, pas un mot générique** : Web Awesome a déprécié son
+  `base` générique au profit d'un part nommé d'après le composant (`<wa-button>` expose `button`,
+  `<wa-details>` expose `details`). Aucune justification officielle écrite trouvée, mais la raison
+  technique plausible et documentée ailleurs sur les CSS Shadow Parts est réelle et déjà rencontrée
+  dans Ariane : `::part()` ne traverse qu'un seul niveau de frontière shadow, il faut chaîner
+  `exportparts` pour remonter à travers plusieurs niveaux d'imbrication — un nom générique commun à
+  tous les composants entre en collision dans cette chaîne. Ariane a déjà ce problème documenté
+  (issue #168, `ar-tooltip` imbriqué dans `ar-table-sort`).
+- **`control`/`field` sont un standard réel** (Spectrum Design Data, registre officiel Adobe), pas
+  une invention Ariane comme l'audit initial le laissait craindre.
+- **`action` isolé n'a aucun précédent** : toutes les sources qui formalisent ce concept le
+  composent toujours avec le type d'élément (`action-button`, `close-button` — Spectrum ; `action-
+button`/`action-item`/`action-card` — PatternFly ; `remove-button` — Vaadin).
+- **`panel` = conteneur flottant** est le sens consensuel (Shoelace/Web Awesome), pas la zone
+  animée d'`ar-collapse` — décision inverse de la première intuition de ce brainstorming.
+- Certains systèmes de référence (Salesforce Lightning Design System, en BEM) n'ont **aucun**
+  vocabulaire transverse et scopent chaque nom à son composant — confirme que la démarche de
+  l'issue #181 n'est pas une évidence universelle, mais un choix cohérent avec la philosophie
+  headless déjà suivie par Ariane.
+
+## Vocabulaire retenu
+
+| Rôle                 | Signification                                             | Sources qui le valident                          |
+| -------------------- | --------------------------------------------------------- | ------------------------------------------------ |
+| _(nom du composant)_ | Racine du composant (remplace `base`/`container`/absence) | Web Awesome                                      |
+| `panel`              | Conteneur flottant secondaire                             | Shoelace, Web Awesome                            |
+| `content`            | Zone de contenu principal (remplace/complète `body`)      | Spectrum, notre `ar-collapse` existant           |
+| `trigger`            | Ouvre/ferme un panel ou une zone repliable                | Shoelace, Web Awesome, Radix, notre existant     |
+| `header` / `footer`  | En-tête / pied de composant                               | Shoelace, Web Awesome, Radix, notre existant     |
+| `control`            | Élément interactif générique (hors field/action/trigger)  | Spectrum (officiel)                              |
+| `field`              | Reçoit une saisie                                         | Spectrum (officiel)                              |
+| `action-button`      | Bouton qui déclenche une action ponctuelle                | Spectrum, PatternFly, Vaadin (pattern `-button`) |
+| `indicator`          | Marqueur/indicateur visuel                                | Spectrum, Radix, notre `ar-table-sort` existant  |
+| `label`              | Texte descriptif                                          | Déjà transverse de fait dans Ariane              |
+| `icon`               | Icône                                                     | Déjà transverse de fait dans Ariane (`ar-alert`) |
+
+`trigger` et `action-button` restent des rôles frères, pas hiérarchiques : `trigger` uniquement
+pour un toggle de panel/zone repliable, `action-button` pour tout autre bouton de commande (close,
+prev/next, today, footer-btn...).
+
+## Hors périmètre (YAGNI)
+
+`help-text`/`validation-marker` (termes Spectrum officiels, proches de nos `hint`/`error`
+existants) ne sont pas ajoutés en rôle transverse : un seul composant (`ar-datepicker`) les utilise
+aujourd'hui, l'ajout n'allège rien tant qu'un deuxième cas réel n'apparaît pas. À reconsidérer si un
+futur composant a besoin d'un texte d'aide ou d'un marqueur de validation.
+
+## Mécanisme
+
+**Additif uniquement, jamais de renommage breaking.** Un élément qui a déjà un part spécifique
+gagne le rôle transverse en plus, dans le même attribut `part` : `part="close action-button"`,
+`part="container base"` devient `part="progressbar"` (voir note racine ci-dessous),
+`part="body content"`.
+
+**Racine du composant — cas particulier.** Contrairement aux autres rôles (additifs), la racine
+n'accumule pas ancien nom + nouveau : le part générique existant (`base` ou `container`) est
+**remplacé** par le nom du composant, sur le modèle Web Awesome. C'est le seul renommage non-additif
+du chantier, justifié par l'absence de valeur d'un doublon `part="container <nom-composant>"` (la
+racine n'a jamais eu de rôle "spécifique" distinct à préserver — `base`/`container` étaient déjà
+eux-mêmes génériques) et par la nécessité d'éviter la collision `exportparts` dès maintenant plutôt
+que de la reporter à un futur renommage. Composants sans aucun part racine actuellement (spinner,
+pagination, dialog) : le part est simplement ajouté, pas de migration.
+
+**JSDoc `@csspart`.** Une ligne dédiée par rôle transverse (même convention que les parts d'état
+`--current`/`--pending`), marquée explicitement comme rôle transverse avec renvoi vers la page de
+doc dédiée :
+
+```ts
+/**
+ * @csspart close - Le bouton de fermeture.
+ * @csspart action-button - Rôle transverse (voir /concepts/parts-roles) : déclenche une action de
+ *   fermeture.
+ */
+```
+
+## Documentation
+
+Nouvelle page dédiée dans `apps/docs` (`/concepts/parts-roles` ou emplacement équivalent choisi au
+moment du plan d'implémentation, cohérent avec l'architecture de nav existante) : liste chaque
+rôle, sa signification, et les composants/parts qui le portent. Référencée depuis chaque page
+composant concernée par au moins un rôle transverse.
+
+## Rollout
+
+Rétrofit progressif par lots sur le modèle du chantier #129 (spec + plan dédiés par lot, exécution
+subagent-driven-development, revue finale de branche). Premier lot suggéré : `ar-datepicker` et
+`ar-pagination` (les plus riches en rôles concernés : `control`, `field`, `action-button`, racine
+absente). Ordre des lots suivants à affiner au moment d'écrire le premier plan.
+
+## Impact `custom-elements.json` / doc générée
+
+Les rôles transverses sont de simples `@csspart` supplémentaires, déjà supportés par le pipeline
+CEM existant — aucun mécanisme nouveau requis côté génération de manifeste. Seule nouveauté :
+détecter et regrouper les parts marqués « rôle transverse » pour alimenter la nouvelle page de doc
+dédiée (mécanisme précis à définir au moment du plan d'implémentation).
+
+## Hors scope de ce chantier
+
+- Renommage des rôles déjà transverses de fait (`trigger`, `header`, `footer`, `label`, `icon`) —
+  confirmés tels quels, aucune migration nécessaire.
+- `help-text`/`validation-marker` — cf. section Hors périmètre.
+- Extension du vocabulaire à des composants futurs non encore conçus — ce chantier couvre le
+  rétrofit des 19 composants existants ; les nouveaux composants adoptent le vocabulaire dès leur
+  conception, sans travail supplémentaire de ce chantier.

--- a/docs/superpowers/specs/2026-08-13-role-parts-vocabulary-181-design.md
+++ b/docs/superpowers/specs/2026-08-13-role-parts-vocabulary-181-design.md
@@ -1,4 +1,4 @@
-# Design — Vocabulaire de rôles `::part()` transverses
+# Design — Vocabulaire de rôles `::part()` et conventions de `slot` transverses
 
 **Statut :** Validé (en attente de plan d'implémentation)
 **Date :** 2026-08-13
@@ -85,6 +85,29 @@ button`/`action-item`/`action-card` — PatternFly ; `remove-button` — Vaadin)
 pour un toggle de panel/zone repliable, `action-button` pour tout autre bouton de commande (close,
 prev/next, today, footer-btn...).
 
+## Slots — documenter l'existant, un correctif de cohérence
+
+Audit des `@slot` sur les 19 composants : contrairement aux `part`, les slots suivent déjà des
+conventions cohérentes de fait, sans l'incohérence type `base`/`container` trouvée sur les parts.
+Un `slot` désigne intrinsèquement un point précis de structure (l'icône du bouton close, pas un
+point d'injection générique réutilisable ailleurs) — la notion de rôle transverse abstrait ne s'y
+transpose pas comme pour les `part`. Décision : **pas de retrofit de code pour les slots**, sauf un
+correctif ponctuel repéré pendant l'audit (ci-dessous). Seule la documentation est nouvelle.
+
+Conventions déjà suivies, à formaliser dans la doc :
+
+- **Slot par défaut (sans nom)** = contenu principal — natif HTML, aucune ambiguïté possible
+  (dropdown, alert, collapse, dialog, tab, tab-panel, tooltip, table-sort...).
+- **`trigger`** — même nom, même sens que le rôle `trigger` des `part` (dropdown, collapse).
+- **Suffixe `<rôle>-icon`** — déjà systématique (mémoire `project_icon_slot_pattern`) : `close-icon`,
+  `home-icon`, `trigger-icon`, `prev-icon`/`next-icon`.
+- **`header-actions`, `footer`** (dialog) — reprennent déjà les noms des `part` homonymes.
+
+**Correctif de cohérence inclus dans ce chantier** : `ar-charcounter` expose `icon-warning`/
+`icon-error`, seul écart au suffixe `<rôle>-icon` établi partout ailleurs. Renommés en
+`warning-icon`/`error-icon`. Renommage sec (pas d'alias, pas de dépréciation) — projet en alpha,
+`warnDeprecated` non requis à ce stade (cf. CLAUDE.md).
+
 ## Hors périmètre (YAGNI)
 
 `help-text`/`validation-marker` (termes Spectrum officiels, proches de nos `hint`/`error`
@@ -117,24 +140,30 @@ doc dédiée :
 ```ts
 /**
  * @csspart close - Le bouton de fermeture.
- * @csspart action-button - Rôle transverse (voir /concepts/parts-roles) : déclenche une action de
+ * @csspart action-button - Rôle transverse (voir /concepts/naming-conventions) : déclenche une action de
  *   fermeture.
  */
 ```
 
 ## Documentation
 
-Nouvelle page dédiée dans `apps/docs` (`/concepts/parts-roles` ou emplacement équivalent choisi au
-moment du plan d'implémentation, cohérent avec l'architecture de nav existante) : liste chaque
-rôle, sa signification, et les composants/parts qui le portent. Référencée depuis chaque page
-composant concernée par au moins un rôle transverse.
+Nouvelle page dédiée dans `apps/docs` (`/concepts/naming-conventions` ou emplacement équivalent
+choisi au moment du plan d'implémentation, cohérent avec l'architecture de nav existante), en deux
+sections :
+
+1. **Rôles `::part()` transverses** : chaque rôle, sa signification, et les composants/parts qui le
+   portent. Référencée depuis chaque page composant concernée par au moins un rôle transverse.
+2. **Conventions de `slot`** : slot par défaut = contenu principal, `trigger`, suffixe `<rôle>-icon`,
+   `header-actions`/`footer` — documente l'existant, pas de nouveau mécanisme.
 
 ## Rollout
 
 Rétrofit progressif par lots sur le modèle du chantier #129 (spec + plan dédiés par lot, exécution
 subagent-driven-development, revue finale de branche). Premier lot suggéré : `ar-datepicker` et
 `ar-pagination` (les plus riches en rôles concernés : `control`, `field`, `action-button`, racine
-absente). Ordre des lots suivants à affiner au moment d'écrire le premier plan.
+absente). Le correctif de slot `ar-charcounter` (`icon-warning`/`icon-error` →
+`warning-icon`/`error-icon`) est indépendant du reste — peut être fait dans n'importe quel lot,
+y compris le premier. Ordre des lots suivants à affiner au moment d'écrire le premier plan.
 
 ## Impact `custom-elements.json` / doc générée
 

--- a/packages/core/src/components/charcounter/charcounter.a11y.test.ts
+++ b/packages/core/src/components/charcounter/charcounter.a11y.test.ts
@@ -141,7 +141,7 @@ describe('ar-charcounter — accessibilité', () => {
     // ── Parts shadow DOM ──────────────────────────────────────────────────
 
     describe('parts shadow DOM', () => {
-        it('expose part="container"', async () => {
+        it('expose part="charcounter"', async () => {
             const el = await fixture<ArCharcounter>(html`
                 <div>
                     <textarea id="fc"></textarea>
@@ -149,7 +149,7 @@ describe('ar-charcounter — accessibilité', () => {
                 </div>
             `);
             const counter = el.querySelector<ArCharcounter>('ar-charcounter')!;
-            expect(counter.shadowRoot!.querySelector('[part="container"]')).to.not.equal(null);
+            expect(counter.shadowRoot!.querySelector('[part="charcounter"]')).to.not.equal(null);
         });
     });
 });

--- a/packages/core/src/components/charcounter/charcounter.styles.ts
+++ b/packages/core/src/components/charcounter/charcounter.styles.ts
@@ -15,16 +15,16 @@ export default css`
         font-weight: var(--ar-charcounter-error-weight, 700);
     }
 
-    slot[name='icon-warning'],
-    slot[name='icon-error'] {
+    slot[name='warning-icon'],
+    slot[name='error-icon'] {
         display: none;
     }
 
-    :host([state='warning']) slot[name='icon-warning'] {
+    :host([state='warning']) slot[name='warning-icon'] {
         display: contents;
     }
 
-    :host([state='error']) slot[name='icon-error'] {
+    :host([state='error']) slot[name='error-icon'] {
         display: contents;
     }
 `;

--- a/packages/core/src/components/charcounter/charcounter.test.ts
+++ b/packages/core/src/components/charcounter/charcounter.test.ts
@@ -54,7 +54,7 @@ describe('ArCharcounter', () => {
             el = await fixture('<ar-charcounter for="f" max="200"></ar-charcounter>');
         });
 
-        it('contient part="container"', () => expect(getPart(el, 'container')).not.toBeNull());
+        it('contient part="charcounter"', () => expect(getPart(el, 'charcounter')).not.toBeNull());
         it('contient part="count"', () => expect(getPart(el, 'count')).not.toBeNull());
         it('contient part="remaining"', () => expect(getPart(el, 'remaining')).not.toBeNull());
         it('contient part="label"', () => expect(getPart(el, 'label')).not.toBeNull());
@@ -79,7 +79,7 @@ describe('ArCharcounter', () => {
             vi.spyOn(console, 'warn').mockImplementation(() => {});
             document.body.innerHTML = '<textarea id="f"></textarea>';
             el = await fixture('<ar-charcounter for="f"></ar-charcounter>');
-            expect(getPart(el, 'container')).toBeNull();
+            expect(getPart(el, 'charcounter')).toBeNull();
             vi.restoreAllMocks();
         });
     });

--- a/packages/core/src/components/charcounter/charcounter.ts
+++ b/packages/core/src/components/charcounter/charcounter.ts
@@ -22,7 +22,7 @@ function pluralize(count: number, label: string): string {
  * @slot warning-icon - Icône affichée en état warning.
  * @slot error-icon   - Icône affichée en état error.
  *
- * @csspart charcounter - L'élément racine.
+ * @csspart charcounter - Rôle transverse (voir /getting-started/naming-conventions) : racine du composant.
  * @csspart count     - Le bloc chiffre + label.
  * @csspart count--warning - Le bloc chiffre + label en état warning (variante d'état de `count`).
  * @csspart count--error - Le bloc chiffre + label en état error (variante d'état de `count`).

--- a/packages/core/src/components/charcounter/charcounter.ts
+++ b/packages/core/src/components/charcounter/charcounter.ts
@@ -19,10 +19,10 @@ function pluralize(count: number, label: string): string {
  * Passe en état `warning` puis `error` quand la limite approche ou est dépassée.
  * Utiliser `aria-describedby` sur le champ pour lier le counter aux lecteurs d'écran.
  *
- * @slot icon-warning - Icône affichée en état warning.
- * @slot icon-error   - Icône affichée en état error.
+ * @slot warning-icon - Icône affichée en état warning.
+ * @slot error-icon   - Icône affichée en état error.
  *
- * @csspart container - L'élément racine.
+ * @csspart charcounter - L'élément racine.
  * @csspart count     - Le bloc chiffre + label.
  * @csspart count--warning - Le bloc chiffre + label en état warning (variante d'état de `count`).
  * @csspart count--error - Le bloc chiffre + label en état error (variante d'état de `count`).
@@ -229,9 +229,9 @@ export class ArCharcounter extends LitElement {
         if (this.max === undefined) return nothing;
         const remaining = this.max - this._count;
         return html`
-            <span part="container">
-                <slot name="icon-warning"></slot>
-                <slot name="icon-error"></slot>
+            <span part="charcounter">
+                <slot name="warning-icon"></slot>
+                <slot name="error-icon"></slot>
                 <span part="count${this._state !== 'normal' ? ` count--${this._state}` : ''}">
                     <span part="remaining">${remaining}</span>
                     <span part="label"> ${pluralize(remaining, this.label)}</span>

--- a/packages/core/src/components/charcounter/charcounter.ts
+++ b/packages/core/src/components/charcounter/charcounter.ts
@@ -22,7 +22,7 @@ function pluralize(count: number, label: string): string {
  * @slot warning-icon - Icône affichée en état warning.
  * @slot error-icon   - Icône affichée en état error.
  *
- * @csspart charcounter - Rôle transverse (voir /getting-started/naming-conventions) : racine du composant.
+ * @csspart charcounter - L'élément racine.
  * @csspart count     - Le bloc chiffre + label.
  * @csspart count--warning - Le bloc chiffre + label en état warning (variante d'état de `count`).
  * @csspart count--error - Le bloc chiffre + label en état error (variante d'état de `count`).

--- a/packages/core/src/components/datepicker/datepicker.a11y.test.ts
+++ b/packages/core/src/components/datepicker/datepicker.a11y.test.ts
@@ -77,13 +77,13 @@ describe('ar-datepicker — accessibilité', () => {
         `);
         await openPicker(el);
 
-        const disabledDays = el.shadowRoot?.querySelectorAll('[part="day"][aria-disabled="true"]');
+        const disabledDays = el.shadowRoot?.querySelectorAll('[part~="day"][aria-disabled="true"]');
         expect(
             disabledDays?.length,
             'au moins un dimanche doit être aria-disabled',
         ).to.be.greaterThan(0);
 
-        const nativeDisabled = el.shadowRoot?.querySelectorAll('[part="day"][disabled]');
+        const nativeDisabled = el.shadowRoot?.querySelectorAll('[part~="day"][disabled]');
         expect(nativeDisabled?.length, 'disabled natif ne doit pas être utilisé').to.equal(0);
     });
 

--- a/packages/core/src/components/datepicker/datepicker.browser.test.ts
+++ b/packages/core/src/components/datepicker/datepicker.browser.test.ts
@@ -83,7 +83,7 @@ describe('ar-datepicker — browser', () => {
             await aTimeout(20);
 
             expect(el.shadowRoot?.activeElement).to.equal(
-                el.shadowRoot?.querySelector('[part="input"]'),
+                el.shadowRoot?.querySelector('[part~="input"]'),
             );
         });
     });

--- a/packages/core/src/components/datepicker/datepicker.browser.test.ts
+++ b/packages/core/src/components/datepicker/datepicker.browser.test.ts
@@ -37,7 +37,7 @@ describe('ar-datepicker — browser', () => {
             await openPicker(el);
 
             const focused = el.shadowRoot?.querySelector<HTMLButtonElement>(
-                '[part="day"][tabindex="0"]',
+                '[part~="day"][tabindex="0"]',
             );
             expect(focused).to.not.equal(null);
             expect(el.shadowRoot?.activeElement).to.equal(focused);
@@ -48,7 +48,7 @@ describe('ar-datepicker — browser', () => {
             await openPicker(el);
 
             const focused = el.shadowRoot?.querySelector<HTMLButtonElement>(
-                '[part="day"][tabindex="0"]',
+                '[part~="day"][tabindex="0"]',
             );
             expect(focused?.getAttribute('aria-label')).to.include('12');
         });
@@ -76,7 +76,7 @@ describe('ar-datepicker — browser', () => {
             await openPicker(el);
 
             const dayBtn = el.shadowRoot?.querySelector<HTMLButtonElement>(
-                '[part="day"][tabindex="0"]',
+                '[part~="day"][tabindex="0"]',
             );
             dayBtn?.click();
             await el.updateComplete;
@@ -101,7 +101,7 @@ describe('ar-datepicker — browser', () => {
             await aTimeout(20);
 
             const focused = el.shadowRoot?.querySelector<HTMLButtonElement>(
-                '[part="day"][tabindex="0"]',
+                '[part~="day"][tabindex="0"]',
             );
             expect(focused?.getAttribute('aria-label')).to.include('13');
         });
@@ -116,7 +116,7 @@ describe('ar-datepicker — browser', () => {
             await aTimeout(20);
 
             const focused = el.shadowRoot?.querySelector<HTMLButtonElement>(
-                '[part="day"][tabindex="0"]',
+                '[part~="day"][tabindex="0"]',
             );
             expect(focused?.getAttribute('aria-label')).to.include('8');
         });
@@ -214,7 +214,7 @@ describe('ar-datepicker — browser', () => {
             await aTimeout(20);
 
             const dayBefore = el.shadowRoot
-                ?.querySelector('[part="day"][tabindex="0"]')
+                ?.querySelector('[part~="day"][tabindex="0"]')
                 ?.getAttribute('aria-label');
 
             // Fermer sans sélectionner, puis rouvrir
@@ -224,7 +224,7 @@ describe('ar-datepicker — browser', () => {
             await openPicker(el);
 
             const dayAfter = el.shadowRoot
-                ?.querySelector('[part="day"][tabindex="0"]')
+                ?.querySelector('[part~="day"][tabindex="0"]')
                 ?.getAttribute('aria-label');
             expect(dayAfter).to.equal(dayBefore);
         });
@@ -246,7 +246,7 @@ describe('ar-datepicker — browser', () => {
 
             // Le curseur (tabindex="0") doit être dans le mois visible (août 2026)
             const focused = el.shadowRoot?.querySelector<HTMLButtonElement>(
-                '[part="day"][tabindex="0"]',
+                '[part~="day"][tabindex="0"]',
             );
             expect(focused).to.not.equal(null);
             // Le jour doit être le 15 (même jour, mois décalé)
@@ -287,7 +287,7 @@ describe('ar-datepicker — browser', () => {
             el = await fixture(html`<ar-datepicker></ar-datepicker>`);
             await openPicker(el);
 
-            const focused = el.shadowRoot?.querySelectorAll('[part="day"][tabindex="0"]') ?? [];
+            const focused = el.shadowRoot?.querySelectorAll('[part~="day"][tabindex="0"]') ?? [];
             expect(focused.length).to.equal(1);
         });
     });
@@ -309,7 +309,7 @@ describe('ar-datepicker — browser', () => {
             const selectedCell = el.shadowRoot?.querySelector(
                 '[role="gridcell"][aria-selected="true"]',
             );
-            const selectedBtn = selectedCell?.querySelector('[part="day"]');
+            const selectedBtn = selectedCell?.querySelector('[part~="day"]');
             expect(selectedBtn?.getAttribute('aria-label')).to.include('12');
         });
     });
@@ -331,8 +331,8 @@ describe('ar-datepicker — browser', () => {
             el = await fixture(html`<ar-datepicker></ar-datepicker>`);
             await openPicker(el);
 
-            const day = el.shadowRoot?.querySelector<HTMLElement>('[part="day"]');
-            if (!day) throw new Error('[part="day"] introuvable');
+            const day = el.shadowRoot?.querySelector<HTMLElement>('[part~="day"]');
+            if (!day) throw new Error('[part~="day"] introuvable');
             const rootFontSize = parseFloat(getComputedStyle(document.documentElement).fontSize);
             const expectedPx = `${2.5 * rootFontSize}px`;
             expect(getComputedStyle(day).width).to.equal(expectedPx);

--- a/packages/core/src/components/datepicker/datepicker.styles.ts
+++ b/packages/core/src/components/datepicker/datepicker.styles.ts
@@ -94,7 +94,7 @@ export default css`
         table-layout: fixed;
     }
 
-    [part='day'] {
+    [part~='day'] {
         /* a11y-fallback: WCAG 2.5.8 (Target Size Minimum) — [part='grid'] a border-collapse: collapse, qui supprime l'espacement natif du <table> ; sans thème la cellule se dimensionnerait à son seul contenu textuel */
         width: var(--ar-datepicker-day-size, 2.5rem);
         /* a11y-fallback: WCAG 2.5.8 (Target Size Minimum) — [part='grid'] a border-collapse: collapse, qui supprime l'espacement natif du <table> ; sans thème la cellule se dimensionnerait à son seul contenu textuel */
@@ -111,7 +111,7 @@ export default css`
         border-color: var(--ar-datepicker-day-border-color, transparent);
     }
 
-    [part='day'].today {
+    [part~='day'].today {
         color: var(--ar-datepicker-day-today-color);
         /* a11y-fallback: garde une distinction visible du reste de la grille sans thème */
         border-color: var(--ar-datepicker-day-today-border, GrayText);
@@ -119,11 +119,11 @@ export default css`
     }
 
     /* Efface la bordure au hover, sauf sur la cellule active de la grille */
-    [part='day']:not([aria-disabled='true']):not(.disabled):not([tabindex='0']):hover {
+    [part~='day']:not([aria-disabled='true']):not(.disabled):not([tabindex='0']):hover {
         border-color: transparent;
     }
 
-    [part='day']:not([aria-disabled='true']):not(.disabled):hover {
+    [part~='day']:not([aria-disabled='true']):not(.disabled):hover {
         /* a11y-fallback: fond et texte pairés — un fallback de fond seul introduirait une combinaison non testée */
         background-color: var(--ar-datepicker-day-hover-bg, ButtonFace);
         color: var(--ar-datepicker-day-hover-color, ButtonText);
@@ -134,7 +134,7 @@ export default css`
      * :focus-within couvre le focus programmatique (ouverture du picker) ET le focus clavier,
      * contrairement à :focus-visible qui ne s'active pas pour le focus programmatique.
      */
-    [part='grid']:focus-within [part='day'][tabindex='0'] {
+    [part='grid']:focus-within [part~='day'][tabindex='0'] {
         outline-style: solid;
         /* a11y-fallback: WCAG 2.4.7 (Focus Visible) */
         outline-width: var(--ar-datepicker-day-focus-ring-width, 2px);
@@ -144,7 +144,7 @@ export default css`
         border-color: var(--ar-datepicker-day-focus-border-color, transparent);
     }
 
-    [part='grid']:focus-within [part='day'][tabindex='0']:not(.selected) {
+    [part='grid']:focus-within [part~='day'][tabindex='0']:not(.selected) {
         background-color: var(--ar-datepicker-day-hover-bg);
         color: var(--ar-datepicker-day-hover-color);
     }
@@ -153,30 +153,30 @@ export default css`
      * Curseur de navigation visible quand le focus est hors de la grille (boutons nav/footer).
      * Indique quel jour prendra le focus au prochain Tab dans la grille.
      */
-    [part='day'][tabindex='0']:not(:focus-visible) {
+    [part~='day'][tabindex='0']:not(:focus-visible) {
         outline: 1px dashed var(--ar-datepicker-day-focus-ring-color, ButtonText);
         outline-offset: var(--ar-datepicker-day-focus-ring-offset);
     }
 
-    [part='day'].selected {
+    [part~='day'].selected {
         /* a11y-fallback: sinon indiscernable des jours non sélectionnés sans thème */
         background-color: var(--ar-datepicker-day-selected-bg, Highlight);
         color: var(--ar-datepicker-day-selected-color, HighlightText);
         border-color: transparent;
     }
 
-    [part='day'].selected:not([aria-disabled='true']):not(.disabled):hover {
+    [part~='day'].selected:not([aria-disabled='true']):not(.disabled):hover {
         background-color: var(--ar-datepicker-day-selected-bg);
         /* border-color: transparent; */
     }
 
-    [part='day'].other-month {
+    [part~='day'].other-month {
         /* a11y-fallback: atténuation visible sans thème */
         color: var(--ar-datepicker-day-other-month-color, GrayText);
     }
 
-    [part='day'].disabled,
-    [part='day'][aria-disabled='true'] {
+    [part~='day'].disabled,
+    [part~='day'][aria-disabled='true'] {
         opacity: 0.4;
         cursor: not-allowed;
     }

--- a/packages/core/src/components/datepicker/datepicker.styles.ts
+++ b/packages/core/src/components/datepicker/datepicker.styles.ts
@@ -2,6 +2,10 @@ import { css } from 'lit';
 
 export default css`
     :host {
+        display: block;
+    }
+
+    [part='datepicker'] {
         display: flex;
         flex-direction: column;
     }

--- a/packages/core/src/components/datepicker/datepicker.styles.ts
+++ b/packages/core/src/components/datepicker/datepicker.styles.ts
@@ -5,7 +5,7 @@ export default css`
         display: block;
     }
 
-    [part='datepicker'] {
+    [part~='datepicker'] {
         display: flex;
         flex-direction: column;
     }

--- a/packages/core/src/components/datepicker/datepicker.styles.ts
+++ b/packages/core/src/components/datepicker/datepicker.styles.ts
@@ -19,7 +19,7 @@ export default css`
         align-items: stretch;
     }
 
-    [part='input'] {
+    [part~='input'] {
         flex: 1;
         min-width: 0;
     }
@@ -37,7 +37,7 @@ export default css`
         pointer-events: none;
     }
 
-    :host([has-error]) [part='input'] {
+    :host([has-error]) [part~='input'] {
         border-color: var(--ar-datepicker-input-error-border-color);
     }
 

--- a/packages/core/src/components/datepicker/datepicker.styles.ts
+++ b/packages/core/src/components/datepicker/datepicker.styles.ts
@@ -57,7 +57,7 @@ export default css`
         text-align: center;
     }
 
-    [part~='nav-btn'] {
+    [part~='nav-button'] {
         display: inline-flex;
         align-items: center;
         justify-content: center;
@@ -66,14 +66,14 @@ export default css`
         font: inherit;
         border-style: solid;
         /* a11y-fallback: border: raccourci scindé en longhands — un var() défaillant dans un raccourci invalide border-style, ce qui ferait disparaître la bordure entièrement sans thème */
-        border-color: var(--ar-datepicker-nav-btn-border-color, transparent);
+        border-color: var(--ar-datepicker-nav-button-border-color, transparent);
     }
 
-    [part~='nav-btn']:focus-visible {
-        outline: 2px solid var(--ar-datepicker-nav-btn-focus-ring-color, ButtonText);
+    [part~='nav-button']:focus-visible {
+        outline: 2px solid var(--ar-datepicker-nav-button-focus-ring-color, ButtonText);
     }
 
-    [part~='footer-btn'] {
+    [part~='footer-button'] {
         display: inline-flex;
         align-items: center;
         justify-content: center;
@@ -81,11 +81,11 @@ export default css`
         font: inherit;
         border-style: solid;
         /* a11y-fallback: border: raccourci scindé en longhands — un var() défaillant dans un raccourci invalide border-style, ce qui ferait disparaître la bordure entièrement sans thème */
-        border-color: var(--ar-datepicker-footer-btn-border-color, transparent);
+        border-color: var(--ar-datepicker-footer-button-border-color, transparent);
     }
 
-    [part~='footer-btn']:focus-visible {
-        outline: 2px solid var(--ar-datepicker-footer-btn-focus-ring-color, ButtonText);
+    [part~='footer-button']:focus-visible {
+        outline: 2px solid var(--ar-datepicker-footer-button-focus-ring-color, ButtonText);
     }
 
     [part='grid'] {

--- a/packages/core/src/components/datepicker/datepicker.test.ts
+++ b/packages/core/src/components/datepicker/datepicker.test.ts
@@ -20,6 +20,12 @@ describe('ArDatepicker', () => {
         it('contient un label part="label"', () => expect(getPart(el, 'label')).not.toBeNull());
         it('contient un p part="hint"', () => expect(getPart(el, 'hint')).not.toBeNull());
         it('contient un p part="error"', () => expect(getPart(el, 'error')).not.toBeNull());
+        it('contient un div racine part="datepicker" enveloppant tout le contenu', () => {
+            const root = getPart(el, 'datepicker');
+            expect(root).not.toBeNull();
+            expect(root?.contains(getPart(el, 'input'))).toBe(true);
+            expect(root?.contains(getPart(el, 'panel'))).toBe(true);
+        });
         it('expose inputElement getter', () =>
             expect(el.inputElement).toBeInstanceOf(HTMLInputElement));
     });

--- a/packages/core/src/components/datepicker/datepicker.test.ts
+++ b/packages/core/src/components/datepicker/datepicker.test.ts
@@ -134,7 +134,7 @@ describe('ArDatepicker', () => {
             el.addEventListener('ar-datepicker-hide', (e) => e.preventDefault());
 
             const dayBtn = el.shadowRoot?.querySelector<HTMLButtonElement>(
-                '[part="day"][tabindex="0"]',
+                '[part~="day"][tabindex="0"]',
             );
             dayBtn?.focus();
             dayBtn?.click();
@@ -162,6 +162,13 @@ describe('ArDatepicker', () => {
             await new Promise((r) => setTimeout(r, 50));
             // Le panel doit rester fermé (show annulé)
             expect(el.open).toBe(false);
+        });
+
+        it('les cellules jour portent le rôle transverse "control"', async () => {
+            el.open = true;
+            await waitForUpdate(el);
+            const day = el.shadowRoot?.querySelector('[part~="day"]');
+            expect(day?.getAttribute('part')?.split(/\s+/)).toContain('control');
         });
     });
 

--- a/packages/core/src/components/datepicker/datepicker.test.ts
+++ b/packages/core/src/components/datepicker/datepicker.test.ts
@@ -14,6 +14,9 @@ describe('ArDatepicker', () => {
 
         it('monte un shadow DOM', () => expect(el.shadowRoot).not.toBeNull());
         it('contient un input part="input"', () => expect(getPart(el, 'input')).not.toBeNull());
+        it('input porte le rôle transverse "field"', () => {
+            expect(getPart(el, 'input')?.getAttribute('part')?.split(/\s+/)).toContain('field');
+        });
         it('contient un bouton part="trigger"', () =>
             expect(getPart(el, 'trigger')).not.toBeNull());
         it('contient un div part="panel"', () => expect(getPart(el, 'panel')).not.toBeNull());

--- a/packages/core/src/components/datepicker/datepicker.test.ts
+++ b/packages/core/src/components/datepicker/datepicker.test.ts
@@ -346,12 +346,22 @@ describe('ArDatepicker', () => {
             );
             el.open = true;
             await waitForUpdate(el);
-            const todayBtn = getPart(el, 'today-btn');
-            const closeBtn = getPart(el, 'close-btn');
+            const todayBtn = getPart(el, 'today-button');
+            const closeBtn = getPart(el, 'close-button');
             expect(todayBtn?.textContent?.trim()).toBe('Today');
             expect(todayBtn?.getAttribute('aria-label')).toBe('Today');
             expect(closeBtn?.textContent?.trim()).toBe('Close');
             expect(closeBtn?.getAttribute('aria-label')).toBe('Close');
+        });
+
+        it('nav-button et footer-button portent le rôle transverse "action-button"', async () => {
+            el = await fixture('<ar-datepicker></ar-datepicker>');
+            el.open = true;
+            await waitForUpdate(el);
+            const navButton = el.shadowRoot?.querySelector('[part~="nav-button"]');
+            const footerButton = el.shadowRoot?.querySelector('[part~="footer-button"]');
+            expect(navButton?.getAttribute('part')?.split(/\s+/)).toContain('action-button');
+            expect(footerButton?.getAttribute('part')?.split(/\s+/)).toContain('action-button');
         });
 
         it('les slots today-label/close-label remplacent le contenu par défaut', async () => {
@@ -382,7 +392,7 @@ describe('ArDatepicker', () => {
             `);
             el.open = true;
             await waitForUpdate(el);
-            const closeBtn = getPart(el, 'close-btn');
+            const closeBtn = getPart(el, 'close-button');
             expect(closeBtn?.getAttribute('aria-label')).toBe('Fermer le calendrier');
         });
     });

--- a/packages/core/src/components/datepicker/datepicker.ts
+++ b/packages/core/src/components/datepicker/datepicker.ts
@@ -24,12 +24,11 @@ import { warn } from '../../utils/warn.js';
  * @slot close-label - Contenu riche du bouton « Fermer » (icône + texte, remplace le prop
  *                     `closeLabel`).
  *
- * @csspart datepicker - Rôle transverse (voir /getting-started/naming-conventions) : racine du
- *   composant.
- * @csspart field      - Rôle transverse (voir /getting-started/naming-conventions), porté par `input` :
- *   élément qui reçoit une saisie. Sous-rôle standard de `field` (avec `select`, cf.
- *   ar-pagination), réutilisable par tout futur composant avec un champ texte.
+ * @csspart datepicker - Racine du composant.
  * @csspart input      - Le champ texte.
+ * @csspart field      - Porté par `input` : élément qui reçoit une saisie. Sous-rôle standard de
+ *   `field` (avec `select`, cf. ar-pagination), réutilisable par tout futur composant avec un
+ *   champ texte.
  * @csspart trigger    - Le bouton d'ouverture du calendrier.
  * @csspart panel      - Le popover flottant.
  * @csspart header     - En-tête du calendrier (navigation).
@@ -44,15 +43,13 @@ import { warn } from '../../utils/warn.js';
  * @csspart hint       - Le texte d'aide sous l'input.
  * @csspart error      - Le message d'erreur sous l'input.
  * @csspart day        - Les boutons jours.
- * @csspart control - Rôle transverse (voir /getting-started/naming-conventions), porté par `day` :
- *   élément interactif générique.
+ * @csspart control - Porté par `day` : élément interactif générique.
  * @csspart footer     - Pied du calendrier.
  * @csspart footer-button - Tous les boutons du footer (ciblage groupé).
  * @csspart today-button  - Bouton « Aujourd'hui ».
  * @csspart close-button  - Bouton « Fermer ».
- * @csspart action-button - Rôle transverse (voir /getting-started/naming-conventions), porté par
- *   les 4 boutons de navigation (`nav-button`) et les 2 boutons du footer (`footer-button`) :
- *   bouton qui déclenche une action ponctuelle.
+ * @csspart action-button - Porté par les 4 boutons de navigation (`nav-button`) et les 2 boutons
+ *   du footer (`footer-button`) : bouton qui déclenche une action ponctuelle.
  *
  * @cssprop --ar-datepicker-error-color - Couleur du message d'erreur.
  * @cssprop --ar-datepicker-panel-max-width - Largeur maximale du popover (valeur propre, non cascadée depuis --ar-panel-max-width ; repli `25rem` si aucun thème n'est chargé, évite que la grille de ~35 jours s'étale sur toute la largeur de la page).

--- a/packages/core/src/components/datepicker/datepicker.ts
+++ b/packages/core/src/components/datepicker/datepicker.ts
@@ -24,6 +24,8 @@ import { warn } from '../../utils/warn.js';
  * @slot close-label - Contenu riche du bouton « Fermer » (icône + texte, remplace le prop
  *                     `closeLabel`).
  *
+ * @csspart datepicker - Rôle transverse (voir /getting-started/naming-conventions) : racine du
+ *   composant.
  * @csspart input      - Le champ texte.
  * @csspart trigger    - Le bouton d'ouverture du calendrier.
  * @csspart panel      - Le popover flottant.
@@ -225,74 +227,76 @@ export class ArDatepicker extends LitElement {
             : formatLine;
 
         return html`
-            <label part="label" id="dp-label-${this._uid}" for="dp-input-${this._uid}">
-                <slot name="label">${this.label}</slot>
-            </label>
-            <slot name="after-label"></slot>
+            <div part="datepicker">
+                <label part="label" id="dp-label-${this._uid}" for="dp-input-${this._uid}">
+                    <slot name="label">${this.label}</slot>
+                </label>
+                <slot name="after-label"></slot>
 
-            <div class="input-wrapper">
-                <input
-                    part="input"
-                    id="dp-input-${this._uid}"
-                    type="text"
-                    ?disabled=${this.disabled}
-                    ?readonly=${this.readonly}
-                    aria-required=${this.required ? 'true' : nothing}
-                    autocomplete=${this.autocomplete || nothing}
-                    placeholder=${this.placeholder || nothing}
-                    aria-labelledby="dp-label-${this._uid}"
-                    aria-describedby=${`dp-hint-${this._uid}${this._hasSlot.test('error') ? ` dp-error-${this._uid}` : ''}`}
-                    @input=${this._handleInput}
-                    @blur=${this._handleBlur}
-                />
-                <button
-                    part="trigger"
-                    type="button"
-                    ?disabled=${this.disabled || this.readonly}
-                    aria-label="Ouvrir le calendrier"
-                    aria-haspopup="dialog"
-                    aria-expanded=${this.open}
-                    @click=${this._handleTriggerClick}
-                >
-                    <svg
-                        aria-hidden="true"
-                        width="16"
-                        height="16"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        stroke-width="2"
+                <div class="input-wrapper">
+                    <input
+                        part="input"
+                        id="dp-input-${this._uid}"
+                        type="text"
+                        ?disabled=${this.disabled}
+                        ?readonly=${this.readonly}
+                        aria-required=${this.required ? 'true' : nothing}
+                        autocomplete=${this.autocomplete || nothing}
+                        placeholder=${this.placeholder || nothing}
+                        aria-labelledby="dp-label-${this._uid}"
+                        aria-describedby=${`dp-hint-${this._uid}${this._hasSlot.test('error') ? ` dp-error-${this._uid}` : ''}`}
+                        @input=${this._handleInput}
+                        @blur=${this._handleBlur}
+                    />
+                    <button
+                        part="trigger"
+                        type="button"
+                        ?disabled=${this.disabled || this.readonly}
+                        aria-label="Ouvrir le calendrier"
+                        aria-haspopup="dialog"
+                        aria-expanded=${this.open}
+                        @click=${this._handleTriggerClick}
                     >
-                        <rect x="3" y="4" width="18" height="18" rx="2" />
-                        <line x1="16" y1="2" x2="16" y2="6" />
-                        <line x1="8" y1="2" x2="8" y2="6" />
-                        <line x1="3" y1="10" x2="21" y2="10" />
-                    </svg>
-                </button>
-            </div>
+                        <svg
+                            aria-hidden="true"
+                            width="16"
+                            height="16"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                        >
+                            <rect x="3" y="4" width="18" height="18" rx="2" />
+                            <line x1="16" y1="2" x2="16" y2="6" />
+                            <line x1="8" y1="2" x2="8" y2="6" />
+                            <line x1="3" y1="10" x2="21" y2="10" />
+                        </svg>
+                    </button>
+                </div>
 
-            <p part="hint" id="dp-hint-${this._uid}">
-                <slot name="hint">${defaultHint}</slot>
-            </p>
-            <p
-                part="error"
-                id="dp-error-${this._uid}"
-                role=${this._hasSlot.test('error') ? 'alert' : nothing}
-            >
-                <slot name="error"></slot>
-            </p>
+                <p part="hint" id="dp-hint-${this._uid}">
+                    <slot name="hint">${defaultHint}</slot>
+                </p>
+                <p
+                    part="error"
+                    id="dp-error-${this._uid}"
+                    role=${this._hasSlot.test('error') ? 'alert' : nothing}
+                >
+                    <slot name="error"></slot>
+                </p>
 
-            <div
-                part="panel"
-                popover="auto"
-                role="dialog"
-                aria-modal="true"
-                aria-label="Sélectionner une date"
-                aria-labelledby=${this.open ? `dp-month-${this._uid}` : nothing}
-                id="ar-dp-panel-${this._uid}"
-                @keydown=${this._handlePanelKeyDown}
-            >
-                ${this.open ? this._renderCalendar(locale) : nothing}
+                <div
+                    part="panel"
+                    popover="auto"
+                    role="dialog"
+                    aria-modal="true"
+                    aria-label="Sélectionner une date"
+                    aria-labelledby=${this.open ? `dp-month-${this._uid}` : nothing}
+                    id="ar-dp-panel-${this._uid}"
+                    @keydown=${this._handlePanelKeyDown}
+                >
+                    ${this.open ? this._renderCalendar(locale) : nothing}
+                </div>
             </div>
         `;
     }

--- a/packages/core/src/components/datepicker/datepicker.ts
+++ b/packages/core/src/components/datepicker/datepicker.ts
@@ -33,7 +33,7 @@ import { warn } from '../../utils/warn.js';
  * @csspart trigger    - Le bouton d'ouverture du calendrier.
  * @csspart panel      - Le popover flottant.
  * @csspart header     - En-tête du calendrier (navigation).
- * @csspart nav-btn    - Tous les boutons de navigation (ciblage groupé).
+ * @csspart nav-button    - Tous les boutons de navigation (ciblage groupé).
  * @csspart prev-year  - Bouton année précédente.
  * @csspart prev-month - Bouton mois précédent.
  * @csspart next-month - Bouton mois suivant.
@@ -47,16 +47,19 @@ import { warn } from '../../utils/warn.js';
  * @csspart control - Rôle transverse (voir /getting-started/naming-conventions), porté par `day` :
  *   élément interactif générique.
  * @csspart footer     - Pied du calendrier.
- * @csspart footer-btn - Tous les boutons du footer (ciblage groupé).
- * @csspart today-btn  - Bouton « Aujourd'hui ».
- * @csspart close-btn  - Bouton « Fermer ».
+ * @csspart footer-button - Tous les boutons du footer (ciblage groupé).
+ * @csspart today-button  - Bouton « Aujourd'hui ».
+ * @csspart close-button  - Bouton « Fermer ».
+ * @csspart action-button - Rôle transverse (voir /getting-started/naming-conventions), porté par
+ *   les 4 boutons de navigation (`nav-button`) et les 2 boutons du footer (`footer-button`) :
+ *   bouton qui déclenche une action ponctuelle.
  *
  * @cssprop --ar-datepicker-error-color - Couleur du message d'erreur.
  * @cssprop --ar-datepicker-panel-max-width - Largeur maximale du popover (valeur propre, non cascadée depuis --ar-panel-max-width ; repli `25rem` si aucun thème n'est chargé, évite que la grille de ~35 jours s'étale sur toute la largeur de la page).
  * @cssprop --ar-datepicker-distance - Espacement entre le trigger et le panel.
  * @cssprop --ar-datepicker-offset - Décalage latéral du panel.
- * @cssprop --ar-datepicker-nav-btn-border-color - Couleur de bordure des boutons nav.
- * @cssprop --ar-datepicker-footer-btn-border-color - Couleur de bordure des boutons footer.
+ * @cssprop --ar-datepicker-nav-button-border-color - Couleur de bordure des boutons nav.
+ * @cssprop --ar-datepicker-footer-button-border-color - Couleur de bordure des boutons footer.
  * @cssprop --ar-datepicker-day-size - Taille des cellules jour (repli `2.5rem` si aucun thème n'est chargé — cible tactile WCAG 2.5.8 Target Size Minimum, la grille utilisant border-collapse: collapse qui supprime l'espacement natif du <table>).
  * @cssprop --ar-datepicker-day-border-color - Couleur de bordure par défaut des cellules jour. Repli `transparent` si aucun thème n'est chargé (préserve l'absence de bordure voulue par défaut ; sans ce repli, une propriété longhand `border-color` isolée dégraderait vers `currentcolor`, une bordure non désirée sur chaque cellule).
  * @cssprop --ar-datepicker-day-color - Couleur du texte des cellules jour (cascade vers --ar-color-text).
@@ -74,8 +77,8 @@ import { warn } from '../../utils/warn.js';
  * @cssprop --ar-datepicker-day-selected-bg - Fond du jour sélectionné. Repli `Highlight` si aucun thème n'est chargé (sinon indiscernable des jours non sélectionnés).
  * @cssprop --ar-datepicker-day-selected-color - Couleur texte du jour sélectionné. Repli `HighlightText` si aucun thème n'est chargé.
  * @cssprop --ar-datepicker-input-error-border-color - Bordure input en état d'erreur.
- * @cssprop --ar-datepicker-nav-btn-focus-ring-color - Couleur de l'anneau de focus des boutons de navigation (cascade vers --ar-focus-ring-color). Repli `ButtonText` si aucun thème n'est chargé (WCAG 2.4.7).
- * @cssprop --ar-datepicker-footer-btn-focus-ring-color - Couleur de l'anneau de focus des boutons du footer (cascade vers --ar-focus-ring-color). Repli `ButtonText` si aucun thème n'est chargé (WCAG 2.4.7).
+ * @cssprop --ar-datepicker-nav-button-focus-ring-color - Couleur de l'anneau de focus des boutons de navigation (cascade vers --ar-focus-ring-color). Repli `ButtonText` si aucun thème n'est chargé (WCAG 2.4.7).
+ * @cssprop --ar-datepicker-footer-button-focus-ring-color - Couleur de l'anneau de focus des boutons du footer (cascade vers --ar-focus-ring-color). Repli `ButtonText` si aucun thème n'est chargé (WCAG 2.4.7).
  * @cssprop --ar-panel-bg - Fond du panel partagé. Repli système `Canvas` si aucun thème n'est chargé.
  * @cssprop --ar-panel-text - Couleur du texte du panel partagé. Repli système `CanvasText` si aucun thème n'est chargé.
  * @cssprop --ar-panel-border-color - Couleur de bordure du panel partagé. Repli système `ButtonBorder` si aucun thème n'est chargé.
@@ -324,7 +327,7 @@ export class ArDatepicker extends LitElement {
         return html`
             <div part="header">
                 <button
-                    part="nav-btn prev-year"
+                    part="nav-button prev-year action-button"
                     type="button"
                     aria-label="Année précédente"
                     @click=${() => this._nav(() => this._calendar.previousYear())}
@@ -332,7 +335,7 @@ export class ArDatepicker extends LitElement {
                     «
                 </button>
                 <button
-                    part="nav-btn prev-month"
+                    part="nav-button prev-month action-button"
                     type="button"
                     aria-label="Mois précédent"
                     @click=${() => this._nav(() => this._calendar.previousMonth())}
@@ -341,7 +344,7 @@ export class ArDatepicker extends LitElement {
                 </button>
                 <span id="dp-month-${this._uid}" aria-live="polite">${monthLabel}</span>
                 <button
-                    part="nav-btn next-month"
+                    part="nav-button next-month action-button"
                     type="button"
                     aria-label="Mois suivant"
                     @click=${() => this._nav(() => this._calendar.nextMonth())}
@@ -349,7 +352,7 @@ export class ArDatepicker extends LitElement {
                     ›
                 </button>
                 <button
-                    part="nav-btn next-year"
+                    part="nav-button next-year action-button"
                     type="button"
                     aria-label="Année suivante"
                     @click=${() => this._nav(() => this._calendar.nextYear())}
@@ -382,7 +385,7 @@ export class ArDatepicker extends LitElement {
 
             <div part="footer">
                 <button
-                    part="footer-btn today-btn"
+                    part="footer-button today-button action-button"
                     type="button"
                     aria-label=${this.todayLabel}
                     @click=${this._handleTodayClick}
@@ -390,7 +393,7 @@ export class ArDatepicker extends LitElement {
                     <slot name="today-label">${this.todayLabel}</slot>
                 </button>
                 <button
-                    part="footer-btn close-btn"
+                    part="footer-button close-button action-button"
                     type="button"
                     aria-label=${this.closeLabel}
                     @click=${this._handleCloseClick}

--- a/packages/core/src/components/datepicker/datepicker.ts
+++ b/packages/core/src/components/datepicker/datepicker.ts
@@ -44,6 +44,8 @@ import { warn } from '../../utils/warn.js';
  * @csspart hint       - Le texte d'aide sous l'input.
  * @csspart error      - Le message d'erreur sous l'input.
  * @csspart day        - Les boutons jours.
+ * @csspart control - Rôle transverse (voir /getting-started/naming-conventions), porté par `day` :
+ *   élément interactif générique.
  * @csspart footer     - Pied du calendrier.
  * @csspart footer-btn - Tous les boutons du footer (ciblage groupé).
  * @csspart today-btn  - Bouton « Aujourd'hui ».
@@ -425,7 +427,7 @@ export class ArDatepicker extends LitElement {
             <td role="gridcell" aria-selected=${selected ? 'true' : 'false'}>
                 <button
                     type="button"
-                    part="day"
+                    part="day control"
                     tabindex=${focused ? '0' : '-1'}
                     aria-label=${ariaLabel}
                     aria-current=${today ? 'date' : nothing}

--- a/packages/core/src/components/datepicker/datepicker.ts
+++ b/packages/core/src/components/datepicker/datepicker.ts
@@ -26,6 +26,9 @@ import { warn } from '../../utils/warn.js';
  *
  * @csspart datepicker - Rôle transverse (voir /getting-started/naming-conventions) : racine du
  *   composant.
+ * @csspart field      - Rôle transverse (voir /getting-started/naming-conventions), porté par `input` :
+ *   élément qui reçoit une saisie. Sous-rôle standard de `field` (avec `select`, cf.
+ *   ar-pagination), réutilisable par tout futur composant avec un champ texte.
  * @csspart input      - Le champ texte.
  * @csspart trigger    - Le bouton d'ouverture du calendrier.
  * @csspart panel      - Le popover flottant.
@@ -156,7 +159,7 @@ export class ArDatepicker extends LitElement {
     /** Élément à focus une fois la fermeture confirmée (non annulée par ar-datepicker-hide). */
     private _focusTargetAfterHide: HTMLElement | null = null;
 
-    @query('[part="input"]') private _input!: HTMLInputElement;
+    @query('[part~="input"]') private _input!: HTMLInputElement;
     @query('[part="panel"]') private _panel!: HTMLElement;
     @query('[part="trigger"]') private _trigger!: HTMLButtonElement;
     @query('.input-wrapper') private _inputWrapper!: HTMLDivElement;
@@ -235,7 +238,7 @@ export class ArDatepicker extends LitElement {
 
                 <div class="input-wrapper">
                     <input
-                        part="input"
+                        part="input field"
                         id="dp-input-${this._uid}"
                         type="text"
                         ?disabled=${this.disabled}

--- a/packages/core/src/components/pagination/pagination.browser.test.ts
+++ b/packages/core/src/components/pagination/pagination.browser.test.ts
@@ -34,7 +34,7 @@ describe('ar-pagination — browser', () => {
             pageLink.click();
             await elementUpdated(el);
 
-            const current = shadowRoot.querySelector('[part~="current"]') as HTMLElement;
+            const current = shadowRoot.querySelector('span[part~="current"]') as HTMLElement;
             expect(shadowRoot.activeElement).to.equal(current);
             expect(current.matches(':focus-visible')).to.equal(true);
         });
@@ -118,9 +118,9 @@ describe('ar-pagination — browser', () => {
             // calculé par le ResizeObserver dépasse `total`, donc `_calculatePages` renvoie la
             // liste complète (cf. `_calculatePages`, branche `total <= effectiveBudget`).
             const shadow = el.shadowRoot as ShadowRoot;
-            expect(shadow.querySelectorAll('[part~="link"], [part~="current"]').length).to.equal(
-                15,
-            );
+            expect(
+                shadow.querySelectorAll('[part~="link"], span[part~="current"]').length,
+            ).to.equal(15);
         });
 
         it('réduit le nombre de pages affichées quand le conteneur est rétréci', async () => {
@@ -142,10 +142,10 @@ describe('ar-pagination — browser', () => {
 
             const shadow = el.shadowRoot as ShadowRoot;
             const numericCount = shadow.querySelectorAll(
-                '[part~="link"], [part~="current"]',
+                '[part~="link"], span[part~="current"]',
             ).length;
             // Valeur exacte mesurée empiriquement à 400px avec le repli headless figé
-            // (`--ar-pagination-btn-size` = 2.5rem = 40px, aucune police variable dans WTR) :
+            // (`--ar-pagination-button-size` = 2.5rem = 40px, aucune police variable dans WTR) :
             // déterministe. Une régression dans `_pagesWithSiblings` (ex. `siblingCount` qui ne
             // retire qu'une page, 14 au lieu de 5) passerait inaperçue avec une simple borne
             // `lessThan(15)` — l'égalité stricte est nécessaire pour couvrir ce cas.
@@ -166,10 +166,12 @@ describe('ar-pagination — browser', () => {
             await waitForResize();
 
             const shadow = el.shadowRoot as ShadowRoot;
-            const select = shadow.querySelector('[part~="select"]') as HTMLSelectElement;
+            const select = shadow.querySelector('select[part~="select"]') as HTMLSelectElement;
             expect(select).to.not.equal(null);
             expect(select.tagName.toLowerCase()).to.equal('select');
-            expect(shadow.querySelectorAll('[part~="link"], [part~="current"]').length).to.equal(0);
+            expect(
+                shadow.querySelectorAll('[part~="link"], span[part~="current"]').length,
+            ).to.equal(0);
 
             // _calculatePages(8, 15) SANS budget (donc budget par défaut 9, pas la fenêtre
             // réduite au budget réel de la largeur actuelle) = [1, -1, 6, 7, 8, 9, 10, -2, 15] —
@@ -198,7 +200,7 @@ describe('ar-pagination — browser', () => {
             await waitForResize();
 
             const shadow = el.shadowRoot as ShadowRoot;
-            const select = shadow.querySelector('[part~="select"]') as HTMLSelectElement;
+            const select = shadow.querySelector('select[part~="select"]') as HTMLSelectElement;
             select.value = '15';
             select.dispatchEvent(new Event('change', { bubbles: true }));
             await elementUpdated(el);
@@ -232,7 +234,7 @@ describe('ar-pagination — browser', () => {
 
             expect((el as unknown as { current: number }).current).to.equal(9);
 
-            const select = shadow.querySelector('[part~="select"]') as HTMLSelectElement;
+            const select = shadow.querySelector('select[part~="select"]') as HTMLSelectElement;
             expect(select.selectedIndex).to.not.equal(-1);
             expect(select.options[select.selectedIndex]?.textContent?.trim()).to.equal(
                 'Page 9 sur 15',
@@ -265,14 +267,16 @@ describe('ar-pagination — browser', () => {
 
             // 1. Conteneur large → numéros affichés, `_itemWidth` mesuré normalement.
             expect(
-                shadow.querySelectorAll('[part~="link"], [part~="current"]').length,
+                shadow.querySelectorAll('[part~="link"], span[part~="current"]').length,
             ).to.be.greaterThan(0);
 
             // 2. Rétrécir jusqu'au palier select.
             wrapper.style.width = '90px';
             await waitForResize();
-            expect(shadow.querySelector('[part~="select"]')).to.not.equal(null);
-            expect(shadow.querySelectorAll('[part~="link"], [part~="current"]').length).to.equal(0);
+            expect(shadow.querySelector('select[part~="select"]')).to.not.equal(null);
+            expect(
+                shadow.querySelectorAll('[part~="link"], span[part~="current"]').length,
+            ).to.equal(0);
 
             // 3. Changer `total` (et `current`, pour rester valide) d'ordre de grandeur pendant
             //    que le composant est au palier select (déclenche l'invalidation de
@@ -288,9 +292,9 @@ describe('ar-pagination — browser', () => {
             wrapper.style.width = '700px';
             await waitForResize();
 
-            expect(shadow.querySelector('[part~="select"]')).to.equal(null);
+            expect(shadow.querySelector('select[part~="select"]')).to.equal(null);
             expect(
-                shadow.querySelectorAll('[part~="link"], [part~="current"]').length,
+                shadow.querySelectorAll('[part~="link"], span[part~="current"]').length,
             ).to.be.greaterThan(0);
         });
     });
@@ -310,7 +314,7 @@ describe('ar-pagination — browser', () => {
 
         it('la page active porte aria-current="page"', async () => {
             const el = await fixture(html`<ar-pagination current="3" total="12"></ar-pagination>`);
-            const current = el.shadowRoot?.querySelector('[part="current"]') as HTMLElement;
+            const current = el.shadowRoot?.querySelector('span[part~="current"]') as HTMLElement;
             expect(current.getAttribute('aria-current')).to.equal('page');
         });
     });
@@ -325,7 +329,7 @@ describe('ar-pagination — browser', () => {
         // ar-pagination (column-gap sur [part='list'], padding sur link/current/ellipsis) sans
         // charger le thème complet : ce sont précisément les règles non budgétées par
         // `_recalculateBudget` avant le fix (Finding Critical #1), à l'origine d'un débordement
-        // horizontal mesuré jusqu'à 61px. `--ar-pagination-btn-size` n'a pas besoin d'être
+        // horizontal mesuré jusqu'à 61px. `--ar-pagination-button-size` n'a pas besoin d'être
         // redéclaré ici : le composant a déjà un repli interne à 2.5rem, valeur identique à
         // celle du thème par défaut.
         let themeStyle: HTMLStyleElement;
@@ -403,8 +407,10 @@ describe('ar-pagination — browser', () => {
 
             const shadow = el.shadowRoot as ShadowRoot;
             expect(shadow.querySelector('[part~="label"]')).to.not.equal(null);
-            expect(shadow.querySelectorAll('[part~="link"], [part~="current"]').length).to.equal(0);
-            expect(shadow.querySelector('[part~="select"]')).to.equal(null);
+            expect(
+                shadow.querySelectorAll('[part~="link"], span[part~="current"]').length,
+            ).to.equal(0);
+            expect(shadow.querySelector('select[part~="select"]')).to.equal(null);
 
             wrapper.style.width = '90px';
             await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
@@ -414,8 +420,10 @@ describe('ar-pagination — browser', () => {
             // sur un <select>..." plus haut dans ce fichier) — le mode compact doit rester
             // strictement identique, aucune bascule.
             expect(shadow.querySelector('[part~="label"]')).to.not.equal(null);
-            expect(shadow.querySelector('[part~="select"]')).to.equal(null);
-            expect(shadow.querySelectorAll('[part~="link"], [part~="current"]').length).to.equal(0);
+            expect(shadow.querySelector('select[part~="select"]')).to.equal(null);
+            expect(
+                shadow.querySelectorAll('[part~="link"], span[part~="current"]').length,
+            ).to.equal(0);
         });
 
         it('bascule compact→false→true→false remplace correctement un <select> déjà actif', async () => {
@@ -436,7 +444,7 @@ describe('ar-pagination — browser', () => {
             await waitForResize();
 
             const shadow = el.shadowRoot as ShadowRoot;
-            expect(shadow.querySelector('[part~="select"]')).to.not.equal(null);
+            expect(shadow.querySelector('select[part~="select"]')).to.not.equal(null);
 
             // 2. Passage en mode compact alors que le <select> est déjà affiché : doit le
             //    remplacer par le label, sans attendre de resize (compact ne dépend pas de la
@@ -444,7 +452,7 @@ describe('ar-pagination — browser', () => {
             (el as unknown as { compact: boolean }).compact = true;
             await elementUpdated(el);
 
-            expect(shadow.querySelector('[part~="select"]')).to.equal(null);
+            expect(shadow.querySelector('select[part~="select"]')).to.equal(null);
             expect(shadow.querySelector('[part~="label"]')).to.not.equal(null);
 
             // 3. Retour en mode non compact, toujours dans le conteneur étroit : le
@@ -453,7 +461,7 @@ describe('ar-pagination — browser', () => {
             await elementUpdated(el);
             await waitForResize();
 
-            expect(shadow.querySelector('[part~="select"]')).to.not.equal(null);
+            expect(shadow.querySelector('select[part~="select"]')).to.not.equal(null);
         });
 
         it('un clic sur next confirmé garde le focus sur le bouton actionné', async () => {

--- a/packages/core/src/components/pagination/pagination.styles.ts
+++ b/packages/core/src/components/pagination/pagination.styles.ts
@@ -31,9 +31,9 @@ export default css`
         align-items: center;
         justify-content: center;
         /* a11y-fallback: WCAG 2.5.8 taille de cible minimale */
-        min-height: var(--ar-pagination-btn-size, 2.5rem);
+        min-height: var(--ar-pagination-button-size, 2.5rem);
         /* a11y-fallback: WCAG 2.5.8 taille de cible minimale */
-        min-width: var(--ar-pagination-btn-size, 2.5rem);
+        min-width: var(--ar-pagination-button-size, 2.5rem);
     }
 
     [part~='prev'],
@@ -83,7 +83,7 @@ export default css`
         width: auto;
     }
 
-    [part~='nav-btn--disabled'] {
+    [part~='nav-button--disabled'] {
         cursor: not-allowed;
     }
 `;

--- a/packages/core/src/components/pagination/pagination.test.ts
+++ b/packages/core/src/components/pagination/pagination.test.ts
@@ -52,6 +52,10 @@ describe('ArPagination', () => {
             expect(getPart(el, 'list')).not.toBeNull();
         });
 
+        it('la racine <nav> porte aussi le part transverse "pagination"', () => {
+            expect(partContains(requirePart(el, 'nav'), 'pagination')).toBe(true);
+        });
+
         it('contient un part="prev"', () => {
             expect(getPart(el, 'prev')).not.toBeNull();
         });
@@ -60,11 +64,16 @@ describe('ArPagination', () => {
             expect(getPart(el, 'next')).not.toBeNull();
         });
 
-        it('contient un part="prev nav-btn" et part="next nav-btn"', () => {
+        it('contient un part="prev nav-button" et part="next nav-button"', () => {
             expect(partContains(requirePart(el, 'prev'), 'prev')).toBe(true);
-            expect(partContains(requirePart(el, 'prev'), 'nav-btn')).toBe(true);
+            expect(partContains(requirePart(el, 'prev'), 'nav-button')).toBe(true);
             expect(partContains(requirePart(el, 'next'), 'next')).toBe(true);
-            expect(partContains(requirePart(el, 'next'), 'nav-btn')).toBe(true);
+            expect(partContains(requirePart(el, 'next'), 'nav-button')).toBe(true);
+        });
+
+        it('prev/next portent aussi le rôle transverse "action-button"', () => {
+            expect(partContains(requirePart(el, 'prev'), 'action-button')).toBe(true);
+            expect(partContains(requirePart(el, 'next'), 'action-button')).toBe(true);
         });
 
         it('part="list" n\'a pas de margin-top (repli UA du <ul> non réinitialisé sinon)', () => {
@@ -181,7 +190,7 @@ describe('ArPagination', () => {
         it('la page active a aria-current="page"', async () => {
             el = await fixture('<ar-pagination current="3" total="5"></ar-pagination>');
             const shadow = el.shadowRoot as ShadowRoot;
-            const current = shadow.querySelector('[part="current"]') as Element;
+            const current = shadow.querySelector('span[part~="current"]') as Element;
             expect(current).not.toBeNull();
             expect(current.getAttribute('aria-current')).toBe('page');
         });
@@ -202,28 +211,36 @@ describe('ArPagination', () => {
         it('toutes les pages sont affichées si total < 10', async () => {
             el = await fixture('<ar-pagination current="1" total="5"></ar-pagination>');
             const shadow = el.shadowRoot as ShadowRoot;
-            const links = shadow.querySelectorAll('[part="link"], [part="current"]');
+            const links = shadow.querySelectorAll('[part~="link"], span[part~="current"]');
             expect(links.length).toBe(5);
         });
 
         it('la page courante utilise part="current" (span, non cliquable)', async () => {
             el = await fixture('<ar-pagination current="2" total="5"></ar-pagination>');
             const shadow = el.shadowRoot as ShadowRoot;
-            // Volontairement `=` strict (pas `~=`) : happy-dom (Vitest) a une implémentation
-            // non conforme de `~=` qui matche aussi "item--current" pour le token "current"
-            // (cf. mise en garde dans test-utils.ts) — un vrai navigateur ne matcherait pas
-            // le <li part="item item--current"> ici, mais happy-dom le ferait et casserait
-            // la distinction span/li que ce test vérifie précisément.
-            const currentPage = shadow.querySelector('[part="current"]') as Element;
+            // Qualifié par balise (`span[part~=...]`, pas juste `[part~=...]`) : happy-dom
+            // (Vitest) a une implémentation non conforme de `~=` qui matche aussi
+            // "item--current" pour le token "current" (cf. mise en garde dans test-utils.ts) —
+            // un vrai navigateur ne matcherait pas le <li part="item item--current"> ici, mais
+            // happy-dom le ferait et casserait la distinction span/li que ce test vérifie
+            // précisément. La qualification par balise écarte le <li>, qui n'est pas un <span>.
+            const currentPage = shadow.querySelector('span[part~="current"]') as Element;
             expect(currentPage.tagName.toLowerCase()).toBe('span');
         });
 
         it('les autres pages utilisent part="link" (lien cliquable)', async () => {
             el = await fixture('<ar-pagination current="1" total="5"></ar-pagination>');
             const shadow = el.shadowRoot as ShadowRoot;
-            const links = shadow.querySelectorAll('[part="link"]');
+            const links = shadow.querySelectorAll('[part~="link"]');
             // Toutes les pages sauf la 1ère sont des liens
             expect(links.length).toBe(4);
+        });
+
+        it('link/current portent le rôle transverse "control"', async () => {
+            el = await fixture('<ar-pagination current="1" total="5"></ar-pagination>');
+            const shadow = el.shadowRoot as ShadowRoot;
+            const link = shadow.querySelector('[part~="link"]');
+            expect(link && partContains(link, 'control')).toBe(true);
         });
 
         it('ellipses présentes si total >= 10 et current éloigné des bords, avec part="ellipsis"', async () => {
@@ -256,7 +273,7 @@ describe('ArPagination', () => {
         it('le sr-only de la page active inclut le total ("Page X sur Y")', async () => {
             el = await fixture('<ar-pagination current="3" total="12"></ar-pagination>');
             const shadow = el.shadowRoot as ShadowRoot;
-            const current = shadow.querySelector('[part="current"]') as Element;
+            const current = shadow.querySelector('span[part~="current"]') as Element;
             const srOnly = current.querySelector('.sr-only');
             expect(srOnly?.textContent).toBe('Page 3 sur 12');
         });
@@ -299,14 +316,14 @@ describe('ArPagination', () => {
             await waitForUpdate(el);
 
             const shadow = el.shadowRoot as ShadowRoot;
-            // Match exact (`=`, pas `~=`) : happy-dom scinde aussi sur les tirets dans son
-            // implémentation de `~=`, donc `[part~="select"]` matcherait à tort le `<li
-            // part="item page-select">` (voir mise en garde dans test-utils.ts) avant même
-            // d'atteindre le `<select part="select">` imbriqué.
-            const select = shadow.querySelector('[part="select"]');
+            // Qualifié par balise (`select[part~=...]`, pas juste `[part~=...]`) : happy-dom
+            // scinde aussi sur les tirets dans son implémentation de `~=`, donc `[part~="select"]`
+            // seul matcherait à tort le `<li part="item page-select">` (voir mise en garde dans
+            // test-utils.ts) avant même d'atteindre le `<select part="select field">` imbriqué.
+            const select = shadow.querySelector('select[part~="select"]');
             expect(select).not.toBeNull();
             expect(select?.tagName.toLowerCase()).toBe('select');
-            expect(shadow.querySelectorAll('[part~="link"], [part~="current"]').length).toBe(0);
+            expect(shadow.querySelectorAll('[part~="link"], span[part~="current"]').length).toBe(0);
         });
 
         it("peuple le select avec le même jeu de pages qu'à largeur confortable, pas la fenêtre réduite au budget actuel", async () => {
@@ -316,9 +333,9 @@ describe('ArPagination', () => {
             el.requestUpdate();
             await waitForUpdate(el);
 
-            // Match exact, cf. mise en garde `~=`/happy-dom ci-dessus.
+            // Qualifié par balise, cf. mise en garde `~=`/happy-dom ci-dessus.
             const select = (el.shadowRoot as ShadowRoot).querySelector(
-                '[part="select"]',
+                'select[part~="select"]',
             ) as HTMLSelectElement;
             const options = Array.from(select.querySelectorAll('option'));
             // _calculatePages(3, 15) SANS budget (donc budget par défaut 9) = [1, 2, 3, 4, 5, 6, 7, -2, 15]
@@ -365,7 +382,7 @@ describe('ArPagination', () => {
             await waitForUpdate(el);
 
             const select = (el.shadowRoot as ShadowRoot).querySelector(
-                '[part="select"]',
+                'select[part~="select"]',
             ) as HTMLSelectElement;
             const options = Array.from(select.querySelectorAll('option'));
             // Même jeu de 9 options qu'avec _budget = 2 ci-dessus : le contenu du select ne varie
@@ -391,9 +408,9 @@ describe('ArPagination', () => {
             el.requestUpdate();
             await waitForUpdate(el);
 
-            // Match exact, cf. mise en garde `~=`/happy-dom plus haut dans ce describe.
+            // Qualifié par balise, cf. mise en garde `~=`/happy-dom plus haut dans ce describe.
             const select = (el.shadowRoot as ShadowRoot).querySelector(
-                '[part="select"]',
+                'select[part~="select"]',
             ) as HTMLSelectElement;
             const options = Array.from(select.querySelectorAll('option'));
             expect(options[0]?.textContent?.trim()).toBe('Page 1 sur 15');
@@ -412,7 +429,7 @@ describe('ArPagination', () => {
             await waitForUpdate(el);
 
             const shadow = el.shadowRoot as ShadowRoot;
-            expect(shadow.querySelector('[part~="select"]')).toBeNull();
+            expect(shadow.querySelector('select[part~="select"]')).toBeNull();
         });
 
         it('bascule en palier select si le budget suffirait techniquement mais la fenêtre obtenue a 2 ellipses (seulement 3 pages réelles)', async () => {
@@ -426,9 +443,21 @@ describe('ArPagination', () => {
             await waitForUpdate(el);
 
             const shadow = el.shadowRoot as ShadowRoot;
-            // Match exact, cf. mise en garde `~=`/happy-dom plus haut dans ce describe.
-            expect(shadow.querySelector('[part="select"]')).not.toBeNull();
-            expect(shadow.querySelectorAll('[part~="link"], [part~="current"]').length).toBe(0);
+            // Qualifié par balise, cf. mise en garde `~=`/happy-dom plus haut dans ce describe.
+            expect(shadow.querySelector('select[part~="select"]')).not.toBeNull();
+            expect(shadow.querySelectorAll('[part~="link"], span[part~="current"]').length).toBe(0);
+        });
+
+        it('select porte le rôle transverse "field"', async () => {
+            el = await fixture('<ar-pagination current="8" total="15"></ar-pagination>');
+            // @ts-expect-error accès à un champ privé pour simuler une mesure ResizeObserver
+            el._budget = 5;
+            el.requestUpdate();
+            await waitForUpdate(el);
+
+            const shadow = el.shadowRoot as ShadowRoot;
+            const select = shadow.querySelector('select[part~="select"]');
+            expect(select && partContains(select, 'field')).toBe(true);
         });
 
         it('le plancher est identique en bord de liste et en position intermédiaire (pas de dépendance à la position de current)', async () => {
@@ -442,8 +471,10 @@ describe('ArPagination', () => {
             el.requestUpdate();
             await waitForUpdate(el);
 
-            // Match exact, cf. mise en garde `~=`/happy-dom plus haut dans ce describe.
-            expect((el.shadowRoot as ShadowRoot).querySelector('[part="select"]')).not.toBeNull();
+            // Qualifié par balise, cf. mise en garde `~=`/happy-dom plus haut dans ce describe.
+            expect(
+                (el.shadowRoot as ShadowRoot).querySelector('select[part~="select"]'),
+            ).not.toBeNull();
         });
     });
 
@@ -523,25 +554,25 @@ describe('ArPagination', () => {
         });
     });
 
-    describe("part d'état nav-btn--disabled", () => {
-        it('prev porte le part nav-btn--disabled en page 1', async () => {
+    describe("part d'état nav-button--disabled", () => {
+        it('prev porte le part nav-button--disabled en page 1', async () => {
             el = await fixture('<ar-pagination current="1" total="5"></ar-pagination>');
-            expect(partContains(requirePart(el, 'prev'), 'nav-btn--disabled')).toBe(true);
+            expect(partContains(requirePart(el, 'prev'), 'nav-button--disabled')).toBe(true);
         });
 
-        it('prev ne porte pas nav-btn--disabled quand current > 1', async () => {
+        it('prev ne porte pas nav-button--disabled quand current > 1', async () => {
             el = await fixture('<ar-pagination current="2" total="5"></ar-pagination>');
-            expect(partContains(requirePart(el, 'prev'), 'nav-btn--disabled')).toBe(false);
+            expect(partContains(requirePart(el, 'prev'), 'nav-button--disabled')).toBe(false);
         });
 
-        it('next porte le part nav-btn--disabled en dernière page', async () => {
+        it('next porte le part nav-button--disabled en dernière page', async () => {
             el = await fixture('<ar-pagination current="5" total="5"></ar-pagination>');
-            expect(partContains(requirePart(el, 'next'), 'nav-btn--disabled')).toBe(true);
+            expect(partContains(requirePart(el, 'next'), 'nav-button--disabled')).toBe(true);
         });
 
-        it('next ne porte pas nav-btn--disabled avant la dernière page', async () => {
+        it('next ne porte pas nav-button--disabled avant la dernière page', async () => {
             el = await fixture('<ar-pagination current="3" total="5"></ar-pagination>');
-            expect(partContains(requirePart(el, 'next'), 'nav-btn--disabled')).toBe(false);
+            expect(partContains(requirePart(el, 'next'), 'nav-button--disabled')).toBe(false);
         });
     });
 
@@ -652,15 +683,15 @@ describe('ArPagination', () => {
         it("n'affiche aucun numéro de page ni <select> de saut de page", async () => {
             el = await fixture('<ar-pagination compact current="3" total="12"></ar-pagination>');
             const shadow = el.shadowRoot as ShadowRoot;
-            expect(shadow.querySelectorAll('[part~="link"], [part~="current"]').length).toBe(0);
-            expect(shadow.querySelector('[part~="select"]')).toBeNull();
+            expect(shadow.querySelectorAll('[part~="link"], span[part~="current"]').length).toBe(0);
+            expect(shadow.querySelector('select[part~="select"]')).toBeNull();
         });
 
         it('total=1 : label affiche "Page 1 / 1", prev et next désactivés', async () => {
             el = await fixture('<ar-pagination compact current="1" total="1"></ar-pagination>');
             expect(requireLabel(el).textContent?.trim()).toBe('Page 1 / 1');
-            expect(partContains(requirePart(el, 'prev'), 'nav-btn--disabled')).toBe(true);
-            expect(partContains(requirePart(el, 'next'), 'nav-btn--disabled')).toBe(true);
+            expect(partContains(requirePart(el, 'prev'), 'nav-button--disabled')).toBe(true);
+            expect(partContains(requirePart(el, 'next'), 'nav-button--disabled')).toBe(true);
         });
 
         it('prev désactivé en page 1, next actif', async () => {
@@ -819,7 +850,7 @@ describe('ArPagination', () => {
             const handler = vi.fn();
             el.addEventListener('ar-pagination-page-change', handler);
             const select = (el.shadowRoot as ShadowRoot).querySelector(
-                '[part="select"]',
+                'select[part~="select"]',
             ) as HTMLSelectElement;
             select.value = '15';
             select.dispatchEvent(new Event('change'));
@@ -841,7 +872,7 @@ describe('ArPagination', () => {
             el.addEventListener('ar-pagination-page-change', (e) => e.preventDefault());
 
             const select = (el.shadowRoot as ShadowRoot).querySelector(
-                '[part="select"]',
+                'select[part~="select"]',
             ) as HTMLSelectElement;
             select.value = '15';
             select.dispatchEvent(new Event('change'));
@@ -862,7 +893,7 @@ describe('ArPagination', () => {
             });
 
             const select = (el.shadowRoot as ShadowRoot).querySelector(
-                '[part="select"]',
+                'select[part~="select"]',
             ) as HTMLSelectElement;
             select.value = '15';
             select.dispatchEvent(new Event('change'));
@@ -1000,14 +1031,14 @@ describe('ArPagination', () => {
             pageLink.click();
             await waitForUpdate(el);
 
-            const current = shadow.querySelector('[part~="current"]') as HTMLElement;
+            const current = shadow.querySelector('span[part~="current"]') as HTMLElement;
             expect(shadow.activeElement).toBe(current);
         });
 
         it('le nouvel élément part="current" porte tabindex="-1"', async () => {
             el = await fixture('<ar-pagination current="2" total="5"></ar-pagination>');
             const shadow = el.shadowRoot as ShadowRoot;
-            const current = shadow.querySelector('[part="current"]') as HTMLElement;
+            const current = shadow.querySelector('span[part~="current"]') as HTMLElement;
             expect(current.getAttribute('tabindex')).toBe('-1');
         });
     });
@@ -1054,7 +1085,7 @@ describe('ArPagination', () => {
 
         it('total négatif : render() reste fonctionnel et ne montre aucun numéro de page négatif', async () => {
             el = await fixture('<ar-pagination total="-3"></ar-pagination>');
-            expect(el.shadowRoot?.querySelector('[part="nav"]')).not.toBeNull();
+            expect(el.shadowRoot?.querySelector('[part~="nav"]')).not.toBeNull();
 
             const prevLabel = el.shadowRoot?.querySelector('[part~="prev"] .sr-only')?.textContent;
             const nextLabel = el.shadowRoot?.querySelector('[part~="next"] .sr-only')?.textContent;

--- a/packages/core/src/components/pagination/pagination.test.ts
+++ b/packages/core/src/components/pagination/pagination.test.ts
@@ -241,6 +241,11 @@ describe('ArPagination', () => {
             const shadow = el.shadowRoot as ShadowRoot;
             const link = shadow.querySelector('[part~="link"]');
             expect(link && partContains(link, 'control')).toBe(true);
+            // span[part~="current"] plutôt que [part~="current"] seul : happy-dom scinde aussi
+            // `~=` sur les tirets (cf. requireLabel plus haut), donc un sélecteur non qualifié
+            // matcherait à tort le `<li part="item item--current">` englobant en premier.
+            const current = shadow.querySelector('span[part~="current"]');
+            expect(current && partContains(current, 'control')).toBe(true);
         });
 
         it('ellipses présentes si total >= 10 et current éloigné des bords, avec part="ellipsis"', async () => {

--- a/packages/core/src/components/pagination/pagination.ts
+++ b/packages/core/src/components/pagination/pagination.ts
@@ -31,21 +31,30 @@ export interface ArPaginationPageChangeDetail {
  * Des ellipses (`...`) sont insérées quand le nombre de pages dépasse le seuil d'affichage.
  *
  * @csspart nav      - L'élément `<nav>` englobant.
+ * @csspart pagination - Rôle transverse (voir /getting-started/naming-conventions) : racine du
+ *   composant.
  * @csspart list     - L'élément `<ul>` de la liste des pages.
  * @csspart item     - Chaque `<li>` de la liste. Porte aussi le part d'état `item--current` sur le `<li>` de la page active.
  * @csspart item--current - Le `<li>` de la page courante (variante d'état de `item`).
  * @csspart link     - Les `<a>` cliquables de chaque page. Personnalisable via `::part(link)` (fond, couleur, bordure, survol/pressé/focus).
+ * @csspart control - Rôle transverse (voir /getting-started/naming-conventions), porté par `link`
+ *   et `current` : élément interactif générique.
  * @csspart current  - Le `<span>` de la page courante (non cliquable). Personnalisable via `::part(current)` (fond, couleur, bordure, épaisseur de trait).
- * @csspart prev     - Le bouton "Page précédente". Porte aussi le part combiné `nav-btn`, partagé avec `next`.
- * @csspart next     - Le bouton "Page suivante". Porte aussi le part combiné `nav-btn`, partagé avec `prev`.
- * @csspart nav-btn  - Part combiné sur `prev`/`next`, pour cibler les deux boutons de navigation ensemble (ex. `::part(nav-btn)` pour un style commun distinct des numéros de page).
- * @csspart nav-btn--disabled - Variante d'état de `nav-btn` posée sur `prev`/`next` quand désactivé (page 1 ou dernière page).
+ * @csspart prev     - Le bouton "Page précédente". Porte aussi le part combiné `nav-button`, partagé avec `next`.
+ * @csspart next     - Le bouton "Page suivante". Porte aussi le part combiné `nav-button`, partagé avec `prev`.
+ * @csspart action-button - Rôle transverse (voir /getting-started/naming-conventions), porté par
+ *   `prev` et `next` : bouton qui déclenche une action ponctuelle.
+ * @csspart nav-button  - Part combiné sur `prev`/`next`, pour cibler les deux boutons de navigation ensemble (ex. `::part(nav-button)` pour un style commun distinct des numéros de page).
+ * @csspart nav-button--disabled - Variante d'état de `nav-button` posée sur `prev`/`next` quand désactivé (page 1 ou dernière page).
  * @csspart ellipsis - Le `<span>` d'ellipse (`...`) entre deux groupes de pages, non interactif.
  * @csspart page-select - Le `<li>` englobant le `<select>` de saut de page, affiché à la place
  *   de la liste de pages quand l'espace disponible ne permet plus d'afficher de numéros (palier
  *   minimal).
  * @csspart select - L'élément `<select>` de saut de page. Personnalisable via `::part(select)`
  *   (apparence). Conserve l'apparence native du navigateur (flèche incluse) par défaut.
+ * @csspart field - Rôle transverse (voir /getting-started/naming-conventions), porté par `select` :
+ *   élément qui reçoit une saisie. Sous-rôle standard de `field` (avec `input`, cf.
+ *   ar-datepicker), réutilisable par tout futur composant avec une liste déroulante.
  * @csspart page-label - Le `<li>` englobant le label de position en mode compact (`compact`),
  *   affiché à la place de la liste de pages. Sur le modèle de `page-select`.
  * @csspart label - Le `<span>` du label de position en mode compact ("Page X / Y"), non
@@ -56,7 +65,7 @@ export interface ArPaginationPageChangeDetail {
  * @slot prev-icon - Icône du bouton "Page précédente". Remplace le chevron SVG par défaut.
  * @slot next-icon - Icône du bouton "Page suivante". Remplace le chevron SVG par défaut.
  *
- * @cssprop --ar-pagination-btn-size - Hauteur et largeur minimales des boutons/pages (repli interne `2.5rem`, WCAG 2.5.8).
+ * @cssprop --ar-pagination-button-size - Hauteur et largeur minimales des boutons/pages (repli interne `2.5rem`, WCAG 2.5.8).
  * @cssprop --ar-pagination-transition-duration - Durée de la transition (fond/couleur) au survol/pressé/focus de prev/next/page.
  *
  * @event {CustomEvent<{from: number, to: number}>} ar-pagination-page-change - Émis avant le
@@ -123,7 +132,7 @@ export class ArPagination extends LitElement {
     override connectedCallback(): void {
         super.connectedCallback();
         // `_initialized` reste faux ici au tout premier montage (le shadow DOM n'existe pas
-        // encore, `_setupResizeObserver` ne trouverait pas `[part="nav"]`) — ce n'est donc PAS un
+        // encore, `_setupResizeObserver` ne trouverait pas `[part~="nav"]`) — ce n'est donc PAS un
         // doublon avec l'appel dans `firstUpdated()` ci-dessous, qui gère ce premier montage une
         // fois le rendu initial fait. Cet appel-ci ne joue que lors d'une reconnexion ultérieure
         // (élément déplacé/réinséré dans le DOM après un premier montage), pour réattacher
@@ -147,7 +156,7 @@ export class ArPagination extends LitElement {
 
     private _setupResizeObserver(): void {
         this._resizeObserver?.disconnect();
-        const nav = this.shadowRoot?.querySelector<HTMLElement>('[part="nav"]');
+        const nav = this.shadowRoot?.querySelector<HTMLElement>('[part~="nav"]');
         if (!nav) return;
         this._resizeObserver = new ResizeObserver(() => this._recalculateBudget());
         this._resizeObserver.observe(nav);
@@ -175,7 +184,7 @@ export class ArPagination extends LitElement {
     }
 
     private _recalculateBudget(): void {
-        const nav = this.shadowRoot?.querySelector<HTMLElement>('[part="nav"]');
+        const nav = this.shadowRoot?.querySelector<HTMLElement>('[part~="nav"]');
         const list = this.shadowRoot?.querySelector<HTMLElement>('[part="list"]');
         const prev = this.shadowRoot?.querySelector<HTMLElement>('[part~="prev"]');
         const next = this.shadowRoot?.querySelector<HTMLElement>('[part~="next"]');
@@ -271,7 +280,12 @@ export class ArPagination extends LitElement {
                 this._emitChanged({ from, to });
                 this._announcePageChange();
                 if (this.current === this._pendingFocusPage) {
-                    void focusAfterUpdate(this, '[part~="current"]');
+                    // Qualifié par balise (`span[part~=...]`) : sous happy-dom (Vitest), `~=`
+                    // scinde aussi sur les tirets et matcherait à tort le `<li
+                    // part="item item--current">` englobant avant le `<span part="current">`
+                    // réel (mise en garde dans test-utils.ts). Sans effet en navigateur réel
+                    // (spec-conforme), où seul le `<span>` matche de toute façon.
+                    void focusAfterUpdate(this, 'span[part~="current"]');
                 }
             }
         }
@@ -316,14 +330,16 @@ export class ArPagination extends LitElement {
         const previousPageNumber = _clamp(current - 1, 1, total > 1 ? total - 1 : 1);
         const nextPageNumber = _clamp(current + 1, 1, total);
 
-        return html` <nav part="nav" role="navigation" aria-labelledby="ar-pagination">
+        return html` <nav part="nav pagination" role="navigation" aria-labelledby="ar-pagination">
             <p id="ar-pagination" class="sr-only">Pagination, page ${current} sur ${total}</p>
             <ul part="list" @click=${this._onPageChange}>
                 ${this.compact ? this.renderCompactLabel(current, total) : nothing}
 
                 <li part="item">
                     <a
-                        part="prev nav-btn${isPreviousDisabled ? ' nav-btn--disabled' : ''}"
+                        part="prev nav-button action-button${isPreviousDisabled
+                            ? ' nav-button--disabled'
+                            : ''}"
                         href="javascript:;"
                         aria-disabled=${isPreviousDisabled}
                         @click=${this._onPreviousPage}
@@ -339,7 +355,9 @@ export class ArPagination extends LitElement {
 
                 <li part="item">
                     <a
-                        part="next nav-btn${isNextDisabled ? ' nav-btn--disabled' : ''}"
+                        part="next nav-button action-button${isNextDisabled
+                            ? ' nav-button--disabled'
+                            : ''}"
                         href="javascript:;"
                         aria-disabled=${isNextDisabled}
                         @click=${this._onNextPage}
@@ -412,7 +430,7 @@ export class ArPagination extends LitElement {
     protected renderPageLink(page: number, active: boolean, total: number): TemplateResult {
         if (active) {
             return html` <span
-                part="current"
+                part="current control"
                 tabindex="-1"
                 aria-current="page"
                 data-ar-pagination-page="${page}"
@@ -420,7 +438,7 @@ export class ArPagination extends LitElement {
                 ${this.renderPageLabel(page, total)}
             </span>`;
         }
-        return html` <a part="link" data-ar-pagination-page="${page}" href="javascript:;">
+        return html` <a part="link control" data-ar-pagination-page="${page}" href="javascript:;">
             ${this.renderPageLabel(page, total)}
         </a>`;
     }
@@ -450,7 +468,7 @@ export class ArPagination extends LitElement {
         return html`<li part="item page-select">
             <span class="sr-only" id="ar-pagination-select-label">Aller à la page</span>
             <select
-                part="select"
+                part="select field"
                 aria-labelledby="ar-pagination-select-label"
                 @change=${this._onSelectChange}
             >

--- a/packages/core/src/components/pagination/pagination.ts
+++ b/packages/core/src/components/pagination/pagination.ts
@@ -31,19 +31,16 @@ export interface ArPaginationPageChangeDetail {
  * Des ellipses (`...`) sont insérées quand le nombre de pages dépasse le seuil d'affichage.
  *
  * @csspart nav      - L'élément `<nav>` englobant.
- * @csspart pagination - Rôle transverse (voir /getting-started/naming-conventions) : racine du
- *   composant.
+ * @csspart pagination - Racine du composant.
  * @csspart list     - L'élément `<ul>` de la liste des pages.
  * @csspart item     - Chaque `<li>` de la liste. Porte aussi le part d'état `item--current` sur le `<li>` de la page active.
  * @csspart item--current - Le `<li>` de la page courante (variante d'état de `item`).
  * @csspart link     - Les `<a>` cliquables de chaque page. Personnalisable via `::part(link)` (fond, couleur, bordure, survol/pressé/focus).
- * @csspart control - Rôle transverse (voir /getting-started/naming-conventions), porté par `link`
- *   et `current` : élément interactif générique.
+ * @csspart control - Porté par `link` et `current` : élément interactif générique.
  * @csspart current  - Le `<span>` de la page courante (non cliquable). Personnalisable via `::part(current)` (fond, couleur, bordure, épaisseur de trait).
  * @csspart prev     - Le bouton "Page précédente". Porte aussi le part combiné `nav-button`, partagé avec `next`.
  * @csspart next     - Le bouton "Page suivante". Porte aussi le part combiné `nav-button`, partagé avec `prev`.
- * @csspart action-button - Rôle transverse (voir /getting-started/naming-conventions), porté par
- *   `prev` et `next` : bouton qui déclenche une action ponctuelle.
+ * @csspart action-button - Porté par `prev` et `next` : bouton qui déclenche une action ponctuelle.
  * @csspart nav-button  - Part combiné sur `prev`/`next`, pour cibler les deux boutons de navigation ensemble (ex. `::part(nav-button)` pour un style commun distinct des numéros de page).
  * @csspart nav-button--disabled - Variante d'état de `nav-button` posée sur `prev`/`next` quand désactivé (page 1 ou dernière page).
  * @csspart ellipsis - Le `<span>` d'ellipse (`...`) entre deux groupes de pages, non interactif.
@@ -52,9 +49,9 @@ export interface ArPaginationPageChangeDetail {
  *   minimal).
  * @csspart select - L'élément `<select>` de saut de page. Personnalisable via `::part(select)`
  *   (apparence). Conserve l'apparence native du navigateur (flèche incluse) par défaut.
- * @csspart field - Rôle transverse (voir /getting-started/naming-conventions), porté par `select` :
- *   élément qui reçoit une saisie. Sous-rôle standard de `field` (avec `input`, cf.
- *   ar-datepicker), réutilisable par tout futur composant avec une liste déroulante.
+ * @csspart field - Porté par `select` : élément qui reçoit une saisie. Sous-rôle standard de
+ *   `field` (avec `input`, cf. ar-datepicker), réutilisable par tout futur composant avec une
+ *   liste déroulante.
  * @csspart page-label - Le `<li>` englobant le label de position en mode compact (`compact`),
  *   affiché à la place de la liste de pages. Sur le modèle de `page-select`.
  * @csspart label - Le `<span>` du label de position en mode compact ("Page X / Y"), non

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -672,11 +672,14 @@
     /* Datepicker */
     ar-datepicker {
         /* Variable locale à ce bloc thème, pas un token public du composant (pas de
-         * préfixe --ar-datepicker-*) : couple gap et margin-bottom de ::part(label)
-         * ci-dessous sans exposer d'API. Un autre thème peut reproduire la même
-         * technique avec sa propre variable. */
+         * préfixe --ar-datepicker-*) : couple gap (::part(datepicker) ci-dessous) et
+         * margin-bottom de ::part(label) plus bas sans exposer d'API. Un autre thème
+         * peut reproduire la même technique avec sa propre variable. */
         --field-gap: 0.35rem;
-        gap: var(--field-gap);
+
+        &::part(datepicker) {
+            gap: var(--field-gap);
+        }
 
         &::part(panel) {
             width: 20rem;

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -401,7 +401,7 @@
         /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
          * Pagination
          * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
-        --ar-pagination-btn-size: 2.5rem;
+        --ar-pagination-button-size: 2.5rem;
         --ar-pagination-transition-duration: var(--ar-button-transition-duration);
 
         /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -683,7 +683,7 @@
             padding: 1rem;
         }
 
-        &::part(nav-btn) {
+        &::part(nav-button) {
             width: 2rem;
             height: 2rem;
             background: transparent;
@@ -692,15 +692,15 @@
             border-radius: var(--ar-border-radius-sm);
         }
 
-        &::part(nav-btn):hover {
+        &::part(nav-button):hover {
             background: color-mix(in srgb, var(--ar-color-text) 8%, transparent);
         }
 
-        &::part(nav-btn):active {
+        &::part(nav-button):active {
             background: color-mix(in srgb, var(--ar-color-text) 14%, transparent);
         }
 
-        &::part(nav-btn):focus-visible {
+        &::part(nav-button):focus-visible {
             outline-offset: var(--ar-focus-ring-offset);
         }
 
@@ -1148,13 +1148,13 @@
         }
 
         /* Spécificité égale aux variantes :focus-visible/:hover/:active ci-dessus (pseudo-élément
-           + pseudo-classe) requise pour gagner la cascade : ::part(nav-btn--disabled) seul
+           + pseudo-classe) requise pour gagner la cascade : ::part(nav-button--disabled) seul
            (spécificité pseudo-élément uniquement) perdrait face à ::part(prev):hover malgré
            un ordre de déclaration ultérieur. */
-        &::part(nav-btn--disabled),
-        &::part(nav-btn--disabled):hover,
-        &::part(nav-btn--disabled):active,
-        &::part(nav-btn--disabled):focus-visible {
+        &::part(nav-button--disabled),
+        &::part(nav-button--disabled):hover,
+        &::part(nav-button--disabled):active,
+        &::part(nav-button--disabled):focus-visible {
             background-color: var(--ar-button-disabled-bg);
             color: var(--ar-button-disabled-color);
         }

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -496,11 +496,11 @@
            précédent que le min-width littéral d'ar-dropdown::part(panel) (10rem, cf. plus bas). */
         --ar-datepicker-panel-max-width: 25rem;
 
-        --ar-datepicker-nav-btn-border-color: transparent;
-        --ar-datepicker-nav-btn-focus-ring-color: var(--ar-focus-ring-color);
+        --ar-datepicker-nav-button-border-color: transparent;
+        --ar-datepicker-nav-button-focus-ring-color: var(--ar-focus-ring-color);
 
-        --ar-datepicker-footer-btn-border-color: var(--ar-color-border);
-        --ar-datepicker-footer-btn-focus-ring-color: var(--ar-focus-ring-color);
+        --ar-datepicker-footer-button-border-color: var(--ar-color-border);
+        --ar-datepicker-footer-button-focus-ring-color: var(--ar-focus-ring-color);
 
         --ar-datepicker-day-other-month-color: var(--ar-color-neutral-50);
 
@@ -711,7 +711,7 @@
             gap: 0.5rem;
         }
 
-        &::part(footer-btn) {
+        &::part(footer-button) {
             background: transparent;
             border-width: 1px;
             color: var(--ar-color-interactive);
@@ -719,16 +719,16 @@
             padding: 0.375rem 0.75rem;
         }
 
-        &::part(footer-btn):hover {
+        &::part(footer-button):hover {
             background: color-mix(in srgb, var(--ar-color-interactive) 10%, transparent);
             border-color: var(--ar-color-interactive);
         }
 
-        &::part(footer-btn):active {
+        &::part(footer-button):active {
             background: color-mix(in srgb, var(--ar-color-interactive) 18%, transparent);
         }
 
-        &::part(footer-btn):focus-visible {
+        &::part(footer-button):focus-visible {
             outline-offset: var(--ar-focus-ring-offset);
         }
 


### PR DESCRIPTION
## Résumé

Premier lot du chantier #181 (vocabulaire de rôles `::part()`/`slot` transverses) :

- `ar-charcounter` : racine `container` → `charcounter`, slots `icon-warning`/`icon-error` →
  `warning-icon`/`error-icon` (cohérence avec le suffixe `<rôle>-icon` déjà établi ailleurs).
- `ar-pagination` : part racine `pagination` (additif sur `nav`), rôles transverses
  `control`(link/current)/`field`(select)/`action-button`(prev/next), `nav-btn` → `nav-button`.
- `ar-datepicker` : nouveau wrapper racine `part="datepicker"`, rôles transverses
  `field`(input)/`control`(day)/`action-button`(nav-button/footer-button), `nav-btn`/`footer-btn`/
  `today-btn`/`close-btn` → `-button` en toutes lettres.
- Nouvelle page de doc `/getting-started/naming-conventions` (rôles `::part()` transverses +
  conventions de `slot`).

Spec : `docs/superpowers/specs/2026-08-13-role-parts-vocabulary-181-design.md`
Plan : `docs/superpowers/plans/2026-08-13-role-parts-vocabulary-181-lot1.md`

## Test plan

- [ ] `npm test --workspace=packages/core` — PASS
- [ ] `npm run test:browser --workspace=packages/core` — PASS
- [ ] `npm run test:a11y --workspace=apps/docs` — PASS
- [ ] `npm run build:manifest --workspace=packages/core && npm run build` — succès

🤖 Generated with [Claude Code](https://claude.com/claude-code)