### PR TITLE
fix(core): vocabulaire de rôles ::part() transverses — lot 3, action-button + ar-stepper (#181)

### DIFF
--- a/packages/core/src/components/alert/alert.styles.ts
+++ b/packages/core/src/components/alert/alert.styles.ts
@@ -20,12 +20,12 @@ export default css`
 
     @media (prefers-reduced-motion: reduce) {
         :host([hiding]),
-        [part='close'] {
+        [part~='close-button'] {
             transition: none;
         }
     }
 
-    [part='close'] {
+    [part~='close-button'] {
         order: 1;
         align-self: flex-start;
         flex-shrink: 0;

--- a/packages/core/src/components/alert/alert.test.ts
+++ b/packages/core/src/components/alert/alert.test.ts
@@ -309,6 +309,13 @@ describe('ArAlert', () => {
             expect(requirePart(el, 'close').getAttribute('aria-label')).toBe("Fermer l'alerte");
         });
 
+        it('porte le part combiné "close-button action-button"', async () => {
+            el = await fixture('<ar-alert next-focus="btn-retour"></ar-alert>');
+            expect(requirePart(el, 'close').getAttribute('part')).toBe(
+                'close-button action-button',
+            );
+        });
+
         it('reflète next-focus en attribut HTML', async () => {
             el = await fixture('<ar-alert></ar-alert>');
             el.nextFocus = 'mon-bouton';

--- a/packages/core/src/components/alert/alert.test.ts
+++ b/packages/core/src/components/alert/alert.test.ts
@@ -50,7 +50,7 @@ describe('ArAlert', () => {
         });
 
         it('le bouton close est absent sans next-focus', () => {
-            expect(getPart(el, 'close')).toBeNull();
+            expect(getPart(el, 'close-button')).toBeNull();
         });
     });
 
@@ -286,32 +286,34 @@ describe('ArAlert', () => {
     describe('bouton close', () => {
         it("n'est pas rendu sans l'attribut next-focus", async () => {
             el = await fixture('<ar-alert></ar-alert>');
-            expect(getPart(el, 'close')).toBeNull();
+            expect(getPart(el, 'close-button')).toBeNull();
         });
 
         it('est rendu quand next-focus est défini', async () => {
             el = await fixture('<ar-alert next-focus="btn-retour"></ar-alert>');
-            expect(getPart(el, 'close')).not.toBeNull();
+            expect(getPart(el, 'close-button')).not.toBeNull();
         });
 
         it("n'est pas rendu si next-focus est une chaîne vide", async () => {
             el = await fixture('<ar-alert next-focus=""></ar-alert>');
-            expect(getPart(el, 'close')).toBeNull();
+            expect(getPart(el, 'close-button')).toBeNull();
         });
 
         it("n'est pas rendu si next-focus ne contient que des espaces", async () => {
             el = await fixture('<ar-alert next-focus="   "></ar-alert>');
-            expect(getPart(el, 'close')).toBeNull();
+            expect(getPart(el, 'close-button')).toBeNull();
         });
 
         it('le bouton close a aria-label="Fermer l\'alerte"', async () => {
             el = await fixture('<ar-alert next-focus="btn-retour"></ar-alert>');
-            expect(requirePart(el, 'close').getAttribute('aria-label')).toBe("Fermer l'alerte");
+            expect(requirePart(el, 'close-button').getAttribute('aria-label')).toBe(
+                "Fermer l'alerte",
+            );
         });
 
         it('porte le part combiné "close-button action-button"', async () => {
             el = await fixture('<ar-alert next-focus="btn-retour"></ar-alert>');
-            expect(requirePart(el, 'close').getAttribute('part')).toBe(
+            expect(requirePart(el, 'close-button').getAttribute('part')).toBe(
                 'close-button action-button',
             );
         });
@@ -361,7 +363,7 @@ describe('ArAlert', () => {
             el.removeAttribute('next-focus');
             await waitForUpdate(el);
             // canBeHidden est false donc le bouton close n'est pas rendu — pas d'appel possible à _hide()
-            expect(getPart(el, 'close')).toBeNull();
+            expect(getPart(el, 'close-button')).toBeNull();
         });
     });
 
@@ -374,7 +376,7 @@ describe('ArAlert', () => {
             // _shouldAnimate() renvoie false et _finishHide() s'exécute de façon synchrone,
             // ce qui repasserait hiding à false avant même l'assertion ci-dessous.
             el.style.transitionDuration = '0.3s';
-            (requirePart(el, 'close') as HTMLButtonElement).click();
+            (requirePart(el, 'close-button') as HTMLButtonElement).click();
             await waitForUpdate(el);
             // hiding est un protected property — on y accède via cast
             expect((el as unknown as { hiding: boolean }).hiding).toBe(true);
@@ -385,7 +387,7 @@ describe('ArAlert', () => {
             // Cf. commentaire ci-dessus : durée de transition non nulle requise pour que
             // hiding reste true (chemin asynchrone) au moment de l'assertion.
             el.style.transitionDuration = '0.3s';
-            (requirePart(el, 'close') as HTMLButtonElement).click();
+            (requirePart(el, 'close-button') as HTMLButtonElement).click();
             await waitForUpdate(el);
             expect(el.hasAttribute('hiding')).toBe(true);
         });
@@ -400,7 +402,7 @@ describe('ArAlert', () => {
             el.addEventListener('ar-alert-close', handler);
 
             // Simule le clic → hiding=true
-            (requirePart(el, 'close') as HTMLButtonElement).click();
+            (requirePart(el, 'close-button') as HTMLButtonElement).click();
             await waitForUpdate(el);
 
             // La fermeture attend bien la transition : rien n'est émis avant transitionend.
@@ -423,7 +425,7 @@ describe('ArAlert', () => {
             const handler = vi.fn();
             el.addEventListener('ar-alert-close', handler);
 
-            (requirePart(el, 'close') as HTMLButtonElement).click();
+            (requirePart(el, 'close-button') as HTMLButtonElement).click();
             await waitForUpdate(el);
 
             // Simule les deux transitionend (opacity, puis transform) dans la même tâche.
@@ -447,7 +449,7 @@ describe('ArAlert', () => {
 
             // Aucun style inline, aucune feuille de thème chargée en environnement de test :
             // getComputedStyle(el).transitionDuration vaut '' (→ 0) en happy-dom par défaut.
-            (requirePart(el, 'close') as HTMLButtonElement).click();
+            (requirePart(el, 'close-button') as HTMLButtonElement).click();
             await waitForUpdate(el);
 
             // La fermeture doit être synchrone : pas de transitionend nécessaire.
@@ -493,7 +495,7 @@ describe('ArAlert', () => {
 
             // Sans thème chargé (durée de transition à 0 en happy-dom), la fermeture se termine
             // synchroniquement au clic — pas besoin de simuler transitionend.
-            (requirePart(el, 'close') as HTMLButtonElement).click();
+            (requirePart(el, 'close-button') as HTMLButtonElement).click();
             await waitForUpdate(el);
 
             expect(spy).toHaveBeenCalledOnce();
@@ -511,7 +513,7 @@ describe('ArAlert', () => {
 
             // Sans thème chargé (durée de transition à 0 en happy-dom), la fermeture se termine
             // synchroniquement au clic — pas besoin de simuler transitionend.
-            (requirePart(el, 'close') as HTMLButtonElement).click();
+            (requirePart(el, 'close-button') as HTMLButtonElement).click();
             await waitForUpdate(el);
 
             expect(document.activeElement).toBe(target);

--- a/packages/core/src/components/alert/alert.ts
+++ b/packages/core/src/components/alert/alert.ts
@@ -28,7 +28,8 @@ export type ArAlertVariant = 'success' | 'warning' | 'error' | 'info';
  * @csspart icon      - Le conteneur de l'icône de variant.
  * @csspart icon-svg  - Le SVG de l'icône de variant par défaut (absent si le slot `icon` est utilisé).
  * @csspart body      - Le conteneur du titre et du contenu.
- * @csspart close     - Le bouton de fermeture (présent uniquement si `next-focus` est défini).
+ * @csspart close-button - Le bouton de fermeture (présent uniquement si `next-focus` est défini).
+ * @csspart action-button - Porté par `close-button` : bouton qui déclenche une action ponctuelle.
  *
  * @cssprop --ar-alert-bg - Fond de l'alerte.
  * @cssprop --ar-alert-border - Bordure de l'alerte.
@@ -198,7 +199,7 @@ export class ArAlert extends LitElement {
             </div>
             ${this.canBeHidden
                 ? html` <button
-                      part="close"
+                      part="close-button action-button"
                       @click=${this._hide}
                       type="button"
                       aria-label="Fermer l'alerte"

--- a/packages/core/src/components/dialog/dialog.browser.test.ts
+++ b/packages/core/src/components/dialog/dialog.browser.test.ts
@@ -204,7 +204,7 @@ describe('ar-dialog — browser', () => {
 
             const shadow = el.shadowRoot!;
             const headerEl = shadow.querySelector('[part="header"]') as HTMLElement;
-            const closeEl = shadow.querySelector('[part="close"]') as HTMLElement;
+            const closeEl = shadow.querySelector('[part~="close-button"]') as HTMLElement;
 
             const headerRect = headerEl.getBoundingClientRect();
             const closeRect = closeEl.getBoundingClientRect();

--- a/packages/core/src/components/dialog/dialog.styles.ts
+++ b/packages/core/src/components/dialog/dialog.styles.ts
@@ -149,7 +149,7 @@ export default [
             justify-content: flex-end;
         }
 
-        [part='close'] {
+        [part~='close-button'] {
             display: flex;
             align-items: center;
             justify-content: center;
@@ -164,7 +164,7 @@ export default [
             transition: background-color var(--ar-dialog-close-transition-duration);
         }
 
-        [part='close']:focus-visible {
+        [part~='close-button']:focus-visible {
             outline: 2px solid currentColor;
             outline-offset: 2px;
         }
@@ -206,7 +206,7 @@ export default [
         @media (prefers-reduced-motion: reduce) {
             dialog,
             dialog::backdrop,
-            [part='close'] {
+            [part~='close-button'] {
                 animation: none !important;
                 transition: none !important;
             }

--- a/packages/core/src/components/dialog/dialog.test.ts
+++ b/packages/core/src/components/dialog/dialog.test.ts
@@ -55,7 +55,9 @@ describe('ArDialog', () => {
         });
 
         it('contient part="close-button action-button"', () => {
-            expect(getPart(el, 'close')?.getAttribute('part')).toBe('close-button action-button');
+            expect(getPart(el, 'close-button')?.getAttribute('part')).toBe(
+                'close-button action-button',
+            );
         });
 
         it("le bouton close n'a pas d'aria-describedby", async () => {
@@ -180,7 +182,7 @@ describe('ArDialog', () => {
             el = await fixture('<ar-dialog without-header label="Titre"></ar-dialog>');
             expect(getPart(el, 'header')).toBeNull();
             expect(getPart(el, 'title')).toBeNull();
-            expect(getPart(el, 'close')).toBeNull();
+            expect(getPart(el, 'close-button')).toBeNull();
             expect(requireShadow(el).querySelector('[data-ar-dismiss]')).toBeNull();
         });
 

--- a/packages/core/src/components/dialog/dialog.test.ts
+++ b/packages/core/src/components/dialog/dialog.test.ts
@@ -54,8 +54,8 @@ describe('ArDialog', () => {
             expect(requireShadow(el).querySelector('[data-ar-dismiss]')).not.toBeNull();
         });
 
-        it('contient part="close"', () => {
-            expect(getPart(el, 'close')).not.toBeNull();
+        it('contient part="close-button action-button"', () => {
+            expect(getPart(el, 'close')?.getAttribute('part')).toBe('close-button action-button');
         });
 
         it("le bouton close n'a pas d'aria-describedby", async () => {

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -60,7 +60,8 @@ if (typeof document !== 'undefined') {
  * @csspart header - L'en-tête contenant le titre et le bouton de fermeture. Absent du DOM si `without-header` est actif.
  * @csspart header-actions - Le conteneur des actions additionnelles du header (slot `header-actions`). Absent du DOM si le slot est vide ou si `without-header` est actif.
  * @csspart title - Le titre du dialog.
- * @csspart close - Le bouton de fermeture dans l'en-tête. Absent du DOM si `without-header` est actif.
+ * @csspart close-button - Le bouton de fermeture dans l'en-tête. Absent du DOM si `without-header` est actif.
+ * @csspart action-button - Porté par `close-button` : bouton qui déclenche une action ponctuelle.
  * @csspart body - La zone de contenu principale.
  * @csspart footer - La zone d'actions (absente du DOM si slot non utilisé).
  *
@@ -309,7 +310,7 @@ export class ArDialog extends LitElement {
                                     <slot name="header-actions"></slot>
                                 </div>`
                               : nothing}
-                          <button part="close" type="button" data-ar-dismiss>
+                          <button part="close-button action-button" type="button" data-ar-dismiss>
                               <slot name="close-icon">
                                   <svg
                                       aria-hidden="true"

--- a/packages/core/src/components/stepper/stepper.renderer.ts
+++ b/packages/core/src/components/stepper/stepper.renderer.ts
@@ -31,8 +31,8 @@ function isGroupCurrent(node: NavigationNode, mode: NavigationMode): boolean {
 }
 
 /** Compose la valeur `part=` d'un élément avec sa variante d'état "current" (convention BEM `--`). */
-function withCurrentPart(base: string, isCurrent: boolean): string {
-    return isCurrent ? `${base} ${base}--current` : base;
+function withCurrentPart(base: string, isCurrent: boolean, role: string): string {
+    return isCurrent ? `${base} ${role} ${base}--current` : `${base} ${role}`;
 }
 
 function renderStepText(
@@ -41,7 +41,7 @@ function renderStepText(
     isCurrent: boolean,
     isSubstep = false,
 ): TemplateResult {
-    const bulletPart = withCurrentPart('bullet', isCurrent);
+    const bulletPart = withCurrentPart('bullet', isCurrent, 'indicator');
     return html`
         <span part=${bulletPart} aria-hidden="true"></span>
         <span class="sr-only">${isSubstep ? 'sous-' : ''}étape ${order}:</span>
@@ -74,7 +74,7 @@ function renderSubStep(
                 ? html`
                       <a
                           class="item-header"
-                          part=${withCurrentPart('step-link', isCurrent)}
+                          part=${withCurrentPart('step-link', isCurrent, 'control')}
                           data-substep-order=${order}
                           data-path=${sub.path}
                           href=${sub.href ?? '#'}
@@ -114,7 +114,7 @@ function renderStep(
                 ? html`
                       <a
                           class="item-header"
-                          part=${withCurrentPart('step-link', isCurrent)}
+                          part=${withCurrentPart('step-link', isCurrent, 'control')}
                           data-path=${step.path}
                           href=${step.href ?? '#'}
                           @click=${onClickLink}

--- a/packages/core/src/components/stepper/stepper.renderer.ts
+++ b/packages/core/src/components/stepper/stepper.renderer.ts
@@ -30,7 +30,7 @@ function isGroupCurrent(node: NavigationNode, mode: NavigationMode): boolean {
     );
 }
 
-/** Compose la valeur `part=` d'un élément avec sa variante d'état "current" (convention BEM `--`). */
+/** Compose la valeur `part=` d'un élément avec son rôle transverse et sa variante d'état "current" (convention BEM `--`). */
 function withCurrentPart(base: string, isCurrent: boolean, role: string): string {
     return isCurrent ? `${base} ${role} ${base}--current` : `${base} ${role}`;
 }

--- a/packages/core/src/components/stepper/stepper.test.ts
+++ b/packages/core/src/components/stepper/stepper.test.ts
@@ -51,14 +51,36 @@ describe('ArStepper', () => {
             expect(shadow(el).querySelector('nav')).toBeNull();
         });
 
-        it('rend un <nav> avec part="nav" quand les items sont enregistrés', async () => {
+        it('rend un <nav> avec part="stepper" quand les items sont enregistrés', async () => {
             const el = await fixtureWithItems(`
                 <ar-stepper current-path="/a">
                     <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
                     <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
                 </ar-stepper>
             `);
-            expect(shadow(el).querySelector('[part="nav"]')).not.toBeNull();
+            expect(shadow(el).querySelector('[part="stepper"]')).not.toBeNull();
+        });
+
+        it('step-link porte aussi le rôle transverse "control"', async () => {
+            const el = await fixtureWithItems(`
+                <ar-stepper current-path="/b" mode="edit">
+                    <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
+                    <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
+                </ar-stepper>
+            `);
+            const link = shadow(el).querySelector('a[part~="step-link"]');
+            expect(link?.getAttribute('part')?.split(/\s+/)).toContain('control');
+        });
+
+        it('bullet porte aussi le rôle transverse "indicator"', async () => {
+            const el = await fixtureWithItems(`
+                <ar-stepper current-path="/a">
+                    <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>
+                    <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
+                </ar-stepper>
+            `);
+            const bullet = shadow(el).querySelector('[part~="bullet"]');
+            expect(bullet?.getAttribute('part')?.split(/\s+/)).toContain('indicator');
         });
 
         it('rend part="list" sur la liste des étapes', async () => {
@@ -113,7 +135,7 @@ describe('ArStepper', () => {
                     <ar-stepper-item path="/b" label="Étape B"></ar-stepper-item>
                 </ar-stepper>
             `);
-            expect(shadow(el).querySelector('[part="bullet"]')).not.toBeNull();
+            expect(shadow(el).querySelector('[part~="bullet"]')).not.toBeNull();
         });
 
         it('rend le part d\'état "bullet--current" uniquement sur la puce de l\'étape courante', async () => {
@@ -127,10 +149,10 @@ describe('ArStepper', () => {
             expect(steps.length).toBe(2);
 
             const bulletA = requireQuery<HTMLElement>(steps[0]!, '[part~="bullet"]');
-            expect(bulletA.getAttribute('part')).toBe('bullet bullet--current');
+            expect(bulletA.getAttribute('part')).toBe('bullet indicator bullet--current');
 
             const bulletB = requireQuery<HTMLElement>(steps[1]!, '[part~="bullet"]');
-            expect(bulletB.getAttribute('part')).toBe('bullet');
+            expect(bulletB.getAttribute('part')).toBe('bullet indicator');
         });
 
         it('rend le part d\'état "step-link--current" sur le lien de la sous-étape courante en mode edit', async () => {
@@ -153,8 +175,8 @@ describe('ArStepper', () => {
 
             const link1 = [...links].find((l) => l.getAttribute('data-path') === '/a/1');
             const link2 = [...links].find((l) => l.getAttribute('data-path') === '/a/2');
-            expect(link1?.getAttribute('part')).toBe('step-link');
-            expect(link2?.getAttribute('part')).toBe('step-link step-link--current');
+            expect(link1?.getAttribute('part')).toBe('step-link control');
+            expect(link2?.getAttribute('part')).toBe('step-link control step-link--current');
         });
 
         it('rend le part d\'état "bullet--current" sur la puce d\'une sous-étape courante', async () => {
@@ -171,8 +193,8 @@ describe('ArStepper', () => {
             );
             expect(substepBullets.length).toBe(2);
             const [bullet1, bullet2] = substepBullets;
-            expect(bullet1?.getAttribute('part')).toBe('bullet bullet--current');
-            expect(bullet2?.getAttribute('part')).toBe('bullet');
+            expect(bullet1?.getAttribute('part')).toBe('bullet indicator bullet--current');
+            expect(bullet2?.getAttribute('part')).toBe('bullet indicator');
         });
     });
 

--- a/packages/core/src/components/stepper/stepper.test.ts
+++ b/packages/core/src/components/stepper/stepper.test.ts
@@ -62,6 +62,8 @@ describe('ArStepper', () => {
         });
 
         it('step-link porte aussi le rôle transverse "control"', async () => {
+            // mode="edit" est requis pour que le renderer produise un vrai <a part="step-link ...">
+            // (sans ce mode, la garde de stepper.renderer.ts rend un simple <div>, sans part testable).
             const el = await fixtureWithItems(`
                 <ar-stepper current-path="/b" mode="edit">
                     <ar-stepper-item path="/a" label="Étape A"></ar-stepper-item>

--- a/packages/core/src/components/stepper/stepper.ts
+++ b/packages/core/src/components/stepper/stepper.ts
@@ -48,13 +48,15 @@ export interface ArStepperStepChangeDetail {
  *
  * @slot - Un ou plusieurs composant <ar-stepper-items>, potentiellement imbriqués pour créer des sous-étapes.
  *
- * @csspart nav          - L'élément `<nav>` englobant.
+ * @csspart stepper      - Racine du composant.
  * @csspart list         - La liste des étapes.
  * @csspart list--substep - La liste des sous-étapes (variante d'état de `list`).
  * @csspart step         - Une étape de premier niveau.
  * @csspart substep      - Une sous-étape.
  * @csspart step-link    - Le lien d'une étape.
+ * @csspart control      - Porté par `step-link` : élément interactif générique.
  * @csspart bullet       - La puce numérotée d'une étape.
+ * @csspart indicator    - Porté par `bullet` : marqueur/indicateur visuel.
  * @csspart bullet--current - La puce numérotée de l'étape courante (variante d'état de `bullet`).
  * @csspart step-link--current - Le lien de l'étape courante (variante d'état de `step-link`).
  * @csspart trigger      - Le bouton d'ouverture du panel mobile.
@@ -342,7 +344,7 @@ export class ArStepper extends LitElement {
                   this.onClickLink,
               );
 
-        return html` <nav part="nav" role="navigation" aria-labelledby="label-nav">
+        return html` <nav part="stepper" role="navigation" aria-labelledby="label-nav">
             <p id="label-nav" class="sr-only">Étapes du formulaire</p>
             ${content}
             <slot></slot>

--- a/packages/core/src/components/table-sort/table-sort.a11y.test.ts
+++ b/packages/core/src/components/table-sort/table-sort.a11y.test.ts
@@ -99,10 +99,12 @@ describe('ar-table-sort — accessibilité', () => {
 
         it('aria-disabled="true" pendant pending', async () => {
             const el = await fixture<ArTableSort>(html`<ar-table-sort>Nom</ar-table-sort>`);
-            el.shadowRoot!.querySelector<HTMLElement>('[part="button"]')!.click();
+            el.shadowRoot!.querySelector<HTMLElement>('[part~="sort-button"]')!.click();
             await el.updateComplete;
             expect(
-                el.shadowRoot!.querySelector('[part~="button"]')!.getAttribute('aria-disabled'),
+                el
+                    .shadowRoot!.querySelector('[part~="sort-button"]')!
+                    .getAttribute('aria-disabled'),
             ).to.equal('true');
         });
     });

--- a/packages/core/src/components/table-sort/table-sort.browser.test.ts
+++ b/packages/core/src/components/table-sort/table-sort.browser.test.ts
@@ -4,8 +4,8 @@ import type { ArTableSort } from './table-sort.js';
 import './index.js';
 
 function btn(el: ArTableSort): HTMLButtonElement {
-    const b = el.shadowRoot?.querySelector<HTMLButtonElement>('[part~="button"]');
-    if (!b) throw new Error('part="button" introuvable');
+    const b = el.shadowRoot?.querySelector<HTMLButtonElement>('[part~="sort-button"]');
+    if (!b) throw new Error('part="sort-button" introuvable');
     return b;
 }
 

--- a/packages/core/src/components/table-sort/table-sort.styles.ts
+++ b/packages/core/src/components/table-sort/table-sort.styles.ts
@@ -13,7 +13,7 @@ export default css`
         font-weight: normal;
     }
 
-    [part~='button'] {
+    [part~='sort-button'] {
         display: inline-flex;
         align-items: center;
         background: none;
@@ -25,7 +25,7 @@ export default css`
         text-align: inherit;
     }
 
-    [part~='button']:focus-visible {
+    [part~='sort-button']:focus-visible {
         outline: 2px solid currentColor;
         outline-offset: 2px;
         border-radius: 2px;

--- a/packages/core/src/components/table-sort/table-sort.test.ts
+++ b/packages/core/src/components/table-sort/table-sort.test.ts
@@ -43,8 +43,10 @@ describe('ArTableSort', () => {
             el = await fixture('<ar-table-sort></ar-table-sort>');
         });
 
-        it('contient part="button"', () => {
-            expect(getPart(el, 'button')).not.toBeNull();
+        it('contient part="sort-button action-button"', () => {
+            expect(getPart(el, 'sort-button')?.getAttribute('part')).toBe(
+                'sort-button action-button',
+            );
         });
 
         it('contient part="indicator"', () => {
@@ -115,7 +117,7 @@ describe('ArTableSort', () => {
     describe('label pendant pending', () => {
         it('tooltip = "Tri en cours…" pendant pending', async () => {
             el = await fixture('<ar-table-sort></ar-table-sort>');
-            (requirePart(el, 'button') as HTMLElement).click();
+            (requirePart(el, 'sort-button') as HTMLElement).click();
             await waitForUpdate(el);
             expect(tooltipLabel(el)).toBe('Tri en cours…');
         });
@@ -129,7 +131,7 @@ describe('ArTableSort', () => {
             const events: CustomEvent[] = [];
             el.addEventListener('ar-table-sort-change', (e) => events.push(e as CustomEvent));
 
-            (requirePart(el, 'button') as HTMLElement).click();
+            (requirePart(el, 'sort-button') as HTMLElement).click();
             await waitForUpdate(el);
 
             expect(el.pending).toBe(true);
@@ -145,7 +147,7 @@ describe('ArTableSort', () => {
             const events: CustomEvent[] = [];
             el.addEventListener('ar-table-sort-change', (e) => events.push(e as CustomEvent));
 
-            (requirePart(el, 'button') as HTMLElement).click();
+            (requirePart(el, 'sort-button') as HTMLElement).click();
             await waitForUpdate(el);
 
             expect(events[0].detail.columnLabel).toBe('Prix');
@@ -156,7 +158,7 @@ describe('ArTableSort', () => {
             const events: CustomEvent[] = [];
             el.addEventListener('ar-table-sort-change', (e) => events.push(e as CustomEvent));
 
-            (requirePart(el, 'button') as HTMLElement).click();
+            (requirePart(el, 'sort-button') as HTMLElement).click();
             await waitForUpdate(el);
             expect(events[0].detail.requestedOrder).toBe('desc');
         });
@@ -166,7 +168,7 @@ describe('ArTableSort', () => {
             const events: CustomEvent[] = [];
             el.addEventListener('ar-table-sort-change', (e) => events.push(e as CustomEvent));
 
-            (requirePart(el, 'button') as HTMLElement).click();
+            (requirePart(el, 'sort-button') as HTMLElement).click();
             await waitForUpdate(el);
             expect(events[0].detail.requestedOrder).toBe('none');
         });
@@ -176,7 +178,7 @@ describe('ArTableSort', () => {
             const events: CustomEvent[] = [];
             el.addEventListener('ar-table-sort-change', (e) => events.push(e as CustomEvent));
 
-            const btn = requirePart(el, 'button') as HTMLElement;
+            const btn = requirePart(el, 'sort-button') as HTMLElement;
             btn.click();
             await waitForUpdate(el);
             btn.click();
@@ -187,21 +189,21 @@ describe('ArTableSort', () => {
 
         it('aria-disabled="true" sur le bouton pendant pending', async () => {
             el = await fixture('<ar-table-sort></ar-table-sort>');
-            (requirePart(el, 'button') as HTMLElement).click();
+            (requirePart(el, 'sort-button') as HTMLElement).click();
             await waitForUpdate(el);
-            expect(requirePart(el, 'button').getAttribute('aria-disabled')).toBe('true');
+            expect(requirePart(el, 'sort-button').getAttribute('aria-disabled')).toBe('true');
         });
 
-        it('émet part="button button--pending" pendant pending', async () => {
+        it('émet part="sort-button sort-button--pending" pendant pending', async () => {
             el = await fixture('<ar-table-sort></ar-table-sort>');
-            (requirePart(el, 'button') as HTMLElement).click();
+            (requirePart(el, 'sort-button') as HTMLElement).click();
             await waitForUpdate(el);
-            expect(requirePart(el, 'button--pending')).not.toBeNull();
+            expect(requirePart(el, 'sort-button--pending')).not.toBeNull();
         });
 
-        it("n'émet pas button--pending avant le clic", async () => {
+        it("n'émet pas sort-button--pending avant le clic", async () => {
             el = await fixture('<ar-table-sort></ar-table-sort>');
-            expect(getPart(el, 'button--pending')).toBeNull();
+            expect(getPart(el, 'sort-button--pending')).toBeNull();
         });
     });
 
@@ -210,7 +212,7 @@ describe('ArTableSort', () => {
     describe('confirm()', () => {
         it('avance order et efface pending', async () => {
             el = await fixture('<ar-table-sort></ar-table-sort>');
-            (requirePart(el, 'button') as HTMLElement).click();
+            (requirePart(el, 'sort-button') as HTMLElement).click();
             await waitForUpdate(el);
 
             el.confirm();
@@ -231,7 +233,7 @@ describe('ArTableSort', () => {
 
         it('second confirm() consécutif sans effet', async () => {
             el = await fixture('<ar-table-sort></ar-table-sort>');
-            (requirePart(el, 'button') as HTMLElement).click();
+            (requirePart(el, 'sort-button') as HTMLElement).click();
             await waitForUpdate(el);
             el.confirm();
             await waitForUpdate(el);
@@ -246,7 +248,7 @@ describe('ArTableSort', () => {
     describe('reject()', () => {
         it('efface pending sans changer order', async () => {
             el = await fixture('<ar-table-sort></ar-table-sort>');
-            (requirePart(el, 'button') as HTMLElement).click();
+            (requirePart(el, 'sort-button') as HTMLElement).click();
             await waitForUpdate(el);
 
             el.reject();
@@ -313,7 +315,7 @@ describe('ArTableSort', () => {
 
         it('met à jour aria-sort après confirm()', async () => {
             const { th, el } = await inTh();
-            (requirePart(el, 'button') as HTMLElement).click();
+            (requirePart(el, 'sort-button') as HTMLElement).click();
             await waitForUpdate(el);
             el.confirm();
             await waitForUpdate(el);

--- a/packages/core/src/components/table-sort/table-sort.ts
+++ b/packages/core/src/components/table-sort/table-sort.ts
@@ -54,8 +54,9 @@ function getActionLabel(type: TableSortType, order: TableSortOrder, pending: boo
  *
  * @slot - Libellé de la colonne.
  *
- * @csspart button    - Le bouton déclencheur.
- * @csspart button--pending - Le bouton pendant l'attente de confirmation (variante d'état de `button`).
+ * @csspart sort-button    - Le bouton déclencheur.
+ * @csspart sort-button--pending - Le bouton pendant l'attente de confirmation (variante d'état de `sort-button`).
+ * @csspart action-button - Porté par `sort-button` : bouton qui déclenche une action ponctuelle.
  * @csspart indicator - L'icône de direction de tri.
  *
  * @cssprop --ar-table-sort-indicator-size - Taille de l'icône indicateur asc / desc.
@@ -172,7 +173,7 @@ export class ArTableSort extends LitElement {
         const label = getActionLabel(this.type, this.order, this.pending);
         return html`
             <button
-                part="button${this.pending ? ' button--pending' : ''}"
+                part="sort-button action-button${this.pending ? ' sort-button--pending' : ''}"
                 type="button"
                 aria-disabled=${this.pending ? 'true' : nothing}
                 @click=${this._handleClick}

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -1229,11 +1229,11 @@
     }
 
     ar-table-sort {
-        &::part(button) {
+        &::part(sort-button) {
             gap: 0.375rem;
         }
 
-        &::part(button--pending) {
+        &::part(sort-button--pending) {
             cursor: wait;
         }
 

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -920,7 +920,7 @@
         column-gap: 0.75rem;
 
         /* Customisation */
-        &::part(close) {
+        &::part(close-button) {
             border-radius: var(--ar-border-radius-md);
             color: currentColor;
             background-color: color-mix(in srgb, currentColor 8%, transparent);
@@ -930,12 +930,12 @@
             inset-inline-end: -0.2rem;
         }
 
-        &::part(close):hover {
+        &::part(close-button):hover {
             background-color: color-mix(in srgb, currentColor 20%, transparent);
             opacity: 1;
         }
 
-        &::part(close):focus-visible {
+        &::part(close-button):focus-visible {
             opacity: 1;
         }
 

--- a/packages/core/src/styles/themes/default.css
+++ b/packages/core/src/styles/themes/default.css
@@ -984,13 +984,13 @@
             border-radius: var(--ar-border-radius-lg);
         }
 
-        &::part(close) {
+        &::part(close-button) {
             border-radius: var(--ar-border-radius-md);
             color: currentColor;
             background-color: color-mix(in srgb, currentColor 8%, transparent);
         }
 
-        &::part(close):hover {
+        &::part(close-button):hover {
             background-color: color-mix(in srgb, currentColor 20%, transparent);
         }
 


### PR DESCRIPTION
## Résumé

Troisième lot du chantier #181 : rôle transverse `action-button` sur les boutons de commande
restants, additif sur un nom spécifique en toutes lettres (même schéma que le lot 1) :

- `ar-alert` : `close` → `part="close-button action-button"`
- `ar-dialog` : `close` → `part="close-button action-button"`
- `ar-table-sort` : `button` → `part="sort-button action-button"` (+ `button--pending` →
  `sort-button--pending`)

Complète aussi `ar-stepper`, oublié lors de l'audit du lot 2 :
- Part racine `nav` → `stepper` (remplacement, comme tous les autres composants du lot 2)
- `step-link` → rôle `control` additif
- `bullet` → rôle `indicator` additif

`ar-tooltip` et `ar-dropdown` ne sont pas concernés (cf. spec — la racine ne peut porter aucun
second rôle, et `ar-dropdown` est déjà conforme). Le thème par défaut (`themes/default.css`) est
mis à jour dans chaque commit correspondant, pour éviter la régression trouvée en revue finale du
lot 2 (sélecteurs `::part()` orphelins après un renommage de part).

**Revue finale de branche** : correctif d'un bug non-spec de happy-dom (environnement DOM de
Vitest) qui scinde aussi les valeurs d'attribut sur les tirets — une quinzaine d'assertions dans
`alert.test.ts`/`dialog.test.ts` recherchaient encore le token `close` au lieu de `close-button`,
et ne passaient que grâce à ce bug d'émulation (jamais en navigateur réel). Le plan lui-même
affirmait à tort que ces tests continueraient de fonctionner sans changement — corrigé.

Spec : `docs/superpowers/specs/2026-08-13-role-parts-vocabulary-181-design.md`
Plan : `docs/superpowers/plans/2026-08-14-role-parts-vocabulary-181-lot3.md`

## Test plan

- [x] `npm test --workspace=packages/core` — 933/933 PASS
- [x] `npm run test:browser --workspace=packages/core` — 273/273 PASS
- [x] `npm run test:a11y --workspace=apps/docs` — 24/24 PASS
- [x] `npm run build:manifest --workspace=packages/core && npm run build --workspace=apps/docs` — succès

🤖 Generated with [Claude Code](https://claude.com/claude-code)