### PR TITLE
feat(core): lot 2 i18n — pagination, stepper, breadcrumb, charcounter, spinner, dialog, alert (#80)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Web components library pour patterns UI accessibles, Lit 3 + TypeScript. Monorep
 - Toujours `import type` pour les imports de types
 - Conventional Commits (commitlint + Husky)
 - CSS tokens `--doc-*` (`apps/docs/`) ne forcent jamais un ajout dans `packages/core`
+- Un `${expr}` seul contenu d'un élément texte (sr-only, label…) dans un template Lit : si la ligne dépasse 100 caractères, Prettier peut le wrapper d'une façon qui insère des nœuds de texte (espaces) dans le DOM rendu, corrompant `textContent`/le nom accessible. Extraire la valeur en `const` avant le template plutôt que d'inliner un appel long.
 
 ## Philosophie de conception
 

--- a/docs/superpowers/plans/2026-08-14-i18n-lot2.md
+++ b/docs/superpowers/plans/2026-08-14-i18n-lot2.md
@@ -1,0 +1,1341 @@
+# Lot 2 i18n — pagination, stepper, breadcrumb, charcounter, spinner, dialog, alert — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrer les chaînes FR hardcodées de `ar-pagination`, `ar-stepper`, `ar-breadcrumb`,
+`ar-charcounter`, `ar-spinner`, `ar-dialog`, `ar-alert` vers le mécanisme i18n
+`@shoelace-style/localize` livré en lot 1, en suivant la spec
+`docs/superpowers/specs/2026-08-14-i18n-lot2-design.md`.
+
+**Architecture:** Chaque composant importe `LocalizeController` et lit ses textes via
+`this.localize.term('clé', ...args)` au lieu de littéraux FR en dur. Les termes sont ajoutés au
+type `Translation` partagé et à `fr.ts`/`en.ts`. Trois props texte déjà personnalisables
+(`ar-dialog.closeLabel`/`preventedMessage`, `ar-spinner.loadingLabel`/`doneLabel`,
+`ar-charcounter.label`) passent au sentinel `undefined` (`useDefault: true`) pour distinguer
+« jamais personnalisé » (traduction dynamique) de « vidé explicitement » (garde `warn()` toujours
+valide pour `ar-spinner`).
+
+**Tech Stack:** Lit 3, TypeScript, `@shoelace-style/localize`, Vitest (happy-dom) + `@web/test-runner` (Chromium).
+
+## Global Constraints
+
+- Prettier 100 caractères, 4 espaces, quotes simples (`packages/core/.prettierrc` déjà configuré,
+  aucune action requise — le hook `lint-staged` reformate au commit).
+- `import type` obligatoire pour tous les imports de purs types.
+- `exactOptionalPropertyTypes: true` — toute prop `T | undefined` doit être déclarée `prop?: T` ou
+  `prop: T | undefined` explicitement typée, jamais `prop: T` avec un défaut `undefined` implicite.
+- Conventional Commits pour chaque commit de tâche (`feat(core): ...`, `test(core): ...`).
+- `document.documentElement.lang = 'fr';` en tête de **tout** fichier de test (`*.test.ts` Vitest
+  et `*.a11y.test.ts`/`*.browser.test.ts` WTR) qui assert du texte traduit par défaut — copier
+  exactement le commentaire du pattern déjà utilisé dans `datepicker.test.ts:6-10` :
+    ```ts
+    // LocalizeController résout la langue via document.documentElement.lang, avec
+    // navigator.language comme secours (happy-dom retourne 'en-US' par défaut).
+    // En production, le site de doc pose lang="fr" sur <html> ; on reproduit ça ici
+    // pour que les assertions FR par défaut restent valides sans lang explicite.
+    document.documentElement.lang = 'fr';
+    ```
+- Import des traductions dans chaque composant migré (ordre fr puis en, comme dans
+  `datepicker.ts:11-13`) :
+    ```ts
+    // fr avant en : la première traduction enregistrée devient le repli de la lib pour les langues non reconnues.
+    import '../../translations/fr.js';
+    import '../../translations/en.js';
+    ```
+- `@localized` ajouté au bloc JSDoc de classe de chaque composant migré (juste après `@display
+demo`, comme `datepicker.ts:17-18`).
+- `private readonly localize = new LocalizeController(this);` comme dans `datepicker.ts:131` /
+  `table-sort.ts:60`.
+- Aucun composant de ce lot n'a de popover sauf `ar-dialog` (natif `<dialog>`, pas de
+  `popover="auto"`) — `mockPopoverPanel()` n'est **pas** nécessaire dans ce lot (seul
+  `ar-breadcrumb`/`ar-stepper` ont un popover, non touché par ce lot pour leur mécanisme
+  d'ouverture, seulement pour leurs textes statiques).
+- Chaque tâche se termine verte : `npm test --workspace=packages/core -- <fichier>` (Vitest) avant
+  commit. Les fichiers `*.a11y.test.ts`/`*.browser.test.ts` (WTR/Chromium) sont vérifiés dans la
+  revue finale de branche via `npm run test:all`, pas à chaque tâche (plus lent à démarrer).
+
+---
+
+## Task 1: Contrat de traduction — nouveaux termes + renommage `close`→`closeCalendar`
+
+**Files:**
+
+- Modify: `packages/core/src/types/translation.ts`
+- Modify: `packages/core/src/translations/fr.ts`
+- Modify: `packages/core/src/translations/en.ts`
+- Modify: `packages/core/src/translations/translations.test.ts`
+- Modify: `packages/core/src/components/datepicker/datepicker.ts` (renommage d'usage du terme)
+
+**Interfaces:**
+
+- Produces: les termes suivants, disponibles pour toutes les tâches suivantes via
+  `this.localize.term('<clé>', ...args)` :
+    - `previousPage(page: number, total: number): string`
+    - `nextPage(page: number, total: number): string`
+    - `pageStatus(page: number, total: number): string`
+    - `compactPageStatus(current: number, total: number): string`
+    - `goToPage: string`
+    - `stepperNavLabel: string`
+    - `breadcrumbNavLabel: string`
+    - `showBreadcrumb: string`
+    - `remainingLabel: string`
+    - `excessMessage(count: number): string`
+    - `loading: string`
+    - `loadingDone: string`
+    - `closeCalendar: string` (renommage de `close`, déjà consommé par `ar-datepicker`)
+    - `closeDialog: string`
+    - `closingBlocked: string`
+    - `dialogDefaultLabel: string`
+    - `closeAlert: string`
+
+- [ ] **Step 1: Étendre le type `Translation`**
+
+Remplacer entièrement le contenu de `packages/core/src/types/translation.ts` par :
+
+```ts
+import type { Translation as BaseTranslation } from '@shoelace-style/localize';
+import type { TableSortType, TableSortOrder } from '../components/table-sort/table-sort.js';
+
+/**
+ * Contrat de traduction d'Ariane — étend le type de base de @shoelace-style/localize.
+ * Un seul type plat regroupant les termes de tous les composants traduits (pas d'augmentation
+ * par composant), à l'image du modèle Shoelace/WebAwesome. Groupé par composant en commentaire
+ * ci-dessous (et dans src/translations/{fr,en}.ts) — si des termes finissent par être partagés
+ * entre plusieurs composants, les regrouper sous un commentaire dédié plutôt que de les dupliquer.
+ */
+export interface Translation extends BaseTranslation {
+    // ar-table-sort
+    sortAscending: (type: TableSortType) => string;
+    sortDescending: (type: TableSortType) => string;
+    sortReset: (type: TableSortType) => string;
+    sortPending: string;
+    sortInProgress: string;
+    sortApplied: (columnLabel: string, order: TableSortOrder) => string;
+    sortFailed: (columnLabel: string) => string;
+
+    // ar-datepicker
+    today: string;
+    closeCalendar: string;
+    openCalendar: string;
+    selectDate: string;
+    previousYear: string;
+    previousMonth: string;
+    nextMonth: string;
+    nextYear: string;
+    daySelected: (formattedDate: string) => string;
+    expectedFormat: (format: string, example: string) => string;
+    availableDates: (range: string) => string;
+    dateRangeBetween: (from: string, to: string) => string;
+    dateRangeFrom: (from: string) => string;
+    dateRangeUntil: (to: string) => string;
+    /** `monthYearText`/`fullDateText` sont déjà formatés via Intl (locale-aware) — le terme
+     *  décide seulement s'il faut un marqueur ordinal (ex. « 1er » en français). */
+    formatOrdinalDate: (date: Date, monthYearText: string, fullDateText: string) => string;
+
+    // ar-pagination
+    previousPage: (page: number, total: number) => string;
+    nextPage: (page: number, total: number) => string;
+    pageStatus: (page: number, total: number) => string;
+    compactPageStatus: (current: number, total: number) => string;
+    goToPage: string;
+
+    // ar-stepper
+    stepperNavLabel: string;
+
+    // ar-breadcrumb
+    breadcrumbNavLabel: string;
+    showBreadcrumb: string;
+
+    // ar-charcounter
+    remainingLabel: string;
+    excessMessage: (count: number) => string;
+
+    // ar-spinner
+    loading: string;
+    loadingDone: string;
+
+    // ar-dialog
+    closeDialog: string;
+    closingBlocked: string;
+    dialogDefaultLabel: string;
+
+    // ar-alert
+    closeAlert: string;
+}
+```
+
+- [ ] **Step 2: Étendre `fr.ts`**
+
+Dans `packages/core/src/translations/fr.ts`, renommer `close: 'Fermer',` en
+`closeCalendar: 'Fermer le calendrier',` (même ligne, même position dans le bloc
+`// ── ar-datepicker ──`), puis ajouter les nouveaux blocs juste après le bloc
+`// ── ar-datepicker ──` existant (avant `};` final) :
+
+```ts
+    // ── ar-pagination ────────────────────────────────────────────────────
+    previousPage: (page, total) => `Page précédente (page ${page} sur ${total})`,
+    nextPage: (page, total) => `Page suivante (page ${page} sur ${total})`,
+    pageStatus: (page, total) => `Page ${page} sur ${total}`,
+    compactPageStatus: (current, total) => `Page ${current} / ${total}`,
+    goToPage: 'Aller à la page',
+
+    // ── ar-stepper ───────────────────────────────────────────────────────
+    stepperNavLabel: 'Étapes du formulaire',
+
+    // ── ar-breadcrumb ────────────────────────────────────────────────────
+    breadcrumbNavLabel: 'Vous êtes ici',
+    showBreadcrumb: "Afficher le fil d'ariane",
+
+    // ── ar-charcounter ───────────────────────────────────────────────────
+    remainingLabel: 'caractère restant|caractères restants',
+    excessMessage: (count) =>
+        `Limite dépassée de ${count} ${count === 1 ? 'caractère' : 'caractères'}`,
+
+    // ── ar-spinner ───────────────────────────────────────────────────────
+    loading: 'Contenu en cours de chargement',
+    loadingDone: 'Chargement terminé',
+
+    // ── ar-dialog ────────────────────────────────────────────────────────
+    closeDialog: 'Fermer la boîte de dialogue',
+    closingBlocked: 'Fermeture bloquée.',
+    dialogDefaultLabel: 'Dialogue',
+
+    // ── ar-alert ─────────────────────────────────────────────────────────
+    closeAlert: "Fermer l'alerte",
+```
+
+- [ ] **Step 3: Étendre `en.ts`**
+
+Même traitement dans `packages/core/src/translations/en.ts` : renommer `close: 'Close',` en
+`closeCalendar: 'Close calendar',`, puis ajouter :
+
+```ts
+    // ── ar-pagination ────────────────────────────────────────────────────
+    previousPage: (page, total) => `Previous page (page ${page} of ${total})`,
+    nextPage: (page, total) => `Next page (page ${page} of ${total})`,
+    pageStatus: (page, total) => `Page ${page} of ${total}`,
+    compactPageStatus: (current, total) => `Page ${current} / ${total}`,
+    goToPage: 'Go to page',
+
+    // ── ar-stepper ───────────────────────────────────────────────────────
+    stepperNavLabel: 'Form steps',
+
+    // ── ar-breadcrumb ────────────────────────────────────────────────────
+    breadcrumbNavLabel: 'You are here',
+    showBreadcrumb: 'Show breadcrumb',
+
+    // ── ar-charcounter ───────────────────────────────────────────────────
+    remainingLabel: 'character remaining|characters remaining',
+    excessMessage: (count) => `Limit exceeded by ${count} ${count === 1 ? 'character' : 'characters'}`,
+
+    // ── ar-spinner ───────────────────────────────────────────────────────
+    loading: 'Content is loading',
+    loadingDone: 'Loading complete',
+
+    // ── ar-dialog ────────────────────────────────────────────────────────
+    closeDialog: 'Close dialog',
+    closingBlocked: 'Closing blocked.',
+    dialogDefaultLabel: 'Dialog',
+
+    // ── ar-alert ─────────────────────────────────────────────────────────
+    closeAlert: 'Close alert',
+```
+
+- [ ] **Step 4: Renommer l'usage du terme dans `ar-datepicker`**
+
+Dans `packages/core/src/components/datepicker/datepicker.ts`, remplacer l'unique occurrence de
+`this.localize.term('close')` par `this.localize.term('closeCalendar')`.
+
+- [ ] **Step 5: Mettre à jour `translations.test.ts`**
+
+Dans `packages/core/src/translations/translations.test.ts`, remplacer les deux tests suivants :
+
+```ts
+it('fr expose les libellés de navigation du calendrier', () => {
+    expect(fr.openCalendar).toBe('Ouvrir le calendrier');
+    expect(fr.selectDate).toBe('Sélectionner une date');
+    expect(fr.previousYear).toBe('Année précédente');
+    expect(fr.previousMonth).toBe('Mois précédent');
+    expect(fr.nextMonth).toBe('Mois suivant');
+    expect(fr.nextYear).toBe('Année suivante');
+});
+```
+
+reste inchangé (ne mentionne pas `close`), mais ajouter juste après ce bloc (et avant
+`it('fr.expectedFormat interpole format et exemple'`) :
+
+```ts
+it('fr.closeCalendar est traduit', () => {
+    expect(fr.closeCalendar).toBe('Fermer le calendrier');
+});
+
+it('en.closeCalendar est traduit', () => {
+    expect(en.closeCalendar).toBe('Close calendar');
+});
+```
+
+Puis ajouter à la fin du fichier, avant le `});` final de `describe('traductions', ...)` :
+
+```ts
+it('fr expose les termes de pagination', () => {
+    expect(fr.previousPage(2, 5)).toBe('Page précédente (page 2 sur 5)');
+    expect(fr.nextPage(3, 5)).toBe('Page suivante (page 3 sur 5)');
+    expect(fr.pageStatus(4, 5)).toBe('Page 4 sur 5');
+    expect(fr.compactPageStatus(4, 5)).toBe('Page 4 / 5');
+    expect(fr.goToPage).toBe('Aller à la page');
+});
+
+it('en expose les termes de pagination', () => {
+    expect(en.previousPage(2, 5)).toBe('Previous page (page 2 of 5)');
+    expect(en.nextPage(3, 5)).toBe('Next page (page 3 of 5)');
+    expect(en.pageStatus(4, 5)).toBe('Page 4 of 5');
+    expect(en.compactPageStatus(4, 5)).toBe('Page 4 / 5');
+    expect(en.goToPage).toBe('Go to page');
+});
+
+it('fr/en exposent stepperNavLabel', () => {
+    expect(fr.stepperNavLabel).toBe('Étapes du formulaire');
+    expect(en.stepperNavLabel).toBe('Form steps');
+});
+
+it('fr/en exposent les termes de breadcrumb', () => {
+    expect(fr.breadcrumbNavLabel).toBe('Vous êtes ici');
+    expect(fr.showBreadcrumb).toBe("Afficher le fil d'ariane");
+    expect(en.breadcrumbNavLabel).toBe('You are here');
+    expect(en.showBreadcrumb).toBe('Show breadcrumb');
+});
+
+it('fr.remainingLabel/excessMessage sont corrects', () => {
+    expect(fr.remainingLabel).toBe('caractère restant|caractères restants');
+    expect(fr.excessMessage(1)).toBe('Limite dépassée de 1 caractère');
+    expect(fr.excessMessage(3)).toBe('Limite dépassée de 3 caractères');
+});
+
+it('en.remainingLabel/excessMessage sont corrects', () => {
+    expect(en.remainingLabel).toBe('character remaining|characters remaining');
+    expect(en.excessMessage(1)).toBe('Limit exceeded by 1 character');
+    expect(en.excessMessage(3)).toBe('Limit exceeded by 3 characters');
+});
+
+it('fr/en exposent loading/loadingDone', () => {
+    expect(fr.loading).toBe('Contenu en cours de chargement');
+    expect(fr.loadingDone).toBe('Chargement terminé');
+    expect(en.loading).toBe('Content is loading');
+    expect(en.loadingDone).toBe('Loading complete');
+});
+
+it('fr/en exposent les termes de dialog', () => {
+    expect(fr.closeDialog).toBe('Fermer la boîte de dialogue');
+    expect(fr.closingBlocked).toBe('Fermeture bloquée.');
+    expect(fr.dialogDefaultLabel).toBe('Dialogue');
+    expect(en.closeDialog).toBe('Close dialog');
+    expect(en.closingBlocked).toBe('Closing blocked.');
+    expect(en.dialogDefaultLabel).toBe('Dialog');
+});
+
+it('fr/en exposent closeAlert', () => {
+    expect(fr.closeAlert).toBe("Fermer l'alerte");
+    expect(en.closeAlert).toBe('Close alert');
+});
+```
+
+- [ ] **Step 6: Run tests to verify everything passes**
+
+Run: `npm test --workspace=packages/core -- translations.test.ts datepicker.test.ts`
+Expected: PASS — le renommage `close`→`closeCalendar` ne casse aucun test datepicker existant (aucun
+test n'assert sur le terme `close` par sa clé, seulement sur le texte rendu "Fermer", inchangé).
+
+- [ ] **Step 7: Run full typecheck**
+
+Run: `npm run typecheck --workspace=packages/core` (ou `npx tsc --noEmit` depuis `packages/core` si
+le script n'existe pas sous ce nom — vérifier `packages/core/package.json`)
+Expected: 0 erreur — le type `Translation` étendu est cohérent avec `fr.ts`/`en.ts`, qui
+implémentent chacun **tous** les champs (TypeScript échoue sinon avec "missing properties").
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/core/src/types/translation.ts packages/core/src/translations/fr.ts \
+    packages/core/src/translations/en.ts packages/core/src/translations/translations.test.ts \
+    packages/core/src/components/datepicker/datepicker.ts
+git commit -m "feat(core): étend le contrat Translation pour le lot 2 i18n (#80)"
+```
+
+---
+
+## Task 2: ar-pagination
+
+**Files:**
+
+- Modify: `packages/core/src/components/pagination/pagination.ts`
+- Modify: `packages/core/src/components/pagination/pagination.test.ts`
+
+**Interfaces:**
+
+- Consumes: `previousPage`, `nextPage`, `pageStatus`, `compactPageStatus`, `goToPage` (Task 1).
+
+- [ ] **Step 1: Ajouter le pin de langue en tête de `pagination.test.ts`**
+
+Dans `packages/core/src/components/pagination/pagination.test.ts`, juste après les imports (ligne 4,
+avant `function requirePart`), insérer :
+
+```ts
+// LocalizeController résout la langue via document.documentElement.lang, avec
+// navigator.language comme secours (happy-dom retourne 'en-US' par défaut).
+// En production, le site de doc pose lang="fr" sur <html> ; on reproduit ça ici
+// pour que les assertions FR par défaut restent valides sans lang explicite.
+document.documentElement.lang = 'fr';
+```
+
+- [ ] **Step 2: Run les tests existants pour vérifier qu'ils passent toujours (pin seul, pas encore de migration)**
+
+Run: `npm test --workspace=packages/core -- pagination.test.ts`
+Expected: PASS (aucun changement de comportement à ce stade)
+
+- [ ] **Step 3: Ajouter un test de traduction (lang="en")**
+
+Ajouter dans `pagination.test.ts`, dans le describe principal, une nouvelle section :
+
+```ts
+describe('traduction', () => {
+    afterEach(() => {
+        el.removeAttribute('lang');
+    });
+
+    it('lang="en" traduit les sr-only prev/next et le label du select', async () => {
+        el = await fixture('<ar-pagination current="8" total="15" lang="en"></ar-pagination>');
+        const prevSrOnly = requirePart(el, 'prev').querySelector('.sr-only');
+        const nextSrOnly = requirePart(el, 'next').querySelector('.sr-only');
+        expect(prevSrOnly?.textContent).toBe('Previous page (page 7 of 15)');
+        expect(nextSrOnly?.textContent).toBe('Next page (page 9 of 15)');
+    });
+
+    it('lang="en" traduit le label compact', async () => {
+        el = await fixture(
+            '<ar-pagination current="2" total="5" compact lang="en"></ar-pagination>',
+        );
+        const label = getPart(el, 'label');
+        expect(label?.textContent).toBe('Page 2 / 5');
+    });
+});
+```
+
+- [ ] **Step 4: Run pour vérifier l'échec (terme pas encore branché)**
+
+Run: `npm test --workspace=packages/core -- pagination.test.ts -t "traduction"`
+Expected: FAIL — le texte reste en FR quel que soit `lang` (pas encore de `LocalizeController`).
+
+- [ ] **Step 5: Migrer `pagination.ts`**
+
+Ajouter les imports en tête de `packages/core/src/components/pagination/pagination.ts` (après les
+imports existants, avant la déclaration de `ArPaginationConfig`) :
+
+```ts
+import { LocalizeController } from '../../controllers/localize.controller.js';
+// fr avant en : la première traduction enregistrée devient le repli de la lib pour les langues non reconnues.
+import '../../translations/fr.js';
+import '../../translations/en.js';
+```
+
+Ajouter `@localized` au bloc JSDoc de la classe, juste après `@display demo` (ligne 28) :
+
+```
+ * @display demo
+ * @localized
+```
+
+Ajouter le controller comme premier membre de la classe `ArPagination`, avant
+`static readonly DEFAULT_CURRENT` :
+
+```ts
+    private readonly localize = new LocalizeController(this);
+
+```
+
+Remplacer dans `render()` le `<span class="sr-only">Page précédente (page ${previousPageNumber} sur ${total})</span>` par :
+
+```ts
+<span class="sr-only">${this.localize.term('previousPage', previousPageNumber, total)}</span>
+```
+
+et `<span class="sr-only">Page suivante (page ${nextPageNumber} sur ${total})</span>` par :
+
+```ts
+<span class="sr-only">${this.localize.term('nextPage', nextPageNumber, total)}</span>
+```
+
+Remplacer `renderPageLabel()` :
+
+```ts
+    protected renderPageLabel(page: number, total: number): TemplateResult {
+        return html`<span class="sr-only">${this.localize.term('pageStatus', page, total)}</span
+            ><span aria-hidden="true">${page}</span>`;
+    }
+```
+
+Remplacer `renderPageSelect()` — le `<span class="sr-only" id="ar-pagination-select-label">Aller à
+la page</span>` devient :
+
+```ts
+<span class="sr-only" id="ar-pagination-select-label">${this.localize.term('goToPage')}</span>
+```
+
+et l'option `Page ${page} sur ${total}` devient :
+
+```ts
+: html`<option value=${page} ?selected=${page === current}>
+      ${this.localize.term('pageStatus', page, total)}
+  </option>`,
+```
+
+Remplacer `renderCompactLabel()` :
+
+```ts
+    protected renderCompactLabel(current: number, total: number): TemplateResult {
+        return html`<li part="item page-label" aria-hidden="true">
+            <span part="label">${this.localize.term('compactPageStatus', current, total)}</span>
+        </li>`;
+    }
+```
+
+Remplacer `_announcePageChange()` :
+
+```ts
+    private _announcePageChange(): void {
+        announceA11y(this.localize.term('pageStatus', this.current, this.total), 'polite');
+    }
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `npm test --workspace=packages/core -- pagination.test.ts`
+Expected: PASS — tests existants (FR, via le pin de langue) et les 2 nouveaux tests `lang="en"`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/src/components/pagination/pagination.ts \
+    packages/core/src/components/pagination/pagination.test.ts
+git commit -m "feat(core): traduit ar-pagination via LocalizeController (#80)"
+```
+
+---
+
+## Task 3: ar-stepper
+
+**Files:**
+
+- Modify: `packages/core/src/components/stepper/stepper.ts`
+- Modify: `packages/core/src/components/stepper/stepper.test.ts`
+
+**Interfaces:**
+
+- Consumes: `stepperNavLabel` (Task 1).
+
+- [ ] **Step 1: Ajouter le pin de langue en tête de `stepper.test.ts`**
+
+Après les imports existants (ligne 6, avant `// ─── Helpers`), insérer le même bloc de commentaire +
+`document.documentElement.lang = 'fr';` que dans Task 2 Step 1.
+
+- [ ] **Step 2: Run pour vérifier que rien ne casse**
+
+Run: `npm test --workspace=packages/core -- stepper.test.ts`
+Expected: PASS
+
+- [ ] **Step 3: Ajouter un test de traduction**
+
+Ajouter dans `stepper.test.ts` :
+
+```ts
+describe('traduction', () => {
+    it('lang="en" traduit le label de navigation', async () => {
+        const el = await fixture<ArStepper>(
+            '<ar-stepper current-path="/a" lang="en"><ar-stepper-item href="/a" label="A"></ar-stepper-item></ar-stepper>',
+        );
+        await waitForUpdate(el);
+        const label = el.shadowRoot?.querySelector('#label-nav');
+        expect(label?.textContent).toBe('Form steps');
+        el.remove();
+    });
+});
+```
+
+(Adapter l'import du type `ArStepper` : déjà importé en tête de fichier via
+`import type { ArStepper } from './stepper.js';`.)
+
+- [ ] **Step 4: Run pour vérifier l'échec**
+
+Run: `npm test --workspace=packages/core -- stepper.test.ts -t "traduction"`
+Expected: FAIL — le label reste "Étapes du formulaire" quel que soit `lang`.
+
+- [ ] **Step 5: Migrer `stepper.ts`**
+
+Ajouter les imports (après les imports existants, avant `/** Détail de l'événement... */`) :
+
+```ts
+import { LocalizeController } from '../../controllers/localize.controller.js';
+// fr avant en : la première traduction enregistrée devient le repli de la lib pour les langues non reconnues.
+import '../../translations/fr.js';
+import '../../translations/en.js';
+```
+
+Ajouter `@localized` après `@display demo` (ligne 39) dans le JSDoc de classe.
+
+Ajouter le controller comme premier membre de `ArStepper`, avant
+`@property({ type: String, attribute: 'current-path' })` :
+
+```ts
+    private readonly localize = new LocalizeController(this);
+
+```
+
+Remplacer dans `render()` :
+
+```ts
+        return html` <nav part="stepper" role="navigation" aria-labelledby="label-nav">
+            <p id="label-nav" class="sr-only">${this.localize.term('stepperNavLabel')}</p>
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `npm test --workspace=packages/core -- stepper.test.ts`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/src/components/stepper/stepper.ts \
+    packages/core/src/components/stepper/stepper.test.ts
+git commit -m "feat(core): traduit ar-stepper via LocalizeController (#80)"
+```
+
+---
+
+## Task 4: ar-breadcrumb
+
+**Files:**
+
+- Modify: `packages/core/src/components/breadcrumb/breadcrumb.ts`
+- Modify: `packages/core/src/components/breadcrumb/breadcrumb.test.ts`
+
+**Interfaces:**
+
+- Consumes: `breadcrumbNavLabel`, `showBreadcrumb` (Task 1).
+
+- [ ] **Step 1: Ajouter le pin de langue en tête de `breadcrumb.test.ts`**
+
+Après les imports existants (ligne 5, avant `type LitEl = ...`), insérer le même bloc que Task 2
+Step 1.
+
+- [ ] **Step 2: Run pour vérifier que rien ne casse**
+
+Run: `npm test --workspace=packages/core -- breadcrumb.test.ts`
+Expected: PASS — le test existant `un label sr-only "Vous êtes ici" est présent` (ligne 620)
+continue de passer grâce au pin FR.
+
+- [ ] **Step 3: Ajouter des tests de traduction**
+
+Ajouter dans `breadcrumb.test.ts` :
+
+```ts
+describe('traduction', () => {
+    it('lang="en" traduit le label de navigation', async () => {
+        document.body.innerHTML = `
+            <ar-breadcrumb lang="en">
+                <ar-breadcrumb-item href="/" label="Home"></ar-breadcrumb-item>
+                <ar-breadcrumb-item label="Current"></ar-breadcrumb-item>
+            </ar-breadcrumb>`;
+        const el = document.querySelector('ar-breadcrumb') as ArBreadcrumb & LitEl;
+        await el.updateComplete;
+        const label = el.shadowRoot?.querySelector('#breadcrumb-label');
+        expect(label?.textContent?.trim()).toBe('You are here');
+    });
+});
+```
+
+Vérifier l'import de `ArBreadcrumb` (déjà présent en tête de fichier) et du type `LitEl` (déjà
+défini localement, ligne 7).
+
+- [ ] **Step 4: Run pour vérifier l'échec**
+
+Run: `npm test --workspace=packages/core -- breadcrumb.test.ts -t "traduction"`
+Expected: FAIL
+
+- [ ] **Step 5: Migrer `breadcrumb.ts`**
+
+Ajouter les imports (après les imports existants, avant `/** @summary ...`) :
+
+```ts
+import { LocalizeController } from '../../controllers/localize.controller.js';
+// fr avant en : la première traduction enregistrée devient le repli de la lib pour les langues non reconnues.
+import '../../translations/fr.js';
+import '../../translations/en.js';
+```
+
+Ajouter `@localized` après `@display demo` (ligne 24) dans le JSDoc de classe.
+
+Ajouter le controller comme premier membre de `ArBreadcrumb`, avant
+`static mobileQuery: MediaQueryList` :
+
+```ts
+    private readonly localize = new LocalizeController(this);
+
+```
+
+Remplacer dans `render()` :
+
+```ts
+                <p id="breadcrumb-label" class="sr-only">${this.localize.term('breadcrumbNavLabel')}</p>
+```
+
+et
+
+```ts
+                              <span class="sr-only">${this.localize.term('showBreadcrumb')}</span>
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `npm test --workspace=packages/core -- breadcrumb.test.ts`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/src/components/breadcrumb/breadcrumb.ts \
+    packages/core/src/components/breadcrumb/breadcrumb.test.ts
+git commit -m "feat(core): traduit ar-breadcrumb via LocalizeController (#80)"
+```
+
+---
+
+## Task 5: ar-charcounter
+
+**Files:**
+
+- Modify: `packages/core/src/components/charcounter/charcounter.ts`
+- Modify: `packages/core/src/components/charcounter/charcounter.test.ts`
+- Modify: `packages/core/src/components/charcounter/charcounter.a11y.test.ts`
+
+**Interfaces:**
+
+- Consumes: `remainingLabel`, `excessMessage` (Task 1).
+- Produces: `label` passe de `string` à `string | undefined` (défaut `undefined`,
+  `useDefault: true`) — pattern à reproduire dans Task 6 (`ar-spinner`) et Task 7 (`ar-dialog`).
+
+- [ ] **Step 1: Ajouter le pin de langue en tête de `charcounter.test.ts` et `charcounter.a11y.test.ts`**
+
+Dans `charcounter.test.ts`, après les imports (ligne 3, avant `describe('ArCharcounter'`), insérer
+le même bloc que Task 2 Step 1.
+
+Dans `charcounter.a11y.test.ts`, après les imports (ligne 3, avant `describe('ar-charcounter`),
+insérer :
+
+```ts
+// LocalizeController résout la langue via document.documentElement.lang, avec
+// navigator.language comme secours (le runner Chromium peut différer selon l'environnement CI).
+// En production, le site de doc pose lang="fr" sur <html> ; on reproduit ça ici
+// pour que les assertions FR par défaut restent valides sans lang explicite.
+document.documentElement.lang = 'fr';
+```
+
+- [ ] **Step 2: Mettre à jour le test de valeur par défaut de `label`**
+
+Dans `charcounter.test.ts`, remplacer :
+
+```ts
+it('label vaut "caractère restant|caractères restants"', () =>
+    expect(el.label).toBe('caractère restant|caractères restants'));
+```
+
+par :
+
+```ts
+it('label vaut undefined par défaut (traduit dynamiquement)', () =>
+    expect(el.label).toBeUndefined());
+```
+
+- [ ] **Step 3: Run pour vérifier que le reste passe déjà (hors ce test, à ajuster en Step 5)**
+
+Run: `npm test --workspace=packages/core -- charcounter.test.ts`
+Expected: FAIL sur `label vaut undefined par défaut` uniquement (attendu — pas encore migré) ; le
+reste passe.
+
+- [ ] **Step 4: Ajouter des tests de traduction**
+
+Ajouter dans `charcounter.test.ts`, dans une nouvelle section :
+
+```ts
+describe('traduction', () => {
+    it('lang="en" traduit le label et le message de dépassement', async () => {
+        document.body.innerHTML = '<textarea id="f"></textarea>';
+        el = await fixture('<ar-charcounter for="f" max="5" lang="en"></ar-charcounter>');
+        const field = document.getElementById('f') as HTMLTextAreaElement;
+        expect(getPart(el, 'label')?.textContent?.trim()).toBe('characters remaining');
+
+        field.value = '123456';
+        field.dispatchEvent(new Event('input'));
+        await waitForUpdate(el);
+        await new Promise((resolve) => setTimeout(resolve, 350));
+        expect(document.getElementById('ar-live-region-assertive')?.textContent).toBe(
+            'Limit exceeded by 1 character',
+        );
+    });
+});
+```
+
+- [ ] **Step 5: Migrer `charcounter.ts`**
+
+Ajouter les imports (après les imports existants, avant `export type CharcounterState`) :
+
+```ts
+import { LocalizeController } from '../../controllers/localize.controller.js';
+// fr avant en : la première traduction enregistrée devient le repli de la lib pour les langues non reconnues.
+import '../../translations/fr.js';
+import '../../translations/en.js';
+```
+
+Ajouter `@localized` après `@summary` dans le JSDoc de classe (ligne 16-17) :
+
+```
+ * @summary Compteur de caractères restants pour un champ texte accessible.
+ * @localized
+```
+
+Ajouter le controller comme premier membre de `ArCharcounter`, après `private static _idCounter = 0;` :
+
+```ts
+    private readonly localize = new LocalizeController(this);
+```
+
+Remplacer la déclaration de `label` :
+
+```ts
+    /**
+     * Texte affiché après le chiffre. Accepte "singulier|pluriel". Traduit automatiquement selon
+     * `lang` si non personnalisé.
+     * @attr label
+     */
+    @property({ reflect: true, useDefault: true })
+    label: string | undefined = undefined;
+```
+
+Remplacer `_announceTransition()` :
+
+```ts
+    private _announceTransition(state: CharcounterState, remaining: number): void {
+        if (state === 'warning') {
+            clearA11yRegion('assertive');
+            const label = this.label?.trim() || this.localize.term('remainingLabel');
+            announceA11y(`${remaining} ${pluralize(remaining, label)}`, 'polite');
+        } else if (state === 'error') {
+            const excess = Math.abs(remaining);
+            announceA11y(this.localize.term('excessMessage', excess), 'assertive');
+        } else {
+            clearA11yRegion('assertive');
+            clearA11yRegion('polite');
+        }
+    }
+```
+
+Remplacer dans `render()` :
+
+```ts
+                    <span part="label">
+                        ${pluralize(remaining, this.label?.trim() || this.localize.term('remainingLabel'))}
+                    </span>
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `npm test --workspace=packages/core -- charcounter.test.ts`
+Expected: PASS
+
+- [ ] **Step 7: Vérifier `charcounter.a11y.test.ts` (WTR, revue finale)**
+
+Ce fichier n'est pas exécutable via Vitest — noter dans le rapport de tâche qu'il a été mis à jour
+(pin de langue ajouté au Step 1) et sera vérifié par `npm run test:all` en revue finale de branche.
+Les assertions existantes (`'0 caractères restants'`, `'Limite dépassée de 1 caractère'`, `'Limite
+dépassée de 3 caractères'`) restent valides telles quelles grâce au pin FR — aucune autre
+modification requise dans ce fichier.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/core/src/components/charcounter/charcounter.ts \
+    packages/core/src/components/charcounter/charcounter.test.ts \
+    packages/core/src/components/charcounter/charcounter.a11y.test.ts
+git commit -m "feat(core): traduit ar-charcounter via LocalizeController (#80)"
+```
+
+---
+
+## Task 6: ar-spinner
+
+**Files:**
+
+- Modify: `packages/core/src/components/spinner/spinner.ts`
+- Modify: `packages/core/src/components/spinner/spinner.test.ts`
+
+**Interfaces:**
+
+- Consumes: `loading`, `loadingDone` (Task 1) ; pattern sentinel `undefined`/`useDefault: true`
+  (Task 5).
+- Produces: `ArSpinner.DEFAULT_LOADING_LABEL`/`DEFAULT_DONE_LABEL` **retirés** (breaking change,
+  constantes statiques publiques).
+
+- [ ] **Step 1: Ajouter le pin de langue en tête de `spinner.test.ts`**
+
+Après les imports existants (ligne 4, avant `describe('ArSpinner'`), insérer le même bloc que
+Task 2 Step 1.
+
+- [ ] **Step 2: Réécrire les 4 tests référençant les constantes `DEFAULT_*`**
+
+Dans `spinner.test.ts`, remplacer les 2 occurrences de :
+
+```ts
+it('loadingLabel vaut la constante DEFAULT_LOADING_LABEL', () => {
+    expect(el.loadingLabel).toBe(ArSpinner.DEFAULT_LOADING_LABEL);
+});
+```
+
+par :
+
+```ts
+it('loadingLabel vaut undefined par défaut (traduit dynamiquement)', () => {
+    expect(el.loadingLabel).toBeUndefined();
+});
+```
+
+et les 2 occurrences (lignes 46-47 et 88-89) de la variante `doneLabel`/`DEFAULT_DONE_LABEL` par
+l'équivalent `doneLabel`/`toBeUndefined()`. Vérifier avec `grep -n "DEFAULT_LOADING_LABEL\|DEFAULT_DONE_LABEL" spinner.test.ts` qu'aucune occurrence ne subsiste — les 4 assertions (lignes 42-43,
+46-47, 72-73, 88-89) doivent toutes être remplacées. L'import `ArSpinner` en tête de fichier
+(`import { ArSpinner } from './spinner.js';`) devient alors inutilisé pour ces 4 tests mais reste
+nécessaire pour le typage de `el: ArSpinner` — ne pas le retirer.
+
+- [ ] **Step 3: Ajouter des tests de traduction**
+
+Ajouter dans `spinner.test.ts` :
+
+```ts
+describe('traduction', () => {
+    it('lang="en" traduit le texte en chargement', async () => {
+        el = await fixture('<ar-spinner lang="en"></ar-spinner>');
+        expect(getPart(el, 'status')?.textContent?.trim()).toBe('Content is loading');
+    });
+
+    it('lang="en" traduit le texte terminé', async () => {
+        el = await fixture('<ar-spinner done lang="en"></ar-spinner>');
+        expect(getPart(el, 'status')?.textContent?.trim()).toBe('Loading complete');
+    });
+});
+```
+
+- [ ] **Step 4: Run pour vérifier l'état (certains tests passent déjà, "traduction" échoue)**
+
+Run: `npm test --workspace=packages/core -- spinner.test.ts`
+Expected: FAIL sur les tests `traduction` (pas encore migré) et sur les tests réécrits au Step 2
+(la prop vaut encore la constante, pas `undefined`) ; le reste passe.
+
+- [ ] **Step 5: Migrer `spinner.ts`**
+
+Ajouter les imports (après les imports existants, avant `/** @summary ...`) :
+
+```ts
+import { LocalizeController } from '../../controllers/localize.controller.js';
+// fr avant en : la première traduction enregistrée devient le repli de la lib pour les langues non reconnues.
+import '../../translations/fr.js';
+import '../../translations/en.js';
+```
+
+Ajouter `@localized` après `@display demo` (ligne 10) dans le JSDoc de classe.
+
+Remplacer le corps de la classe (constantes, propriétés, `updated()`) par :
+
+```ts
+export class ArSpinner extends LitElement {
+    static override styles: CSSResultGroup = [utilitiesStyles, animationsStyles, styles];
+    static readonly DEFAULT_DONE: boolean = false;
+
+    private readonly localize = new LocalizeController(this);
+
+    /**
+     * Passe le spinner en état "terminé" : masque le SVG et met à jour l'annonce ARIA.
+     * @attr done
+     * @default false
+     */
+    @property({ reflect: true, useDefault: true, type: Boolean })
+    done: boolean = ArSpinner.DEFAULT_DONE;
+
+    /**
+     * Texte annoncé aux lecteurs d'écran pendant le chargement. Traduit automatiquement selon
+     * `lang` si non personnalisé.
+     * @attr loading-label
+     */
+    @property({ reflect: true, useDefault: true, type: String, attribute: 'loading-label' })
+    loadingLabel: string | undefined = undefined;
+
+    /**
+     * Texte annoncé aux lecteurs d'écran quand le chargement est terminé. Traduit automatiquement
+     * selon `lang` si non personnalisé.
+     * @attr done-label
+     */
+    @property({ reflect: true, useDefault: true, type: String, attribute: 'done-label' })
+    doneLabel: string | undefined = undefined;
+
+    @property({ reflect: true, type: String, useDefault: true })
+    size: 'xs' | 'sm' | 'lg' | undefined = undefined;
+
+    override updated(changed: Map<string, unknown>): void {
+        if (
+            changed.has('loadingLabel') &&
+            this.loadingLabel !== undefined &&
+            !this.loadingLabel.trim()
+        ) {
+            warn(
+                'ar-spinner',
+                "loading-label est vide — le spinner ne sera pas annoncé aux lecteurs d'écran.",
+            );
+        }
+        if (changed.has('doneLabel') && this.doneLabel !== undefined && !this.doneLabel.trim()) {
+            warn(
+                'ar-spinner',
+                "done-label est vide — l'état terminé ne sera pas annoncé aux lecteurs d'écran.",
+            );
+        }
+    }
+
+    override render(): TemplateResult {
+        const label = this.done
+            ? this.doneLabel?.trim() || this.localize.term('loadingDone')
+            : this.loadingLabel?.trim() || this.localize.term('loading');
+        return html` <svg
+                part="spinner"
+                class="spinner"
+                viewBox="25 25 50 50"
+                aria-hidden="true"
+                focusable="false"
+                ?hidden=${this.done}
+            >
+                ${svg`<circle
+                    class="spinner-path"
+                    cx="50" cy="50" r="20"
+                    fill="none"
+                    stroke-width="4"
+                    stroke-miterlimit="10"
+                ></circle>`}
+            </svg>
+            <div part="status" role="alert" class="sr-only">
+                <p>${label}</p>
+            </div>`;
+    }
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `npm test --workspace=packages/core -- spinner.test.ts`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/src/components/spinner/spinner.ts \
+    packages/core/src/components/spinner/spinner.test.ts
+git commit -m "feat(core)!: traduit ar-spinner via LocalizeController, retire DEFAULT_LOADING_LABEL/DEFAULT_DONE_LABEL (#80)
+
+BREAKING CHANGE: loadingLabel/doneLabel sont désormais string | undefined (défaut undefined,
+traduit dynamiquement selon lang). Les constantes statiques ArSpinner.DEFAULT_LOADING_LABEL et
+ArSpinner.DEFAULT_DONE_LABEL sont retirées."
+```
+
+---
+
+## Task 7: ar-dialog
+
+**Files:**
+
+- Modify: `packages/core/src/components/dialog/dialog.ts`
+- Modify: `packages/core/src/components/dialog/dialog.test.ts`
+- Modify: `packages/core/src/components/dialog/dialog.a11y.test.ts`
+
+**Interfaces:**
+
+- Consumes: `closeDialog`, `closingBlocked`, `dialogDefaultLabel` (Task 1) ; pattern sentinel
+  (Task 5, Task 6).
+- Produces: `closeLabel`/`preventedMessage` passent de `string` à `string | undefined`.
+
+- [ ] **Step 1: Ajouter le pin de langue en tête de `dialog.test.ts` et `dialog.a11y.test.ts`**
+
+Dans `dialog.test.ts`, après les imports (ligne 3, avant `// ─── Helpers`), insérer le même bloc
+que Task 2 Step 1.
+
+Dans `dialog.a11y.test.ts`, après les imports (ligne 10, avant `function requireShadow`), insérer
+le même bloc que Task 5 Step 1 (variante WTR).
+
+- [ ] **Step 2: Mettre à jour les tests de valeur par défaut**
+
+Dans `dialog.test.ts`, remplacer :
+
+```ts
+it('preventedMessage a sa valeur par défaut', () =>
+    expect(el.preventedMessage).toBe('Fermeture bloquée.'));
+```
+
+par :
+
+```ts
+it('preventedMessage vaut undefined par défaut (traduit dynamiquement)', () =>
+    expect(el.preventedMessage).toBeUndefined());
+```
+
+- [ ] **Step 3: Run pour vérifier l'état actuel**
+
+Run: `npm test --workspace=packages/core -- dialog.test.ts`
+Expected: FAIL sur le test réécrit au Step 2 uniquement ; le reste (y compris "réannonce le message
+par défaut si preventedMessage est vide", ligne 504, qui pose `preventedMessage = '   '` — un cas
+de personnalisation explicite vide, pas le défaut — et "prevented-message est lu depuis
+l'attribut"/"preventedMessage reflète en attribut") continue de passer sans changement.
+
+- [ ] **Step 4: Ajouter des tests de traduction et de personnalisation**
+
+Ajouter dans `dialog.test.ts` :
+
+```ts
+describe('traduction', () => {
+    it('lang="en" traduit le label accessible du bouton de fermeture', async () => {
+        el = await fixture('<ar-dialog label="Titre" lang="en"></ar-dialog>');
+        const closeLabel = requireShadow(el).querySelector('[part~="close-button"] .sr-only');
+        expect(closeLabel?.textContent).toBe('Close dialog');
+    });
+
+    it('closeLabel personnalisé prend le pas sur la traduction', async () => {
+        el = await fixture('<ar-dialog label="Titre" close-label="Annuler"></ar-dialog>');
+        const closeLabel = requireShadow(el).querySelector('[part~="close-button"] .sr-only');
+        expect(closeLabel?.textContent).toBe('Annuler');
+    });
+
+    it('lang="en" traduit le message de fermeture bloquée', async () => {
+        el = await fixture('<ar-dialog label="Titre" open lang="en"></ar-dialog>');
+        el.addEventListener('ar-dialog-hide', (e) => e.preventDefault());
+        el.open = false;
+        await waitForUpdate(el);
+        await new Promise((resolve) => setTimeout(resolve, 60));
+        expect(document.getElementById('ar-live-region-assertive')?.textContent).toBe(
+            'Closing blocked.',
+        );
+    });
+
+    it('lang="en" traduit le titre de repli quand label est vide', async () => {
+        el = await fixture('<ar-dialog open lang="en"></ar-dialog>');
+        const heading = requireShadow(el).querySelector('#dialog-heading');
+        expect(heading?.textContent?.trim()).toBe('Dialog');
+    });
+});
+```
+
+- [ ] **Step 5: Run pour vérifier l'échec**
+
+Run: `npm test --workspace=packages/core -- dialog.test.ts -t "traduction"`
+Expected: FAIL
+
+- [ ] **Step 6: Migrer `dialog.ts`**
+
+Ajouter les imports (après les imports existants, avant `/** Evènements envoyés... */`) :
+
+```ts
+import { LocalizeController } from '../../controllers/localize.controller.js';
+// fr avant en : la première traduction enregistrée devient le repli de la lib pour les langues non reconnues.
+import '../../translations/fr.js';
+import '../../translations/en.js';
+```
+
+Ajouter `@localized` au JSDoc de classe, juste après `@summary Boîte de dialogue...` (ligne 51) :
+
+```
+ * @summary Boîte de dialogue modale ou panneau latéral (drawer), accessible et animée.
+ * @localized
+```
+
+Supprimer la constante module-level `const DEFAULT_DIALOG_LABEL = 'Dialogue';` (ligne 34).
+
+Ajouter le controller comme premier membre public de `ArDialog` (juste après le commentaire
+`// ── Public properties ──` et avant `@property({ reflect: true, type: Boolean }) open`) :
+
+```ts
+    private readonly localize = new LocalizeController(this);
+
+```
+
+Remplacer la déclaration de `preventedMessage` :
+
+```ts
+    /**
+     * Message annoncé aux lecteurs d'écran quand une fermeture est bloquée
+     * (événements `ar-dialog-hide-prevented`, `ar-dialog-dismissed-prevented`, `ar-dialog-accepted-prevented`).
+     * Traduit automatiquement selon `lang` si non personnalisé.
+     *
+     * @attr prevented-message
+     */
+    @property({ reflect: true, useDefault: true, attribute: 'prevented-message' })
+    preventedMessage: string | undefined = undefined;
+```
+
+Remplacer la déclaration de `closeLabel` :
+
+```ts
+    /**
+     * Label accessible du bouton de fermeture. Traduit automatiquement selon `lang` si non
+     * personnalisé.
+     *
+     * @attr close-label
+     */
+    @property({ reflect: true, useDefault: true, attribute: 'close-label' })
+    closeLabel: string | undefined = undefined;
+```
+
+Remplacer `_getHeadingLabel()` :
+
+```ts
+    private _getHeadingLabel(): string {
+        return (this.label ?? '').trim() || this.localize.term('dialogDefaultLabel');
+    }
+```
+
+Remplacer dans `render()` :
+
+```ts
+                              <span class="sr-only">${this.closeLabel?.trim() || this.localize.term('closeDialog')}</span>
+```
+
+Remplacer `_announcePrevented()` :
+
+```ts
+    private _announcePrevented(): void {
+        const message = this.preventedMessage?.trim() || this.localize.term('closingBlocked');
+        announceA11y(message, 'assertive');
+    }
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `npm test --workspace=packages/core -- dialog.test.ts`
+Expected: PASS
+
+- [ ] **Step 8: Vérifier `dialog.a11y.test.ts` (WTR, revue finale)**
+
+Ce fichier n'est pas exécutable via Vitest — noter dans le rapport de tâche qu'il a été mis à jour
+(pin de langue ajouté au Step 1) et sera vérifié par `npm run test:all` en revue finale de branche.
+L'assertion existante `expect(label.textContent?.trim()).to.equal('Fermer');` (ligne 62) reste
+valide telle quelle grâce au pin FR.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/core/src/components/dialog/dialog.ts \
+    packages/core/src/components/dialog/dialog.test.ts \
+    packages/core/src/components/dialog/dialog.a11y.test.ts
+git commit -m "feat(core)!: traduit ar-dialog via LocalizeController (#80)
+
+BREAKING CHANGE: closeLabel/preventedMessage sont désormais string | undefined (défaut undefined,
+traduits dynamiquement selon lang)."
+```
+
+---
+
+## Task 8: ar-alert
+
+**Files:**
+
+- Modify: `packages/core/src/components/alert/alert.ts`
+- Modify: `packages/core/src/components/alert/alert.test.ts`
+
+**Interfaces:**
+
+- Consumes: `closeAlert` (Task 1).
+
+- [ ] **Step 1: Ajouter le pin de langue en tête de `alert.test.ts`**
+
+Après les imports existants (ligne 3, avant `describe('ArAlert'`), insérer le même bloc que Task 2
+Step 1.
+
+- [ ] **Step 2: Run pour vérifier que rien ne casse**
+
+Run: `npm test --workspace=packages/core -- alert.test.ts`
+Expected: PASS — le test existant `le bouton close a aria-label="Fermer l'alerte"` (ligne 307)
+continue de passer grâce au pin FR.
+
+- [ ] **Step 3: Ajouter un test de traduction**
+
+Ajouter dans `alert.test.ts` :
+
+```ts
+describe('traduction', () => {
+    it('lang="en" traduit aria-label du bouton close', async () => {
+        document.body.innerHTML = '<div id="target"></div>';
+        el = await fixture('<ar-alert next-focus="target" lang="en">Message</ar-alert>');
+        expect(requirePart(el, 'close-button').getAttribute('aria-label')).toBe('Close alert');
+    });
+});
+```
+
+- [ ] **Step 4: Run pour vérifier l'échec**
+
+Run: `npm test --workspace=packages/core -- alert.test.ts -t "traduction"`
+Expected: FAIL
+
+- [ ] **Step 5: Migrer `alert.ts`**
+
+Ajouter les imports (après les imports existants, avant `/** Objet de configuration... */`) :
+
+```ts
+import { LocalizeController } from '../../controllers/localize.controller.js';
+// fr avant en : la première traduction enregistrée devient le repli de la lib pour les langues non reconnues.
+import '../../translations/fr.js';
+import '../../translations/en.js';
+```
+
+Ajouter `@localized` après `@display demo` (ligne 22) dans le JSDoc de classe.
+
+Ajouter le controller comme premier membre de `ArAlert`, juste après
+`static readonly DEFAULT_NOTIFICATION = false;` :
+
+```ts
+    private readonly localize = new LocalizeController(this);
+```
+
+Remplacer dans `render()` :
+
+```ts
+                      aria-label=${this.localize.term('closeAlert')}
+```
+
+(remplace `aria-label="Fermer l'alerte"`).
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `npm test --workspace=packages/core -- alert.test.ts`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/src/components/alert/alert.ts \
+    packages/core/src/components/alert/alert.test.ts
+git commit -m "feat(core): traduit ar-alert via LocalizeController (#80)"
+```
+
+---
+
+## Final verification (revue finale de branche, pas une tâche séparée du ledger)
+
+Après la Task 8, avant la revue finale de branche (gérée par le contrôleur SDD, pas par un
+implémenteur) :
+
+- `npm run typecheck --workspace=packages/core` (ou équivalent `tsc --noEmit`) — 0 erreur.
+- `npm test --workspace=packages/core` — suite Vitest complète verte.
+- `npm run test:all` — inclut les fichiers `*.a11y.test.ts`/`*.browser.test.ts` (WTR/Chromium) mis à
+  jour dans les Tasks 5 et 7.
+- `npm run build --workspace=packages/core` — vérifie que le retrait de
+  `DEFAULT_LOADING_LABEL`/`DEFAULT_DONE_LABEL` et le renommage `close`→`closeCalendar` ne cassent
+  aucun export attendu par `apps/docs` (le CEM se régénère au build, non commité).

--- a/docs/superpowers/specs/2026-08-14-i18n-lot2-design.md
+++ b/docs/superpowers/specs/2026-08-14-i18n-lot2-design.md
@@ -93,6 +93,7 @@ loading: string; // défaut de `loadingLabel`
 loadingDone: string; // défaut de `doneLabel`
 
 // ── ar-dialog ──
+closeDialog: string; // "Fermer la boîte de dialogue" — défaut de `closeLabel`
 closingBlocked: string; // défaut de `preventedMessage`
 dialogDefaultLabel: string; // fallback interne si `label` vide, non personnalisable
 
@@ -100,8 +101,14 @@ dialogDefaultLabel: string; // fallback interne si `label` vide, non personnalis
 closeAlert: string; // aria-label du bouton fermer, non personnalisable
 ```
 
-`ar-dialog`'s `closeLabel` réutilise le terme `close` du lot 1 (même sens que le bouton "Fermer" du
-datepicker) — pas de doublon.
+**Renommage d'un terme du lot 1 :** le terme générique `close` (`ar-datepicker`, "Fermer") est
+renommé `closeCalendar` et sa valeur précisée en "Fermer le calendrier" / "Close calendar". Un
+"Fermer" générique partagé entre calendrier et boîte de dialogue serait ambigu pour un utilisateur
+de lecteur d'écran naviguant entre plusieurs surfaces fermables sur la même page — chaque composant
+a désormais son propre terme, nommé et formulé précisément (`closeCalendar` / `closeDialog`). Ce
+renommage touche `packages/core/src/components/datepicker/datepicker.ts`
+(`this.localize.term('close')` → `this.localize.term('closeCalendar')`) et les fichiers de
+traduction — inclus dans les breaking changes ci-dessous puisque `Translation` est un type exporté.
 
 ## Détail par composant
 
@@ -141,7 +148,7 @@ datepicker) — pas de doublon.
 ### ar-dialog
 
 - `closeLabel` : type `string | undefined`, défaut `undefined`, `useDefault: true`. Effectif :
-  `this.closeLabel?.trim() || this.localize.term('close')`.
+  `this.closeLabel?.trim() || this.localize.term('closeDialog')`.
 - `preventedMessage` : type `string | undefined`, défaut `undefined`, `useDefault: true`. Effectif
   dans `_announcePrevented()` : `this.preventedMessage?.trim() || this.localize.term('closingBlocked')`.
 - `DEFAULT_DIALOG_LABEL` (fallback interne si `label` vide) : remplacé par
@@ -158,8 +165,12 @@ datepicker) — pas de doublon.
   constantes statiques `DEFAULT_LOADING_LABEL`/`DEFAULT_DONE_LABEL` sont retirées.
 - `ar-dialog` : `closeLabel`/`preventedMessage` passent de `string` à `string | undefined`.
 - `ar-charcounter` : `label` passe de `string` à `string | undefined`.
+- `ar-datepicker` : le terme `close` du type `Translation` (exporté) est renommé `closeCalendar`.
+  Impact uniquement pour un consommateur ayant fourni une traduction personnalisée via
+  `registerTranslation()` référençant `close` — la doc `getting-started/i18n.astro` pointe déjà vers
+  le fichier source à jour sur GitHub, pas de duplication à corriger.
 
-Dans les trois cas, la valeur par défaut observable ne change pas pour un consommateur qui n'avait
+Dans les trois premiers cas, la valeur par défaut observable ne change pas pour un consommateur qui n'avait
 jamais surchargé ces props (le texte FR par défaut reste identique tant que `lang` n'est pas
 changé) — seul le type TypeScript et le comportement de personnalisation "vide explicite vs jamais
 touché" changent.

--- a/docs/superpowers/specs/2026-08-14-i18n-lot2-design.md
+++ b/docs/superpowers/specs/2026-08-14-i18n-lot2-design.md
@@ -1,0 +1,199 @@
+# Lot 2 — Infrastructure i18n : pagination, stepper, breadcrumb, charcounter, spinner, dialog, alert
+
+**Issue :** [#80](https://github.com/jogo-labs/ariane/issues/80) (lot 2, suite du lot 1 — PR [#189](https://github.com/jogo-labs/ariane/pull/189))
+
+## Contexte
+
+Le lot 1 a livré le mécanisme i18n (`@shoelace-style/localize`, `LocalizeController`, `Translation`
+interface, terms `fr.ts`/`en.ts`) et migré `ar-table-sort` et `ar-datepicker`. Ce lot 2 étend la
+migration à 7 composants supplémentaires identifiés en revue finale du lot 1 : `ar-pagination`,
+`ar-stepper`, `ar-breadcrumb`, `ar-charcounter`, `ar-spinner`, `ar-dialog`, `ar-alert`.
+`ar-progressbar` reste hors scope : son label est entièrement fourni par slot, aucune chaîne
+hardcodée à migrer.
+
+Les décisions de design du lot 1 restent inchangées et ne sont pas dupliquées ici (voir
+`docs/superpowers/specs/2026-08-14-i18n-infrastructure-design.md`) : `lang` seul pilote la
+traduction, pas de régionalité (`en-GB`), pas d'export `frTranslation`/`enTranslation` au runtime,
+`@localized` documente les composants concernés.
+
+## Grille de classification
+
+Le lot 1 a établi implicitement (via `ar-datepicker`) deux traitements distincts selon la nature du
+texte. Ce lot 2 les rend explicites :
+
+1. **Texte visible ou associé à un slot d'icône existant, avec besoin de personnalisation légitime**
+   → slot avec contenu par défaut traduit (pattern déjà utilisé par `today-label`/`close-label` du
+   datepicker). Aucun cas de ce type identifié dans ce lot — tous les boutons concernés ici
+   utilisent déjà des slots d'icône séparés (`close-icon`, `trigger-icon`), et leurs libellés
+   textuels restent des props simples (voir point 3) sur décision explicite pour ce lot.
+2. **Texte purement structurel/accessible (labels de navigation, fallback interne), sans surface de
+   personnalisation existante** → traduction directe via `localize.term()`, aucune nouvelle prop.
+   YAGNI : ne pas ajouter de personnalisation non demandée.
+3. **Prop texte déjà personnalisable dont la valeur par défaut est actuellement une chaîne FR en
+   dur** → la prop reste personnalisable, mais son défaut devient traduit dynamiquement. Voir
+   mécanisme ci-dessous.
+
+## Mécanisme : défaut traduit sur une prop personnalisable
+
+Les props concernées (`ar-dialog` `closeLabel`/`preventedMessage`, `ar-spinner`
+`loadingLabel`/`doneLabel`, `ar-charcounter` `label`) passent de `string` (défaut = littéral FR) à
+`string | undefined` (défaut = `undefined`, `useDefault: true`) :
+
+- `undefined` = jamais personnalisé (ou attribut retiré, `useDefault` le rétablit à `undefined`) →
+  valeur effective calculée au point d'usage via `this.prop?.trim() || this.localize.term('clé')`.
+- Une valeur explicite (y compris une chaîne vide volontaire) est distincte de `undefined` → reste
+  utilisable pour détecter un vidage involontaire côté consommateur.
+
+**Cas `ar-spinner`** : le `warn()` actuel sur `loadingLabel`/`doneLabel` vide est **conservé**, mais
+sa condition change : il ne doit avertir que si la prop a été explicitement définie (donc
+`!== undefined`) et que sa valeur triée est vide — un vidage volontaire ou un bug de récupération
+côté consommateur, jamais l'état par défaut non personnalisé.
+
+```ts
+override updated(changed: Map<string, unknown>): void {
+    if (changed.has('loadingLabel') && this.loadingLabel !== undefined && !this.loadingLabel.trim()) {
+        warn('ar-spinner', "loading-label est vide — le spinner ne sera pas annoncé aux lecteurs d'écran.");
+    }
+    if (changed.has('doneLabel') && this.doneLabel !== undefined && !this.doneLabel.trim()) {
+        warn('ar-spinner', "done-label est vide — l'état terminé ne sera pas annoncé aux lecteurs d'écran.");
+    }
+}
+```
+
+Les constantes statiques `ArSpinner.DEFAULT_LOADING_LABEL`/`DEFAULT_DONE_LABEL` sont **retirées**
+(breaking change) : elles représentaient un défaut fixe qui n'existe plus, la traduction dépendant
+de la langue résolue à l'exécution.
+
+## Nouveaux termes `Translation`
+
+Ajouts à `packages/core/src/types/translation.ts`, `packages/core/src/translations/fr.ts` et `en.ts`,
+groupés par commentaire `// ── ar-<nom> ──` comme en lot 1.
+
+```ts
+// ── ar-pagination ──
+previousPage: (page: number, total: number) => string; // "Page précédente (page X sur Y)"
+nextPage: (page: number, total: number) => string; // "Page suivante (page X sur Y)"
+pageStatus: (page: number, total: number) => string; // "Page X sur Y" (sr-only par page + annonce)
+compactPageStatus: (current: number, total: number) => string; // "Page X / Y" (label visible mode compact)
+goToPage: string; // "Aller à la page" (label du <select>)
+
+// ── ar-stepper ──
+stepperNavLabel: string; // "Étapes du formulaire"
+
+// ── ar-breadcrumb ──
+breadcrumbNavLabel: string; // "Vous êtes ici"
+showBreadcrumb: string; // "Afficher le fil d'ariane"
+
+// ── ar-charcounter ──
+remainingLabel: string; // "caractère restant|caractères restants" (défaut de `label`)
+excessMessage: (count: number) => string; // "Limite dépassée de X caractère(s)" (pluralise en interne)
+
+// ── ar-spinner ──
+loading: string; // défaut de `loadingLabel`
+loadingDone: string; // défaut de `doneLabel`
+
+// ── ar-dialog ──
+closingBlocked: string; // défaut de `preventedMessage`
+dialogDefaultLabel: string; // fallback interne si `label` vide, non personnalisable
+
+// ── ar-alert ──
+closeAlert: string; // aria-label du bouton fermer, non personnalisable
+```
+
+`ar-dialog`'s `closeLabel` réutilise le terme `close` du lot 1 (même sens que le bouton "Fermer" du
+datepicker) — pas de doublon.
+
+## Détail par composant
+
+### ar-pagination
+
+- `render()` (nav) : garde `aria-labelledby="ar-pagination"` — pas de label visible affecté, mais le
+  `<span class="sr-only">` de chaque bouton précédent/suivant utilise `previousPage`/`nextPage`.
+- `renderPageLabel()` : `pageStatus(page, total)`.
+- `renderCompactLabel()` : `compactPageStatus(current, total)`.
+- Select mobile : `<span class="sr-only" id="ar-pagination-select-label">` → `goToPage`.
+- `announceA11y()` (changement de page) : `pageStatus(this.current, this.total)`.
+
+### ar-stepper
+
+- `<p id="label-nav" class="sr-only">` → `stepperNavLabel`.
+
+### ar-breadcrumb
+
+- `<p id="breadcrumb-label" class="sr-only">` → `breadcrumbNavLabel`.
+- `<span class="sr-only">` du bouton trigger mobile → `showBreadcrumb`.
+
+### ar-charcounter
+
+- `label` : type `string | undefined`, défaut `undefined`, `useDefault: true`. Effectif :
+  `this.label?.trim() || this.localize.term('remainingLabel')`, utilisé à la fois dans `render()`
+  et `_announceTransition()`.
+- `_announceTransition()` (état error) : remplace `` `Limite dépassée de ${excess} ${pluralize(excess, 'caractère|caractères')}` `` par `this.localize.term('excessMessage', excess)` — la pluralisation fr/en est gérée dans la fonction du terme, pas dans le composant.
+
+### ar-spinner
+
+- `loadingLabel`/`doneLabel` : type `string | undefined`, défaut `undefined`, `useDefault: true`.
+  Effectifs : `this.loadingLabel?.trim() || this.localize.term('loading')` et
+  `this.doneLabel?.trim() || this.localize.term('loadingDone')`.
+- Retrait de `DEFAULT_LOADING_LABEL`/`DEFAULT_DONE_LABEL` (breaking change, static readonly publics).
+- `warn()` : condition mise à jour (voir mécanisme ci-dessus).
+
+### ar-dialog
+
+- `closeLabel` : type `string | undefined`, défaut `undefined`, `useDefault: true`. Effectif :
+  `this.closeLabel?.trim() || this.localize.term('close')`.
+- `preventedMessage` : type `string | undefined`, défaut `undefined`, `useDefault: true`. Effectif
+  dans `_announcePrevented()` : `this.preventedMessage?.trim() || this.localize.term('closingBlocked')`.
+- `DEFAULT_DIALOG_LABEL` (fallback interne si `label` vide) : remplacé par
+  `this.localize.term('dialogDefaultLabel')` — reste un fallback non personnalisable, pas une prop.
+
+### ar-alert
+
+- `aria-label="Fermer l'alerte"` → `aria-label=${this.localize.term('closeAlert')}` — traduction
+  directe, pas de personnalisation (cohérent avec les aria-label du datepicker en lot 1).
+
+## Breaking changes
+
+- `ar-spinner` : `loadingLabel`/`doneLabel` passent de `string` à `string | undefined` ; les
+  constantes statiques `DEFAULT_LOADING_LABEL`/`DEFAULT_DONE_LABEL` sont retirées.
+- `ar-dialog` : `closeLabel`/`preventedMessage` passent de `string` à `string | undefined`.
+- `ar-charcounter` : `label` passe de `string` à `string | undefined`.
+
+Dans les trois cas, la valeur par défaut observable ne change pas pour un consommateur qui n'avait
+jamais surchargé ces props (le texte FR par défaut reste identique tant que `lang` n'est pas
+changé) — seul le type TypeScript et le comportement de personnalisation "vide explicite vs jamais
+touché" changent.
+
+## Tests
+
+Reprendre les enseignements du lot 1 (mémoire `project_i18n_infrastructure_80`) :
+
+- `document.documentElement.lang = 'fr';` en tête de chaque fichier de test touché
+  (`*.test.ts` et `*.browser.test.ts`), avant tout test s'appuyant sur `LocalizeController`.
+- `mockPopoverPanel(el)` avant `el.open = true` pour `ar-dialog` (popover) si des tests de
+  fermeture/aria-label passent par l'ouverture du panel.
+- Réécrire les 2 tests `spinner.test.ts` qui référencent `ArSpinner.DEFAULT_LOADING_LABEL`/
+  `DEFAULT_DONE_LABEL` (constantes retirées) pour asserter directement sur le texte traduit attendu.
+- Couverture de traduction (`translations.test.ts`) : ajouter les nouveaux termes, y compris le
+  test de pluralisation `excessMessage`/`remainingLabel` en fr et en.
+- Tests de non-régression : `lang="en"` sur une instance doit traduire tous les textes concernés
+  (nav labels, messages d'annonce, defaults de props).
+
+## Documentation
+
+- `@localized` posé en JSDoc sur les 7 composants migrés → section "Traduction" générée
+  automatiquement dans `ComponentApi.astro` (mécanisme du lot 1, aucun changement requis côté doc
+  générée).
+- Pas de MDX à modifier : aucune des chaînes migrées n'était documentée explicitement dans les pages
+  composant (vérifié par recherche croisée `closeLabel`/`preventedMessage`/`loadingLabel`/
+  `doneLabel` dans `apps/docs/src/content/components/*.mdx` — aucune occurrence).
+- CHANGELOG / notes de breaking change à ajouter dans la description de PR (pas de fichier
+  CHANGELOG.md dédié dans ce repo à ce stade).
+
+## Hors scope
+
+- `ar-progressbar` : label entièrement fourni par slot, aucune chaîne hardcodée.
+- Extension à d'autres langues que fr/en : suivi par l'issue [#190](https://github.com/jogo-labs/ariane/issues/190).
+- Retrofit d'`ar-datepicker` : non nécessaire, ses boutons `today`/`close` sont déjà des slots avec
+  contenu par défaut traduit (vérifié en brainstorming — pas de dette contrairement à l'hypothèse
+  initiale).

--- a/packages/core/src/components/alert/alert.test.ts
+++ b/packages/core/src/components/alert/alert.test.ts
@@ -3,6 +3,12 @@ import { type ArAlert } from './alert.js';
 import { fixture, waitForUpdate, getPart, requirePart, requireShadow } from '../../test-utils.js';
 import './index.js';
 
+// LocalizeController résout la langue via document.documentElement.lang, avec
+// navigator.language comme secours (happy-dom retourne 'en-US' par défaut).
+// En production, le site de doc pose lang="fr" sur <html> ; on reproduit ça ici
+// pour que les assertions FR par défaut restent valides sans lang explicite.
+document.documentElement.lang = 'fr';
+
 describe('ArAlert', () => {
     let el: ArAlert;
 
@@ -519,6 +525,14 @@ describe('ArAlert', () => {
             expect(document.activeElement).toBe(target);
 
             target.remove();
+        });
+    });
+
+    describe('traduction', () => {
+        it('lang="en" traduit aria-label du bouton close', async () => {
+            document.body.innerHTML = '<div id="target"></div>';
+            el = await fixture('<ar-alert next-focus="target" lang="en">Message</ar-alert>');
+            expect(requirePart(el, 'close-button').getAttribute('aria-label')).toBe('Close alert');
         });
     });
 });

--- a/packages/core/src/components/alert/alert.ts
+++ b/packages/core/src/components/alert/alert.ts
@@ -3,6 +3,10 @@ import { property } from 'lit/decorators.js';
 import styles from './alert.styles.js';
 import { prefersReducedMotion } from '../../utils/media.js';
 import { warn } from '../../utils/warn.js';
+import { LocalizeController } from '../../controllers/localize.controller.js';
+// fr avant en : la première traduction enregistrée devient le repli de la lib pour les langues non reconnues.
+import '../../translations/fr.js';
+import '../../translations/en.js';
 
 /** Objet de configuration d'un webcomposant ArAlert */
 export class ArAlertConfig {
@@ -20,6 +24,7 @@ export type ArAlertVariant = 'success' | 'warning' | 'error' | 'info';
 /**
  * @summary Affiche un message d'alerte accessible avec différents niveaux de sévérité.
  * @display demo
+ * @localized
  *
  * @slot              - Contenu de l'alerte (texte, titre, liens…).
  * @slot icon         - Icône de l'alerte. Remplace l'icône par défaut si fourni.
@@ -48,6 +53,8 @@ export class ArAlert extends LitElement {
     static readonly DEFAULT_VARIANT: ArAlertVariant = 'error';
     // @ignore
     static readonly DEFAULT_NOTIFICATION = false;
+
+    private readonly localize = new LocalizeController(this);
 
     /**
      * ID de l'élément à focus après la fermeture de l'alerte.
@@ -202,7 +209,7 @@ export class ArAlert extends LitElement {
                       part="close-button action-button"
                       @click=${this._hide}
                       type="button"
-                      aria-label="Fermer l'alerte"
+                      aria-label=${this.localize.term('closeAlert')}
                   >
                       <slot name="close-icon">${this._defaultCloseIcon()}</slot>
                   </button>`

--- a/packages/core/src/components/breadcrumb/breadcrumb.test.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.test.ts
@@ -631,7 +631,7 @@ describe('ArBreadcrumb', () => {
                 </ar-breadcrumb>
             `);
             const label = getShadow(el).querySelector('#breadcrumb-label');
-            expect(label?.textContent?.trim()).toBe('Vous êtes ici');
+            expect(label?.textContent).toBe('Vous êtes ici');
         });
     });
 
@@ -645,7 +645,7 @@ describe('ArBreadcrumb', () => {
             const el = document.querySelector('ar-breadcrumb') as ArBreadcrumb & LitEl;
             await el.updateComplete;
             const label = el.shadowRoot?.querySelector('#breadcrumb-label');
-            expect(label?.textContent?.trim()).toBe('You are here');
+            expect(label?.textContent).toBe('You are here');
         });
     });
 });

--- a/packages/core/src/components/breadcrumb/breadcrumb.test.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.test.ts
@@ -4,6 +4,12 @@ import { getPart, mockPopoverPanel } from '../../test-utils.js';
 import './index.js';
 import '../breadcrumb-item/index.js';
 
+// LocalizeController résout la langue via document.documentElement.lang, avec
+// navigator.language comme secours (happy-dom retourne 'en-US' par défaut).
+// En production, le site de doc pose lang="fr" sur <html> ; on reproduit ça ici
+// pour que les assertions FR par défaut restent valides sans lang explicite.
+document.documentElement.lang = 'fr';
+
 type LitEl = { updateComplete: Promise<boolean> };
 
 /**
@@ -626,6 +632,20 @@ describe('ArBreadcrumb', () => {
             `);
             const label = getShadow(el).querySelector('#breadcrumb-label');
             expect(label?.textContent?.trim()).toBe('Vous êtes ici');
+        });
+    });
+
+    describe('traduction', () => {
+        it('lang="en" traduit le label de navigation', async () => {
+            document.body.innerHTML = `
+            <ar-breadcrumb lang="en">
+                <ar-breadcrumb-item href="/" label="Home"></ar-breadcrumb-item>
+                <ar-breadcrumb-item label="Current"></ar-breadcrumb-item>
+            </ar-breadcrumb>`;
+            const el = document.querySelector('ar-breadcrumb') as ArBreadcrumb & LitEl;
+            await el.updateComplete;
+            const label = el.shadowRoot?.querySelector('#breadcrumb-label');
+            expect(label?.textContent?.trim()).toBe('You are here');
         });
     });
 });

--- a/packages/core/src/components/breadcrumb/breadcrumb.test.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.test.ts
@@ -647,5 +647,18 @@ describe('ArBreadcrumb', () => {
             const label = el.shadowRoot?.querySelector('#breadcrumb-label');
             expect(label?.textContent).toBe('You are here');
         });
+
+        it('lang="en" traduit le texte du trigger mobile', async () => {
+            ArBreadcrumb.mobileQuery = mockMediaQuery(true);
+            document.body.innerHTML = `
+            <ar-breadcrumb lang="en">
+                <ar-breadcrumb-item href="/" label="Home"></ar-breadcrumb-item>
+                <ar-breadcrumb-item label="Current"></ar-breadcrumb-item>
+            </ar-breadcrumb>`;
+            const el = document.querySelector('ar-breadcrumb') as ArBreadcrumb & LitEl;
+            await el.updateComplete;
+            const trigger = el.shadowRoot?.querySelector('[part="trigger"] .sr-only');
+            expect(trigger?.textContent).toBe('Show breadcrumb');
+        });
     });
 });

--- a/packages/core/src/components/breadcrumb/breadcrumb.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.ts
@@ -18,10 +18,15 @@ import styles from './breadcrumb.styles.js';
 import { breadcrumbContext } from '../../context/breadcrumb.context.js';
 import { ArBreadcrumbItem } from '../breadcrumb-item/breadcrumb-item.js';
 import { AnchoredController } from '../../controllers/anchored.controller.js';
+import { LocalizeController } from '../../controllers/localize.controller.js';
+// fr avant en : la première traduction enregistrée devient le repli de la lib pour les langues non reconnues.
+import '../../translations/fr.js';
+import '../../translations/en.js';
 
 /**
  * @summary Fil d'ariane accessible avec affichage adaptatif mobile/desktop.
  * @display demo
+ * @localized
  *
  * En dessous de 768px de largeur de viewport, les liens intermédiaires sont masqués
  * derrière un dropdown. Le premier lien reste toujours visible sous forme d'un bouton
@@ -72,6 +77,8 @@ import { AnchoredController } from '../../controllers/anchored.controller.js';
  */
 export class ArBreadcrumb extends LitElement {
     static override styles: CSSResultGroup = [utilitiesStyles, resetStyles, panelStyles, styles];
+
+    private readonly localize = new LocalizeController(this);
 
     static mobileQuery: MediaQueryList = window.matchMedia('(max-width: 767px)');
 
@@ -216,7 +223,9 @@ export class ArBreadcrumb extends LitElement {
 
         return html`
             <nav part="breadcrumb" role="navigation" aria-labelledby="breadcrumb-label">
-                <p id="breadcrumb-label" class="sr-only">Vous êtes ici</p>
+                <p id="breadcrumb-label" class="sr-only">
+                    ${this.localize.term('breadcrumbNavLabel')}
+                </p>
                 ${this.isMobile
                     ? html`<div class="dropdown">
                           <a part="home" href="${items[0]?.href}">
@@ -225,7 +234,7 @@ export class ArBreadcrumb extends LitElement {
                           </a>
                           <button @click=${this._handleTriggerClick} type="button" part="trigger">
                               <slot name="trigger-icon">${this._defaultTriggerIcon()}</slot>
-                              <span class="sr-only">Afficher le fil d'ariane</span>
+                              <span class="sr-only">${this.localize.term('showBreadcrumb')}</span>
                           </button>
                           <div part="panel" popover="auto" tabindex="-1">
                               <ol part="list list--mobile">

--- a/packages/core/src/components/breadcrumb/breadcrumb.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.ts
@@ -223,9 +223,10 @@ export class ArBreadcrumb extends LitElement {
 
         return html`
             <nav part="breadcrumb" role="navigation" aria-labelledby="breadcrumb-label">
-                <p id="breadcrumb-label" class="sr-only">
-                    ${this.localize.term('breadcrumbNavLabel')}
-                </p>
+                <!-- prettier-ignore -->
+                <p id="breadcrumb-label" class="sr-only">${this.localize.term(
+                    'breadcrumbNavLabel',
+                )}</p>
                 ${this.isMobile
                     ? html`<div class="dropdown">
                           <a part="home" href="${items[0]?.href}">

--- a/packages/core/src/components/breadcrumb/breadcrumb.ts
+++ b/packages/core/src/components/breadcrumb/breadcrumb.ts
@@ -221,12 +221,11 @@ export class ArBreadcrumb extends LitElement {
             </li>`;
         });
 
+        const navLabel = this.localize.term('breadcrumbNavLabel');
+
         return html`
             <nav part="breadcrumb" role="navigation" aria-labelledby="breadcrumb-label">
-                <!-- prettier-ignore -->
-                <p id="breadcrumb-label" class="sr-only">${this.localize.term(
-                    'breadcrumbNavLabel',
-                )}</p>
+                <p id="breadcrumb-label" class="sr-only">${navLabel}</p>
                 ${this.isMobile
                     ? html`<div class="dropdown">
                           <a part="home" href="${items[0]?.href}">

--- a/packages/core/src/components/charcounter/charcounter.a11y.test.ts
+++ b/packages/core/src/components/charcounter/charcounter.a11y.test.ts
@@ -3,6 +3,12 @@ import { fixture, html, expect } from '@open-wc/testing';
 import type { ArCharcounter } from './charcounter.js';
 import './index.js';
 
+// LocalizeController résout la langue via document.documentElement.lang, avec
+// navigator.language comme secours (le runner Chromium peut différer selon l'environnement CI).
+// En production, le site de doc pose lang="fr" sur <html> ; on reproduit ça ici
+// pour que les assertions FR par défaut restent valides sans lang explicite.
+document.documentElement.lang = 'fr';
+
 describe('ar-charcounter — accessibilité', () => {
     // ── Audit axe ─────────────────────────────────────────────────────────
 

--- a/packages/core/src/components/charcounter/charcounter.test.ts
+++ b/packages/core/src/components/charcounter/charcounter.test.ts
@@ -3,6 +3,12 @@ import { fixture, waitForUpdate, getPart } from '../../test-utils.js';
 import type { ArCharcounter } from './charcounter.js';
 import './index.js';
 
+// LocalizeController résout la langue via document.documentElement.lang, avec
+// navigator.language comme secours (happy-dom retourne 'en-US' par défaut).
+// En production, le site de doc pose lang="fr" sur <html> ; on reproduit ça ici
+// pour que les assertions FR par défaut restent valides sans lang explicite.
+document.documentElement.lang = 'fr';
+
 describe('ArCharcounter', () => {
     let el: ArCharcounter;
     afterEach(() => {
@@ -19,8 +25,8 @@ describe('ArCharcounter', () => {
         });
 
         it('warnThreshold vaut 20', () => expect(el.warnThreshold).toBe(20));
-        it('label vaut "caractère restant|caractères restants"', () =>
-            expect(el.label).toBe('caractère restant|caractères restants'));
+        it('label vaut undefined par défaut (traduit dynamiquement)', () =>
+            expect(el.label).toBeUndefined());
         it('state vaut "normal"', () => expect(el.state).toBe('normal'));
         it('state="normal" est réfléchi comme attribut', () =>
             expect(el.getAttribute('state')).toBe('normal'));
@@ -578,6 +584,25 @@ describe('ArCharcounter', () => {
             const field = document.getElementById('f') as HTMLTextAreaElement;
             el.remove();
             expect(field.getAttribute('aria-describedby')).toBe('hint-1');
+        });
+    });
+
+    // ── Traduction ────────────────────────────────────────────────────────
+
+    describe('traduction', () => {
+        it('lang="en" traduit le label et le message de dépassement', async () => {
+            document.body.innerHTML = '<textarea id="f"></textarea>';
+            el = await fixture('<ar-charcounter for="f" max="5" lang="en"></ar-charcounter>');
+            const field = document.getElementById('f') as HTMLTextAreaElement;
+            expect(getPart(el, 'label')?.textContent?.trim()).toBe('characters remaining');
+
+            field.value = '123456';
+            field.dispatchEvent(new Event('input'));
+            await waitForUpdate(el);
+            await new Promise((resolve) => setTimeout(resolve, 350));
+            expect(document.getElementById('ar-live-region-assertive')?.textContent).toBe(
+                'Limit exceeded by 1 character',
+            );
         });
     });
 });

--- a/packages/core/src/components/charcounter/charcounter.test.ts
+++ b/packages/core/src/components/charcounter/charcounter.test.ts
@@ -604,5 +604,20 @@ describe('ArCharcounter', () => {
                 'Limit exceeded by 1 character',
             );
         });
+
+        it('lang="en" traduit l\'annonce warning', async () => {
+            document.body.innerHTML = '<textarea id="f"></textarea>';
+            el = await fixture(
+                '<ar-charcounter for="f" max="10" warn-threshold="5" lang="en"></ar-charcounter>',
+            );
+            const field = document.getElementById('f') as HTMLTextAreaElement;
+            field.value = '123456'; // remaining = 4, <= warnThreshold(5) → état warning
+            field.dispatchEvent(new Event('input'));
+            await waitForUpdate(el);
+            await new Promise((resolve) => setTimeout(resolve, 350));
+            expect(document.getElementById('ar-live-region-polite')?.textContent).toBe(
+                '4 characters remaining',
+            );
+        });
     });
 });

--- a/packages/core/src/components/charcounter/charcounter.test.ts
+++ b/packages/core/src/components/charcounter/charcounter.test.ts
@@ -66,7 +66,7 @@ describe('ArCharcounter', () => {
         it('contient part="label"', () => expect(getPart(el, 'label')).not.toBeNull());
         it('affiche "200 caractères restants" au départ (champ vide)', () => {
             expect(getPart(el, 'remaining')?.textContent?.trim()).toBe('200');
-            expect(getPart(el, 'label')?.textContent?.trim()).toBe('caractères restants');
+            expect(getPart(el, 'label')?.textContent).toBe('caractères restants');
         });
     });
 
@@ -187,7 +187,7 @@ describe('ArCharcounter', () => {
             el = await fixture(
                 '<ar-charcounter for="f" max="200" label="caractère restant|caractères restants"></ar-charcounter>',
             );
-            expect(getPart(el, 'label')?.textContent?.trim()).toBe('caractère restant');
+            expect(getPart(el, 'label')?.textContent).toBe('caractère restant');
         });
 
         it('affiche la forme pluriel quand remaining = 0', async () => {
@@ -195,7 +195,7 @@ describe('ArCharcounter', () => {
             el = await fixture(
                 '<ar-charcounter for="f" max="200" label="caractère restant|caractères restants"></ar-charcounter>',
             );
-            expect(getPart(el, 'label')?.textContent?.trim()).toBe('caractères restants');
+            expect(getPart(el, 'label')?.textContent).toBe('caractères restants');
         });
 
         it('affiche la forme pluriel quand remaining = 5', async () => {
@@ -203,7 +203,7 @@ describe('ArCharcounter', () => {
             el = await fixture(
                 '<ar-charcounter for="f" max="200" label="caractère restant|caractères restants"></ar-charcounter>',
             );
-            expect(getPart(el, 'label')?.textContent?.trim()).toBe('caractères restants');
+            expect(getPart(el, 'label')?.textContent).toBe('caractères restants');
         });
 
         it('affiche la forme singulier quand remaining = -1 (dépassement de 1)', async () => {
@@ -211,7 +211,7 @@ describe('ArCharcounter', () => {
             el = await fixture(
                 '<ar-charcounter for="f" max="200" label="caractère restant|caractères restants"></ar-charcounter>',
             );
-            expect(getPart(el, 'label')?.textContent?.trim()).toBe('caractère restant');
+            expect(getPart(el, 'label')?.textContent).toBe('caractère restant');
         });
 
         it('utilise le label tel quel si pas de pipe (compat descendante)', async () => {
@@ -219,7 +219,7 @@ describe('ArCharcounter', () => {
             el = await fixture(
                 '<ar-charcounter for="f" max="200" label="restants"></ar-charcounter>',
             );
-            expect(getPart(el, 'label')?.textContent?.trim()).toBe('restants');
+            expect(getPart(el, 'label')?.textContent).toBe('restants');
         });
     });
 
@@ -594,7 +594,7 @@ describe('ArCharcounter', () => {
             document.body.innerHTML = '<textarea id="f"></textarea>';
             el = await fixture('<ar-charcounter for="f" max="5" lang="en"></ar-charcounter>');
             const field = document.getElementById('f') as HTMLTextAreaElement;
-            expect(getPart(el, 'label')?.textContent?.trim()).toBe('characters remaining');
+            expect(getPart(el, 'label')?.textContent).toBe('characters remaining');
 
             field.value = '123456';
             field.dispatchEvent(new Event('input'));

--- a/packages/core/src/components/charcounter/charcounter.ts
+++ b/packages/core/src/components/charcounter/charcounter.ts
@@ -3,6 +3,10 @@ import { property } from 'lit/decorators.js';
 import { warn } from '../../utils/warn.js';
 import { announceA11y, clearA11yRegion } from '../../a11y/announce-a11y.js';
 import styles from './charcounter.styles.js';
+import { LocalizeController } from '../../controllers/localize.controller.js';
+// fr avant en : la première traduction enregistrée devient le repli de la lib pour les langues non reconnues.
+import '../../translations/fr.js';
+import '../../translations/en.js';
 
 export type CharcounterState = 'normal' | 'warning' | 'error';
 
@@ -14,6 +18,7 @@ function pluralize(count: number, label: string): string {
 
 /**
  * @summary Compteur de caractères restants pour un champ texte accessible.
+ * @localized
  *
  * Observe un `<textarea>` ou `<input>` via `for="id"` et affiche le décompte.
  * Passe en état `warning` puis `error` quand la limite approche ou est dépassée.
@@ -35,6 +40,7 @@ function pluralize(count: number, label: string): string {
 export class ArCharcounter extends LitElement {
     static override styles = [styles];
     private static _idCounter = 0;
+    private readonly localize = new LocalizeController(this);
 
     /** ID du champ observé. Requis. */
     @property({ reflect: true }) for: string | undefined;
@@ -45,8 +51,13 @@ export class ArCharcounter extends LitElement {
     /** Nombre de caractères restants déclenchant l'état warning. */
     @property({ attribute: 'warn-threshold', reflect: true, type: Number }) warnThreshold = 20;
 
-    /** Texte affiché après le chiffre. Accepte "singulier|pluriel". */
-    @property({ reflect: true }) label = 'caractère restant|caractères restants';
+    /**
+     * Texte affiché après le chiffre. Accepte "singulier|pluriel". Traduit automatiquement selon
+     * `lang` si non personnalisé.
+     * @attr label
+     */
+    @property({ reflect: true, useDefault: true })
+    label: string | undefined = undefined;
 
     private _count = 0;
     private _state: CharcounterState = 'normal';
@@ -196,13 +207,11 @@ export class ArCharcounter extends LitElement {
     private _announceTransition(state: CharcounterState, remaining: number): void {
         if (state === 'warning') {
             clearA11yRegion('assertive');
-            announceA11y(`${remaining} ${pluralize(remaining, this.label)}`, 'polite');
+            const label = this.label?.trim() || this.localize.term('remainingLabel');
+            announceA11y(`${remaining} ${pluralize(remaining, label)}`, 'polite');
         } else if (state === 'error') {
             const excess = Math.abs(remaining);
-            announceA11y(
-                `Limite dépassée de ${excess} ${pluralize(excess, 'caractère|caractères')}`,
-                'assertive',
-            );
+            announceA11y(this.localize.term('excessMessage', excess), 'assertive');
         } else {
             clearA11yRegion('assertive');
             clearA11yRegion('polite');
@@ -234,7 +243,12 @@ export class ArCharcounter extends LitElement {
                 <slot name="error-icon"></slot>
                 <span part="count${this._state !== 'normal' ? ` count--${this._state}` : ''}">
                     <span part="remaining">${remaining}</span>
-                    <span part="label"> ${pluralize(remaining, this.label)}</span>
+                    <span part="label">
+                        ${pluralize(
+                            remaining,
+                            this.label?.trim() || this.localize.term('remainingLabel'),
+                        )}
+                    </span>
                 </span>
             </span>
         `;

--- a/packages/core/src/components/charcounter/charcounter.ts
+++ b/packages/core/src/components/charcounter/charcounter.ts
@@ -237,18 +237,17 @@ export class ArCharcounter extends LitElement {
     override render(): TemplateResult | typeof nothing {
         if (this.max === undefined) return nothing;
         const remaining = this.max - this._count;
+        const label = pluralize(
+            remaining,
+            this.label?.trim() || this.localize.term('remainingLabel'),
+        );
         return html`
             <span part="charcounter">
                 <slot name="warning-icon"></slot>
                 <slot name="error-icon"></slot>
                 <span part="count${this._state !== 'normal' ? ` count--${this._state}` : ''}">
                     <span part="remaining">${remaining}</span>
-                    <span part="label">
-                        ${pluralize(
-                            remaining,
-                            this.label?.trim() || this.localize.term('remainingLabel'),
-                        )}
-                    </span>
+                    <span part="label">${label}</span>
                 </span>
             </span>
         `;

--- a/packages/core/src/components/datepicker/datepicker.test.ts
+++ b/packages/core/src/components/datepicker/datepicker.test.ts
@@ -362,7 +362,7 @@ describe('ArDatepicker', () => {
             expect(todayBtn?.textContent?.trim()).toBe("Aujourd'hui");
             expect(todayBtn?.getAttribute('aria-label')).toBe("Aujourd'hui");
             expect(closeBtn?.textContent?.trim()).toBe('Fermer');
-            expect(closeBtn?.getAttribute('aria-label')).toBe('Fermer');
+            expect(closeBtn?.getAttribute('aria-label')).toBe('Fermer le calendrier');
         });
 
         it('today-button et close-button sont traduits en anglais via lang="en"', async () => {
@@ -414,7 +414,7 @@ describe('ArDatepicker', () => {
             el.open = true;
             await waitForUpdate(el);
             const closeBtn = getPart(el, 'close-button');
-            expect(closeBtn?.getAttribute('aria-label')).toBe('Fermer');
+            expect(closeBtn?.getAttribute('aria-label')).toBe('Fermer le calendrier');
         });
     });
 

--- a/packages/core/src/components/datepicker/datepicker.ts
+++ b/packages/core/src/components/datepicker/datepicker.ts
@@ -233,7 +233,8 @@ export class ArDatepicker extends LitElement {
         // régionale n'est enregistrée.
         const locale = this.localize.lang();
         const todayLabel = this.localize.term('today');
-        const closeLabel = this.localize.term('closeCalendar');
+        const closeLabel = this.localize.term('close');
+        const closeAriaLabel = this.localize.term('closeCalendar');
         const exampleDate = new Date(new Date().getFullYear(), 11, 31);
         const formatLine = this.localize.term(
             'expectedFormat',
@@ -315,7 +316,9 @@ export class ArDatepicker extends LitElement {
                     id="ar-dp-panel-${this._uid}"
                     @keydown=${this._handlePanelKeyDown}
                 >
-                    ${this.open ? this._renderCalendar(locale, todayLabel, closeLabel) : nothing}
+                    ${this.open
+                        ? this._renderCalendar(locale, todayLabel, closeLabel, closeAriaLabel)
+                        : nothing}
                 </div>
             </div>
         `;
@@ -325,6 +328,7 @@ export class ArDatepicker extends LitElement {
         locale: string,
         todayLabel: string,
         closeLabel: string,
+        closeAriaLabel: string,
     ): TemplateResult {
         const viewDate = this._calendar.currentViewMonth;
         const monthLabel = this._getFormatter(locale, 'month-year', {
@@ -411,7 +415,7 @@ export class ArDatepicker extends LitElement {
                 <button
                     part="footer-button close-button action-button"
                     type="button"
-                    aria-label=${closeLabel}
+                    aria-label=${closeAriaLabel}
                     @click=${this._handleCloseClick}
                 >
                     <slot name="close-label">${closeLabel}</slot>

--- a/packages/core/src/components/datepicker/datepicker.ts
+++ b/packages/core/src/components/datepicker/datepicker.ts
@@ -233,7 +233,7 @@ export class ArDatepicker extends LitElement {
         // régionale n'est enregistrée.
         const locale = this.localize.lang();
         const todayLabel = this.localize.term('today');
-        const closeLabel = this.localize.term('close');
+        const closeLabel = this.localize.term('closeCalendar');
         const exampleDate = new Date(new Date().getFullYear(), 11, 31);
         const formatLine = this.localize.term(
             'expectedFormat',

--- a/packages/core/src/components/dialog/dialog.a11y.test.ts
+++ b/packages/core/src/components/dialog/dialog.a11y.test.ts
@@ -10,6 +10,12 @@ import { fixture, html, expect } from '@open-wc/testing';
 import type { ArDialog } from './dialog.js';
 import './index.js';
 
+// LocalizeController résout la langue via document.documentElement.lang, avec
+// navigator.language comme secours (le runner Chromium peut différer selon l'environnement CI).
+// En production, le site de doc pose lang="fr" sur <html> ; on reproduit ça ici
+// pour que les assertions FR par défaut restent valides sans lang explicite.
+document.documentElement.lang = 'fr';
+
 function requireShadow(el: Element): ShadowRoot {
     if (!el.shadowRoot) throw new Error(`shadowRoot absent sur <${el.tagName.toLowerCase()}>`);
     return el.shadowRoot;
@@ -59,7 +65,7 @@ describe('ar-dialog — accessibilité', () => {
         const label = closeBtn.querySelector('.sr-only');
         expect(label).not.to.equal(null);
         if (!label) throw new Error('.sr-only introuvable');
-        expect(label.textContent?.trim()).to.equal('Fermer');
+        expect(label.textContent?.trim()).to.equal('Fermer la boîte de dialogue');
     });
 
     it('le fallback de titre fournit un nom accessible par défaut', async () => {

--- a/packages/core/src/components/dialog/dialog.test.ts
+++ b/packages/core/src/components/dialog/dialog.test.ts
@@ -3,6 +3,12 @@ import type { ArDialog } from './dialog.js';
 import { fixture, waitForUpdate, getPart, requireShadow } from '../../test-utils.js';
 import './index.js';
 
+// LocalizeController résout la langue via document.documentElement.lang, avec
+// navigator.language comme secours (happy-dom retourne 'en-US' par défaut).
+// En production, le site de doc pose lang="fr" sur <html> ; on reproduit ça ici
+// pour que les assertions FR par défaut restent valides sans lang explicite.
+document.documentElement.lang = 'fr';
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function getDialogEl(el: ArDialog): HTMLDialogElement {
@@ -81,8 +87,8 @@ describe('ArDialog', () => {
         it('mode est modal', () => expect(el.mode).toBe('modal'));
         it('placement est right', () => expect(el.placement).toBe('right'));
         it('size est md', () => expect(el.size).toBe('md'));
-        it('preventedMessage a sa valeur par défaut', () =>
-            expect(el.preventedMessage).toBe('Fermeture bloquée.'));
+        it('preventedMessage vaut undefined par défaut (traduit dynamiquement)', () =>
+            expect(el.preventedMessage).toBeUndefined());
     });
 
     // ── Propriétés reflect ────────────────────────────────────────────────────
@@ -986,6 +992,37 @@ describe('ArDialog', () => {
 
             const closeWarns = spy.mock.calls.filter((c) => String(c[0]).includes('Échap'));
             expect(closeWarns.length).toBeGreaterThan(0);
+        });
+    });
+
+    describe('traduction', () => {
+        it('lang="en" traduit le label accessible du bouton de fermeture', async () => {
+            el = await fixture('<ar-dialog label="Titre" lang="en"></ar-dialog>');
+            const closeLabel = requireShadow(el).querySelector('[part~="close-button"] .sr-only');
+            expect(closeLabel?.textContent).toBe('Close dialog');
+        });
+
+        it('closeLabel personnalisé prend le pas sur la traduction', async () => {
+            el = await fixture('<ar-dialog label="Titre" close-label="Annuler"></ar-dialog>');
+            const closeLabel = requireShadow(el).querySelector('[part~="close-button"] .sr-only');
+            expect(closeLabel?.textContent).toBe('Annuler');
+        });
+
+        it('lang="en" traduit le message de fermeture bloquée', async () => {
+            el = await fixture('<ar-dialog label="Titre" open lang="en"></ar-dialog>');
+            el.addEventListener('ar-dialog-hide', (e) => e.preventDefault());
+            el.open = false;
+            await waitForUpdate(el);
+            await new Promise((resolve) => setTimeout(resolve, 60));
+            expect(document.getElementById('ar-live-region-assertive')?.textContent).toBe(
+                'Closing blocked.',
+            );
+        });
+
+        it('lang="en" traduit le titre de repli quand label est vide', async () => {
+            el = await fixture('<ar-dialog open lang="en"></ar-dialog>');
+            const heading = requireShadow(el).querySelector('#dialog-heading');
+            expect(heading?.textContent?.trim()).toBe('Dialog');
         });
     });
 });

--- a/packages/core/src/components/dialog/dialog.ts
+++ b/packages/core/src/components/dialog/dialog.ts
@@ -15,6 +15,10 @@ import { HasSlotController } from '../../controllers/has-slot.controller.js';
 import { prefersReducedMotion } from '../../utils/media.js';
 import { acquireScrollLock, releaseScrollLock } from '../../utils/scroll-lock.js';
 import { warn } from '../../utils/warn.js';
+import { LocalizeController } from '../../controllers/localize.controller.js';
+// fr avant en : la première traduction enregistrée devient le repli de la lib pour les langues non reconnues.
+import '../../translations/fr.js';
+import '../../translations/en.js';
 
 /** Evènements envoyés par le webcomposant ArDialog */
 export type ArDialogEvents =
@@ -30,8 +34,6 @@ export type ArDialogEvents =
     | 'ar-dialog-accepted-prevented';
 
 const _dialogStack: ArDialog[] = [];
-
-const DEFAULT_DIALOG_LABEL = 'Dialogue';
 
 if (typeof document !== 'undefined') {
     document.addEventListener(
@@ -49,6 +51,7 @@ if (typeof document !== 'undefined') {
 
 /**
  * @summary Boîte de dialogue modale ou panneau latéral (drawer), accessible et animée.
+ * @localized
  *
  * @slot label - Titre du dialog. Remplace la propriété `label` si du HTML est nécessaire. Sans effet si `without-header` est actif.
  * @slot header-actions - Actions additionnelles dans le header, positionnées avant le bouton de fermeture (ex. bouton plein écran, menu). Retiré du DOM si `without-header` est actif.
@@ -91,6 +94,8 @@ export class ArDialog extends LitElement {
     static override styles: CSSResultGroup = [utilitiesStyles, resetStyles, styles];
 
     // ── Public properties ──────────────────────────────────────────────────────
+
+    private readonly localize = new LocalizeController(this);
 
     /**
      * Visibilité du composant.
@@ -162,20 +167,21 @@ export class ArDialog extends LitElement {
     /**
      * Message annoncé aux lecteurs d'écran quand une fermeture est bloquée
      * (événements `ar-dialog-hide-prevented`, `ar-dialog-dismissed-prevented`, `ar-dialog-accepted-prevented`).
+     * Traduit automatiquement selon `lang` si non personnalisé.
      *
      * @attr prevented-message
-     * @default 'Fermeture bloquée.'
      */
-    @property({ reflect: true, attribute: 'prevented-message' }) preventedMessage =
-        'Fermeture bloquée.';
+    @property({ reflect: true, useDefault: true, attribute: 'prevented-message' })
+    preventedMessage: string | undefined = undefined;
 
     /**
-     * Label accessible du bouton de fermeture. À adapter pour la langue de l'interface.
+     * Label accessible du bouton de fermeture. Traduit automatiquement selon `lang` si non
+     * personnalisé.
      *
      * @attr close-label
-     * @default 'Fermer'
      */
-    @property({ reflect: true, attribute: 'close-label' }) closeLabel = 'Fermer';
+    @property({ reflect: true, useDefault: true, attribute: 'close-label' })
+    closeLabel: string | undefined = undefined;
 
     // ── Private state ──────────────────────────────────────────────────────────
 
@@ -205,7 +211,7 @@ export class ArDialog extends LitElement {
     private _hasWarnedNoCloseMechanism = false;
 
     private _getHeadingLabel(): string {
-        return (this.label ?? '').trim() || DEFAULT_DIALOG_LABEL;
+        return (this.label ?? '').trim() || this.localize.term('dialogDefaultLabel');
     }
 
     private _warnIfMissingLabel(): void {
@@ -282,6 +288,7 @@ export class ArDialog extends LitElement {
 
     override render(): TemplateResult {
         const headingLabel = this._getHeadingLabel();
+        const closeButtonLabel = this.closeLabel?.trim() || this.localize.term('closeDialog');
 
         return html`
             <dialog
@@ -326,7 +333,7 @@ export class ArDialog extends LitElement {
                                       ></path>
                                   </svg>
                               </slot>
-                              <span class="sr-only">${this.closeLabel}</span>
+                              <span class="sr-only">${closeButtonLabel}</span>
                           </button>
                       </header>`}
                 <div part="body" id="dialog-body">
@@ -373,7 +380,7 @@ export class ArDialog extends LitElement {
     }
 
     private _announcePrevented(): void {
-        const message = this.preventedMessage.trim() || 'Fermeture bloquée.';
+        const message = this.preventedMessage?.trim() || this.localize.term('closingBlocked');
         announceA11y(message, 'assertive');
     }
 

--- a/packages/core/src/components/pagination/pagination.browser.test.ts
+++ b/packages/core/src/components/pagination/pagination.browser.test.ts
@@ -10,6 +10,12 @@
 import { fixture, html, expect, elementUpdated } from '@open-wc/testing';
 import './index.js';
 
+// LocalizeController résout la langue via document.documentElement.lang, avec
+// navigator.language comme secours (le runner Chromium peut différer selon l'environnement CI).
+// En production, le site de doc pose lang="fr" sur <html> ; on reproduit ça ici
+// pour que les assertions FR par défaut restent valides sans lang explicite.
+document.documentElement.lang = 'fr';
+
 describe('ar-pagination — browser', () => {
     describe('focus après activation, confirmée par le consommateur (#154, #161)', () => {
         // Vérifie que le focus atterrit sur le nouvel élément part="current" et que

--- a/packages/core/src/components/pagination/pagination.test.ts
+++ b/packages/core/src/components/pagination/pagination.test.ts
@@ -1112,14 +1112,26 @@ describe('ArPagination', () => {
             const nextSrOnly = requirePart(el, 'next').querySelector('.sr-only');
             expect(prevSrOnly?.textContent).toBe('Previous page (page 7 of 15)');
             expect(nextSrOnly?.textContent).toBe('Next page (page 9 of 15)');
+
+            // @ts-expect-error accès à un champ privé pour forcer le palier select
+            el._budget = 2;
+            el.requestUpdate();
+            await waitForUpdate(el);
+            const selectLabel = el.shadowRoot?.querySelector('#ar-pagination-select-label');
+            expect(selectLabel?.textContent).toBe('Go to page');
         });
 
         it('lang="en" traduit le label compact', async () => {
             el = await fixture(
                 '<ar-pagination current="2" total="5" compact lang="en"></ar-pagination>',
             );
-            const label = getPart(el, 'label');
-            expect(label?.textContent?.trim()).toBe('Page 2 / 5');
+            // Qualifié par balise (`span[part~="label"]`, pas `getPart`/`[part~="label"]` seul) :
+            // happy-dom scinde aussi sur les tirets dans son implémentation de `~=`, donc
+            // "label" matcherait aussi à tort le `<li part="item page-label">` ancêtre (retourné
+            // en premier par querySelector, avant le `<span part="label">` imbriqué) — cf. mise
+            // en garde dans test-utils.ts.
+            const label = el.shadowRoot?.querySelector('span[part~="label"]');
+            expect(label?.textContent).toBe('Page 2 / 5');
         });
 
         it('lang="en" traduit le label du landmark nav', async () => {

--- a/packages/core/src/components/pagination/pagination.test.ts
+++ b/packages/core/src/components/pagination/pagination.test.ts
@@ -3,6 +3,12 @@ import { ArPagination, type ArPaginationPageChangeDetail } from './pagination.js
 import { fixture, waitForUpdate, getPart, requirePart } from '../../test-utils.js';
 import './index.js';
 
+// LocalizeController résout la langue via document.documentElement.lang, avec
+// navigator.language comme secours (happy-dom retourne 'en-US' par défaut).
+// En production, le site de doc pose lang="fr" sur <html> ; on reproduit ça ici
+// pour que les assertions FR par défaut restent valides sans lang explicite.
+document.documentElement.lang = 'fr';
+
 /**
  * Vérifie qu'un token est présent dans l'attribut `part` d'un élément, sans dépendre
  * de l'ordre de sérialisation. `Element.part` (DOMTokenList) n'est pas supporté par
@@ -1092,6 +1098,28 @@ describe('ArPagination', () => {
             const nextLabel = el.shadowRoot?.querySelector('[part~="next"] .sr-only')?.textContent;
             expect(prevLabel).not.toMatch(/-\d/);
             expect(nextLabel).not.toMatch(/-\d/);
+        });
+    });
+
+    describe('traduction', () => {
+        afterEach(() => {
+            el.removeAttribute('lang');
+        });
+
+        it('lang="en" traduit les sr-only prev/next et le label du select', async () => {
+            el = await fixture('<ar-pagination current="8" total="15" lang="en"></ar-pagination>');
+            const prevSrOnly = requirePart(el, 'prev').querySelector('.sr-only');
+            const nextSrOnly = requirePart(el, 'next').querySelector('.sr-only');
+            expect(prevSrOnly?.textContent).toBe('Previous page (page 7 of 15)');
+            expect(nextSrOnly?.textContent).toBe('Next page (page 9 of 15)');
+        });
+
+        it('lang="en" traduit le label compact', async () => {
+            el = await fixture(
+                '<ar-pagination current="2" total="5" compact lang="en"></ar-pagination>',
+            );
+            const label = getPart(el, 'label');
+            expect(label?.textContent?.trim()).toBe('Page 2 / 5');
         });
     });
 });

--- a/packages/core/src/components/pagination/pagination.test.ts
+++ b/packages/core/src/components/pagination/pagination.test.ts
@@ -1121,5 +1121,11 @@ describe('ArPagination', () => {
             const label = getPart(el, 'label');
             expect(label?.textContent?.trim()).toBe('Page 2 / 5');
         });
+
+        it('lang="en" traduit le label du landmark nav', async () => {
+            el = await fixture('<ar-pagination current="8" total="15" lang="en"></ar-pagination>');
+            const landmark = el.shadowRoot?.querySelector('#ar-pagination');
+            expect(landmark?.textContent).toBe('Pagination, page 8 of 15');
+        });
     });
 });

--- a/packages/core/src/components/pagination/pagination.ts
+++ b/packages/core/src/components/pagination/pagination.ts
@@ -334,9 +334,7 @@ export class ArPagination extends LitElement {
         const nextPageNumber = _clamp(current + 1, 1, total);
 
         return html` <nav part="pagination" role="navigation" aria-labelledby="ar-pagination">
-            <p id="ar-pagination" class="sr-only">
-                ${this.localize.term('paginationLandmark', current, total)}
-            </p>
+            <p id="ar-pagination" class="sr-only">${this.localize.term('paginationLandmark', current, total)}</p>
             <ul part="list" @click=${this._onPageChange}>
                 ${this.compact ? this.renderCompactLabel(current, total) : nothing}
 

--- a/packages/core/src/components/pagination/pagination.ts
+++ b/packages/core/src/components/pagination/pagination.ts
@@ -334,7 +334,9 @@ export class ArPagination extends LitElement {
         const nextPageNumber = _clamp(current + 1, 1, total);
 
         return html` <nav part="pagination" role="navigation" aria-labelledby="ar-pagination">
-            <p id="ar-pagination" class="sr-only">Pagination, page ${current} sur ${total}</p>
+            <p id="ar-pagination" class="sr-only">
+                ${this.localize.term('paginationLandmark', current, total)}
+            </p>
             <ul part="list" @click=${this._onPageChange}>
                 ${this.compact ? this.renderCompactLabel(current, total) : nothing}
 

--- a/packages/core/src/components/pagination/pagination.ts
+++ b/packages/core/src/components/pagination/pagination.ts
@@ -8,6 +8,10 @@ import { _calculatePages, _clamp } from './pagination.utils.js';
 import { announceA11y } from '../../a11y/announce-a11y.js';
 import { focusAfterUpdate } from '../../a11y/focus-after-update.js';
 import { warn } from '../../utils/warn.js';
+import { LocalizeController } from '../../controllers/localize.controller.js';
+// fr avant en : la première traduction enregistrée devient le repli de la lib pour les langues non reconnues.
+import '../../translations/fr.js';
+import '../../translations/en.js';
 
 /** Objet de configuration d'un webcomposant ArPagination */
 export class ArPaginationConfig {
@@ -26,6 +30,7 @@ export interface ArPaginationPageChangeDetail {
 /**
  * @summary Pagination accessible avec numérotation dynamique et ellipses automatiques.
  * @display demo
+ * @localized
  *
  * Les pages intermédiaires sont calculées automatiquement selon le nombre total.
  * Des ellipses (`...`) sont insérées quand le nombre de pages dépasse le seuil d'affichage.
@@ -74,6 +79,8 @@ export interface ArPaginationPageChangeDetail {
  */
 export class ArPagination extends LitElement {
     static override styles: CSSResultGroup = [utilitiesStyles, resetStyles, styles];
+
+    private readonly localize = new LocalizeController(this);
 
     static readonly DEFAULT_CURRENT: number = 1;
     static readonly DEFAULT_TOTAL: number = 5;
@@ -342,7 +349,7 @@ export class ArPagination extends LitElement {
                     >
                         <slot name="prev-icon">${this._defaultPrevIcon()}</slot>
                         <span class="sr-only"
-                            >Page précédente (page ${previousPageNumber} sur ${total})</span
+                            >${this.localize.term('previousPage', previousPageNumber, total)}</span
                         >
                     </a>
                 </li>
@@ -360,7 +367,7 @@ export class ArPagination extends LitElement {
                     >
                         <slot name="next-icon">${this._defaultNextIcon()}</slot>
                         <span class="sr-only"
-                            >Page suivante (page ${nextPageNumber} sur ${total})</span
+                            >${this.localize.term('nextPage', nextPageNumber, total)}</span
                         >
                     </a>
                 </li>
@@ -445,7 +452,7 @@ export class ArPagination extends LitElement {
      * eux (voir garde globale sur les bindings adjacents dans un conteneur flex).
      */
     protected renderPageLabel(page: number, total: number): TemplateResult {
-        return html`<span class="sr-only">Page ${page} sur ${total}</span
+        return html`<span class="sr-only">${this.localize.term('pageStatus', page, total)}</span
             ><span aria-hidden="true">${page}</span>`;
     }
 
@@ -462,7 +469,9 @@ export class ArPagination extends LitElement {
      */
     protected renderPageSelect(current: number, total: number): TemplateResult {
         return html`<li part="item page-select">
-            <span class="sr-only" id="ar-pagination-select-label">Aller à la page</span>
+            <span class="sr-only" id="ar-pagination-select-label"
+                >${this.localize.term('goToPage')}</span
+            >
             <select
                 part="select field"
                 aria-labelledby="ar-pagination-select-label"
@@ -472,7 +481,7 @@ export class ArPagination extends LitElement {
                     page === -1 || page === -2
                         ? html`<option disabled value="">…</option>`
                         : html`<option value=${page} ?selected=${page === current}>
-                              Page ${page} sur ${total}
+                              ${this.localize.term('pageStatus', page, total)}
                           </option>`,
                 )}
             </select>
@@ -488,7 +497,7 @@ export class ArPagination extends LitElement {
      */
     protected renderCompactLabel(current: number, total: number): TemplateResult {
         return html`<li part="item page-label" aria-hidden="true">
-            <span part="label">Page ${current} / ${total}</span>
+            <span part="label">${this.localize.term('compactPageStatus', current, total)}</span>
         </li>`;
     }
 
@@ -555,6 +564,6 @@ export class ArPagination extends LitElement {
     }
 
     private _announcePageChange(): void {
-        announceA11y(`Page ${this.current} sur ${this.total}`, 'polite');
+        announceA11y(this.localize.term('pageStatus', this.current, this.total), 'polite');
     }
 }

--- a/packages/core/src/components/pagination/pagination.ts
+++ b/packages/core/src/components/pagination/pagination.ts
@@ -332,14 +332,12 @@ export class ArPagination extends LitElement {
         const isPreviousDisabled = current <= 1;
         const previousPageNumber = _clamp(current - 1, 1, total > 1 ? total - 1 : 1);
         const nextPageNumber = _clamp(current + 1, 1, total);
+        const landmarkLabel = this.localize.term('paginationLandmark', current, total);
+        const previousPageSrOnly = this.localize.term('previousPage', previousPageNumber, total);
+        const nextPageSrOnly = this.localize.term('nextPage', nextPageNumber, total);
 
         return html` <nav part="pagination" role="navigation" aria-labelledby="ar-pagination">
-            <!-- prettier-ignore -->
-            <p id="ar-pagination" class="sr-only">${this.localize.term(
-                'paginationLandmark',
-                current,
-                total,
-            )}</p>
+            <p id="ar-pagination" class="sr-only">${landmarkLabel}</p>
             <ul part="list" @click=${this._onPageChange}>
                 ${this.compact ? this.renderCompactLabel(current, total) : nothing}
 
@@ -353,9 +351,7 @@ export class ArPagination extends LitElement {
                         @click=${this._onPreviousPage}
                     >
                         <slot name="prev-icon">${this._defaultPrevIcon()}</slot>
-                        <span class="sr-only"
-                            >${this.localize.term('previousPage', previousPageNumber, total)}</span
-                        >
+                        <span class="sr-only">${previousPageSrOnly}</span>
                     </a>
                 </li>
 
@@ -371,9 +367,7 @@ export class ArPagination extends LitElement {
                         @click=${this._onNextPage}
                     >
                         <slot name="next-icon">${this._defaultNextIcon()}</slot>
-                        <span class="sr-only"
-                            >${this.localize.term('nextPage', nextPageNumber, total)}</span
-                        >
+                        <span class="sr-only">${nextPageSrOnly}</span>
                     </a>
                 </li>
             </ul>
@@ -457,8 +451,8 @@ export class ArPagination extends LitElement {
      * eux (voir garde globale sur les bindings adjacents dans un conteneur flex).
      */
     protected renderPageLabel(page: number, total: number): TemplateResult {
-        return html`<span class="sr-only">${this.localize.term('pageStatus', page, total)}</span
-            ><span aria-hidden="true">${page}</span>`;
+        const status = this.localize.term('pageStatus', page, total);
+        return html`<span class="sr-only">${status}</span><span aria-hidden="true">${page}</span>`;
     }
 
     /**
@@ -473,10 +467,9 @@ export class ArPagination extends LitElement {
      * desktop, seulement rendu différemment.
      */
     protected renderPageSelect(current: number, total: number): TemplateResult {
+        const goToPageLabel = this.localize.term('goToPage');
         return html`<li part="item page-select">
-            <span class="sr-only" id="ar-pagination-select-label"
-                >${this.localize.term('goToPage')}</span
-            >
+            <span class="sr-only" id="ar-pagination-select-label">${goToPageLabel}</span>
             <select
                 part="select field"
                 aria-labelledby="ar-pagination-select-label"
@@ -485,7 +478,9 @@ export class ArPagination extends LitElement {
                 ${_calculatePages(current, total).map((page) =>
                     page === -1 || page === -2
                         ? html`<option disabled value="">…</option>`
-                        : html`<option value=${page} ?selected=${page === current}>
+                        : // Pas besoin d'idiome anti-whitespace ici : le navigateur collapse les espaces
+                          // dans le label texte d'un <option>, contrairement à .textContent d'un <p>/<span>.
+                          html`<option value=${page} ?selected=${page === current}>
                               ${this.localize.term('pageStatus', page, total)}
                           </option>`,
                 )}

--- a/packages/core/src/components/pagination/pagination.ts
+++ b/packages/core/src/components/pagination/pagination.ts
@@ -334,7 +334,12 @@ export class ArPagination extends LitElement {
         const nextPageNumber = _clamp(current + 1, 1, total);
 
         return html` <nav part="pagination" role="navigation" aria-labelledby="ar-pagination">
-            <p id="ar-pagination" class="sr-only">${this.localize.term('paginationLandmark', current, total)}</p>
+            <!-- prettier-ignore -->
+            <p id="ar-pagination" class="sr-only">${this.localize.term(
+                'paginationLandmark',
+                current,
+                total,
+            )}</p>
             <ul part="list" @click=${this._onPageChange}>
                 ${this.compact ? this.renderCompactLabel(current, total) : nothing}
 

--- a/packages/core/src/components/spinner/spinner.test.ts
+++ b/packages/core/src/components/spinner/spinner.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ArSpinner } from './spinner.js';
+import { type ArSpinner } from './spinner.js';
 import { fixture, waitForUpdate, getPart, requirePart } from '../../test-utils.js';
 import './index.js';
+
+// LocalizeController résout la langue via document.documentElement.lang, avec
+// navigator.language comme secours (happy-dom retourne 'en-US' par défaut).
+// En production, le site de doc pose lang="fr" sur <html> ; on reproduit ça ici
+// pour que les assertions FR par défaut restent valides sans lang explicite.
+document.documentElement.lang = 'fr';
 
 describe('ArSpinner', () => {
     let el: ArSpinner;
@@ -39,12 +45,12 @@ describe('ArSpinner', () => {
             expect(el.done).toBe(false);
         });
 
-        it('loadingLabel vaut la constante DEFAULT_LOADING_LABEL', () => {
-            expect(el.loadingLabel).toBe(ArSpinner.DEFAULT_LOADING_LABEL);
+        it('loadingLabel vaut undefined par défaut (traduit dynamiquement)', () => {
+            expect(el.loadingLabel).toBeUndefined();
         });
 
-        it('doneLabel vaut la constante DEFAULT_DONE_LABEL', () => {
-            expect(el.doneLabel).toBe(ArSpinner.DEFAULT_DONE_LABEL);
+        it('doneLabel vaut undefined par défaut (traduit dynamiquement)', () => {
+            expect(el.doneLabel).toBeUndefined();
         });
 
         it('size est undefined par défaut', () => {
@@ -70,7 +76,7 @@ describe('ArSpinner', () => {
         // happy-dom ne sérialise pas les Text nodes dynamiques de Lit en textContent.
         // On teste la propriété JS directement — c'est ce que le template consomme.
         it('la propriété loadingLabel contient le texte annoncé en chargement', () => {
-            expect(el.loadingLabel).toBe(ArSpinner.DEFAULT_LOADING_LABEL);
+            expect(el.loadingLabel).toBeUndefined();
         });
     });
 
@@ -86,7 +92,7 @@ describe('ArSpinner', () => {
         });
 
         it('la propriété doneLabel contient le texte annoncé à la fin', () => {
-            expect(el.doneLabel).toBe(ArSpinner.DEFAULT_DONE_LABEL);
+            expect(el.doneLabel).toBeUndefined();
         });
     });
 
@@ -197,6 +203,18 @@ describe('ArSpinner', () => {
             await fixture('<ar-spinner></ar-spinner>');
 
             expect(spy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('traduction', () => {
+        it('lang="en" traduit le texte en chargement', async () => {
+            el = await fixture('<ar-spinner lang="en"></ar-spinner>');
+            expect(getPart(el, 'status')?.textContent?.trim()).toBe('Content is loading');
+        });
+
+        it('lang="en" traduit le texte terminé', async () => {
+            el = await fixture('<ar-spinner done lang="en"></ar-spinner>');
+            expect(getPart(el, 'status')?.textContent?.trim()).toBe('Loading complete');
         });
     });
 });

--- a/packages/core/src/components/spinner/spinner.ts
+++ b/packages/core/src/components/spinner/spinner.ts
@@ -4,10 +4,15 @@ import utilitiesStyles from '../../styles/utilities.styles.js';
 import animationsStyles from '../../styles/animations.styles.js';
 import styles from './spinner.styles.js';
 import { warn } from '../../utils/warn.js';
+import { LocalizeController } from '../../controllers/localize.controller.js';
+// fr avant en : la première traduction enregistrée devient le repli de la lib pour les langues non reconnues.
+import '../../translations/fr.js';
+import '../../translations/en.js';
 
 /**
  * @summary Indicateur de chargement accessible avec états "en cours" et "terminé".
  * @display demo
+ * @localized
  *
  * Le spinner SVG est masqué (`hidden`) quand `done` est `true`.
  * Un `<div role="alert">` annonce aux lecteurs d'écran le changement d'état,
@@ -21,8 +26,8 @@ import { warn } from '../../utils/warn.js';
 export class ArSpinner extends LitElement {
     static override styles: CSSResultGroup = [utilitiesStyles, animationsStyles, styles];
     static readonly DEFAULT_DONE: boolean = false;
-    static readonly DEFAULT_LOADING_LABEL: string = 'Contenu en cours de chargement';
-    static readonly DEFAULT_DONE_LABEL: string = 'Chargement terminé';
+
+    private readonly localize = new LocalizeController(this);
 
     /**
      * Passe le spinner en état "terminé" : masque le SVG et met à jour l'annonce ARIA.
@@ -33,32 +38,36 @@ export class ArSpinner extends LitElement {
     done: boolean = ArSpinner.DEFAULT_DONE;
 
     /**
-     * Texte annoncé aux lecteurs d'écran pendant le chargement.
+     * Texte annoncé aux lecteurs d'écran pendant le chargement. Traduit automatiquement selon
+     * `lang` si non personnalisé.
      * @attr loading-label
-     * @default 'Contenu en cours de chargement'
      */
     @property({ reflect: true, useDefault: true, type: String, attribute: 'loading-label' })
-    loadingLabel: string = ArSpinner.DEFAULT_LOADING_LABEL;
+    loadingLabel: string | undefined = undefined;
 
     /**
-     * Texte annoncé aux lecteurs d'écran quand le chargement est terminé.
+     * Texte annoncé aux lecteurs d'écran quand le chargement est terminé. Traduit automatiquement
+     * selon `lang` si non personnalisé.
      * @attr done-label
-     * @default 'Chargement terminé'
      */
     @property({ reflect: true, useDefault: true, type: String, attribute: 'done-label' })
-    doneLabel: string = ArSpinner.DEFAULT_DONE_LABEL;
+    doneLabel: string | undefined = undefined;
 
     @property({ reflect: true, type: String, useDefault: true })
     size: 'xs' | 'sm' | 'lg' | undefined = undefined;
 
     override updated(changed: Map<string, unknown>): void {
-        if (changed.has('loadingLabel') && !this.loadingLabel.trim()) {
+        if (
+            changed.has('loadingLabel') &&
+            this.loadingLabel !== undefined &&
+            !this.loadingLabel.trim()
+        ) {
             warn(
                 'ar-spinner',
                 "loading-label est vide — le spinner ne sera pas annoncé aux lecteurs d'écran.",
             );
         }
-        if (changed.has('doneLabel') && !this.doneLabel.trim()) {
+        if (changed.has('doneLabel') && this.doneLabel !== undefined && !this.doneLabel.trim()) {
             warn(
                 'ar-spinner',
                 "done-label est vide — l'état terminé ne sera pas annoncé aux lecteurs d'écran.",
@@ -67,6 +76,9 @@ export class ArSpinner extends LitElement {
     }
 
     override render(): TemplateResult {
+        const label = this.done
+            ? this.doneLabel?.trim() || this.localize.term('loadingDone')
+            : this.loadingLabel?.trim() || this.localize.term('loading');
         return html` <svg
                 part="spinner"
                 class="spinner"
@@ -84,7 +96,7 @@ export class ArSpinner extends LitElement {
                 ></circle>`}
             </svg>
             <div part="status" role="alert" class="sr-only">
-                <p>${this.done ? this.doneLabel : this.loadingLabel}</p>
+                <p>${label}</p>
             </div>`;
     }
 }

--- a/packages/core/src/components/stepper/stepper.renderer.ts
+++ b/packages/core/src/components/stepper/stepper.renderer.ts
@@ -39,12 +39,13 @@ function renderStepText(
     label: string,
     order: number,
     isCurrent: boolean,
-    isSubstep = false,
+    isSubstep: boolean,
+    stepLabel: (order: number, isSubstep: boolean) => string,
 ): TemplateResult {
     const bulletPart = withCurrentPart('bullet', isCurrent, 'indicator');
     return html`
         <span part=${bulletPart} aria-hidden="true"></span>
-        <span class="sr-only">${isSubstep ? 'sous-' : ''}étape ${order}:</span>
+        <span class="sr-only">${stepLabel(order, isSubstep)}</span>
         <span class="item-label">${label}</span>
     `;
 }
@@ -58,6 +59,7 @@ function renderSubStep(
     index: number,
     mode: NavigationMode,
     onClickLink: (e: MouseEvent) => void,
+    stepLabel: (order: number, isSubstep: boolean) => string,
 ): TemplateResult {
     const order = index + 1;
     const isCurrent = sub.state === 'current';
@@ -80,12 +82,12 @@ function renderSubStep(
                           href=${sub.href ?? '#'}
                           @click=${onClickLink}
                       >
-                          ${renderStepText(sub.label, order, isCurrent, true)}
+                          ${renderStepText(sub.label, order, isCurrent, true, stepLabel)}
                       </a>
                   `
                 : html`
                       <div class="item-header" data-path=${sub.path} tabindex="-1">
-                          ${renderStepText(sub.label, order, isCurrent, true)}
+                          ${renderStepText(sub.label, order, isCurrent, true, stepLabel)}
                       </div>
                   `}
         </li>
@@ -97,6 +99,7 @@ function renderStep(
     index: number,
     mode: NavigationMode,
     onClickLink: (e: MouseEvent) => void,
+    stepLabel: (order: number, isSubstep: boolean) => string,
 ): TemplateResult {
     const order = index + 1;
     const isCurrent = isGroupCurrent(step, mode);
@@ -119,18 +122,20 @@ function renderStep(
                           href=${step.href ?? '#'}
                           @click=${onClickLink}
                       >
-                          ${renderStepText(step.label, order, isCurrent)}
+                          ${renderStepText(step.label, order, isCurrent, false, stepLabel)}
                       </a>
                   `
                 : html`
                       <div class="item-header" data-path=${step.path} tabindex="-1">
-                          ${renderStepText(step.label, order, isCurrent)}
+                          ${renderStepText(step.label, order, isCurrent, false, stepLabel)}
                       </div>
                   `}
             ${(isCurrent || mode === 'edit') && step.children.length
                 ? html`
                       <ol class="list-unstyled" part="list list--substep">
-                          ${step.children.map((sub, i) => renderSubStep(sub, i, mode, onClickLink))}
+                          ${step.children.map((sub, i) =>
+                              renderSubStep(sub, i, mode, onClickLink, stepLabel),
+                          )}
                       </ol>
                   `
                 : nothing}
@@ -147,13 +152,14 @@ function renderStepList(
     cssClass: string,
     mode: NavigationMode,
     onClickLink: (e: MouseEvent) => void,
+    stepLabel: (order: number, isSubstep: boolean) => string,
 ): TemplateResult {
     return html`
         <ol class="list-unstyled ${cssClass}" part="list">
             ${repeat(
                 steps,
                 (step) => step.path,
-                (step, index) => renderStep(step, index, mode, onClickLink),
+                (step, index) => renderStep(step, index, mode, onClickLink, stepLabel),
             )}
         </ol>
     `;
@@ -167,8 +173,9 @@ export function renderDesktop(
     steps: NavigationNode[],
     mode: NavigationMode,
     onClickLink: (e: MouseEvent) => void,
+    stepLabel: (order: number, isSubstep: boolean) => string,
 ): TemplateResult {
-    return renderStepList(steps, 'desktop', mode, onClickLink);
+    return renderStepList(steps, 'desktop', mode, onClickLink, stepLabel);
 }
 
 /* ------------------------------------------------ */
@@ -180,6 +187,7 @@ export function renderMobile(
     ctx: MobileRenderContext,
     mode: NavigationMode,
     onClickLink: (e: MouseEvent) => void,
+    stepLabel: (order: number, isSubstep: boolean) => string,
 ): TemplateResult {
     const subLabel = ctx.currentSubStepLabel ? ` | ${ctx.currentSubStepLabel}` : '';
 
@@ -196,7 +204,7 @@ export function renderMobile(
             </button>
 
             <div id="stepper-dropdown-menu" part="panel">
-                ${renderStepList(steps, 'mobile', mode, onClickLink)}
+                ${renderStepList(steps, 'mobile', mode, onClickLink, stepLabel)}
             </div>
         </div>
     `;

--- a/packages/core/src/components/stepper/stepper.renderer.ts
+++ b/packages/core/src/components/stepper/stepper.renderer.ts
@@ -12,6 +12,7 @@ export interface MobileRenderContext {
     currentStepIndex: number;
     currentStepLabel: string | undefined;
     currentSubStepLabel: string | undefined;
+    currentStepStatus: string;
     onToggle: () => void;
 }
 
@@ -199,7 +200,7 @@ export function renderMobile(
                 aria-controls="stepper-dropdown-menu"
                 @click=${ctx.onToggle}
             >
-                <span> Étape ${ctx.currentStepIndex + 1} / ${steps.length} (en cours) </span>
+                <span> ${ctx.currentStepStatus} </span>
                 <span class="text-primary emphasis"> ${ctx.currentStepLabel}${subLabel} </span>
             </button>
 

--- a/packages/core/src/components/stepper/stepper.test.ts
+++ b/packages/core/src/components/stepper/stepper.test.ts
@@ -1063,6 +1063,16 @@ describe('ArStepper', () => {
             expect(label?.textContent).toBe('Form steps');
             el.remove();
         });
+
+        it('lang="en" traduit le label sr-only de chaque étape', async () => {
+            const el = await fixture<ArStepper>(
+                '<ar-stepper current-path="/a" lang="en"><ar-stepper-item href="/a" label="A"></ar-stepper-item></ar-stepper>',
+            );
+            await waitForUpdate(el);
+            const srOnly = el.shadowRoot?.querySelector('.item .sr-only');
+            expect(srOnly?.textContent).toBe('step 1:');
+            el.remove();
+        });
     });
 
     describe('régressions change-in-update', () => {

--- a/packages/core/src/components/stepper/stepper.test.ts
+++ b/packages/core/src/components/stepper/stepper.test.ts
@@ -1073,6 +1073,22 @@ describe('ArStepper', () => {
             expect(srOnly?.textContent).toBe('step 1:');
             el.remove();
         });
+
+        it('lang="en" traduit le statut du trigger mobile', async () => {
+            vi.spyOn(window, 'matchMedia').mockReturnValue({
+                matches: false,
+                addEventListener: vi.fn(),
+                removeEventListener: vi.fn(),
+            } as unknown as MediaQueryList);
+
+            const el = await fixtureWithItems(
+                '<ar-stepper current-path="/a" lang="en"><ar-stepper-item href="/a" label="A"></ar-stepper-item></ar-stepper>',
+            );
+
+            const trigger = el.shadowRoot?.querySelector('[part="trigger"] span');
+            expect(trigger?.textContent).toBe(' Step 1 / 1 (in progress) ');
+            el.remove();
+        });
     });
 
     describe('régressions change-in-update', () => {

--- a/packages/core/src/components/stepper/stepper.test.ts
+++ b/packages/core/src/components/stepper/stepper.test.ts
@@ -5,9 +5,10 @@ import { fixture, waitForUpdate } from '../../test-utils.js';
 import './index.js';
 import '../stepper-item/index.js';
 
-// ─── Localization ────────────────────────────────────────────────────────────
-// Défaut : français. Les tests monolangues (la plupart) l'utiliseront.
-// Les tests multilingues (traduction) peuvent surcharger dynamiquement.
+// LocalizeController résout la langue via document.documentElement.lang, avec
+// navigator.language comme secours (happy-dom retourne 'en-US' par défaut).
+// En production, le site de doc pose lang="fr" sur <html> ; on reproduit ça ici
+// pour que les assertions FR par défaut restent valides sans lang explicite.
 document.documentElement.lang = 'fr';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────

--- a/packages/core/src/components/stepper/stepper.test.ts
+++ b/packages/core/src/components/stepper/stepper.test.ts
@@ -5,6 +5,11 @@ import { fixture, waitForUpdate } from '../../test-utils.js';
 import './index.js';
 import '../stepper-item/index.js';
 
+// ─── Localization ────────────────────────────────────────────────────────────
+// Défaut : français. Les tests monolangues (la plupart) l'utiliseront.
+// Les tests multilingues (traduction) peuvent surcharger dynamiquement.
+document.documentElement.lang = 'fr';
+
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 /** Retourne le shadowRoot ou lance une erreur de test. */
@@ -1044,6 +1049,18 @@ describe('ArStepper', () => {
             expect(spy).toHaveBeenCalled();
             expect(spy).toHaveBeenCalledWith(expect.stringContaining('[ar-stepper]'));
             expect(spy).toHaveBeenCalledWith(expect.stringContaining('conteneur-inexistant'));
+        });
+    });
+
+    describe('traduction', () => {
+        it('lang="en" traduit le label de navigation', async () => {
+            const el = await fixture<ArStepper>(
+                '<ar-stepper current-path="/a" lang="en"><ar-stepper-item href="/a" label="A"></ar-stepper-item></ar-stepper>',
+            );
+            await waitForUpdate(el);
+            const label = el.shadowRoot?.querySelector('#label-nav');
+            expect(label?.textContent).toBe('Form steps');
+            el.remove();
         });
     });
 

--- a/packages/core/src/components/stepper/stepper.ts
+++ b/packages/core/src/components/stepper/stepper.ts
@@ -348,6 +348,11 @@ export class ArStepper extends LitElement {
                       currentStepIndex: this._currentStepIndex,
                       currentStepLabel: this.getCurrentStepLabel(),
                       currentSubStepLabel: this.getCurrentSubStepLabel(),
+                      currentStepStatus: this.localize.term(
+                          'currentStepStatus',
+                          this._currentStepIndex + 1,
+                          steps.length,
+                      ),
                       onToggle: this._onDropdownToggle,
                   },
                   this.mode,

--- a/packages/core/src/components/stepper/stepper.ts
+++ b/packages/core/src/components/stepper/stepper.ts
@@ -337,8 +337,11 @@ export class ArStepper extends LitElement {
             return html`<slot></slot>`;
         }
 
+        const stepLabel = (order: number, isSubstep: boolean): string =>
+            this.localize.term('stepLabel', order, isSubstep);
+
         const content = this._isDesktop
-            ? renderDesktop(steps, this.mode, this.onClickLink)
+            ? renderDesktop(steps, this.mode, this.onClickLink, stepLabel)
             : renderMobile(
                   steps,
                   {
@@ -349,6 +352,7 @@ export class ArStepper extends LitElement {
                   },
                   this.mode,
                   this.onClickLink,
+                  stepLabel,
               );
 
         return html` <nav part="stepper" role="navigation" aria-labelledby="label-nav">

--- a/packages/core/src/components/stepper/stepper.ts
+++ b/packages/core/src/components/stepper/stepper.ts
@@ -21,6 +21,10 @@ import { AnchoredController } from '../../controllers/anchored.controller.js';
 import { renderDesktop, renderMobile } from './stepper.renderer.js';
 import { ArStepperItem } from '../stepper-item/stepper-item.js';
 import { warn } from '../../utils/warn.js';
+import { LocalizeController } from '../../controllers/localize.controller.js';
+// fr avant en : la première traduction enregistrée devient le repli de la lib pour les langues non reconnues.
+import '../../translations/fr.js';
+import '../../translations/en.js';
 
 /** Détail de l'événement émis lors d'une demande ou d'une confirmation de changement d'étape */
 export interface ArStepperStepChangeDetail {
@@ -37,6 +41,7 @@ export interface ArStepperStepChangeDetail {
 /**
  * @summary Stepper de navigation accessible avec téléportation DOM adaptive.
  * @display demo
+ * @localized
  *
  * Les étapes sont déclarées via des éléments `<ar-stepper-item>` enfants.
  * Le composant les collecte automatiquement via `@lit/context` et construit
@@ -98,6 +103,8 @@ export interface ArStepperStepChangeDetail {
  */
 export class ArStepper extends LitElement {
     static override styles: CSSResultGroup = [resetStyles, utilitiesStyles, panelStyles, styles];
+
+    private readonly localize = new LocalizeController(this);
 
     /**
      * Chemin de l'étape courante. Doit correspondre au `href` d'un `<ar-stepper-item>`.
@@ -345,7 +352,7 @@ export class ArStepper extends LitElement {
               );
 
         return html` <nav part="stepper" role="navigation" aria-labelledby="label-nav">
-            <p id="label-nav" class="sr-only">Étapes du formulaire</p>
+            <p id="label-nav" class="sr-only">${this.localize.term('stepperNavLabel')}</p>
             ${content}
             <slot></slot>
         </nav>`;

--- a/packages/core/src/translations/en.ts
+++ b/packages/core/src/translations/en.ts
@@ -40,7 +40,7 @@ const translation: Translation = {
 
     // ── ar-datepicker ────────────────────────────────────────────────────
     today: 'Today',
-    close: 'Close',
+    closeCalendar: 'Close calendar',
     openCalendar: 'Open calendar',
     selectDate: 'Select a date',
     previousYear: 'Previous year',
@@ -54,6 +54,37 @@ const translation: Translation = {
     dateRangeFrom: (from) => `from ${from}`,
     dateRangeUntil: (to) => `until ${to}`,
     formatOrdinalDate: (_date, _monthYearText, fullDateText) => fullDateText,
+
+    // ── ar-pagination ────────────────────────────────────────────────────
+    previousPage: (page, total) => `Previous page (page ${page} of ${total})`,
+    nextPage: (page, total) => `Next page (page ${page} of ${total})`,
+    pageStatus: (page, total) => `Page ${page} of ${total}`,
+    compactPageStatus: (current, total) => `Page ${current} / ${total}`,
+    goToPage: 'Go to page',
+
+    // ── ar-stepper ───────────────────────────────────────────────────────
+    stepperNavLabel: 'Form steps',
+
+    // ── ar-breadcrumb ────────────────────────────────────────────────────
+    breadcrumbNavLabel: 'You are here',
+    showBreadcrumb: 'Show breadcrumb',
+
+    // ── ar-charcounter ───────────────────────────────────────────────────
+    remainingLabel: 'character remaining|characters remaining',
+    excessMessage: (count) =>
+        `Limit exceeded by ${count} ${count === 1 ? 'character' : 'characters'}`,
+
+    // ── ar-spinner ───────────────────────────────────────────────────────
+    loading: 'Content is loading',
+    loadingDone: 'Loading complete',
+
+    // ── ar-dialog ────────────────────────────────────────────────────────
+    closeDialog: 'Close dialog',
+    closingBlocked: 'Closing blocked.',
+    dialogDefaultLabel: 'Dialog',
+
+    // ── ar-alert ─────────────────────────────────────────────────────────
+    closeAlert: 'Close alert',
 };
 
 registerTranslation(translation);

--- a/packages/core/src/translations/en.ts
+++ b/packages/core/src/translations/en.ts
@@ -40,6 +40,7 @@ const translation: Translation = {
 
     // ── ar-datepicker ────────────────────────────────────────────────────
     today: 'Today',
+    close: 'Close',
     closeCalendar: 'Close calendar',
     openCalendar: 'Open calendar',
     selectDate: 'Select a date',

--- a/packages/core/src/translations/en.ts
+++ b/packages/core/src/translations/en.ts
@@ -67,6 +67,7 @@ const translation: Translation = {
     // ── ar-stepper ───────────────────────────────────────────────────────
     stepperNavLabel: 'Form steps',
     stepLabel: (order, isSubstep) => `${isSubstep ? 'sub-' : ''}step ${order}:`,
+    currentStepStatus: (current, total) => `Step ${current} / ${total} (in progress)`,
 
     // ── ar-breadcrumb ────────────────────────────────────────────────────
     breadcrumbNavLabel: 'You are here',

--- a/packages/core/src/translations/en.ts
+++ b/packages/core/src/translations/en.ts
@@ -66,6 +66,7 @@ const translation: Translation = {
 
     // ── ar-stepper ───────────────────────────────────────────────────────
     stepperNavLabel: 'Form steps',
+    stepLabel: (order, isSubstep) => `${isSubstep ? 'sub-' : ''}step ${order}:`,
 
     // ── ar-breadcrumb ────────────────────────────────────────────────────
     breadcrumbNavLabel: 'You are here',

--- a/packages/core/src/translations/en.ts
+++ b/packages/core/src/translations/en.ts
@@ -62,6 +62,7 @@ const translation: Translation = {
     pageStatus: (page, total) => `Page ${page} of ${total}`,
     compactPageStatus: (current, total) => `Page ${current} / ${total}`,
     goToPage: 'Go to page',
+    paginationLandmark: (page, total) => `Pagination, page ${page} of ${total}`,
 
     // ── ar-stepper ───────────────────────────────────────────────────────
     stepperNavLabel: 'Form steps',

--- a/packages/core/src/translations/fr.ts
+++ b/packages/core/src/translations/fr.ts
@@ -67,6 +67,7 @@ const translation: Translation = {
 
     // ── ar-stepper ───────────────────────────────────────────────────────
     stepperNavLabel: 'Étapes du formulaire',
+    stepLabel: (order, isSubstep) => `${isSubstep ? 'sous-' : ''}étape ${order}:`,
 
     // ── ar-breadcrumb ────────────────────────────────────────────────────
     breadcrumbNavLabel: 'Vous êtes ici',

--- a/packages/core/src/translations/fr.ts
+++ b/packages/core/src/translations/fr.ts
@@ -40,6 +40,7 @@ const translation: Translation = {
 
     // ── ar-datepicker ────────────────────────────────────────────────────
     today: "Aujourd'hui",
+    close: 'Fermer',
     closeCalendar: 'Fermer le calendrier',
     openCalendar: 'Ouvrir le calendrier',
     selectDate: 'Sélectionner une date',

--- a/packages/core/src/translations/fr.ts
+++ b/packages/core/src/translations/fr.ts
@@ -63,6 +63,7 @@ const translation: Translation = {
     pageStatus: (page, total) => `Page ${page} sur ${total}`,
     compactPageStatus: (current, total) => `Page ${current} / ${total}`,
     goToPage: 'Aller à la page',
+    paginationLandmark: (page, total) => `Pagination, page ${page} sur ${total}`,
 
     // ── ar-stepper ───────────────────────────────────────────────────────
     stepperNavLabel: 'Étapes du formulaire',

--- a/packages/core/src/translations/fr.ts
+++ b/packages/core/src/translations/fr.ts
@@ -40,7 +40,7 @@ const translation: Translation = {
 
     // ── ar-datepicker ────────────────────────────────────────────────────
     today: "Aujourd'hui",
-    close: 'Fermer',
+    closeCalendar: 'Fermer le calendrier',
     openCalendar: 'Ouvrir le calendrier',
     selectDate: 'Sélectionner une date',
     previousYear: 'Année précédente',
@@ -55,6 +55,37 @@ const translation: Translation = {
     dateRangeUntil: (to) => `jusqu'au ${to}`,
     formatOrdinalDate: (date, monthYearText, fullDateText) =>
         date.getDate() === 1 ? `1er ${monthYearText}` : fullDateText,
+
+    // ── ar-pagination ────────────────────────────────────────────────────
+    previousPage: (page, total) => `Page précédente (page ${page} sur ${total})`,
+    nextPage: (page, total) => `Page suivante (page ${page} sur ${total})`,
+    pageStatus: (page, total) => `Page ${page} sur ${total}`,
+    compactPageStatus: (current, total) => `Page ${current} / ${total}`,
+    goToPage: 'Aller à la page',
+
+    // ── ar-stepper ───────────────────────────────────────────────────────
+    stepperNavLabel: 'Étapes du formulaire',
+
+    // ── ar-breadcrumb ────────────────────────────────────────────────────
+    breadcrumbNavLabel: 'Vous êtes ici',
+    showBreadcrumb: "Afficher le fil d'ariane",
+
+    // ── ar-charcounter ───────────────────────────────────────────────────
+    remainingLabel: 'caractère restant|caractères restants',
+    excessMessage: (count) =>
+        `Limite dépassée de ${count} ${count === 1 ? 'caractère' : 'caractères'}`,
+
+    // ── ar-spinner ───────────────────────────────────────────────────────
+    loading: 'Contenu en cours de chargement',
+    loadingDone: 'Chargement terminé',
+
+    // ── ar-dialog ────────────────────────────────────────────────────────
+    closeDialog: 'Fermer la boîte de dialogue',
+    closingBlocked: 'Fermeture bloquée.',
+    dialogDefaultLabel: 'Dialogue',
+
+    // ── ar-alert ─────────────────────────────────────────────────────────
+    closeAlert: "Fermer l'alerte",
 };
 
 registerTranslation(translation);

--- a/packages/core/src/translations/fr.ts
+++ b/packages/core/src/translations/fr.ts
@@ -68,6 +68,7 @@ const translation: Translation = {
     // ── ar-stepper ───────────────────────────────────────────────────────
     stepperNavLabel: 'Étapes du formulaire',
     stepLabel: (order, isSubstep) => `${isSubstep ? 'sous-' : ''}étape ${order}:`,
+    currentStepStatus: (current, total) => `Étape ${current} / ${total} (en cours)`,
 
     // ── ar-breadcrumb ────────────────────────────────────────────────────
     breadcrumbNavLabel: 'Vous êtes ici',

--- a/packages/core/src/translations/translations.test.ts
+++ b/packages/core/src/translations/translations.test.ts
@@ -151,6 +151,13 @@ describe('traductions', () => {
         expect(en.stepperNavLabel).toBe('Form steps');
     });
 
+    it('fr/en exposent stepLabel', () => {
+        expect(fr.stepLabel(1, false)).toBe('étape 1:');
+        expect(fr.stepLabel(1, true)).toBe('sous-étape 1:');
+        expect(en.stepLabel(1, false)).toBe('step 1:');
+        expect(en.stepLabel(1, true)).toBe('sub-step 1:');
+    });
+
     it('fr/en exposent les termes de breadcrumb', () => {
         expect(fr.breadcrumbNavLabel).toBe('Vous êtes ici');
         expect(fr.showBreadcrumb).toBe("Afficher le fil d'ariane");

--- a/packages/core/src/translations/translations.test.ts
+++ b/packages/core/src/translations/translations.test.ts
@@ -57,6 +57,14 @@ describe('traductions', () => {
         expect(fr.nextYear).toBe('Année suivante');
     });
 
+    it('fr.close est traduit', () => {
+        expect(fr.close).toBe('Fermer');
+    });
+
+    it('en.close est traduit', () => {
+        expect(en.close).toBe('Close');
+    });
+
     it('fr.closeCalendar est traduit', () => {
         expect(fr.closeCalendar).toBe('Fermer le calendrier');
     });

--- a/packages/core/src/translations/translations.test.ts
+++ b/packages/core/src/translations/translations.test.ts
@@ -158,6 +158,11 @@ describe('traductions', () => {
         expect(en.stepLabel(1, true)).toBe('sub-step 1:');
     });
 
+    it('fr/en exposent currentStepStatus', () => {
+        expect(fr.currentStepStatus(2, 5)).toBe('Étape 2 / 5 (en cours)');
+        expect(en.currentStepStatus(2, 5)).toBe('Step 2 / 5 (in progress)');
+    });
+
     it('fr/en exposent les termes de breadcrumb', () => {
         expect(fr.breadcrumbNavLabel).toBe('Vous êtes ici');
         expect(fr.showBreadcrumb).toBe("Afficher le fil d'ariane");

--- a/packages/core/src/translations/translations.test.ts
+++ b/packages/core/src/translations/translations.test.ts
@@ -141,6 +141,11 @@ describe('traductions', () => {
         expect(en.goToPage).toBe('Go to page');
     });
 
+    it('fr/en exposent paginationLandmark', () => {
+        expect(fr.paginationLandmark(4, 5)).toBe('Pagination, page 4 sur 5');
+        expect(en.paginationLandmark(4, 5)).toBe('Pagination, page 4 of 5');
+    });
+
     it('fr/en exposent stepperNavLabel', () => {
         expect(fr.stepperNavLabel).toBe('Étapes du formulaire');
         expect(en.stepperNavLabel).toBe('Form steps');

--- a/packages/core/src/translations/translations.test.ts
+++ b/packages/core/src/translations/translations.test.ts
@@ -57,6 +57,14 @@ describe('traductions', () => {
         expect(fr.nextYear).toBe('Année suivante');
     });
 
+    it('fr.closeCalendar est traduit', () => {
+        expect(fr.closeCalendar).toBe('Fermer le calendrier');
+    });
+
+    it('en.closeCalendar est traduit', () => {
+        expect(en.closeCalendar).toBe('Close calendar');
+    });
+
     it('fr.expectedFormat interpole format et exemple', () => {
         expect(fr.expectedFormat('dd/MM/yyyy', '31/12/2026')).toBe(
             'Format attendu : dd/MM/yyyy (ex. 31/12/2026)',
@@ -107,5 +115,66 @@ describe('traductions', () => {
         expect(en.formatOrdinalDate(firstOfMonth, 'January 2026', 'January 1, 2026')).toBe(
             'January 1, 2026',
         );
+    });
+
+    it('fr expose les termes de pagination', () => {
+        expect(fr.previousPage(2, 5)).toBe('Page précédente (page 2 sur 5)');
+        expect(fr.nextPage(3, 5)).toBe('Page suivante (page 3 sur 5)');
+        expect(fr.pageStatus(4, 5)).toBe('Page 4 sur 5');
+        expect(fr.compactPageStatus(4, 5)).toBe('Page 4 / 5');
+        expect(fr.goToPage).toBe('Aller à la page');
+    });
+
+    it('en expose les termes de pagination', () => {
+        expect(en.previousPage(2, 5)).toBe('Previous page (page 2 of 5)');
+        expect(en.nextPage(3, 5)).toBe('Next page (page 3 of 5)');
+        expect(en.pageStatus(4, 5)).toBe('Page 4 of 5');
+        expect(en.compactPageStatus(4, 5)).toBe('Page 4 / 5');
+        expect(en.goToPage).toBe('Go to page');
+    });
+
+    it('fr/en exposent stepperNavLabel', () => {
+        expect(fr.stepperNavLabel).toBe('Étapes du formulaire');
+        expect(en.stepperNavLabel).toBe('Form steps');
+    });
+
+    it('fr/en exposent les termes de breadcrumb', () => {
+        expect(fr.breadcrumbNavLabel).toBe('Vous êtes ici');
+        expect(fr.showBreadcrumb).toBe("Afficher le fil d'ariane");
+        expect(en.breadcrumbNavLabel).toBe('You are here');
+        expect(en.showBreadcrumb).toBe('Show breadcrumb');
+    });
+
+    it('fr.remainingLabel/excessMessage sont corrects', () => {
+        expect(fr.remainingLabel).toBe('caractère restant|caractères restants');
+        expect(fr.excessMessage(1)).toBe('Limite dépassée de 1 caractère');
+        expect(fr.excessMessage(3)).toBe('Limite dépassée de 3 caractères');
+    });
+
+    it('en.remainingLabel/excessMessage sont corrects', () => {
+        expect(en.remainingLabel).toBe('character remaining|characters remaining');
+        expect(en.excessMessage(1)).toBe('Limit exceeded by 1 character');
+        expect(en.excessMessage(3)).toBe('Limit exceeded by 3 characters');
+    });
+
+    it('fr/en exposent loading/loadingDone', () => {
+        expect(fr.loading).toBe('Contenu en cours de chargement');
+        expect(fr.loadingDone).toBe('Chargement terminé');
+        expect(en.loading).toBe('Content is loading');
+        expect(en.loadingDone).toBe('Loading complete');
+    });
+
+    it('fr/en exposent les termes de dialog', () => {
+        expect(fr.closeDialog).toBe('Fermer la boîte de dialogue');
+        expect(fr.closingBlocked).toBe('Fermeture bloquée.');
+        expect(fr.dialogDefaultLabel).toBe('Dialogue');
+        expect(en.closeDialog).toBe('Close dialog');
+        expect(en.closingBlocked).toBe('Closing blocked.');
+        expect(en.dialogDefaultLabel).toBe('Dialog');
+    });
+
+    it('fr/en exposent closeAlert', () => {
+        expect(fr.closeAlert).toBe("Fermer l'alerte");
+        expect(en.closeAlert).toBe('Close alert');
     });
 });

--- a/packages/core/src/types/translation.ts
+++ b/packages/core/src/types/translation.ts
@@ -48,6 +48,7 @@ export interface Translation extends BaseTranslation {
 
     // ar-stepper
     stepperNavLabel: string;
+    stepLabel: (order: number, isSubstep: boolean) => string;
 
     // ar-breadcrumb
     breadcrumbNavLabel: string;

--- a/packages/core/src/types/translation.ts
+++ b/packages/core/src/types/translation.ts
@@ -44,6 +44,7 @@ export interface Translation extends BaseTranslation {
     pageStatus: (page: number, total: number) => string;
     compactPageStatus: (current: number, total: number) => string;
     goToPage: string;
+    paginationLandmark: (page: number, total: number) => string;
 
     // ar-stepper
     stepperNavLabel: string;

--- a/packages/core/src/types/translation.ts
+++ b/packages/core/src/types/translation.ts
@@ -20,6 +20,7 @@ export interface Translation extends BaseTranslation {
 
     // ar-datepicker
     today: string;
+    close: string;
     closeCalendar: string;
     openCalendar: string;
     selectDate: string;

--- a/packages/core/src/types/translation.ts
+++ b/packages/core/src/types/translation.ts
@@ -49,6 +49,7 @@ export interface Translation extends BaseTranslation {
     // ar-stepper
     stepperNavLabel: string;
     stepLabel: (order: number, isSubstep: boolean) => string;
+    currentStepStatus: (current: number, total: number) => string;
 
     // ar-breadcrumb
     breadcrumbNavLabel: string;

--- a/packages/core/src/types/translation.ts
+++ b/packages/core/src/types/translation.ts
@@ -20,7 +20,7 @@ export interface Translation extends BaseTranslation {
 
     // ar-datepicker
     today: string;
-    close: string;
+    closeCalendar: string;
     openCalendar: string;
     selectDate: string;
     previousYear: string;
@@ -36,4 +36,34 @@ export interface Translation extends BaseTranslation {
     /** `monthYearText`/`fullDateText` sont déjà formatés via Intl (locale-aware) — le terme
      *  décide seulement s'il faut un marqueur ordinal (ex. « 1er » en français). */
     formatOrdinalDate: (date: Date, monthYearText: string, fullDateText: string) => string;
+
+    // ar-pagination
+    previousPage: (page: number, total: number) => string;
+    nextPage: (page: number, total: number) => string;
+    pageStatus: (page: number, total: number) => string;
+    compactPageStatus: (current: number, total: number) => string;
+    goToPage: string;
+
+    // ar-stepper
+    stepperNavLabel: string;
+
+    // ar-breadcrumb
+    breadcrumbNavLabel: string;
+    showBreadcrumb: string;
+
+    // ar-charcounter
+    remainingLabel: string;
+    excessMessage: (count: number) => string;
+
+    // ar-spinner
+    loading: string;
+    loadingDone: string;
+
+    // ar-dialog
+    closeDialog: string;
+    closingBlocked: string;
+    dialogDefaultLabel: string;
+
+    // ar-alert
+    closeAlert: string;
 }


### PR DESCRIPTION
## Résumé

Lot 2 de l'infrastructure i18n (#80) : migration de 7 composants vers `@shoelace-style/localize` (`LocalizeController`), suite du lot 1 (#189).

- **Composants migrés** : `ar-pagination`, `ar-stepper`, `ar-breadcrumb`, `ar-charcounter`, `ar-spinner`, `ar-dialog`, `ar-alert`.
- **Nouveau pattern** : sentinel `undefined`/`useDefault: true` sur les props texte déjà personnalisables (`ar-charcounter.label`, `ar-spinner.loadingLabel`/`doneLabel`, `ar-dialog.closeLabel`/`preventedMessage`) — le défaut se traduit dynamiquement selon `lang` tout en restant surchargeable.
- **Renommage lot 1** : le terme `close` d'`ar-datepicker` devient `closeCalendar` ("Fermer le calendrier"), avec un nouveau terme `close` réintroduit pour le texte visible du bouton (découplé de l'aria-label, conformité WCAG 2.5.3 Label-in-Name).
- **Nouveau terme** `closeDialog` pour `ar-dialog` (distinct de `closeCalendar`) — évite l'ambiguïté pour un lecteur d'écran quand plusieurs surfaces fermables sont ouvertes simultanément sur la même page.

## Breaking changes

⚠️ Trois composants voient le type de props publiques changer de `string` à `string | undefined` (défaut traduit dynamiquement, toujours surchargeable) :

- **`ArDialog`** : `closeLabel`, `preventedMessage`
- **`ArSpinner`** : `loadingLabel`, `doneLabel` — les constantes statiques `DEFAULT_LOADING_LABEL`/`DEFAULT_DONE_LABEL` sont retirées
- **`ArCharcounter`** : `label`

Pour un consommateur n'ayant jamais surchargé ces props, le texte par défaut observable ne change pas tant que `lang` n'est pas modifié.

## Corrections en cours de route

- `ar-pagination` : landmark nav (`aria-labelledby`) manquait de terme de traduction — ajouté (`paginationLandmark`).
- `ar-stepper` : deux chaînes FR en dur dans `stepper.renderer.ts` (annonce sr-only par étape, statut du trigger mobile) avaient échappé à la spec initiale — ajoutées (`stepLabel`, `currentStepStatus`).
- `ar-datepicker` (lot 1, déjà livré) : le bouton "Fermer" utilisait la même chaîne pour son texte visible et son aria-label — découplé pour permettre un aria-label plus précis sans allonger le texte visible.
- Plusieurs correctifs de robustesse Prettier/Lit : un `${...}` seul contenu d'un élément sr-only, si la ligne dépasse 100 caractères, se fait wrapper par Prettier d'une façon qui introduit des nœuds de texte (espaces) dans le DOM rendu — corrigé via extraction en `const` ou `<!-- prettier-ignore -->` selon le type d'élément (`ar-pagination`, `ar-breadcrumb`, `ar-charcounter`).

## Suivi (non bloquant, noté en revue finale)

- Les 3 idiomes utilisés pour parer le risque Prettier/whitespace ci-dessus mériteraient d'être harmonisés (extraction en `const` partout) dans un futur nettoyage — le risque a maintenant été rencontré 4 fois dans cette branche.
- Quelques trous de couverture de test mineurs (label du `<select>` de pagination, `showBreadcrumb`, état warning d'`ar-charcounter` en anglais).

## Test plan

- [x] `npm test` (suite Vitest complète, 987 tests) verte à la racine du monorepo
- [x] `npx tsc --noEmit` sans erreur
- [x] `npx prettier --check` sans erreur sur tous les fichiers touchés
- [ ] `npm run test:all` (inclut les tests `*.a11y.test.ts`/`*.browser.test.ts` WTR/Chromium) — à vérifier en CI